### PR TITLE
PSF extraction / astigmatism tweaks

### DIFF
--- a/PYME/Analysis/PSFEst/extractImages.py
+++ b/PYME/Analysis/PSFEst/extractImages.py
@@ -114,15 +114,11 @@ def getIntCenter(im):
     im = im.squeeze()
     X, Y, Z = np.ogrid[0:im.shape[0], 0:im.shape[1], 0:im.shape[2]]
 
-    #from pylab import *
-    #imshow(im.max(2))
-
     X = X.astype('f') - X.mean()
     Y = Y.astype('f') - Y.mean()
     Z = Z.astype('f')
 
-    im2 = im - im.min()
-    im2 = im2 - 0.5*im2.max()
+    im2 = im - np.median(im, axis=(0, 1))
     im2 = im2*(im2 > 0)
 
     ims = im2.sum()
@@ -130,8 +126,6 @@ def getIntCenter(im):
     x = (im2*X).sum()/ims
     y = (im2*Y).sum()/ims
     z = (im2*Z).sum()/ims
-
-    #print x, y, z
 
     return x, y, z
 

--- a/PYME/DSView/modules/psfTools.py
+++ b/PYME/DSView/modules/psfTools.py
@@ -303,6 +303,7 @@ class PSFTools(HasTraits):
         from PYME.Analysis.PSFEst import extractImages
         import wx
         from PYME.Analysis.points.astigmatism import astigTools
+        import sys
 
         # query user for type of calibration
         # NB - GPU fit is not enabled here because it exits on number of iterations, which is not necessarily convergence for very bright beads!
@@ -408,8 +409,7 @@ class PSFTools(HasTraits):
         #dat = {'z' : objPositions['z'][valid].tolist(), 'sigmax' : res['fitResults_sigmax'][valid].tolist(),
         #                   'sigmay' : res['fitResults_sigmay'][valid].tolist(), 'dsigma' : dsigma[valid].tolist()}
 
-
-        if use_web_view:
+        if use_web_view and (sys.platform != 'linux' and int(wx.version()[0]) > 3):  # fixme - remove special case once PYME github issue #94 is resolved
             fig = mpld3.fig_to_html(f)
             data = json.dumps(results)
 


### PR DESCRIPTION
- make PSF tagging getIntCenter more robust to intensity variations in time/frame (e.g. if your mountant auto-fluoresces but bleaches quickly, you do a weird z-scan pattern, etc.. The current code will give you ~the brightest frame)
- skip webview plotting for linux/wx4. See issue #94 