### PR TITLE
speed improvements for traveling salesperson/ sorted queueing

### DIFF
--- a/PYME/Acquire/ui/actionUI.py
+++ b/PYME/Acquire/ui/actionUI.py
@@ -7,7 +7,7 @@ Created on Sat May 28 23:55:50 2016
 import wx
 import numpy as np
 import logging
-from PYME.Analysis.points.traveling_salesperson.sort import tsp_sort
+from PYME.Analysis.points.traveling_salesperson import sort, queue_opt
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,8 @@ ACTION_DEFAULTS = ['spoolController.StartSpooling',
 
 SORT_FUNCTIONS = {
     'None': lambda positions, scope_position: positions,
-    'TSP': tsp_sort,
+    'TSP': sort.tsp_sort,
+    'QTSP': queue_opt.TSPQueue
 }
 
 class ActionPanel(wx.Panel):

--- a/PYME/Analysis/points/setup.py
+++ b/PYME/Analysis/points/setup.py
@@ -39,7 +39,7 @@ def configuration(parent_package='',top_path=None):
     config.add_subpackage('EdgeDB')
     config.add_subpackage('arcfit')
     config.add_subpackage('astigmatism')
-    #config.add_subpackage('Colocalisation')
+    config.add_subpackage('traveling_salesperson')
     #config.add_subpackage('Modules')
     #config.add_subpackage('Tracking')
     

--- a/PYME/Analysis/points/traveling_salesperson/queue_opt.py
+++ b/PYME/Analysis/points/traveling_salesperson/queue_opt.py
@@ -1,0 +1,87 @@
+
+import numpy as np
+import time
+import threading
+
+class TSPQueue(object):
+    def __init__(self, positions, start=0, epsilon=0.01, t_step=1):
+        from scipy.spatial import distance_matrix, cKDTree
+        from PYME.Analysis.points.traveling_salesperson import sort
+
+        self.epsilon = epsilon
+        self.t_step = t_step
+
+        self.distances = distance_matrix(positions, positions)
+
+        if np.isscalar(start):
+            start_index = int(start)
+        else:
+            kdt = cKDTree(positions)
+            d, start_index = kdt.query(start)
+
+        # bootstrap with a greedy sort
+        self.initial_route, self.initial_path_length, self.greedy_sort_dist = sort.greedy_sort(positions, start_index,
+                                                                                               self.distances)
+        self.route = [self.initial_route[0]]
+        self.t0 = time.time()
+        self.sort_thread = threading.Thread(target=self.queue_two_opt, args=(self.initial_route,
+                                                                             self.epsilon, self.t_step, self.distances,
+                                                                             self.greedy_sort_dist))
+        self.sort_thread.start()
+        self.positions = positions
+        self.shape = positions.shape
+
+    @property
+    def start_ind(self):
+        return len(self.route)
+
+    def queue_two_opt(self, initial_route, epsilon, t_step, distances, og_distance):
+        from PYME.Analysis.points.traveling_salesperson import two_opt, two_opt_utils
+        route = initial_route.astype(int)
+        endpoint_offset = 0
+
+        # initialize values we'll be updating
+        improvement = 1
+        best_distance = og_distance
+        k_max = distances.shape[0] - 1
+        t0 = self.t0
+        while improvement > epsilon:
+            last_distance = best_distance
+            t1 = time.time()
+            steps = np.ceil((t1 - t0)/t_step)
+            t0 = t1  # prepare for next go-round
+            if steps:
+                for ind in range(int(steps)):
+                    # append to master route
+                    self.route.append(route[self.start_ind])
+            print('n sorted: %d' % self.start_ind)
+            for i in range(self.start_ind, distances.shape[0] - 2):
+                # start swapping at the current 'start' of our route
+                for k in range(i + 1, distances.shape[0] - endpoint_offset):
+                    d_dist = two_opt_utils.two_opt_test(route, i, k, distances, k_max)
+                    if d_dist < 0:
+                        # do the swap in-place since we tested before we leaped and we don't need the old route
+                        route[i:k + 1] = route[k:i - 1: -1]
+                        best_distance = best_distance + d_dist
+
+            improvement = (last_distance - best_distance) / last_distance
+        # add the rest of the route
+        self.route = route
+        # return route, best_distance, og_distance
+
+    def __getitem__(self, item):
+        # our positions array is shape n, 2
+        if len(item) == 1:
+            n, xy = item, slice(None, None, None)
+        elif len(item) == 2:
+            n, xy = item
+        else:
+            raise IndexError
+
+        if n > len(self.positions) or n < 0:  # don't allow wrapping for now
+            raise IndexError
+
+        while n > self.start_ind - 1:
+            time.sleep(self.t_step)
+
+        return self.positions[self.route, :][item]

--- a/PYME/Analysis/points/traveling_salesperson/queue_opt.py
+++ b/PYME/Analysis/points/traveling_salesperson/queue_opt.py
@@ -79,7 +79,7 @@ class TSPQueue(object):
                 for ind in range(int(steps)):
                     # append to master route
                     self.route.append(route[self.start_ind])
-            print('n sorted: %d' % self.start_ind)
+            print('n sorted: %d, after %f s' % (self.start_ind, (time.time() - self.t0)))
             for i in range(self.start_ind, distances.shape[0] - 2):
                 # start swapping at the current 'start' of our route
                 for k in range(i + 1, distances.shape[0] - endpoint_offset):

--- a/PYME/Analysis/points/traveling_salesperson/setup.py
+++ b/PYME/Analysis/points/traveling_salesperson/setup.py
@@ -3,9 +3,9 @@ import sys
 import os
 
 if sys.platform == 'darwin'  :  # MacOS
-    linkArgs = []
+    link_args = []
 else:
-    linkArgs = ['-static-libgcc']
+    link_args = ['-static-libgcc']
 
 # windows VC++ has really shocking c standard support so we need to include
 # custom stdint.h and intypes.h files from https://code.google.com/archive/p/msinttypes
@@ -24,11 +24,11 @@ def configuration(parent_package='', top_path=None):
 
     cur_dir = os.path.dirname(__file__)
 
-    ext = Extension(name='.'.join([parent_package, 'two_opt_utils']),
+    ext = Extension(name='.'.join([parent_package, 'traveling_salesperson', 'two_opt_utils']),
                     sources=[os.path.join(cur_dir, 'two_opt_utils.pyx')],
                     include_dirs= get_numpy_include_dirs() + extra_include_dirs,
                     extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math', '-march=native', '-mtune=native'],
-                    extra_link_args=linkArgs)
+                    extra_link_args=link_args)
 
     config = Configuration('traveling_salesperson', parent_package, top_path, ext_modules=cythonize([ext]))
     return config

--- a/PYME/Analysis/points/traveling_salesperson/setup.py
+++ b/PYME/Analysis/points/traveling_salesperson/setup.py
@@ -1,13 +1,36 @@
 
+import sys
+import os
 
-def configuration(parent_package = '', top_path = None):
+if sys.platform == 'darwin'  :  # MacOS
+    linkArgs = []
+else:
+    linkArgs = ['-static-libgcc']
+
+# windows VC++ has really shocking c standard support so we need to include
+# custom stdint.h and intypes.h files from https://code.google.com/archive/p/msinttypes
+# print os.environ.get('CC', 'foo')
+if sys.platform == 'win32' and not os.environ.get('CC', '') == 'mingw':
+    extra_include_dirs = ['win_incl']
+else:
+    extra_include_dirs = []
+
+from Cython.Build import cythonize
+
+def configuration(parent_package='', top_path=None):
+
+    from numpy.distutils.core import Extension
     from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
-    config = Configuration('astigmatism', parent_package, top_path)
 
-    config.add_extension('two_opt_utils',
-        sources=['two_opt_utils.c'],
-        include_dirs = [get_numpy_include_dirs()])
+    cur_dir = os.path.dirname(__file__)
 
+    ext = Extension(name='.'.join([parent_package, 'two_opt_utils']),
+                    sources=[os.path.join(cur_dir, 'two_opt_utils.pyx')],
+                    include_dirs= get_numpy_include_dirs() + extra_include_dirs,
+                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math', '-march=native', '-mtune=native'],
+                    extra_link_args=linkArgs)
+
+    config = Configuration('traveling_salesperson', parent_package, top_path, ext_modules=cythonize([ext]))
     return config
 
 if __name__ == '__main__':

--- a/PYME/Analysis/points/traveling_salesperson/setup.py
+++ b/PYME/Analysis/points/traveling_salesperson/setup.py
@@ -1,0 +1,17 @@
+
+
+def configuration(parent_package = '', top_path = None):
+    from numpy.distutils.misc_util import Configuration, get_numpy_include_dirs
+    config = Configuration('astigmatism', parent_package, top_path)
+
+    config.add_extension('two_opt_utils',
+        sources=['two_opt_utils.c'],
+        include_dirs = [get_numpy_include_dirs()])
+
+    return config
+
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(
+          **configuration(top_path='').todict()
+          )

--- a/PYME/Analysis/points/traveling_salesperson/sort.py
+++ b/PYME/Analysis/points/traveling_salesperson/sort.py
@@ -72,7 +72,10 @@ def tsp_sort(positions, start=0, epsilon=0.01, return_path_length=False):
 
     # bootstrap with a greedy sort
     route, ogd, gsd = greedy_sort(positions, start_index, distances)
+    import time
+    t0 = time.time()
     route, final_distance, gsd = two_opt.two_opt(distances, epsilon, route)
+    print(time.time() - t0)
     if return_path_length:
         return positions[route, :], ogd, final_distance
     return positions[route, :]

--- a/PYME/Analysis/points/traveling_salesperson/sort.py
+++ b/PYME/Analysis/points/traveling_salesperson/sort.py
@@ -46,7 +46,7 @@ def greedy_sort(positions, start_index=0, distances=None):
     final_distance = two_opt.calculate_path_length(distances, route)
     return route, og_distance, final_distance
 
-def tsp_sort(positions, start=0, epsilon=0.01, return_path_length=False):
+def tsp_sort(positions, start=0, epsilon=0.01, return_path_length=False, use_c=True):
     """
     Parameters
     ----------
@@ -72,7 +72,10 @@ def tsp_sort(positions, start=0, epsilon=0.01, return_path_length=False):
 
     # bootstrap with a greedy sort
     route, ogd, gsd = greedy_sort(positions, start_index, distances)
-    route, final_distance, gsd = two_opt.two_opt(distances, epsilon, route)
+    if use_c:
+        route, final_distance, gsd = two_opt.c_two_opt(distances, epsilon, route)
+    else:
+        route, final_distance, gsd = two_opt.two_opt(distances, epsilon, route)
     if return_path_length:
         return positions[route, :], ogd, final_distance
     return positions[route, :]

--- a/PYME/Analysis/points/traveling_salesperson/sort.py
+++ b/PYME/Analysis/points/traveling_salesperson/sort.py
@@ -46,7 +46,7 @@ def greedy_sort(positions, start_index=0, distances=None):
     final_distance = two_opt.calculate_path_length(distances, route)
     return route, og_distance, final_distance
 
-def tsp_sort(positions, start=0, epsilon=0.01, return_path_length=False, use_c=True):
+def tsp_sort(positions, start=0, epsilon=0.01, return_path_length=False):
     """
     Parameters
     ----------
@@ -72,10 +72,8 @@ def tsp_sort(positions, start=0, epsilon=0.01, return_path_length=False, use_c=T
 
     # bootstrap with a greedy sort
     route, ogd, gsd = greedy_sort(positions, start_index, distances)
-    if use_c:
-        route, final_distance, gsd = two_opt.c_two_opt(distances, epsilon, route)
-    else:
-        route, final_distance, gsd = two_opt.two_opt(distances, epsilon, route)
+    route, final_distance, gsd = two_opt.two_opt(distances, epsilon, route)
+
     if return_path_length:
         return positions[route, :], ogd, final_distance
     return positions[route, :]

--- a/PYME/Analysis/points/traveling_salesperson/sort.py
+++ b/PYME/Analysis/points/traveling_salesperson/sort.py
@@ -73,7 +73,6 @@ def tsp_sort(positions, start=0, epsilon=0.01, return_path_length=False):
     # bootstrap with a greedy sort
     route, ogd, gsd = greedy_sort(positions, start_index, distances)
     route, final_distance, gsd = two_opt.two_opt(distances, epsilon, route)
-
     if return_path_length:
         return positions[route, :], ogd, final_distance
     return positions[route, :]

--- a/PYME/Analysis/points/traveling_salesperson/sort.py
+++ b/PYME/Analysis/points/traveling_salesperson/sort.py
@@ -72,10 +72,7 @@ def tsp_sort(positions, start=0, epsilon=0.01, return_path_length=False):
 
     # bootstrap with a greedy sort
     route, ogd, gsd = greedy_sort(positions, start_index, distances)
-    import time
-    t0 = time.time()
     route, final_distance, gsd = two_opt.two_opt(distances, epsilon, route)
-    print(time.time() - t0)
     if return_path_length:
         return positions[route, :], ogd, final_distance
     return positions[route, :]

--- a/PYME/Analysis/points/traveling_salesperson/two_opt.py
+++ b/PYME/Analysis/points/traveling_salesperson/two_opt.py
@@ -1,5 +1,6 @@
 
 import numpy as np
+from PYME.Analysis.points.traveling_salesperson import two_opt_utils
 
 def calculate_path_length(distances, route):
     """
@@ -108,7 +109,7 @@ def two_opt(distances, epsilon, initial_route=None, fixed_endpoint=False):
     see https://en.wikipedia.org/wiki/2-opt for pseudo code
 
     """
-    route = initial_route if initial_route is not None else np.arange(distances.shape[0], dtype=int)
+    route = initial_route.astype(int) if initial_route is not None else np.arange(distances.shape[0], dtype=int)
     endpoint_offset = int(fixed_endpoint)
 
     og_distance = calculate_path_length(distances, route)
@@ -122,8 +123,8 @@ def two_opt(distances, epsilon, initial_route=None, fixed_endpoint=False):
             for k in range(i + 1, distances.shape[0] - endpoint_offset):
                 d_dist = two_opt_test(route, i, k, distances, k_max)
                 if d_dist < 0:
-                    route = two_opt_swap(route, i, k)
-                    best_distance =  best_distance + d_dist #calculate_path_length(distances, route)
+                    route = two_opt_utils.two_opt_swap(route, i, k)
+                    best_distance = best_distance + d_dist #calculate_path_length(distances, route)
 
         improvement = (last_distance - best_distance) / last_distance
 

--- a/PYME/Analysis/points/traveling_salesperson/two_opt.py
+++ b/PYME/Analysis/points/traveling_salesperson/two_opt.py
@@ -121,9 +121,9 @@ def two_opt(distances, epsilon, initial_route=None, fixed_endpoint=False):
         last_distance = best_distance
         for i in range(1, distances.shape[0] - 2):  # don't swap the first position
             for k in range(i + 1, distances.shape[0] - endpoint_offset):
-                d_dist = two_opt_test(route, i, k, distances, k_max)
+                d_dist = two_opt_utils.two_opt_test(route, i, k, distances, k_max)
                 if d_dist < 0:
-                    route = two_opt_utils.two_opt_swap(route, i, k)
+                    route = two_opt_swap(route, i, k)
                     best_distance = best_distance + d_dist #calculate_path_length(distances, route)
 
         improvement = (last_distance - best_distance) / last_distance

--- a/PYME/Analysis/points/traveling_salesperson/two_opt.py
+++ b/PYME/Analysis/points/traveling_salesperson/two_opt.py
@@ -63,7 +63,7 @@ def two_opt_test(route, i, k, distances, k_max):
 
     Notes
     -----
-    This could really benefit from being cythonized!
+    There is a cythonized version in two_opt_utils which is considerably faster.
 
     """
     removed = 0
@@ -130,10 +130,6 @@ def two_opt(distances, epsilon, initial_route=None, fixed_endpoint=False):
         improvement = (last_distance - best_distance) / last_distance
 
     return route, best_distance, og_distance
-
-def c_two_opt(distances, epsilon, initial_route=None, fixed_endpoint=False):
-    route = initial_route.astype(int) if initial_route is not None else np.arange(distances.shape[0], dtype=int)
-    return two_opt_utils.two_opt(distances.astype(float), route, float(epsilon), int(fixed_endpoint))
 
 
 def timeout_two_opt(distances, epsilon, timeout, initial_route=None):

--- a/PYME/Analysis/points/traveling_salesperson/two_opt.py
+++ b/PYME/Analysis/points/traveling_salesperson/two_opt.py
@@ -123,8 +123,9 @@ def two_opt(distances, epsilon, initial_route=None, fixed_endpoint=False):
             for k in range(i + 1, distances.shape[0] - endpoint_offset):
                 d_dist = two_opt_utils.two_opt_test(route, i, k, distances, k_max)
                 if d_dist < 0:
-                    route = two_opt_swap(route, i, k)
-                    best_distance = best_distance + d_dist #calculate_path_length(distances, route)
+                    # do the swap in-place since we tested before we leaped and we don't need the old route
+                    route[i:k + 1] = route[k:i - 1: -1]
+                    best_distance = best_distance + d_dist
 
         improvement = (last_distance - best_distance) / last_distance
 

--- a/PYME/Analysis/points/traveling_salesperson/two_opt.py
+++ b/PYME/Analysis/points/traveling_salesperson/two_opt.py
@@ -130,6 +130,10 @@ def two_opt(distances, epsilon, initial_route=None, fixed_endpoint=False):
 
     return route, best_distance, og_distance
 
+def c_two_opt(distances, epsilon, initial_route=None, fixed_endpoint=False):
+    route = initial_route.astype(int) if initial_route is not None else np.arange(distances.shape[0], dtype=int)
+    return two_opt_utils.two_opt(distances.astype(float), route, float(epsilon), int(fixed_endpoint))
+
 
 def timeout_two_opt(distances, epsilon, timeout, initial_route=None):
     """

--- a/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx
+++ b/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx
@@ -1,0 +1,28 @@
+
+
+import numpy as np
+cimport numpy as np
+cimport cython
+
+ctypedef np.int_t DTYPE_t
+
+@cython.boundscheck(False) # turn off bounds-checking for entire function
+@cython.wraparound(False)  # turn off negative index wrapping for entire function
+def two_opt_swap(np.ndarray[DTYPE_t, ndim=1] route, int i, int k):
+    cdef int ind, ind1
+    cdef int route_length = route.shape[0]
+
+    new_route = np.empty_like(route)
+
+    for ind in range(i):
+        # [start up to first swap position)
+        new_route[ind] = route[ind]
+
+    for ind, ind1 in zip(range(i, k + 1), range(k, i - 1, -1)):
+        # [from first swap to second], reversed
+        new_route[ind] = route[ind1]
+
+    for ind in range(k + 1, route_length):
+        new_route[ind] = route[ind]
+
+    return new_route

--- a/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx
+++ b/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx
@@ -1,19 +1,32 @@
 
-import numpy as np
 cimport numpy as np
 
 ctypedef np.int_t DTYPE_it
 ctypedef np.float_t DTYPE_ft
 
-def two_opt_swap(np.ndarray[DTYPE_it, ndim=1] route, int i, int k):
-    cdef int ind, ind1
-    # cdef int route_length = route.shape[0]
-
-    return np.concatenate([route[:i],  # [start up to first swap position)
-                       route[k:i - 1: -1],  # [from first swap to second], reversed
-                       route[k + 1:]])  # (everything else]
-
 def two_opt_test(np.ndarray[DTYPE_it, ndim=1] route, int i, int k, np.ndarray[DTYPE_ft, ndim=2] distances, int k_max):
+    """
+    Test to see what distance change we'd get doing a two_opt_swap.
+    Take everything the same up to i, then reverse i:k, then take k: normally.
+
+
+    Parameters
+    ----------
+    route: ndarray
+        Path to swap postions in
+    i: int
+        first swap index
+    k: int
+        second swap index
+    distances: NxN matrix of float
+        distances between points
+    k_max: pre-computed maximum value of k  == distances.shape[0] -1
+
+    Returns
+    -------
+    distance change on swap
+
+    """
     cdef float removed = 0
     cdef float added = 0
 
@@ -26,71 +39,3 @@ def two_opt_test(np.ndarray[DTYPE_it, ndim=1] route, int i, int k, np.ndarray[DT
         added += distances[route[i], route[k + 1]]
 
     return added - removed
-
-def calculate_path_length(np.ndarray[DTYPE_ft, ndim=2] distances, np.ndarray[DTYPE_it, ndim=1] route):
-    """
-    Parameters
-    ----------
-    distances: ndarray
-        distance array, for which distances[i, j] is the distance from the ith to the jth point
-    route: ndarray
-        array of indices defining the path
-    """
-    cdef float distance = 0
-    cdef int ind_r, ind_c, route_length = route.shape[0]
-
-    for ind_r, ind_c in zip(range(route_length - 1), range(1, route_length)):
-            distance += distances[route[ind_r], route[ind_c]]
-
-    return distance
-
-def two_opt(np.ndarray[DTYPE_ft, ndim=2] distances, np.ndarray[DTYPE_it, ndim=1] route, float epsilon,
-            int endpoint_offset):
-    """
-
-    Solves the traveling salesperson problem (TSP) using two-opt swaps to untangle a route.
-
-    Parameters
-    ----------
-    distances: ndarray
-        distance array, which distances[i, j] is the distance from the ith to the jth point
-    epsilon: float
-        exit tolerence on relative improvement. 0.01 corresponds to 1%
-    initial_route: ndarray
-        route to initialize search with. Note that the first position in the route is fixed, but all others may vary.
-    endpoint_offset: int
-        toggles whether endpoint of route is fixed (1) or not (0)
-
-    Returns
-    -------
-    route: ndarray
-        "solved" route
-    best_distance: float
-        distance of the route
-    og_distance: float
-        distance of the initial route.
-
-    Notes
-    -----
-    see https://en.wikipedia.org/wiki/2-opt for pseudo code
-
-    """
-    cdef int k_max = distances.shape[0] - 1
-    cdef float improvement = 1
-    cdef float og_distance = calculate_path_length(distances, route)
-    cdef float best_distance = og_distance
-    cdef float last_distance
-    cdef float d_dist
-
-    while improvement > epsilon:
-        last_distance = best_distance
-        for i in range(1, distances.shape[0] - 2):  # don't swap the first position
-            for k in range(i + 1, distances.shape[0] - endpoint_offset):
-                d_dist = two_opt_test(route, i, k, distances, k_max)
-                if d_dist < 0:
-                    route = two_opt_swap(route, i, k)
-                    best_distance = best_distance + d_dist #calculate_path_length(distances, route)
-
-        improvement = (last_distance - best_distance) / last_distance
-
-    return route, best_distance, og_distance

--- a/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx
+++ b/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx
@@ -1,32 +1,17 @@
 
-
 import numpy as np
 cimport numpy as np
-cimport cython
 
 ctypedef np.int_t DTYPE_it
 ctypedef np.float_t DTYPE_ft
 
-@cython.boundscheck(False) # turn off bounds-checking for entire function
-@cython.wraparound(False)  # turn off negative index wrapping for entire function
 def two_opt_swap(np.ndarray[DTYPE_it, ndim=1] route, int i, int k):
     cdef int ind, ind1
-    cdef int route_length = route.shape[0]
+    # cdef int route_length = route.shape[0]
 
-    new_route = np.empty_like(route)
-
-    for ind in range(i):
-        # [start up to first swap position)
-        new_route[ind] = route[ind]
-
-    for ind, ind1 in zip(range(i, k + 1), range(k, i - 1, -1)):
-        # [from first swap to second], reversed
-        new_route[ind] = route[ind1]
-
-    for ind in range(k + 1, route_length):
-        new_route[ind] = route[ind]
-
-    return new_route
+    return np.concatenate([route[:i],  # [start up to first swap position)
+                       route[k:i - 1: -1],  # [from first swap to second], reversed
+                       route[k + 1:]])  # (everything else]
 
 def two_opt_test(np.ndarray[DTYPE_it, ndim=1] route, int i, int k, np.ndarray[DTYPE_ft, ndim=2] distances, int k_max):
     cdef float removed = 0
@@ -41,3 +26,71 @@ def two_opt_test(np.ndarray[DTYPE_it, ndim=1] route, int i, int k, np.ndarray[DT
         added += distances[route[i], route[k + 1]]
 
     return added - removed
+
+def calculate_path_length(np.ndarray[DTYPE_ft, ndim=2] distances, np.ndarray[DTYPE_it, ndim=1] route):
+    """
+    Parameters
+    ----------
+    distances: ndarray
+        distance array, for which distances[i, j] is the distance from the ith to the jth point
+    route: ndarray
+        array of indices defining the path
+    """
+    cdef float distance = 0
+    cdef int ind_r, ind_c, route_length = route.shape[0]
+
+    for ind_r, ind_c in zip(range(route_length - 1), range(1, route_length)):
+            distance += distances[route[ind_r], route[ind_c]]
+
+    return distance
+
+def two_opt(np.ndarray[DTYPE_ft, ndim=2] distances, np.ndarray[DTYPE_it, ndim=1] route, float epsilon,
+            int endpoint_offset):
+    """
+
+    Solves the traveling salesperson problem (TSP) using two-opt swaps to untangle a route.
+
+    Parameters
+    ----------
+    distances: ndarray
+        distance array, which distances[i, j] is the distance from the ith to the jth point
+    epsilon: float
+        exit tolerence on relative improvement. 0.01 corresponds to 1%
+    initial_route: ndarray
+        route to initialize search with. Note that the first position in the route is fixed, but all others may vary.
+    endpoint_offset: int
+        toggles whether endpoint of route is fixed (1) or not (0)
+
+    Returns
+    -------
+    route: ndarray
+        "solved" route
+    best_distance: float
+        distance of the route
+    og_distance: float
+        distance of the initial route.
+
+    Notes
+    -----
+    see https://en.wikipedia.org/wiki/2-opt for pseudo code
+
+    """
+    cdef int k_max = distances.shape[0] - 1
+    cdef float improvement = 1
+    cdef float og_distance = calculate_path_length(distances, route)
+    cdef float best_distance = og_distance
+    cdef float last_distance
+    cdef float d_dist
+
+    while improvement > epsilon:
+        last_distance = best_distance
+        for i in range(1, distances.shape[0] - 2):  # don't swap the first position
+            for k in range(i + 1, distances.shape[0] - endpoint_offset):
+                d_dist = two_opt_test(route, i, k, distances, k_max)
+                if d_dist < 0:
+                    route = two_opt_swap(route, i, k)
+                    best_distance = best_distance + d_dist #calculate_path_length(distances, route)
+
+        improvement = (last_distance - best_distance) / last_distance
+
+    return route, best_distance, og_distance

--- a/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx
+++ b/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx
@@ -4,11 +4,12 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
-ctypedef np.int_t DTYPE_t
+ctypedef np.int_t DTYPE_it
+ctypedef np.float_t DTYPE_ft
 
 @cython.boundscheck(False) # turn off bounds-checking for entire function
 @cython.wraparound(False)  # turn off negative index wrapping for entire function
-def two_opt_swap(np.ndarray[DTYPE_t, ndim=1] route, int i, int k):
+def two_opt_swap(np.ndarray[DTYPE_it, ndim=1] route, int i, int k):
     cdef int ind, ind1
     cdef int route_length = route.shape[0]
 
@@ -26,3 +27,17 @@ def two_opt_swap(np.ndarray[DTYPE_t, ndim=1] route, int i, int k):
         new_route[ind] = route[ind]
 
     return new_route
+
+def two_opt_test(np.ndarray[DTYPE_it, ndim=1] route, int i, int k, np.ndarray[DTYPE_ft, ndim=2] distances, int k_max):
+    cdef float removed = 0
+    cdef float added = 0
+
+    if i > 0:
+        removed = distances[route[i - 1], route[i]]
+        added = distances[route[i - 1], route[k]]
+
+    if k < k_max:
+        removed += distances[route[k], route[k + 1]]
+        added += distances[route[i], route[k + 1]]
+
+    return added - removed

--- a/tests/PYME/Analysis/points/test_traveling_salesperson.py
+++ b/tests/PYME/Analysis/points/test_traveling_salesperson.py
@@ -40,3 +40,14 @@ def test_tsp_sort():
     positions, og_distance, final_distance = sort.tsp_sort(og_positions, return_path_length=True)
     np.testing.assert_array_equal(np.unique(positions), np.unique(og_positions))
     assert final_distance < og_distance
+
+def test_c_calculate_path_length():
+    from PYME.Analysis.points.traveling_salesperson.two_opt_utils import calculate_path_length as c_cpl
+    from PYME.Analysis.points.traveling_salesperson.two_opt import calculate_path_length as cpl
+    n = 500
+    x = np.random.rand(n) * 100
+    y = np.random.rand(n) * 100
+    positions = np.stack([x, y], axis=1)
+    distances = distance_matrix(positions, positions)
+    route = np.random.choice(distances.shape[0], distances.shape[0], replace=False)
+    np.testing.assert_almost_equal(cpl(distances, route), c_cpl(distances, route), decimal=1)

--- a/tests/PYME/Analysis/points/test_traveling_salesperson.py
+++ b/tests/PYME/Analysis/points/test_traveling_salesperson.py
@@ -60,3 +60,22 @@ def test_swap():
     tos_route = two_opt_swap(route, i, k)
     route[i:k + 1] = route[k:i - 1: -1]
     assert np.array_equal(tos_route, route)
+
+def test_tsp_queue():
+    from PYME.Analysis.points.traveling_salesperson.queue_opt import TSPQueue
+    from PYME.Analysis.points.traveling_salesperson.two_opt import calculate_path_length
+
+    n = 2000
+    x = np.random.rand(n) * 100
+    y = np.random.rand(n) * 100
+    positions = np.stack([x, y], axis=1)
+    sorter = TSPQueue(positions, start=0, epsilon=0.01, t_step=1)
+    sorted_positions = []
+    for ind in range(n):
+        sorted_positions.append((sorter[ind, 0], sorter[ind, 1]))
+    sorted_positions = np.asarray(sorted_positions)
+    assert (np.unique(sorted_positions) == np.unique(positions)).all()
+    dummy_route = np.arange(len(positions), dtype=int)
+    unsorted_distance = calculate_path_length(distance_matrix(positions, positions), dummy_route)
+    sorted_distance = calculate_path_length(distance_matrix(sorted_positions, sorted_positions), dummy_route)
+    assert sorted_distance < unsorted_distance / 10

--- a/tests/PYME/Analysis/points/test_traveling_salesperson.py
+++ b/tests/PYME/Analysis/points/test_traveling_salesperson.py
@@ -51,3 +51,12 @@ def test_c_calculate_path_length():
     distances = distance_matrix(positions, positions)
     route = np.random.choice(distances.shape[0], distances.shape[0], replace=False)
     np.testing.assert_almost_equal(cpl(distances, route), c_cpl(distances, route), decimal=1)
+
+def test_swap():
+    from PYME.Analysis.points.traveling_salesperson.two_opt import two_opt_swap
+    route = np.arange(100, dtype=int)
+    i = 30
+    k = 60
+    tos_route = two_opt_swap(route, i, k)
+    route[i:k + 1] = route[k:i - 1: -1]
+    assert np.array_equal(tos_route, route)

--- a/tests/PYME/Analysis/points/test_traveling_salesperson.py
+++ b/tests/PYME/Analysis/points/test_traveling_salesperson.py
@@ -41,17 +41,6 @@ def test_tsp_sort():
     np.testing.assert_array_equal(np.unique(positions), np.unique(og_positions))
     assert final_distance < og_distance
 
-def test_c_calculate_path_length():
-    from PYME.Analysis.points.traveling_salesperson.two_opt_utils import calculate_path_length as c_cpl
-    from PYME.Analysis.points.traveling_salesperson.two_opt import calculate_path_length as cpl
-    n = 500
-    x = np.random.rand(n) * 100
-    y = np.random.rand(n) * 100
-    positions = np.stack([x, y], axis=1)
-    distances = distance_matrix(positions, positions)
-    route = np.random.choice(distances.shape[0], distances.shape[0], replace=False)
-    np.testing.assert_almost_equal(cpl(distances, route), c_cpl(distances, route), decimal=1)
-
 def test_swap():
     from PYME.Analysis.points.traveling_salesperson.two_opt import two_opt_swap
     route = np.arange(100, dtype=int)


### PR DESCRIPTION
Queueing >10k series with TSP sorting the other day took around 15 minutes on the instrument computer. Cythonizing the `two_opt_test` function and a small tweak or two get this down to under 4 minutes (on my macbook, didn't have patience to benchmark 10k pure python for comparison). The `QTSP` actionUI sorting mode added in this PR additionally hides time of the sorting.

Changes include:
- cython version of the two_opt_test, which indeed makes things considerably faster
- modify the route in-place for the look-before-you-leap two-opt sorting (i.e. using the two_opt_test)
- addition of a sorting mode which allows queueing of points gradually metered by an average time per point on the route (currently set at 1 s) while the traveling salesperson problem is solved on the remaining route in the background. The initial route is bootstrapped by a greedy sort which makes the two-opt sorting faster, but also makes taking points out of the sort early less painful. For 10,000 points, each loop takes longer than one second, but the average meter is maintained until the exit criteria is hit:
```
n sorted: 2, after 0.000230 s
n sorted: 61, after 58.713484 s
n sorted: 120, after 117.001526 s
n sorted: 177, after 173.521098 s
```
![image](https://user-images.githubusercontent.com/31105780/77124733-14454780-6a1a-11ea-868a-d7e90325e529.png)
