### PR TITLE
Offset piezo / e816T dll event logging

### DIFF
--- a/PYME/Acquire/Hardware/Piezos/offsetPiezo.py
+++ b/PYME/Acquire/Hardware/Piezos/offsetPiezo.py
@@ -68,7 +68,7 @@ class piezoOffsetProxy(PiezoBase, Pyro.core.ObjBase):
 
     def LogFocusCorrection(self,offset):
         import wx
-        wx.CallAfter(eventLog.logEvent, 'update offset', '%3.4f' %offset)
+        wx.CallAfter(eventLog.logEvent, 'PiezoOffsetUpdate', '%3.4f' %offset)
 
     # @property
     # def lastPos(self):

--- a/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
+++ b/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
@@ -97,7 +97,7 @@ class OffsetPiezo(PiezoBase):
     @webframework.register_endpoint('/LogFocusCorrection', output_is_json=False)
     def LogFocusCorrection(self, offset):
         import wx
-        wx.CallAfter(eventLog.logEvent, 'update offset', '%3.4f' % float(offset))
+        wx.CallAfter(eventLog.logEvent, 'PiezoOffsetUpdate', '%3.4f' % float(offset))
 
 
 import requests

--- a/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
+++ b/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
@@ -95,7 +95,7 @@ class OffsetPiezo(PiezoBase):
         return self.basePiezo.OnTarget()
 
     @webframework.register_endpoint('/LogFocusCorrection', output_is_json=False)
-    def LogFocusCorrection(self,offset):
+    def LogFocusCorrection(self, offset):
         import wx
         wx.CallAfter(eventLog.logEvent, 'update offset', '%3.4f' % float(offset))
 
@@ -151,11 +151,10 @@ class OffsetPiezoClient(PiezoBase):
 
     def OnTarget(self):
         res = requests.get(self.urlbase + '/OnTarget')
-        return float(res.json())
+        return bool(res.json())
 
     def LogFocusCorrection(self, offset):
         res = requests.get(self.urlbase + '/LogFocusCorrection?offset=%3.3f' % (offset,))
-        return float(res.json())
 
 def generate_offset_piezo_server(offset_piezo_base_class):
     """

--- a/PYME/Acquire/Hardware/Piezos/piezo_e816_dll.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_e816_dll.py
@@ -296,8 +296,12 @@ class piezo_e816T(PiezoBase):
 
                 if np.allclose(self.position, self.targetPosition, atol=self._target_tol):
                     if not self.onTarget and self._spool_controller:
-                        self._spool_controller.spooler.evtLogger.logEvent(self, 'PiezoOnTarget',
-                                                                          '%.3f' % self.position[0], time.time())
+                        try:
+                            self._spool_controller.spooler.evtLogger.logEvent('PiezoOnTarget',
+                                                                              '%.3f' % self.position[0], time.time())
+                        except AttributeError:
+                            # controller won't always have a spooler, and if that's the case we aren't logging anyway
+                            pass
                     self.onTarget = True
 
                 # check to see if we're on target

--- a/PYME/Acquire/Hardware/Piezos/piezo_e816_dll.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_e816_dll.py
@@ -200,7 +200,7 @@ class piezo_e816(PiezoBase):
 import numpy as np
 class piezo_e816T(PiezoBase):
     def __init__(self, identifier=None, maxtravel=12.00, Osen=None, hasTrigger=False, target_tol=.002,
-                 update_rate=0.005):
+                 update_rate=0.005, spool_controller=None):
         """
 
         Parameters
@@ -221,6 +221,7 @@ class piezo_e816T(PiezoBase):
         self.units = 'um'
         self._target_tol = target_tol
         self._update_rate = update_rate
+        self._spool_controller = spool_controller
 
         self.lock = threading.Lock()
 
@@ -294,6 +295,9 @@ class piezo_e816T(PiezoBase):
                     # logging.debug('Moving piezo to target: %f' % (pos[0],))
 
                 if np.allclose(self.position, self.targetPosition, atol=self._target_tol):
+                    if not self.onTarget and self._spool_controller:
+                        self._spool_controller.spooler.evtLogger.logEvent(self, 'PiezoOnTarget',
+                                                                          '%.3f' % self.position[0], time.time())
                     self.onTarget = True
 
                 # check to see if we're on target

--- a/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
+++ b/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
@@ -190,8 +190,9 @@ class ReflectedLinePIDFocusLock(PID):
 
     @webframework.register_endpoint('/DisableLock', output_is_json=False)
     def DisableLock(self):
-        logger.debug('Disabling focus lock')
         self.set_auto_mode(False)
+        logger.debug('Disabling focus lock')
+        self.piezo.LogFocusCorrection(self.piezo.GetOffset())
 
     def register(self):
         if self.mode == 'time':

--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -231,7 +231,7 @@ def focus_keys(MainFrame, scope):
 def action_manager(MainFrame, scope):
     from PYME.Acquire.ui import actionUI
 
-    ap = actionUI.PathMinimizingActionPanel(MainFrame, scope.actions, scope)
+    ap = actionUI.ActionPanel(MainFrame, scope.actions, scope)
     MainFrame.AddPage(ap, caption='Queued Actions')
 
 @init_hardware('tweeter')
@@ -253,7 +253,7 @@ def tweeter(scope):
 def action_manager(MainFrame, scope):
     from PYME.Acquire.ui import tile_panel
 
-    ap = tile_panel.CircularTilePanel(MainFrame, scope)
+    ap = tile_panel.TilePanel(MainFrame, scope)
     MainFrame.aqPanels.append((ap, 'Tiling'))
 
 #must be here!!!

--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -51,8 +51,7 @@ def pz(scope):
     from PYME.Acquire.Hardware.Piezos import piezo_e816_dll, offsetPiezoREST as opr
 
     # try and update the pifoc position roughly as often as the PID / camera, but a little faster if we can
-    scope._piFoc = piezo_e816_dll.piezo_e816T(maxtravel=100, target_tol=0.035, update_rate=0.002,
-                                              spool_controller=scope.spoolController)
+    scope._piFoc = piezo_e816_dll.piezo_e816T(maxtravel=100, target_tol=0.035, update_rate=0.002)
     scope.CleanupFunctions.append(scope._piFoc.close)
 
     scope.piFoc = opr.generate_offset_piezo_server(opr.TargetOwningOffsetPiezo)(scope._piFoc)

--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -51,10 +51,9 @@ def pz(scope):
     from PYME.Acquire.Hardware.Piezos import piezo_e816_dll, offsetPiezoREST as opr
 
     # try and update the pifoc position roughly as often as the PID / camera, but a little faster if we can
-    scope._piFoc = piezo_e816_dll.piezo_e816T(maxtravel=100, target_tol=0.05, update_rate=0.002)
-    #scope.hardwareChecks.append(scope._piFoc.OnTarget)
+    scope._piFoc = piezo_e816_dll.piezo_e816T(maxtravel=100, target_tol=0.035, update_rate=0.002,
+                                              spool_controller=scope.spoolController)
     scope.CleanupFunctions.append(scope._piFoc.close)
-    #scope.piFoc = scope._piFoc
 
     scope.piFoc = opr.generate_offset_piezo_server(opr.TargetOwningOffsetPiezo)(scope._piFoc)
     scope.register_piezo(scope.piFoc, 'z', needCamRestart=False)
@@ -149,7 +148,7 @@ def lasers(scope):
     scope.aotf = AAOptoMDS(aotf_calibration, 'COM14', 'AAOptoMDS', n_chans=4)
     scope.CleanupFunctions.append(scope.aotf.Close)
 
-    fiber_shaker = ServoFiberShaker('COM9', channel=9, on_value=30)  # pin 9
+    fiber_shaker = ServoFiberShaker('COM9', channel=9, on_value=25)  # pin 9
 
     l405 = OBIS.CoherentOBISLaser('COM10', name='OBIS405', turn_on=False)
     scope.CleanupFunctions.append(l405.Close)
@@ -232,7 +231,7 @@ def focus_keys(MainFrame, scope):
 def action_manager(MainFrame, scope):
     from PYME.Acquire.ui import actionUI
 
-    ap = actionUI.ActionPanel(MainFrame, scope.actions, scope)
+    ap = actionUI.PathMinimizingActionPanel(MainFrame, scope.actions, scope)
     MainFrame.AddPage(ap, caption='Queued Actions')
 
 @init_hardware('tweeter')
@@ -254,7 +253,7 @@ def tweeter(scope):
 def action_manager(MainFrame, scope):
     from PYME.Acquire.ui import tile_panel
 
-    ap = tile_panel.TilePanel(MainFrame, scope)
+    ap = tile_panel.CircularTilePanel(MainFrame, scope)
     MainFrame.aqPanels.append((ap, 'Tiling'))
 
 #must be here!!!


### PR DESCRIPTION
- Adds PiezoOnTarget events for the e816T dll piezo so we know where we actually land and when rather than guessing / being inaccurate (given our target tolerance)
- Adds `LogFocusCorrection` call to disablelock such that we get an 'update offset' event and know how to interpret the position logged by the PiezoOnTarget events, since these are from the base piezo (with no offset included in the position)