### PR TITLE
fix to refresh_warpdrive

### DIFF
--- a/PYME/localization/FitFactories/AstigGaussGPUFitFR.py
+++ b/PYME/localization/FitFactories/AstigGaussGPUFitFR.py
@@ -168,12 +168,12 @@ class GaussianFitFactory:
             small_filter_size = self.metadata.getEntry('Analysis.DetectionFilterSize')
             large_filter_size = 2 * small_filter_size
             _warpdrive = warpdrive.detector(small_filter_size, large_filter_size, guess_psf_sigma_pix)
-            _warpdrive.allocate_memory(np.shape(self.data), self.data.dtype.itemsize)
+            _warpdrive.allocate_memory(np.shape(self.data))
             _warpdrive.prepare_maps(self.darkmap, self.varmap, self.flatmap, self.metadata['Camera.ElectronsPerCount'],
                                     self.metadata['Camera.NoiseFactor'], self.metadata['Camera.TrueEMGain'])
 
         # If the data is coming from a different region of the camera, reallocate
-        elif _warpdrive.data.shape == self.data.shape:
+        elif _warpdrive.varmap.shape == self.varmap.shape:
             # check if both corners are the same
             topLeft = np.array_equal(self.varmap[:20, :20], _warpdrive.varmap[:20, :20])
             botRight = np.array_equal(self.varmap[-20:, -20:], _warpdrive.varmap[-20:, -20:])
@@ -182,7 +182,7 @@ class GaussianFitFactory:
                                         self.metadata['Camera.ElectronsPerCount'], self.metadata['Camera.NoiseFactor'],
                                         self.metadata['Camera.TrueEMGain'])
         else:  # data is a different shape - we know that we need to re-allocate and prepvar
-            _warpdrive.allocate_memory(np.shape(self.data), self.data.dtype.itemsize)
+            _warpdrive.allocate_memory(np.shape(self.data))
             _warpdrive.prepare_maps(self.darkmap, self.varmap, self.flatmap,
                                     self.metadata['Camera.ElectronsPerCount'], self.metadata['Camera.NoiseFactor'],
                                     self.metadata['Camera.TrueEMGain'])


### PR DESCRIPTION
we now send data to the gpu after refreshing the warpdrive, so warpdrive might not have a `data` attribute just yet. OK to use variance map instead for shape.

```

Traceback (most recent call last):
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/cluster/taskWorkerHTTP.py", line 305, in computeLoop
    res = task()
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/localization/remFitBuf.py", line 432, in __call__
    self.res = ff.FindAndFit(self.threshold, cameraMaps=cameraMaps, gui=gui)
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/localization/FitFactories/AstigGaussGPUFitFR.py", line 245, in FindAndFit
    self.refresh_warpdrive(cameraMaps)
  File "/home/ubuntu/miniconda3/lib/python3.6/site-packages/PYME/localization/FitFactories/AstigGaussGPUFitFR.py", line 176, in refresh_warpdrive
    elif _warpdrive.data.shape == self.data.shape:
AttributeError: 'detector' object has no attribute 'data'
```
Race condition between threads where _warpdrive has been initiated but none of them have called prepare_frame. Notably worth thinking about race conditions that may arise on camera ROI change.