### PR TITLE
silence freespace not implemented for cluster warning

### DIFF
--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -153,7 +153,6 @@ class SpoolController(object):
 
         """
         if self.spoolType == 'Cluster':
-            logger.warn('Cluster free space calculation not yet implemented, using fake value')
             return float('nan')
         else:
             from PYME.IO.FileUtils.freeSpace import get_free_space


### PR DESCRIPTION
It is obviously not implemented/functional from the "nan" displayed in the spool panel, and the debug logs (much less std out) are painful to look through since this warning gets displayed on each spool progress tick