### PR TITLE
removing problematic en-/de-codings in recipe outputs

### DIFF
--- a/PYME/recipes/output.py
+++ b/PYME/recipes/output.py
@@ -365,9 +365,9 @@ class UnifiedLoader(jinja2.BaseLoader):
         from PYME.IO import unifiedIO
         try:
             if os.path.exists(os.path.join(os.path.dirname(__file__), template)):
-                source = unifiedIO.read(os.path.join(os.path.dirname(__file__), template)).decode('utf-8')
+                source = unifiedIO.read(os.path.join(os.path.dirname(__file__), template))
             else:
-                source = unifiedIO.read(template).decode('utf-8')
+                source = unifiedIO.read(template)
         except:
             logger.exception('Error loading template')
             raise jinja2.TemplateNotFound
@@ -470,7 +470,7 @@ class ReportOutput(OutputModule):
             os.makedirs(out_dir)
 
         with open(out_filename, 'w') as f:
-            f.write(self.generate(namespace, recipe_context=context).encode('utf-8'))
+            f.write(self.generate(namespace, recipe_context=context))
 
 
 @register_module('ReportForEachOutput')


### PR DESCRIPTION
jinja2.Environment.render returns a (unicode) str, and unless we change open(filename) to open(filename, 'r+b'), which we currently don't, in unifiedIO.read, we get a str out:

```
Traceback (most recent call last):
  File "/home/smeagol/code/python-microscopy/PYME/recipes/output.py", line 368, in get_source
    source = unifiedIO.read(os.path.join(os.path.dirname(__file__), template)).decode('utf-8')
AttributeError: 'str' object has no attribute 'decode'
```

Even on py2
```
Python 2.7.16 |Anaconda custom (64-bit)| (default, Mar 14 2019, 21:00:58) 
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> with open('/home/smeagol/code/localization-survey/localization_survey/reports/localization_survey.html') as f:
...     s = f.read()
... 
>>> type(s)
<type 'str'>
```