### PR TITLE
small fixes

### DIFF
--- a/PYME/Acquire/Hardware/Camera.py
+++ b/PYME/Acquire/Hardware/Camera.py
@@ -851,6 +851,7 @@ class MultiviewCameraMixin(object):
             """
             self.camera_class = camera_class
             self.multiview_info = multiview_info
+            self._channel_color = multiview_info['Multiview.ChannelColor']
 
             self.n_views = multiview_info['Multiview.NumROIs']
             self.view_origins = [multiview_info['Multiview.ROI%dOrigin' % i] for i in range(self.n_views)]
@@ -1035,6 +1036,7 @@ class MultiviewCameraMixin(object):
             if self.multiview_enabled:
                 mdh.setEntry('Multiview.NumROIs', self.n_views)
                 mdh.setEntry('Multiview.ROISize', [self.size_x, self.size_y])
+                mdh.setEntry('Multiview.ChannelColor', self._channel_color)
                 mdh.setEntry('Multiview.ActiveViews', self.active_views)
                 for ind in range(self.n_views):
                     mdh.setEntry('Multiview.ROI%dOrigin' % ind, self.view_origins[ind])

--- a/PYME/Analysis/points/multiview.py
+++ b/PYME/Analysis/points/multiview.py
@@ -140,7 +140,7 @@ def correlative_shift(x0, y0, which_channel, pix_size_nm=115.):
 
     # generate first channel histogram
     channels = iter(np.unique(which_channel))
-    first_chan = channels.next()
+    first_chan = next(channels)
     mask = which_channel == first_chan
     first_channel, r_bins, c_bins = np.histogram2d(x[mask], y[mask], bins=(bin_count, bin_count))
     first_channel = first_channel >= filters.threshold_otsu(first_channel)

--- a/PYME/DSView/modules/blobMeasure.py
+++ b/PYME/DSView/modules/blobMeasure.py
@@ -36,7 +36,7 @@ def iGen():
 ig = iGen()
 
 def getNewID():
-    return ig.next()
+    return next(ig)
 
 
 class DataBlock(object):

--- a/PYME/contrib/lzw.py
+++ b/PYME/contrib/lzw.py
@@ -623,7 +623,7 @@ class PagingDecoder(object):
 
         try:
             while 1:
-                cp = codepoints.next()
+                cp = next(codepoints)
                 if cp != END_OF_INFO_CODE:
                     yield cp
                 else:

--- a/PYME/tileviewer/tileviewer.py
+++ b/PYME/tileviewer/tileviewer.py
@@ -78,9 +78,12 @@ class TileServer(object):
         
         Parameters
         ----------
-        x : x position (in um)
-        y : y position (in um)
-        hit_radius : radius around current point to use when looking for existing ROIS (um)
+        x : str
+            x position (in um)
+        y : str
+            y position (in um)
+        hit_radius : float
+            radius around current point to use when looking for existing ROIS (um)
         
         Notes
         -----
@@ -96,7 +99,7 @@ class TileServer(object):
         hr2 = hit_radius**2
         
         for l in self.roi_locations:
-            if ((l.x - x)**2 + (l.y - y)**2) < hr2:
+            if ((l.x - float(x))**2 + (l.y - float(y))**2) < hr2:
                 #found a hit, remove and redirect
                 self.roi_locations.remove(l)
                 raise cherrypy.HTTPRedirect('/roi_list')


### PR DESCRIPTION
1. type error in tileviewer toggle_roi
2. use next function instead of method so things run py2 and 3 instead of just 2. Change to multiview is tested, as is the non-iterator usage in PYME/DSView/modules/blobMeasure.getNewID. PYME/contrib/lzw.py change is to an iterator so this should be fine but I did not explicitly test.
3. recent PYME.IO.tabular changes have removed the h5f attribute of HDFSource's that opened a file. Not sure if there is a cleaner way to open an HDFSource and MetaDataHandler, but this is at least functional.