### PR TITLE
spoolframe quantization settings fixes

### DIFF
--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -393,9 +393,7 @@ class PanSpool(afp.foldingPane):
             try:
                 q_offset = self.scope.cam.noiseProps['ADOffset']
             except AttributeError:
-                msg = "Camera doesn't define noise properties, manually set the desired quantization offset"
-                ans = wx.MessageBox(msg, 'Error', wx.OK)
-                raise AttributeError(msg)
+                ans = wx.MessageBox("Camera doesn't define noise properties, manually set the desired quantization offset" , 'Error', wx.OK)
         else:
             q_offset = float(q_offset)
 

--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -400,7 +400,7 @@ class PanSpool(afp.foldingPane):
 
         #quantization scale in GUI is in units of sigma, convert to ADU
         try:
-            q_scale = float(self.tQuantizeScale.GetValue())/self.scope.cam.GetElectrPerCount()
+            q_scale = float(self.tQuantizeScale.GetValue())/self.scope.cam.GetElectronsPerCount()
         except (AttributeError, NotImplementedError):
             print("WARNING: Camera doesn't provide electrons per count, using qscale in units of ADUs instead")
             q_scale = float(self.tQuantizeScale.GetValue())

--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -393,7 +393,9 @@ class PanSpool(afp.foldingPane):
             try:
                 q_offset = self.scope.cam.noiseProps['ADOffset']
             except AttributeError:
-                ans = wx.MessageBox("Camera doesn't define noise properties, manually set the desired quantization offset" , 'Error', wx.OK)
+                msg = "Camera doesn't define noise properties, manually set the desired quantization offset"
+                ans = wx.MessageBox(msg, 'Error', wx.OK)
+                raise AttributeError(msg)
         else:
             q_offset = float(q_offset)
 


### PR DESCRIPTION
Typo in electronsPerCount is self explanatory. Other fix is someone one can encounter with a noise-prop-less camera, e.g. fakecam in the simulator, see below. Raising an error gives the user a chance to manually set the offset.

```ERROR:root:Exception whilst putting files
Traceback (most recent call last):
  File "/home/smeagol/code/python-microscopy/PYME/Acquire/HTTPSpooler.py", line 176, in _queuePoll
    pzf = PZFFormat.dumps(frame, sequenceID=self.sequenceID, frameNum = imNum, **self.compSettings)
  File "/home/smeagol/code/python-microscopy/PYME/IO/PZFFormat.py", line 255, in dumps
    header['QuantOffset'] = quantizationOffset
ValueError: could not convert string to float: 'auto'
Exception in thread Thread-33:
Traceback (most recent call last):
  File "/home/smeagol/anaconda2/envs/py36/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/smeagol/anaconda2/envs/py36/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/smeagol/code/python-microscopy/PYME/Acquire/HTTPSpooler.py", line 176, in _queuePoll
    pzf = PZFFormat.dumps(frame, sequenceID=self.sequenceID, frameNum = imNum, **self.compSettings)
  File "/home/smeagol/code/python-microscopy/PYME/IO/PZFFormat.py", line 255, in dumps
    header['QuantOffset'] = quantizationOffset
ValueError: could not convert string to float: 'auto'```
