### PR TITLE
Make visualizing LUT optional by layer

### DIFF
--- a/PYME/LMVis/layers/LUTOverlayLayer.py
+++ b/PYME/LMVis/layers/LUTOverlayLayer.py
@@ -76,30 +76,31 @@ class LUTOverlayLayer(OverlayLayer):
             visible_layers = [l for l in gl_canvas.layers if getattr(l, 'visble', True)]
             
             for j, l in enumerate(visible_layers):
-                cmap = l.colour_map
-                
-                # upper right x
-                lb_ur_x = -gl_canvas.xc + gl_canvas.xmax - self.get_offset()[0] * view_size_x / gl_canvas.Size[0] - j*1.5*lb_width
-                
-                # upper left x
-                lb_ul_x = lb_ur_x - lb_width
-          
-    
-                
-    
-                glBegin(GL_QUAD_STRIP)
-    
-                for i in numpy.arange(0, 1.01, .01):
-                    glColor3fv(cmap(i)[:3])
-                    glVertex2f(lb_ul_x, lb_lr_y + i * lb_len)
-                    glVertex2f(lb_ur_x, lb_lr_y + i * lb_len)
-    
-                glEnd()
-    
-                glBegin(GL_LINE_LOOP)
-                glColor3fv(self._border_colour)
-                glVertex2f(lb_ul_x, lb_lr_y)
-                glVertex2f(lb_ur_x, lb_lr_y)
-                glVertex2f(lb_ur_x, lb_ur_y)
-                glVertex2f(lb_ul_x, lb_ur_y)
-                glEnd()
+                if l.show_lut:
+                    cmap = l.colour_map
+                    
+                    # upper right x
+                    lb_ur_x = -gl_canvas.xc + gl_canvas.xmax - self.get_offset()[0] * view_size_x / gl_canvas.Size[0] - j*1.5*lb_width
+                    
+                    # upper left x
+                    lb_ul_x = lb_ur_x - lb_width
+            
+        
+                    
+        
+                    glBegin(GL_QUAD_STRIP)
+        
+                    for i in numpy.arange(0, 1.01, .01):
+                        glColor3fv(cmap(i)[:3])
+                        glVertex2f(lb_ul_x, lb_lr_y + i * lb_len)
+                        glVertex2f(lb_ur_x, lb_lr_y + i * lb_len)
+        
+                    glEnd()
+        
+                    glBegin(GL_LINE_LOOP)
+                    glColor3fv(self._border_colour)
+                    glVertex2f(lb_ul_x, lb_lr_y)
+                    glVertex2f(lb_ur_x, lb_lr_y)
+                    glVertex2f(lb_ur_x, lb_ur_y)
+                    glVertex2f(lb_ul_x, lb_ur_y)
+                    glEnd()

--- a/PYME/LMVis/layers/LUTOverlayLayer.py
+++ b/PYME/LMVis/layers/LUTOverlayLayer.py
@@ -73,34 +73,30 @@ class LUTOverlayLayer(OverlayLayer):
             
             lb_width = self._lut_width_px * view_size_x / gl_canvas.Size[0]
             
-            visible_layers = [l for l in gl_canvas.layers if getattr(l, 'visble', True)]
+            visible_layers = [l for l in gl_canvas.layers if (getattr(l, 'visible', True) and getattr(l, 'show_lut', True))]
             
             for j, l in enumerate(visible_layers):
-                if l.show_lut:
-                    cmap = l.colour_map
-                    
-                    # upper right x
-                    lb_ur_x = -gl_canvas.xc + gl_canvas.xmax - self.get_offset()[0] * view_size_x / gl_canvas.Size[0] - j*1.5*lb_width
-                    
-                    # upper left x
-                    lb_ul_x = lb_ur_x - lb_width
-            
-        
-                    
-        
-                    glBegin(GL_QUAD_STRIP)
-        
-                    for i in numpy.arange(0, 1.01, .01):
-                        glColor3fv(cmap(i)[:3])
-                        glVertex2f(lb_ul_x, lb_lr_y + i * lb_len)
-                        glVertex2f(lb_ur_x, lb_lr_y + i * lb_len)
-        
-                    glEnd()
-        
-                    glBegin(GL_LINE_LOOP)
-                    glColor3fv(self._border_colour)
-                    glVertex2f(lb_ul_x, lb_lr_y)
-                    glVertex2f(lb_ur_x, lb_lr_y)
-                    glVertex2f(lb_ur_x, lb_ur_y)
-                    glVertex2f(lb_ul_x, lb_ur_y)
-                    glEnd()
+                cmap = l.colour_map
+                
+                # upper right x
+                lb_ur_x = -gl_canvas.xc + gl_canvas.xmax - self.get_offset()[0] * view_size_x / gl_canvas.Size[0] - j*1.5*lb_width
+                
+                # upper left x
+                lb_ul_x = lb_ur_x - lb_width
+
+                glBegin(GL_QUAD_STRIP)
+    
+                for i in numpy.arange(0, 1.01, .01):
+                    glColor3fv(cmap(i)[:3])
+                    glVertex2f(lb_ul_x, lb_lr_y + i * lb_len)
+                    glVertex2f(lb_ur_x, lb_lr_y + i * lb_len)
+    
+                glEnd()
+    
+                glBegin(GL_LINE_LOOP)
+                glColor3fv(self._border_colour)
+                glVertex2f(lb_ul_x, lb_lr_y)
+                glVertex2f(lb_ur_x, lb_lr_y)
+                glVertex2f(lb_ur_x, lb_ur_y)
+                glVertex2f(lb_ul_x, lb_ur_y)
+                glEnd()

--- a/PYME/LMVis/layers/base.py
+++ b/PYME/LMVis/layers/base.py
@@ -111,6 +111,7 @@ class EngineLayer(BaseLayer):
     Base class for layers who delegate their rendering to an engine.
     """
     engine = Instance(BaseEngine)
+    show_lut = Bool(True)
 
     def render(self, gl_canvas):
         if self.visible:


### PR DESCRIPTION
Sometimes I want to turn off the LUT for a constant-color mesh, but not for the points it's approximating. I thought about adding this to the GUI, e.g add `Item('show_lut', label='Show LUT'),` on line 292 in PYME.LMVis.layers.mesh, but I think it's fine to leave as a shell option.