### PR TITLE
fix small regression (maybe?) in voxel size dialog

### DIFF
--- a/PYME/Acquire/ui/voxelSizeDialog.py
+++ b/PYME/Acquire/ui/voxelSizeDialog.py
@@ -107,7 +107,7 @@ class VoxelSizeDialog(wx.Dialog):
 
 
     def _setVoxelSizeChoices(self):
-        with self.settingsDB as conn:
+        with self.scope.settingsDB as conn:
             voxelsizes = conn.execute("SELECT ID, name, x,y FROM VoxelSizes ORDER BY ID DESC").fetchall()
     
             voxIDs = []


### PR DESCRIPTION
VoxelSizeDialog doesn't have it's own settingsDB, as that is a scope property.

```
Traceback (most recent call last):
  File "/Users/Andrew/code/python-microscopy/PYME/Acquire/acquiremainframe.py", line 530, in OnMCamSetPixelSize
    dlg = voxelSizeDialog.VoxelSizeDialog(self, self.scope)
  File "/Users/Andrew/code/python-microscopy/PYME/Acquire/ui/voxelSizeDialog.py", line 47, in __init__
    self._setVoxelSizeChoices()
  File "/Users/Andrew/code/python-microscopy/PYME/Acquire/ui/voxelSizeDialog.py", line 110, in _setVoxelSizeChoices
    with self.settingsDB as conn:
AttributeError: 'VoxelSizeDialog' object has no attribute 'settingsDB'
```