### PR TITLE
store datasource uri in cluster localization results metadata

### DIFF
--- a/PYME/cluster/HTTPTaskPusher.py
+++ b/PYME/cluster/HTTPTaskPusher.py
@@ -159,6 +159,7 @@ class HTTPTaskPusher(object):
         self.taskQueueURI = _getTaskQueueURI()
 
         self.mdh = metadata
+        self.mdh['DataSourceID'] = self.dataSourceID  # for convenient linking after results files get downloaded/moved
 
         #load data source
         if dataSourceModule is None:

--- a/PYME/cluster/HTTPTaskPusher.py
+++ b/PYME/cluster/HTTPTaskPusher.py
@@ -159,7 +159,7 @@ class HTTPTaskPusher(object):
         self.taskQueueURI = _getTaskQueueURI()
 
         self.mdh = metadata
-        self.mdh['DataSourceID'] = self.dataSourceID  # for convenient linking after results files get downloaded/moved
+        self.mdh['Analysis.DataFileURI'] = self.dataSourceID  # for convenient linking after results files get downloaded/moved
 
         #load data source
         if dataSourceModule is None:


### PR DESCRIPTION
store datasource name in localization results metadata for convenience in linking. Particularly helpful for recipes which require both localizations and the datasource they came from.