### PR TITLE
Fix to pzf tests

### DIFF
--- a/tests/PYME/IO/test_pzf.py
+++ b/tests/PYME/IO/test_pzf.py
@@ -77,7 +77,7 @@ def test_PZFFormat_lossy_uint16():
                                                      quantizationOffset=0, quantizationScale=1))
 
     #print result
-    test_quant = (np.floor(np.sqrt(test_data.astype('f')-.1)).astype('i'))**2
+    test_quant = (np.round(np.sqrt(test_data.astype('f'))).astype('i'))**2
 
     #print(test_quant.squeeze() - result.squeeze())
     #print(test_data.squeeze())
@@ -98,7 +98,7 @@ def test_PZFFormat_lossy_uint16_qs():
                                                      quantizationOffset=0, quantizationScale=qs))
 
     #print result
-    test_quant = ((np.floor(np.sqrt(test_data.astype('f')-.1)/qs).astype('i')*qs)**2).astype('i')
+    test_quant = ((np.round(np.sqrt(test_data.astype('f'))/qs).astype('i')*qs)**2).astype('i')
 
     
     print(test_data.min(), test_data.max(), result.min(), result.max(), test_quant.min(), test_quant.max())


### PR DESCRIPTION
See https://github.com/python-microscopy/pymecompress/pull/4, which corrected a quantization bias and has now been merged. This PR changes the tests to reflect that.

Including demonstrative pytest output, though after having fixed `test_PZFFormat_lossy_uint16`

```
_________________________________________________________________________________________________________________________ test_PZFFormat_lossy_uint16_qs __________________________________________________________________________________________________________________________

    def test_PZFFormat_lossy_uint16_qs():
        from PYME.IO import PZFFormat
        test_data = np.random.poisson(100, 100).reshape(10,10).astype('uint16')
    
        qs = .2
    
        result, header = PZFFormat.loads(PZFFormat.dumps(test_data,
                                                         compression = PZFFormat.DATA_COMP_HUFFCODE,
                                                         quantization = PZFFormat.DATA_QUANT_SQRT,
                                                         quantizationOffset=0, quantizationScale=qs))
    
        #print result
        test_quant = ((np.floor(np.sqrt(test_data.astype('f')-.1)/qs).astype('i')*qs)**2).astype('i')
    
    
        print(test_data.min(), test_data.max(), result.min(), result.max(), test_quant.min(), test_quant.max())
    
        #print(test_quant.squeeze() - result.squeeze())
        #print(test_data.squeeze())
        #print(test_quant.squeeze())
        #print(result.squeeze())
    
        print(result.squeeze() - test_quant.squeeze())
    
>       assert np.allclose(result.squeeze(), test_quant.squeeze())
E       assert False
E        +  where False = <function allclose at 0x7f94a34d2620>(array([[121, 100, 100, 100,  92,  84, 104,  96,  77, 121],\n       [100,  96, 104,  92, 100, 112, 112, 112, 104, 100],\n... 92, 112, 100,  88,  96,  96, 100, 100, 112],\n       [108, 129,  92, 108, 121, 116,  96, 100,  92, 104]], dtype=uint16), array([[116, 100, 100,  96,  92,  81, 104,  96,  77, 116],\n       [100,  92, 100,  88, 100, 112, 108, 108, 100,  96],\n...  92, 108, 100,  84,  96,  96, 100,  96, 108],\n       [108, 125,  88, 104, 116, 112,  92,  96,  88, 104]], dtype=int32))
E        +    where <function allclose at 0x7f94a34d2620> = np.allclose
E        +    and   array([[121, 100, 100, 100,  92,  84, 104,  96,  77, 121],\n       [100,  96, 104,  92, 100, 112, 112, 112, 104, 100],\n... 92, 112, 100,  88,  96,  96, 100, 100, 112],\n       [108, 129,  92, 108, 121, 116,  96, 100,  92, 104]], dtype=uint16) = <built-in method squeeze of numpy.ndarray object at 0x7f94975c2080>()
E        +      where <built-in method squeeze of numpy.ndarray object at 0x7f94975c2080> = array([[[121],\n        [100],\n        [100],\n        [100],\n        [ 92],\n        [ 84],\n        [104],\n        [ 96]...       [108],\n        [121],\n        [116],\n        [ 96],\n        [100],\n        [ 92],\n        [104]]], dtype=uint16).squeeze
E        +    and   array([[116, 100, 100,  96,  92,  81, 104,  96,  77, 116],\n       [100,  92, 100,  88, 100, 112, 108, 108, 100,  96],\n...  92, 108, 100,  84,  96,  96, 100,  96, 108],\n       [108, 125,  88, 104, 116, 112,  92,  96,  88, 104]], dtype=int32) = <built-in method squeeze of numpy.ndarray object at 0x7f94975c2170>()
E        +      where <built-in method squeeze of numpy.ndarray object at 0x7f94975c2170> = array([[116, 100, 100,  96,  92,  81, 104,  96,  77, 116],\n       [100,  92, 100,  88, 100, 112, 108, 108, 100,  96],\n...  92, 108, 100,  84,  96,  96, 100,  96, 108],\n       [108, 125,  88, 104, 116, 112,  92,  96,  88, 104]], dtype=int32).squeeze

test_pzf.py:113: AssertionError
------------------------------------------------------------------------------------------------------------------------------ Captured stdout call -------------------------------------------------------------------------------------------------------------------------------
79 130 77 129 77 125
[[5 0 0 4 0 3 0 0 0 5]
 [0 4 4 4 0 0 4 4 4 4]
 [3 4 0 4 0 4 4 0 4 0]
 [0 4 0 0 0 4 4 4 0 4]
 [4 0 0 0 4 0 0 4 4 4]
 [0 4 4 4 4 0 0 4 0 0]
 [0 0 0 0 4 0 0 4 4 0]
 [4 0 4 4 4 0 0 4 0 0]
 [3 0 4 0 4 0 0 0 4 4]
 [0 4 4 4 5 4 4 4 4 0]]
================================================================================================================================ warnings summary =================================================================================================================================
tests/PYME/IO/test_pzf.py::test_PZFFormat_raw_uint16
tests/PYME/IO/test_pzf.py::test_PZFFormat_raw_uint16_F
tests/PYME/IO/test_pzf.py::test_PZFFormat_raw_uint8
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossless_uint16
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossy_uint16
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossy_uint16_qs
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossless_uint8
  /home/smeagol/code/python-microscopy/PYME/IO/PZFFormat.py:292: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    return np.fromstring(datastring[:HEADER_LENGTH_V3], header_dtype_v3)

tests/PYME/IO/test_pzf.py::test_PZFFormat_raw_uint16
tests/PYME/IO/test_pzf.py::test_PZFFormat_raw_uint16_F
tests/PYME/IO/test_pzf.py::test_PZFFormat_raw_uint8
  /home/smeagol/code/python-microscopy/PYME/IO/PZFFormat.py:351: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    data = np.fromstring(data_s, 'u1')

tests/PYME/IO/test_pzf.py::test_PZFFormat_lossless_uint16
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossy_uint16
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossy_uint16_qs
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossless_uint8
  /home/smeagol/code/python-microscopy/PYME/IO/PZFFormat.py:354: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    data = bcl.HuffmanDecompress(np.fromstring(data_s, 'u1'), outsize)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================================================= 1 failed, 8 passed, 14 warnings in 0.14 seconds =================================================================================================================
Fatal Python error: Segmentation fault

Current thread 0x00007f94a6bac700 (most recent call first):
Segmentation fault (core dumped)
```

```
(py36) smeagol@smeagol:~/code/python-microscopy/tests/PYME/IO$ pytest test_pzf.py 
=============================================================================================================================== test session starts ===============================================================================================================================
platform linux -- Python 3.6.8, pytest-5.0.1, py-1.8.0, pluggy-0.12.0
rootdir: /home/smeagol/code/python-microscopy
collected 9 items                                                                                                                                                                                                                                                                 

test_pzf.py .........                                                                                                                                                                                                                                                       [100%]

================================================================================================================================ warnings summary =================================================================================================================================
tests/PYME/IO/test_pzf.py::test_PZFFormat_raw_uint16
tests/PYME/IO/test_pzf.py::test_PZFFormat_raw_uint16_F
tests/PYME/IO/test_pzf.py::test_PZFFormat_raw_uint8
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossless_uint16
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossy_uint16
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossy_uint16_qs
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossless_uint8
  /home/smeagol/code/python-microscopy/PYME/IO/PZFFormat.py:292: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    return np.fromstring(datastring[:HEADER_LENGTH_V3], header_dtype_v3)

tests/PYME/IO/test_pzf.py::test_PZFFormat_raw_uint16
tests/PYME/IO/test_pzf.py::test_PZFFormat_raw_uint16_F
tests/PYME/IO/test_pzf.py::test_PZFFormat_raw_uint8
  /home/smeagol/code/python-microscopy/PYME/IO/PZFFormat.py:351: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    data = np.fromstring(data_s, 'u1')

tests/PYME/IO/test_pzf.py::test_PZFFormat_lossless_uint16
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossy_uint16
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossy_uint16_qs
tests/PYME/IO/test_pzf.py::test_PZFFormat_lossless_uint8
  /home/smeagol/code/python-microscopy/PYME/IO/PZFFormat.py:354: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    data = bcl.HuffmanDecompress(np.fromstring(data_s, 'u1'), outsize)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
====================================================================================================================== 9 passed, 14 warnings in 0.13 seconds ======================================================================================================================
```