### PR TITLE
fix blobFinding issues

### DIFF
--- a/PYME/DSView/modules/blobFinding.py
+++ b/PYME/DSView/modules/blobFinding.py
@@ -328,7 +328,7 @@ class blobFinder:
 
     def savePositions(self, event=None):
         fdialog = wx.FileDialog(None, 'Save Positions ...',
-            wildcard='Tab formatted text|*.txt', defaultFile=os.path.splitext(self.image.seriesName)[0] + '_pos.txt', style=wx.FD_SAVE|wx.HIDE_READONLY)
+            wildcard='Tab formatted text|*.txt', defaultFile=os.path.splitext(self.image.seriesName)[0] + '_pos.txt', style=wx.FD_SAVE)
         succ = fdialog.ShowModal()
         if (succ == wx.ID_OK):
             outFilename = fdialog.GetPath()
@@ -346,7 +346,7 @@ class blobFinder:
 
     def saveFits(self, event=None):
         fdialog = wx.FileDialog(None, 'Save Fit Results ...',
-            wildcard='Tab formatted text|*.txt', defaultFile=os.path.splitext(self.image.seriesName)[0] + '_fits.txt', style=wx.FD_SAVE|wx.HIDE_READONLY)
+            wildcard='Tab formatted text|*.txt', defaultFile=os.path.splitext(self.image.seriesName)[0] + '_fits.txt', style=wx.FD_SAVE)
         succ = fdialog.ShowModal()
         if (succ == wx.ID_OK):
             outFilename = fdialog.GetPath()

--- a/PYME/localization/ofind3d.py
+++ b/PYME/localization/ofind3d.py
@@ -208,7 +208,6 @@ class ObjectIdentifier(list):
         if (self.numThresholdSteps == 0): #don't do threshold scan - just use lower threshold (faster)
             im = maskedFilteredData
             #View3D(im)
-            print(('Threshold: %3.2f' %self.lowerThreshold))
             (labeledPoints, nLabeled) = ndimage.label(im > self.lowerThreshold)
             
             objSlices = ndimage.find_objects(labeledPoints)


### PR DESCRIPTION
When trying to use blob finding the other day I came across two buglets that kept me from using the module successfully. One is in the main blobFinding module and seems to be from using a now discontinued wx flag, the other was an invalid print statement from within ofind3d. I removed the invalid flag; I deleted the print statement since I felt this was a debugging hack that is most likely not needed any more.