### PR TITLE
type error in psf extraction

### DIFF
--- a/PYME/Analysis/PSFEst/extractImages.py
+++ b/PYME/Analysis/PSFEst/extractImages.py
@@ -158,7 +158,7 @@ def _expand_z(ps_shape, im_shape, points):
     dzl = np.min(pts[:,2]) - 1
     dzh = np.min(im_shape[2] - pts[:,2]) -1
     
-    szn = min(dzl, dzh)
+    szn = int(min(dzl, dzh))
     
     if szn < sz:
         logger.warning('New PSF is SMALLER than requested (szn = %d, request = %d)' % (szn, sz))


### PR DESCRIPTION
points is an array of float, so szn is also float, which isn't great
```
Traceback (most recent call last):
  File "c:\users\bergamot\code\python-microscopy\PYME\DSView\modules\psfExtraction.py", line 293, in OnExtract
    return  self.OnExtractMultiviewPSF(event)
  File "c:\users\bergamot\code\python-microscopy\PYME\DSView\modules\psfExtraction.py", line 336, in OnExtractMultiviewPSF
    centreZ=alignZ, expand_z=self.cbExpandROI.GetValue())
  File "c:\users\bergamot\code\python-microscopy\PYME\Analysis\PSFEst\extractImages.py", line 197, in getPSF3D
    imi = im[(px-sx):(px+sx+1),(py-sy):(py+sy+1),(pz-sz):(pz+sz+1)]
TypeError: slice indices must be integers or None or have an __index__ method
```
