### PR TITLE
Define scope "camera position"

### DIFF
--- a/PYME/Acquire/microscope.py
+++ b/PYME/Acquire/microscope.py
@@ -412,6 +412,9 @@ class microscope(object):
         For convenience, we'll follow the conventions of PanCamera, namely that positive stage motion is negative camera
         motion, rotation (switching x and y) happens 'before' flipping x, which happens 'before' flipping y.
 
+        Note that the origin here is currently implemented as the center of the 0, 0 pixel on the camera. There is a
+        half-pixel one could consider, but let us consider it ignored.
+
         """
         # prepare
         mdh = MetaDataHandler.NestedClassMDHandler()

--- a/PYME/Acquire/microscope.py
+++ b/PYME/Acquire/microscope.py
@@ -407,6 +407,13 @@ class microscope(object):
         Assume the stage 0 position and the camera chip origin are the same. Now, change your ROI position on the chip
         - from the perspective of the origin, you moved the stage! You didn't, but we'll tell you by how much.
 
+        Returns
+        -------
+        x: float
+            Current camera x position [um]
+        y: float
+            Current camera y position [um]
+
         Notes
         -----
         For convenience, we'll follow the conventions of PanCamera, namely that positive stage motion is negative camera
@@ -448,7 +455,7 @@ class microscope(object):
 
     def SetCameraPosition(self, x, y):
         """
-        Move the camera origin
+        Move the camera, and be kind of lazy about it.
 
         Parameters
         ----------


### PR DESCRIPTION
Set center of (0, 0) pixel as (0, 0) xy stage position, and call this (0, 0) "camera position". 

"Camera position" is more omniscient than stage position, as it tracks the stage position as well as camera ROI changes. 