### PR TITLE
another py3 wx unicode bytes str compatibility tweak

### DIFF
--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -92,7 +92,7 @@ def _verifyClusterResultsFilename(resultsFilename):
         fdialog.SetValue(stub + '_%d.h5r' % i)
         succ = fdialog.ShowModal()
         if (succ == wx.ID_OK):
-            resultsFilename = os.path.join(di, fdialog.GetValue().encode())
+            resultsFilename = os.path.join(di, str(fdialog.GetValue()))
         else:
             raise RuntimeError('Invalid results file - not running')
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/smeagol/code/python-microscopy/PYME/DSView/modules/LMAnalysis.py", line 255, in <lambda>
    self.bGo.Bind(wx.EVT_BUTTON, lambda e : self.lmanal.OnGo(e))
  File "/home/smeagol/code/python-microscopy/PYME/DSView/modules/LMAnalysis.py", line 639, in OnGo
    self.analysisController.pushImagesCluster(self.image)
  File "/home/smeagol/code/python-microscopy/PYME/DSView/modules/LMAnalysis.py", line 315, in pushImagesCluster
    resultsFilename = _verifyClusterResultsFilename(genClusterResultFileName(image.seriesName))
  File "/home/smeagol/code/python-microscopy/PYME/DSView/modules/LMAnalysis.py", line 95, in _verifyClusterResultsFilename
    resultsFilename = os.path.join(di, fdialog.GetValue().encode())
  File "/home/smeagol/miniconda3/lib/python3.6/posixpath.py", line 94, in join
    genericpath._check_arg_types('join', a, *p)
  File "/home/smeagol/miniconda3/lib/python3.6/genericpath.py", line 151, in _check_arg_types
    raise TypeError("Can't mix strings and bytes in path components") from None
TypeError: Can't mix strings and bytes in path components
```