### PR TITLE
bytes vs bytearray fix for arraypanel grabpngtobuffer on py3

### DIFF
--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -554,15 +554,11 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
         
     def GrabPNGToBuffer(self, fullImage=True):
         '''Get PNG data in a buffer (rather than writing directly to file)'''
-        from PIL import Image
         from io import BytesIO
-        
-        img =self.GrabImage(fullImage)
-        im1 = Image.frombytes(mode='RGB', size=tuple(img.GetSize()), data=img.ConvertToImage().GetData())
-        
+
+        img = self.GrabImage(fullImage)
         out = BytesIO()
-        im1.save(out, format='PNG')
-        
+        img.ConvertToImage().SaveFile(out, wx.BITMAP_TYPE_PNG)
         return out.getvalue()
 
     def CopyImage(self, fullImage=True):

--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -558,6 +558,8 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
 
         img = self.GrabImage(fullImage)
         out = BytesIO()
+        # NB - using wx functionality rather than pillow here as wxImage.GetData() returns a BytesArray object rather
+        # than a buffer on py3. This underlying problem may need to be revisited.
         img.ConvertToImage().SaveFile(out, wx.BITMAP_TYPE_PNG)
         return out.getvalue()
 


### PR DESCRIPTION
fix bytes vs bytearray issue in GrabPNGToBuffer on py3 by removing PIL.Image.frombytes() usage. Originally mentioned in the py3 superissue, #69. We've already fixed the bit about the image as string starting with `b'`, so report generation would work if there was no image to grab, but for the case where we have one to include, we run into:
```
Traceback (most recent call last):
  File "c:\users\laf62\nep-fitting\nep_fitting\dsviewer_modules\sted_psf_fitting.py", line 199, in <lambda>
    ensemble_btn.Bind(wx.EVT_BUTTON, lambda e: self._on_ensemble_fit())
  File "c:\users\laf62\nep-fitting\nep_fitting\dsviewer_modules\sted_psf_fitting.py", line 355, in _on_ensemble_fit
    context['img_data'] = reports.img_as_strb64(self._dsviewer.view.GrabPNGToBuffer())
  File "c:\users\laf62\python-microscopy\PYME\DSView\arrayViewPanel.py", line 561, in GrabPNGToBuffer
    im1 = Image.frombytes(mode='RGB', size=tuple(img.GetSize()), data=img.ConvertToImage().GetData())
  File "C:\Users\laf62\.conda\envs\pyme\lib\site-packages\PIL\Image.py", line 2581, in frombytes
    im.frombytes(data, decoder_name, args)
  File "C:\Users\laf62\.conda\envs\pyme\lib\site-packages\PIL\Image.py", line 769, in frombytes
    s = d.decode(data)
TypeError: argument 1 must be read-only bytes-like object, not bytearray
```


As mentioned previously, we can fix that in a couple of ways, namely by avoiding PIL altogether.