### PR TITLE
allow all remfitbuf prefit steps to be done on the GPU

### DIFF
--- a/PYME/localization/FitFactories/AstigGaussGPUFitFR.py
+++ b/PYME/localization/FitFactories/AstigGaussGPUFitFR.py
@@ -143,28 +143,23 @@ class GaussianFitFactory:
 
         global _warpdrive  # One instance for each process, re-used for subsequent fits.
 
-        # get flatmap [unitless]
+        # get darkmap [ADU]
         self.darkmap = cameraMaps.getDarkMap(self.metadata)
         if np.isscalar(self.darkmap):
             self.darkmap = self.darkmap * np.ones_like(self.data)
 
         # get flatmap [unitless]
-        flatmap = cameraMaps.getFlatfieldMap(self.metadata)
-        if not np.isscalar(flatmap):
-            self.flatmap = flatmap.astype(np.float32)
-        else:
-            self.flatmap = flatmap * np.ones_like(self.data)
+        self.flatmap = cameraMaps.getFlatfieldMap(self.metadata)
+        if np.isscalar(self.flatmap):
+            self.flatmap = self.flatmap * np.ones_like(self.data)
 
         # get varmap [e-^2]
-        varmap = cameraMaps.getVarianceMap(self.metadata)
-        if not np.isscalar(varmap):
-            self.varmap = varmap.astype(np.float32)  # np.ascontiguousarray(varmap)
-        else:
-            if varmap == 0:
+        self.varmap = cameraMaps.getVarianceMap(self.metadata)
+        if np.isscalar(self.varmap):
+            if self.varmap == 0:
                 self.varmap = np.ones_like(self.data)
                 logger.error('Variance map not found and read noise defaulted to 0; changing to 1 to avoid x/0.')
-            else:
-                self.varmap = varmap*np.ones_like(self.data)
+            self.varmap = self.varmap*np.ones_like(self.data)
 
         if isinstance(self.background, np.ndarray):  # flatfielding is done on CPU-calculated backgrounds
             # fixme - do we change this control flow in remfitbuf by doing our own sigma calc?

--- a/PYME/localization/FitFactories/AstigGaussGPUFitFR.py
+++ b/PYME/localization/FitFactories/AstigGaussGPUFitFR.py
@@ -131,8 +131,8 @@ class GaussianFitFactory:
             self.background = np.ascontiguousarray(background * np.ones_like(self.data), dtype=np.float32)
         else:  # it's a buffer!
             self.background = background
-        self.noiseSigma = noiseSigma
-        self.fitfcn = fitfcn
+        # self.noiseSigma = noiseSigma
+        # self.fitfcn = fitfcn
 
 
     def refreshWarpDrive(self, cameraMaps):
@@ -241,7 +241,7 @@ class GaussianFitFactory:
 
         return np.hstack(resList)
 
-    def FindAndFit(self, threshold, cameraMaps):
+    def FindAndFit(self, threshold, cameraMaps, **kwargs):
         """
 
         Args:

--- a/PYME/localization/FitFactories/AstigGaussGPUFitFR.py
+++ b/PYME/localization/FitFactories/AstigGaussGPUFitFR.py
@@ -109,7 +109,7 @@ class GaussianFitFactory:
         Parameters
         ----------
         data : numpy.ndarray
-            Note, remFitBuf subtracts the ADOffset and flatfields before passing us the data in units of ADU
+            Uncorrected data, in raw ADU
         metadata : PYME.IO.MetaDataHandler.MDHandlerBase or derived class
         background : numpy.ndarray, warpdrive.buffers.Buffer, or scalar
             warpdrive.buffers.Buffer allows asynchronous estimation of the per-pixel background on the GPU.
@@ -172,7 +172,7 @@ class GaussianFitFactory:
             _warpdrive.prepare_maps(self.darkmap, self.varmap, self.flatmap, self.metadata['Camera.ElectronsPerCount'],
                                     self.metadata['Camera.NoiseFactor'], self.metadata['Camera.TrueEMGain'])
 
-            #If the data is coming from a different region of the camera, reallocate
+        # If the data is coming from a different region of the camera, reallocate
         elif _warpdrive.data.shape == self.data.shape:
             # check if both corners are the same
             topLeft = np.array_equal(self.varmap[:20, :20], _warpdrive.varmap[:20, :20])

--- a/PYME/localization/FitFactories/AstigGaussGPUFitFR.py
+++ b/PYME/localization/FitFactories/AstigGaussGPUFitFR.py
@@ -100,7 +100,7 @@ class GaussianFitFactory:
     X = None
     Y = None
 
-    def __init__(self, data, metadata, background):
+    def __init__(self, data, metadata, fitfcn=None, background=None, noiseSigma=None, **kwargs):
         """
 
         Create a fit factory which will operate on image data (data), potentially using voxel sizes etc contained in

--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -108,8 +108,9 @@ class BufferManager(object):
                     # NB: The GPU version should result in a uniform background but will NOT completely remove the background. As such it will only work 
                     # for fits which have a constant background as a fit parameter, and not those which assume that background subtraction reduces the 
                     # background to zero (as is the case for our CPU based background estimation). Use with caution.
-                    self.bBuffer = GPUPercentileBuffer(self.dBuffer, md['Analysis.PCTBackground'],
-                                                       buffer_length=bufferLen, dark_map=cameraMaps.getDarkMap(md))
+                    self.bBuffer = GPUPercentileBuffer(self.dBuffer, md['Analysis.PCTBackground'], bufferLen,
+                                                       cameraMaps.getDarkMap(md), cameraMaps.getFlatfieldMap(md),
+                                                       md['Camera.ElectronsPerCount'])
                 else: 
                     # use our default CPU implementation
                     self.bBuffer = buffers.backgroundBufferM(self.dBuffer, md['Analysis.PCTBackground'])
@@ -441,7 +442,7 @@ class fitTask(taskDef.Task):
             self.data = self.data.squeeze()
             # fit module does it's own object finding
             ff = self.fitMod.FitFactory(self.data, md, self.bg)
-            self.res = ff.FindAndFit(self.threshold, gui=gui, cameraMaps=cameraMaps)
+            self.res = ff.FindAndFit(self.threshold, cameraMaps=cameraMaps, gui=gui)
             return fitResult(self, self.res, [])
         else:
             #squash 4th dimension

--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -428,11 +428,12 @@ class fitTask(taskDef.Task):
                 self.bg = bufferManager.bBuffer
             # fit module does its own prefit steps on the GPU
             self.data = self.data.squeeze()
-            ff = self.fitMod.FitFactory(self.data, md, self.bg)
+            ff = self.fitMod.FitFactory(self.data, md, background=self.bg, noiseSigma=None)
             self.res = ff.FindAndFit(self.threshold, cameraMaps=cameraMaps, gui=gui)
             return fitResult(self, self.res, [])
 
-        #squash 4th dimension
+        # squash 4th dimension
+        # NOTE: correctImage now subtracts ADOffset
         self.data = cameraMaps.correctImage(md, self.data.squeeze()).reshape((self.data.shape[0], self.data.shape[1],1))
         # calculate noise
         self.sigma = self.calcSigma(md, self.data)

--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -98,13 +98,13 @@ class BufferManager(object):
         if md.getOrDefault('Analysis.PCTBackground', 0) > 0:
             if not isinstance(self.bBuffer, buffers.backgroundBufferM):
                 try:
-                    from warpDrive.buffers import Buffer as GPUPercentileBuffer
+                    from warpdrive.buffers import Buffer as GPUPercentileBuffer
                     HAVE_GPU_PCT_BUFFER = True
                 except ImportError:
                     HAVE_GPU_PCT_BUFFER = False
                 
                 if (HAVE_GPU_PCT_BUFFER and md.getOrDefault('Analysis.GPUPCTBackground', False)):
-                    # calculate percentile buffer on the GPU. Only applies if warpDrive module is available AND we explcitly ask for the GPU version
+                    # calculate percentile buffer on the GPU. Only applies if warpdrive module is available AND we explcitly ask for the GPU version
                     # NB: The GPU version should result in a uniform background but will NOT completely remove the background. As such it will only work 
                     # for fits which have a constant background as a fit parameter, and not those which assume that background subtraction reduces the 
                     # background to zero (as is the case for our CPU based background estimation). Use with caution.
@@ -430,7 +430,7 @@ class fitTask(taskDef.Task):
                 bufferManager.bBuffer.calc_background(self.bgindices)
                 self.bg = bufferManager.bBuffer  # NB - GPUFIT flag means the fit can handle an asynchronous background calculation
                 
-                # TODO - due to the way the GPU fits in warpDrive works (undoing our flatfielding corrections), it would make sense to have a special case 
+                # TODO - due to the way the GPU fits in warpdrive works (undoing our flatfielding corrections), it would make sense to have a special case
                 # before the data correction 
             else:
                 # the "normal" way - calculate the background for this frame and correct this for camera characteristics

--- a/tests/PYME/localization/test_MultifitSR.py
+++ b/tests/PYME/localization/test_MultifitSR.py
@@ -61,10 +61,10 @@ def test_AstigGaussGPUFitFR():
     actual fit performance.
     """
     try:
-        import warpDrive
+        import warpdrive
     except ImportError:
         print("PYME warp drive GPU fitting not installed")
-        pytest.skip('"warpDrive" GPU fitting module not installed')
+        pytest.skip('"warpdrive" GPU fitting module not installed')
         return
     
     from PYME.localization.FitFactories import AstigGaussGPUFitFR


### PR DESCRIPTION
Corresponds to the varunits branch of the pyme-warp-drive repository. 

Note that depending on what we decide to do with remFitBuf, we will need to fix/remove functionality for AstigGaussGPUFitFR accepting a background parameter as an ndarray.