### PR TITLE
Hardware/microscope_adapter: add adapter for Python microscope laser devices

### DIFF
--- a/PYME/Acquire/Hardware/microscope_adapter.py
+++ b/PYME/Acquire/Hardware/microscope_adapter.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+
+##################
+# Copyright David Miguel Susano Pinto, 2020
+# david.pinto@bioch.ox.ac.uk
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##################
+
+"""Adapters to the Python microscope package devices.
+
+This module provides adapter classes to devices controlled with the
+Python microscope package <https://pypi.org/project/microscope/>.
+"""
+
+import PYME.Acquire.Hardware.lasers
+
+
+class MicroscopeLaser(PYME.Acquire.Hardware.lasers.Laser):
+    """
+    Adapter for Python microscope laser classes.
+
+    Parameters
+    ----------
+        laser: an object, already initialized, implementing the
+            `microscope.devices.LaserDevice` interface.
+    """
+    def __init__(self, laser, *args, **kwargs):
+        # We can't call super() at the start because the parent class
+        # may try to call self.TurnOn().
+        self._laser = laser
+        self.powerControlable = True
+        self.MIN_POWER = self._laser.get_min_power_mw()
+        self.MAX_POWER = self._laser.get_max_power_mw()
+        super().__init__(*args, **kwargs)
+
+    def IsOn(self):
+        return self._laser.get_is_on()
+
+    def TurnOn(self):
+        self._laser.enable()
+
+    def TurnOff(self):
+        self._laser.disable()
+
+    def SetPower(self, power):
+        self._laser.set_power_mw(power)
+
+    def GetPower(self):
+        return self._laser.get_power_mw()


### PR DESCRIPTION
This provides a Python microscope laser adapter for PyME. It should enable PyME to use all the lasers that Python microscope currently supports. I have tested with a Toptica iBeam and fake laser.

Configuration wise, something like this can be used (for the Toptica case):

```
@init_hardware('Lasers')
def lasers(scope):
    from microscope.lasers.toptica import TopticaiBeam
    from PYME.Acquire.Hardware.microscope_adapter import MicroscopeLaser
    l = TopticaiBeam('/dev/ttyUSB0')
    l.initialize()
    scope.l488 = MicroscopeLaser(l, name='mslaser')
    scope.l488.register(scope)
```

or like this for the test lasers on microscope side:

```
@init_hardware('Lasers')
def lasers(scope):
    from microscope.testsuite.devices import TestLaser
    from PYME.Acquire.Hardware.microscope_adapter import MicroscopeLaser
    l = TestLaser()
    l.initialize()
    scope.l488 = MicroscopeLaser(l, name='mslaser')
    scope.l488.register(scope)
```