### PR TITLE
fix to hamamatsu serial number metadata to allow camera map metadata completion

### DIFF
--- a/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuDCAM.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuDCAM.py
@@ -279,7 +279,7 @@ class HamamatsuDCAM(Camera):
             self.properties = self.getCamProperties()
 
             self._camera_model = self.getCamInfo(DCAM_IDSTR_MODEL)
-            self._serial_number = self.getCamInfo(DCAM_IDSTR_CAMERAID)
+            self._serial_number = self.getCamInfo(DCAM_IDSTR_CAMERAID).strip('S/N: ')
 
             self.SetIntegTime(0.1)
             

--- a/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
@@ -78,7 +78,7 @@ DCAMPROP_TRIGGERSOURCE_SOFTWARE = 3
 DCAMCAP_START_SEQUENCE = ctypes.c_int32(int("-1",0))
 
 noiseProperties = {
-'S/N: 100233' : {
+'100233' : {
         'ReadNoise': 3.51,
         'ElectronsPerCount': 0.47,
         'NGainStages': 0,
@@ -86,7 +86,7 @@ noiseProperties = {
         'DefaultEMGain': 1,
         'SaturationThreshold': (2**16 - 1)
         },
-'S/N: 720795' : {
+'720795' : {
         'ReadNoise': 2.3940335559897847,  # rn is sqrt(var) in units of ADU. Median of varmap is 0.9947778 [e-^2]
         'ElectronsPerCount': 0.416613,
         'NGainStages': 0,


### PR DESCRIPTION
cannot create a folder on windows named 'S/N: stuff'