### PR TITLE
py3 type error fix in tif asarray

### DIFF
--- a/PYME/contrib/gohlke/tifffile.py
+++ b/PYME/contrib/gohlke/tifffile.py
@@ -1387,7 +1387,7 @@ class TIFFpage(object):
                 # handle reading from BytesIO and similar 'file like' objects
                 # np.fromfile memmaps and hence doesn't work for things which aren't a physical file
                 # we look for the name attribute as a python version independent way of telling the difference
-                result = numpy.frombuffer(fd.read(numpy.prod(shape)*numpy.dtype(typecode).itemsize), typecode)
+                result = numpy.frombuffer(fd.read(int(numpy.prod(shape)*numpy.dtype(typecode).itemsize)), typecode)
             else:
                 result = numpy.fromfile(fd, typecode, numpy.prod(shape))
             

--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -164,12 +164,12 @@ class CameraInfoManager(object):
         """retrive a map, with a given name. First try and get it from the Queue,
         then try finding it locally"""
         try:
-            varmap = md.taskQueue.getQueueData(md.dataSourceID, 'MAP',  mapName)
+            map = md.taskQueue.getQueueData(md.dataSourceID, 'MAP',  mapName)
         except:
             fn = getFullExistingFilename(mapName)
-            varmap = ImageStack(filename=fn, haveGUI=False).data[:,:,0].squeeze() #this should handle .tif, .h5, and a few others
+            map = ImageStack(filename=fn, haveGUI=False).data[:,:,0].squeeze() #this should handle .tif, .h5, and a few others
 
-        return varmap
+        return map
 
     def _getMap(self, md, mapName):
         """Returns the map specified, from cache if possible"""


### PR DESCRIPTION
and call varmap map in remFitBuf _fetchMap

```
Traceback (most recent call last):
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/cluster/taskWorkerHTTP.py", line 305, in computeLoop
    res = task()
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/localization/remFitBuf.py", line 410, in __call__
    bufferManager.updateBuffers(md, self.dataSourceModule, self.bufferLen)
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/localization/remFitBuf.py", line 112, in updateBuffers
    cameraMaps.getDarkMap(md), cameraMaps.getFlatfieldMap(md),
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/localization/remFitBuf.py", line 212, in getDarkMap
    mp = self._getMap(md, darkMapName)
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/localization/remFitBuf.py", line 185, in _getMap
    full_map = self._fetchMap(md, mapName)
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/localization/remFitBuf.py", line 170, in _fetchMap
    varmap = ImageStack(filename=fn, haveGUI=False).data[:,:,0].squeeze() #this should handle .tif, .h5, and a few others
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/IO/DataSources/BaseDataSource.py", line 104, in __getitem__
    r = np.concatenate([np.atleast_2d(self.getSlice(i)[keys[0], keys[1]])[:,:,None] for i in range(*keys[2].indices(self.getNumSlices()))], 2)
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/IO/DataSources/BaseDataSource.py", line 104, in <listcomp>
    r = np.concatenate([np.atleast_2d(self.getSlice(i)[keys[0], keys[1]])[:,:,None] for i in range(*keys[2].indices(self.getNumSlices()))], 2)
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/IO/DataSources/BufferedDataSource.py", line 52, in getSlice
    sl = self.dataSource.getSlice(ind)
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/IO/DataSources/TiffDataSource.py", line 101, in getSlice
    res =  self.im[ind].asarray(False, False)
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/contrib/gohlke/tifffile.py", line 1390, in asarray
    result = numpy.frombuffer(fd.read(numpy.prod(shape)*numpy.dtype(typecode).itemsize), typecode)
TypeError: integer argument expected, got 'numpy.int64'
```