### PR TITLE
swapping __getitem__ attribute error holdovers in gen_scmos_maps

### DIFF
--- a/PYME/Analysis/gen_sCMOS_maps.py
+++ b/PYME/Analysis/gen_sCMOS_maps.py
@@ -225,11 +225,11 @@ def main():
     sensorSize = list(defaultSensorSize)
     try:
         sensorSize[0] = source.mdh['Camera.SensorWidth']
-    except AttributeError:
+    except KeyError:
         logger.warning('no valid sensor width in metadata - using default %d' % sensorSize[0])
     try:
         sensorSize[1] = source.mdh['Camera.SensorHeight']
-    except AttributeError:
+    except KeyError:
         logger.warning('no valid sensor height in metadata - using default %d' % sensorSize[1])
     
     if not ((source.mdh['Camera.ROIWidth'] == sensorSize[0]) and (source.mdh['Camera.ROIHeight'] == sensorSize[1])):

--- a/PYME/Analysis/gen_sCMOS_maps.py
+++ b/PYME/Analysis/gen_sCMOS_maps.py
@@ -225,11 +225,11 @@ def main():
     sensorSize = list(defaultSensorSize)
     try:
         sensorSize[0] = source.mdh['Camera.SensorWidth']
-    except KeyError:
+    except (KeyError, AttributeError):
         logger.warning('no valid sensor width in metadata - using default %d' % sensorSize[0])
     try:
         sensorSize[1] = source.mdh['Camera.SensorHeight']
-    except KeyError:
+    except (KeyError, AttributeError):
         logger.warning('no valid sensor height in metadata - using default %d' % sensorSize[1])
     
     if not ((source.mdh['Camera.ROIWidth'] == sensorSize[0]) and (source.mdh['Camera.ROIHeight'] == sensorSize[1])):


### PR DESCRIPTION
caused some issues for @zacsimile and Helen. We have swapped metadata handler to throw KeyErrors for __getitem__ as is standard, but it probably wasn't so when this file was originally written.