### PR TITLE
fix to z positions for triangle order 

### DIFF
--- a/PYME/Acquire/protocol.py
+++ b/PYME/Acquire/protocol.py
@@ -193,9 +193,11 @@ class ZStackTaskListProtocol(TaskListProtocol):
                 self.zPoss = self.zPoss[np.argsort(np.random.rand(len(self.zPoss)))]
             elif self.slice_order == 'triangle':
                 if len(self.zPoss) % 2:
-                    self.zPoss = np.concatenate([self.zPoss[::2], self.zPoss[-1::-2]])
-                else:
+                    # odd
                     self.zPoss = np.concatenate([self.zPoss[1::2], self.zPoss[::-2]])
+                else:
+                    # even
+                    self.zPoss = np.concatenate([self.zPoss[::2], self.zPoss[-1::-2]])
 
 
         self.piezoName = 'Positioning.%s' % scope.stackSettings.GetScanChannel()


### PR DESCRIPTION
Was previously just doubling up on half of them - I'd gotten the if statement backwards.

```
zPoss
Out[35]: array([50. , 50.7, 51.4, 52.1, 52.8, 53.5, 54.2, 54.9, 55.6, 56.3])
np.concatenate([zPoss[1::2], zPoss[::-2]])
Out[36]: array([50.7, 52.1, 53.5, 54.9, 56.3, 56.3, 54.9, 53.5, 52.1, 50.7])
np.concatenate([zPoss[::2], zPoss[-1::-2]])
Out[37]: array([50. , 51.4, 52.8, 54.2, 55.6, 56.3, 54.9, 53.5, 52.1, 50.7])
```