### PR TITLE
roi-switching speed improvements

### DIFF
--- a/PYME/Acquire/Hardware/AndorNeo/AndorZyla.py
+++ b/PYME/Acquire/Hardware/AndorNeo/AndorZyla.py
@@ -149,6 +149,7 @@ class AndorBase(SDK3Camera, CameraMapMixin):
 
 
     def __init__(self, camNum):
+        CameraMapMixin.__init__(self)
         #define properties
         self.CameraAcquiring = ATBool()
         self.SensorCooling = ATBool()

--- a/PYME/Acquire/Hardware/Camera.py
+++ b/PYME/Acquire/Hardware/Camera.py
@@ -53,6 +53,17 @@ class CameraMapMixin(object):
         self._camera_map_fields = map_fields
         self._camera_map_cache = {}
 
+    def prefill_camera_map_cache(self, integration_time):
+        """
+        Search the cluster / local camera map directories and pre-fill the camera map cache for a given integration time
+
+        Parameters
+        ----------
+        integration_time: float
+            integration time in milliseconds
+        """
+        self.fill_camera_map_metadata({'Camera.IntegrationTime': integration_time})
+
     def fill_camera_map_metadata(self, mdh):
         """
         Store camera map locations in the input metadata. The results (including camera-map does not exist) are cached.

--- a/PYME/Acquire/Hardware/Camera.py
+++ b/PYME/Acquire/Hardware/Camera.py
@@ -62,7 +62,8 @@ class CameraMapMixin(object):
         integration_time: float
             integration time in milliseconds
         """
-        self.fill_camera_map_metadata({'Camera.IntegrationTime': integration_time})
+        self.fill_camera_map_metadata({'Camera.IntegrationTime': integration_time,
+                                       'Camera.SerialNumber': self.GetSerialNumber()})
 
     def fill_camera_map_metadata(self, mdh):
         """

--- a/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
@@ -106,6 +106,7 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
 
     def __init__(self, camNum):
         HamamatsuDCAM.__init__(self, camNum)
+        CameraMapMixin.__init__(self)
 
         self.noiseProps = {}
         self.waitopen = DCAMWAIT_OPEN()

--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -86,6 +86,7 @@ def orca_cam(scope):
     }
     cam = MultiviewOrca(0, multiview_info)
     cam.Init()
+    cam.prefill_camera_map_cache(0.00125)
 
     # flip and rotate on primary camera should always be false - make the stage match the camera reference frame instead
     # as it's much easier

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -184,8 +184,8 @@ class SpoolController(object):
         return self._sep.join([self.dirname.rstrip(self._sep), fn + ext])
 
 
-    def StartSpooling(self, fn=None, stack=False, compLevel = 2, zDwellTime = None, doPreflightCheck=True, maxFrames = sys.maxsize,
-                      compressionSettings=None, cluster_h5 = False):
+    def StartSpooling(self, fn=None, stack=False, compLevel=2, zDwellTime=None, doPreflightCheck=True,
+                      maxFrames=sys.maxsize, compressionSettings=None, cluster_h5=False, check_file_exists=True):
         """Start spooling
         """
         
@@ -201,7 +201,7 @@ class SpoolController(object):
             if not os.path.exists(dirname):
                 os.makedirs(dirname)
 
-        if self._checkOutputExists(fn): #check to see if data with the same name exists
+        if check_file_exists and self._checkOutputExists(fn): #check to see if data with the same name exists
             self.seriesCounter +=1
             self.seriesName = self._GenSeriesName()
             

--- a/PYME/Acquire/Spooler.py
+++ b/PYME/Acquire/Spooler.py
@@ -191,7 +191,8 @@ class Spooler:
             
 
     def doStartLog(self):
-        """Record pertinant information to metadata at start of acquisition.
+        """
+        Record pertinent information to metadata at start of acquisition.
         
         Loops through all registered sources of start metadata and adds their entries.
         
@@ -204,23 +205,18 @@ class Spooler:
         self.dtStart = dt
         
         self.tStart = time.time()
-          
-        mdt = MetaDataHandler.NestedClassMDHandler()
-          
-        mdt.setEntry('StartTime', self.tStart)
 
-        #loop over all providers of metadata
+        # loop over all providers of start-metadata
         for mdgen in MetaDataHandler.provideStartMetadata:
-            mdgen(mdt)
-            
-        self.md.copyEntriesFrom(mdt)
+            mdgen(self.md)
+        self.md.setEntry('StartTime', self.tStart)
        
 
     def doStopLog(self):
         """Record information to metadata at end of acquisition"""
         self.md.setEntry('EndTime', time.time())
         
-        #loop over all providers of metadata
+        #loop over all providers of stop-metadata
         for mdgen in MetaDataHandler.provideStopMetadata:
            mdgen(self.md)
 

--- a/PYME/Acquire/protocol.py
+++ b/PYME/Acquire/protocol.py
@@ -214,7 +214,7 @@ class ZStackTaskListProtocol(TaskListProtocol):
 
     def OnFrame(self, frameNum):
         if frameNum > self.startFrame:
-            fn = int(floor((frameNum - self.startFrame)/self.dwellTime) % len(self.zPoss))
+            fn = int((frameNum - self.startFrame)/self.dwellTime) % len(self.zPoss)
             if not fn == self.pos:
                 self.pos = fn
                 #self.piezo.MoveTo(self.piezoChan, self.zPoss[self.pos])

--- a/PYME/Acquire/ui/actionUI.py
+++ b/PYME/Acquire/ui/actionUI.py
@@ -216,7 +216,7 @@ class ActionPanel(wx.Panel):
         for ri in range(positions.shape[0]):
             args = {'state': {'Positioning.x': positions[ri, 0], 'Positioning.y': positions[ri, 1]}}
             self.actionManager.QueueAction('state.update', args, nice, timeout)
-            args = {'maxFrames': n_frames, 'stack': bool(self.rbZStepped.GetValue())}
+            args = {'maxFrames': n_frames, 'stack': bool(self.rbZStepped.GetValue()), 'check_file_exists': False}
             self.actionManager.QueueAction('spoolController.StartSpooling', args, nice, timeout)
     
     def OnROIsFromFile(self, event):

--- a/PYME/Analysis/gen_sCMOS_maps.py
+++ b/PYME/Analysis/gen_sCMOS_maps.py
@@ -9,6 +9,13 @@ from PYME.IO.FileUtils import nameUtils
 import logging
 logger = logging.getLogger(__name__)
 
+STEM_TO_MDH = {
+    'flatfield': 'Camera.FlatfieldMapID',
+    'variance': 'Camera.VarianceMapID',
+    'dark': 'Camera.DarkMapID'
+}
+MDH_TO_STEM = {v:k for k, v in STEM_TO_MDH.items()}
+
 def _meanvards(dataSource, start=0, end=-1):
     """
     Calculate the mean and variance of a data source
@@ -42,12 +49,27 @@ def _meanvards(dataSource, start=0, end=-1):
 
     return (m,v)
 
-def map_filename(mdh, type):
-    if type != 'flatfield':
+def map_filename(mdh, stem):
+    """
+    Generate a default filestub to save/search for camera maps
+    Parameters
+    ----------
+    mdh: PYME.IO.MetaDataHandler
+        dict-like metadata
+    stem: str
+        standards are 'flatfield', 'variance', and 'dark'
+
+    Returns
+    -------
+    filename: str
+        filename of camera map including integration time, if relevant.
+
+    """
+    if stem != 'flatfield':
         itime = int(1000*mdh['Camera.IntegrationTime'])
-        return '%s_%dms.tif' % (type,itime)
+        return '%s_%dms.tif' % (stem, itime)
     else:
-        return '%s.tif' % (type)
+        return '%s.tif' % stem
 
 
 def makePathUnlessExists(path):


### PR DESCRIPTION
Effectively just removing as many file-exists calls to the cluster as possible since they're expensive if the file doesn't exist or is otherwise not in the DataServer cache. We were basically guaranteed to make two non-cached clusterIO.exists calls on every StartSpooling due to not using a flatfield map and incrementing the series name.

To this end:
- add argument to spool frame StartSpooling to not bother checking if the new file exists. This is now the default when adding a batch of ROIs from file/tileviewer. 
- made `CameraMapMixin` cache the camera maps it finds (and doesn't find).