### PR TITLE
Adding / correcting camera intensity-related unit docs

### DIFF
--- a/PYME/Acquire/Hardware/Camera.py
+++ b/PYME/Acquire/Hardware/Camera.py
@@ -668,14 +668,15 @@ class Camera(object):
 
         a dictionary with the following entries:
 
-        'ReadNoise' : camera read noise in electrons
-        'ElectronsPerCount' : AD conversion factor - how many electrons per camera count
-        'NoiseFactor' : excess (multiplicative) noise factor 1.44 for EMCCD, 1 for standard CCD/sCMOS
+        'ReadNoise' : camera read noise as a standard deviation in units of ADU
+        'ElectronsPerCount' : AD conversion factor - how many electrons per ADU
+        'NoiseFactor' : excess (multiplicative) noise factor 1.44 for EMCCD, 1 for standard CCD/sCMOS. See
+            doi: 10.1109/TED.2003.813462
 
         and optionally
-        'ADOffset' : the dark level (in counts)
+        'ADOffset' : the dark level (in ADU)
         'DefaultEMGain' : a sensible EM gain setting to use for localization recording
-        'SaturationThreshold' : the full well capacity (in counts)
+        'SaturationThreshold' : the full well capacity (in ADU)
 
         """
         raise NotImplementedError('Implement in derived class')

--- a/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
@@ -86,11 +86,11 @@ noiseProperties = {
         'DefaultEMGain': 1,
         'SaturationThreshold': (2**16 - 1)
         },
-'S/N: 720795' : { #FIXME - values are currently copied from above, and are probably wrong
-        'ReadNoise': 3.51,
+'S/N: 720795' : {
+        'ReadNoise': 2.3940335559897847,  # rn is sqrt(var) in units of ADU. Median of varmap is 0.9947778 [e-^2]
         'ElectronsPerCount': 0.416613,
         'NGainStages': 0,
-        'ADOffset': 100,
+        'ADOffset': 101.753685,
         'DefaultEMGain': 1,
         'SaturationThreshold': (2**16 - 1)
         },

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -905,7 +905,7 @@ class LMAnalyser2(object):
                 
                 if 'tIm' in dir(ft.ofd):
                     plt.figure()
-                    plt.imshow(ft.ofd.tIm.T, cmap=cm.hot, interpolation='nearest')
+                    plt.imshow(ft.ofd.tIm.T, cmap=plt.cm.hot, interpolation='nearest')
                     #axis('tight')
                     plt.xlim(0, d.shape[1])
                     plt.ylim(d.shape[0], 0)

--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -559,7 +559,7 @@ class fitTask(taskDef.Task):
     @classmethod
     def calcSigma(cls, md, data):
         """
-        Estimate a per-pixel noise standard deviation (overestimate).
+        Estimate a per-pixel noise standard deviation.
         Parameters
         ----------
         md: PYME.IO.MetaDataHandler.MDHandlerBase
@@ -570,7 +570,7 @@ class fitTask(taskDef.Task):
         Returns
         -------
         sigma: ndarray
-            estimated per-pixel noise as a (overestimate of the) standard deviation. [ADU]
+            estimated per-pixel noise as a standard deviation. [ADU]
 
         Notes
         -----

--- a/doc/AnalysingForeignData.rst
+++ b/doc/AnalysingForeignData.rst
@@ -38,8 +38,8 @@ Camera.TrueEMGain         The calibrated electron multiplying gain (1 for
                           ordinary CCDs and sCMOS)
 Camera.NoiseFactor        EM excess noise factor (1.41 for EMCCDs, 1 for
                           standard CCDs / sCMOS). See doi:10.1109/TED.2003.813462
-Camera.ElectronsPerCount  Number of photo-electrons per analog-digital unit (ADU)
-Camera.ReadNoise          Read out noise as a standard deviation in ADU.
+Camera.ElectronsPerCount  Number of photo-electrons per camera count (ADU)
+Camera.ReadNoise          Read out noise (standard deviation) in ADU.
 Camera.ADOffset           Analog to digital offset (dark level, or average value of camera
                           pixels when no light is incident) in ADU. Not strictly
                           required as PYME will try and guess this from dark frames

--- a/doc/AnalysingForeignData.rst
+++ b/doc/AnalysingForeignData.rst
@@ -37,13 +37,13 @@ voxelsize.y               y pixel size in μm
 Camera.TrueEMGain         The calibrated electron multiplying gain (1 for
                           ordinary CCDs and sCMOS)
 Camera.NoiseFactor        EM excess noise factor (1.41 for EMCCDs, 1 for
-                          standard CCDs / sCMOS)
-Camera.ElectronsPerCount  Number of photo-electons per AD unit
-Camera.ReadNoise          Read out noise in photo-electrons
-Camera.ADOffset           Analog to digital offset (dark level / average value of camera
-                          pixels when no light is incident). Not strictly
+                          standard CCDs / sCMOS). See doi:10.1109/TED.2003.813462
+Camera.ElectronsPerCount  Number of photo-electrons per analog-digital unit (ADU)
+Camera.ReadNoise          Read out noise as a standard deviation in ADU.
+Camera.ADOffset           Analog to digital offset (dark level, or average value of camera
+                          pixels when no light is incident) in ADU. Not strictly
                           required as PYME will try and guess this from dark frames
-                          at the beginning of the sequence, but unless your acquistion
+                          at the beginning of the sequence, but unless your acquisition
                           is a very good match to the PYMEAcquire protocols this is
                           unlikely to work well.
 ========================  ============================================================

--- a/doc/html/_sources/AnalysingForeignData.txt
+++ b/doc/html/_sources/AnalysingForeignData.txt
@@ -37,10 +37,10 @@ voxelsize.y               y pixel size in μm
 Camera.TrueEMGain         The calibrated electron multiplying gain (1 for
                           ordinary CCDs)
 Camera.NoiseFactor        EM excess noise factor (1.41 for EMCCDs, 1 for
-                          standard CCDs / sCMOS). See doi:10.1109/TED.2003.813462
-Camera.ElectronsPerCount  Number of photo-electons per analog-digital unit (ADU)
-Camera.ReadNoise          Read out noise in ADU
-Camera.ADOffset           Analog to digital offset (dark level) in ADU. Not strictly
+                          standard CCDs / sCMOS)
+Camera.ElectronsPerCount  Number of photo-electons per AD unit
+Camera.ReadNoise          Read out noise in photo-electrons
+Camera.ADOffset           Analog to digital offset (dark level). Not strictly
                           required as PYME will try and guess this from dark frames
                           at the beginning of the sequence, but unless your acquistion
                           is a very good match to the PYMEAcquire protocols this is

--- a/doc/html/_sources/AnalysingForeignData.txt
+++ b/doc/html/_sources/AnalysingForeignData.txt
@@ -37,10 +37,10 @@ voxelsize.y               y pixel size in μm
 Camera.TrueEMGain         The calibrated electron multiplying gain (1 for
                           ordinary CCDs)
 Camera.NoiseFactor        EM excess noise factor (1.41 for EMCCDs, 1 for
-                          standard CCDs / sCMOS)
-Camera.ElectronsPerCount  Number of photo-electons per AD unit
-Camera.ReadNoise          Read out noise in photo-electrons
-Camera.ADOffset           Analog to digital offset (dark level). Not strictly
+                          standard CCDs / sCMOS). See doi:10.1109/TED.2003.813462
+Camera.ElectronsPerCount  Number of photo-electons per analog-digital unit (ADU)
+Camera.ReadNoise          Read out noise in ADU
+Camera.ADOffset           Analog to digital offset (dark level) in ADU. Not strictly
                           required as PYME will try and guess this from dark frames
                           at the beginning of the sequence, but unless your acquistion
                           is a very good match to the PYMEAcquire protocols this is


### PR DESCRIPTION
also includes trivial fix to a `plt.cm` missing the `plt`, and updating the noise properties of the htsms camera.