### PR TITLE
Cameramap selection to PYMEAcquire and startacq metadata

### DIFF
--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -79,7 +79,8 @@ class PYMEMainFrame(AUIFrame):
         self.AddMenuItem('Camera', 'Toggle ROI\tF8', self.OnMCamRoi)
         self.miCamBin = self.AddMenuItem('Camera', 'Turn binning on', self.OnMCamBin, itemType='check')
         self.AddMenuItem('Camera', 'Set pixel size', self.OnMCamSetPixelSize)
-        
+        self.AddMenuItem('Camera', 'Set camera maps', self.OnMCamSetCameraMaps)
+
         #Acquire menu
         self.AddMenuItem('Acquire', 'Snapshot\tF5', self.OnMAquireOnePic)
               
@@ -530,6 +531,11 @@ class PYMEMainFrame(AUIFrame):
         dlg = voxelSizeDialog.VoxelSizeDialog(self, self.scope)
         dlg.ShowModal()
 
+    def OnMCamSetCameraMaps(self, event):
+        from PYME.Acquire.ui.camera_map_dialog import CameraMapDialog
+
+        dlg = CameraMapDialog(self, self.scope)
+        dlg.ShowModal()
 
     def OnMCamRoi(self, event):
         logging.debug('Stopping frame wrangler to set ROI')

--- a/PYME/Acquire/ui/camera_map_dialog.py
+++ b/PYME/Acquire/ui/camera_map_dialog.py
@@ -1,0 +1,109 @@
+
+import wx
+
+
+class CameraMapDialog(wx.Dialog):
+    def __init__(self, parent, scope):
+        wx.Dialog.__init__(self, parent, -1, 'Camera Calibrations')
+        self.scope = scope
+
+        sizer1 = wx.BoxSizer(wx.VERTICAL)
+
+        self.cam_names = list(scope.cameras.keys())
+        self.cal_choices = []
+
+        gsizer = wx.FlexGridSizer(2, 2, 2)
+        gsizer.AddGrowableCol(1, 1)
+        for name in self.cam_names:
+            gsizer.Add(wx.StaticText(self, -1, '%s: ' % name), 0, wx.ALIGN_CENTER_VERTICAL, 0)
+            ch = wx.Choice(self, -1)
+            ch.Bind(wx.EVT_CHOICE, self.OnChooseMaps)
+            gsizer.Add(ch, 1, wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, 0)
+            self.cal_choices.append(ch)
+
+        self._set_calibration_choices()
+
+        sizer1.Add(gsizer, 0, wx.EXPAND | wx.ALL, 5)
+
+        hsizer = wx.StaticBoxSizer(wx.StaticBox(self, -1, 'New Setting'), wx.HORIZONTAL)
+
+        hsizer.Add(wx.StaticText(self, -1, 'Name: '), 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        self._name = wx.TextCtrl(self, -1, size=(80, -1))
+        hsizer.Add(self._name, 1, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
+
+        hsizer.Add(wx.StaticText(self, -1, 'dark path:'), 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        self._dark = wx.TextCtrl(self, -1, size=(30, -1))
+        hsizer.Add(self._dark, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+
+        hsizer.Add(wx.StaticText(self, -1, 'flat path:'), 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        self._flat = wx.TextCtrl(self, -1, size=(30, -1))
+        hsizer.Add(self._flat, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+
+        hsizer.Add(wx.StaticText(self, -1, 'variance path:'), 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        self._variance = wx.TextCtrl(self, -1, size=(30, -1))
+        hsizer.Add(self._variance, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        # hsizer.Add(wx.StaticText(self, -1, ') [\u03BCm] '), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
+
+        self.bAdd = wx.Button(self, -1, 'Add', style=wx.BU_EXACTFIT)
+        self.bAdd.Bind(wx.EVT_BUTTON, self.OnAddMaps)
+        hsizer.Add(self.bAdd, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+
+        sizer1.Add(hsizer, 0, wx.EXPAND | wx.ALL, 5)
+
+        btSizer = wx.StdDialogButtonSizer()
+
+        btn = wx.Button(self, wx.ID_OK)
+        btn.SetDefault()
+
+        btSizer.AddButton(btn)
+
+        # btn = wx.Button(self, wx.ID_CANCEL)
+
+        # btSizer.AddButton(btn)
+
+        btSizer.Realize()
+
+        sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+
+        self.SetSizer(sizer1)
+        sizer1.Fit(self)
+
+    def OnAddMaps(self, event):
+        self.scope.AddCameraMaps(self._name.GetValue(), self._dark.GetValue(), self._flat.GetValue(), self._variance.GetValue())
+        self._set_calibration_choices()
+
+    def OnChooseMaps(self, event):
+        choice = event.GetEventObject()
+        cam_name = self.cam_names[self.cal_choices.index(choice)]
+        cal_name = self.cal_choices[choice.GetStringSelection()]
+
+        self.scope.SetCameraMaps(cal_name, cam_name)
+
+    def _set_calibration_choices(self):
+        camera_maps = self.scope.settingsDB.execute("SELECT ID, name, dark_path, flat_path, var_path FROM CameraMaps ORDER BY ID DESC").fetchall()
+
+        map_ids = []
+        self.map_names = {}
+
+        for ch in self.cal_choices:
+            ch.Clear()
+
+        for ID, name, dark_path, flat_path, var_path in camera_maps:
+            comp_name = '%s - (%s, %s, %s)' % (name, dark_path, flat_path, var_path)
+
+            map_ids.append(ID)
+            self.map_names[comp_name] = name
+
+            for ch in self.cal_choices:
+                ch.Append(comp_name)
+
+        for ch, cam_name in zip(self.cal_choices, self.cam_names):
+            try:
+                curr_choice_id = self.scope.settingsDB.execute(
+                    "SELECT choice_id FROM CameraMapsHistory WHERE cam_serial=? ORDER BY time DESC",
+                    (self.scope.cameras[cam_name].GetSerialNumber(),)).fetchone()[0]
+
+                if curr_choice_id is not None:
+                    ch.SetSelection(map_ids.index(curr_choice_id))
+            except:
+                pass

--- a/PYME/Acquire/ui/camera_map_dialog.py
+++ b/PYME/Acquire/ui/camera_map_dialog.py
@@ -42,7 +42,6 @@ class CameraMapDialog(wx.Dialog):
         hsizer.Add(wx.StaticText(self, -1, 'variance path:'), 0, wx.ALIGN_CENTER_VERTICAL, 0)
         self._variance = wx.TextCtrl(self, -1, size=(30, -1))
         hsizer.Add(self._variance, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
-        # hsizer.Add(wx.StaticText(self, -1, ') [\u03BCm] '), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
 
         self.bAdd = wx.Button(self, -1, 'Add', style=wx.BU_EXACTFIT)
         self.bAdd.Bind(wx.EVT_BUTTON, self.OnAddMaps)
@@ -56,11 +55,6 @@ class CameraMapDialog(wx.Dialog):
         btn.SetDefault()
 
         btSizer.AddButton(btn)
-
-        # btn = wx.Button(self, wx.ID_CANCEL)
-
-        # btSizer.AddButton(btn)
-
         btSizer.Realize()
 
         sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)

--- a/PYME/Acquire/ui/camera_map_dialog.py
+++ b/PYME/Acquire/ui/camera_map_dialog.py
@@ -69,7 +69,7 @@ class CameraMapDialog(wx.Dialog):
     def OnChooseMaps(self, event):
         choice = event.GetEventObject()
         cam_name = self.cam_names[self.cal_choices.index(choice)]
-        cal_name = self.cal_choices[choice.GetStringSelection()]
+        cal_name = self.map_names[choice.GetStringSelection()]
 
         self.scope.SetCameraMaps(cal_name, cam_name)
 

--- a/PYME/Acquire/ui/voxelSizeDialog.py
+++ b/PYME/Acquire/ui/voxelSizeDialog.py
@@ -54,14 +54,14 @@ class VoxelSizeDialog(wx.Dialog):
         self.tName = wx.TextCtrl(self, -1, size=(80, -1))
         hsizer.Add(self.tName, 1, wx.ALIGN_CENTER_VERTICAL|wx.RIGHT, 10)
 
-        hsizer.Add(wx.StaticText(self, -1, u'(x '), 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        hsizer.Add(wx.StaticText(self, -1, '(x '), 0, wx.ALIGN_CENTER_VERTICAL, 0)
         self.tx = wx.TextCtrl(self, -1, size=(30, -1))
         hsizer.Add(self.tx, 0, wx.ALIGN_CENTER_VERTICAL|wx.RIGHT, 5)
 
-        hsizer.Add(wx.StaticText(self, -1, u', y '), 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        hsizer.Add(wx.StaticText(self, -1, ', y '), 0, wx.ALIGN_CENTER_VERTICAL, 0)
         self.ty = wx.TextCtrl(self, -1, size=(30, -1))
         hsizer.Add(self.ty, 0, wx.ALIGN_CENTER_VERTICAL|wx.RIGHT, 5)
-        hsizer.Add(wx.StaticText(self, -1, u') [\u03BCm] '), 0, wx.ALIGN_CENTER_VERTICAL|wx.RIGHT, 10)
+        hsizer.Add(wx.StaticText(self, -1, ') [\u03BCm] '), 0, wx.ALIGN_CENTER_VERTICAL|wx.RIGHT, 10)
 
         self.bAdd = wx.Button(self, -1, 'Add', style=wx.BU_EXACTFIT)
         self.bAdd.Bind(wx.EVT_BUTTON, self.OnAddVSSetting)
@@ -117,7 +117,7 @@ class VoxelSizeDialog(wx.Dialog):
             ch.Clear()
 
         for ID, name, x, y in voxelsizes:
-            compName = '%s - (%3.2f, %3.2f)' % (name, x, y)
+            compName = '%s - (%3.3f, %3.3f)' % (name, x, y)
 
             voxIDs.append(ID)
             self.voxNames[compName] = name


### PR DESCRIPTION
- Allows camera calibration maps to be set / saved into metadata following the same database model as for the pixel size
- removes explicitly printed u's and displays pixel size out to 1 nm precision