### PR TITLE
catch series starting with 'pyme-cluster' for new-style task distribution from dh5view

### DIFF
--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -635,7 +635,7 @@ class LMAnalyser2(object):
         self._checkmap('DarkMapID')
         self._checkmap('VarianceMapID')
         self._checkmap('FlatfieldMapID')
-        if self.newStyleTaskDistribution and self.image.filename.startswith('PYME-CLUSTER'):
+        if self.newStyleTaskDistribution and self.image.filename.upper().startswith('PYME-CLUSTER'):
             self.analysisController.pushImagesCluster(self.image)
         else:
             self.analysisController.pushImages(self.image)


### PR DESCRIPTION
Currently only catches upper case, while lower-case is also a valid load in dh5view