### PR TITLE
Adds a Multiwell tiler and associated gui panel

### DIFF
--- a/PYME/Acquire/Utils/tiler.py
+++ b/PYME/Acquire/Utils/tiler.py
@@ -161,8 +161,7 @@ class CircularTiler(Tiler):
 
 class MultiwellCircularTiler(object):
     """
-    Creates a circular tiler for each well at a given spacing. For now create a singular, very large pyramid image of
-    overview (practical? Maybe, maybe not, but would look coolest in the viewer).
+    Creates a circular tiler for each well at a given spacing. For now create a separate tilepyramid for each well.
     """
     def __init__(self, well_scan_radius, x_spacing, y_spacing, n_x, n_y, scope, tile_dir, tile_spacing=None,
                  dwelltime=1, background=0, evtLog=False, trigger=False, base_tile_size=256):

--- a/PYME/Acquire/Utils/tiler.py
+++ b/PYME/Acquire/Utils/tiler.py
@@ -236,8 +236,8 @@ class MultiwellCircularTiler(object):
         self._x_wells = np.asarray(self._x_wells)
 
         # add the current scope position offset
-        self._x_wells += self.curr_pos[0]
-        self._y_wells += self.curr_pos[1]
+        self._x_wells += self.curr_pos['x']
+        self._y_wells += self.curr_pos['y']
 
         self.max_ind = self.n_x * self.n_y
 

--- a/PYME/Acquire/Utils/tiler.py
+++ b/PYME/Acquire/Utils/tiler.py
@@ -241,7 +241,16 @@ class MultiwellCircularTiler(object):
 
         self.max_ind = self.n_x * self.n_y
 
-    def start_next(self):
+    def start_next(self, *args, **kwargs):
+        """
+        Creates and starts the tiler for the next well until we're finished.
+
+        Parameters
+        ----------
+        args
+        kwargs:
+            necessary as dispatch calls will include a signal keyword argument
+        """
         try:
             self.tiler.on_stop.disconnect()
         except:
@@ -257,13 +266,14 @@ class MultiwellCircularTiler(object):
                                   self.background, self.evt_log, self.trigger, self.base_tile_size, False)
             self.tiler.start()
             self.ind += 1
-            self.tiler.on_stop.connect(self.start_next())  # todo - is it problematic not ot call disconnect?
+            self.tiler.on_stop.connect(self.start_next)
 
 
     def start(self):
         self.start_next()
 
     def stop(self):
+        self.max_ind = 0
         try:
             self.tiler.stop()
         except AttributeError:

--- a/PYME/Acquire/Utils/tiler.py
+++ b/PYME/Acquire/Utils/tiler.py
@@ -121,7 +121,7 @@ class CircularTiler(Tiler):
             tile_spacing = (1/np.sqrt(2)) * fs * np.array(scope.GetPixelSize())
         # take the pixel size to be the same or at least similar in both directions
         self.pixel_radius = int(max_radius_um / tile_spacing.mean())
-        logger.debug('Circular tiler target radius in units of ~30 percent overlapped FOVs: %d' % self.pixel_radius)
+        logger.debug('Circular tiler target radius in units of (overlapped) FOVs: %d' % self.pixel_radius)
         
         Tiler.__init__(self, scope, tile_dir, n_tiles=self.pixel_radius, tile_spacing=tile_spacing, dwelltime=dwelltime,
                        background=background, evtLog=evtLog, trigger=trigger, base_tile_size=base_tile_size,
@@ -158,4 +158,103 @@ class CircularTiler(Tiler):
         ind = callN % self.nx
         return self.xp[ind], self.yp[ind]
 
+
+class MultiwellCircularTiler(object):
+    """
+    Creates a circular tiler for each well at a given spacing. For now create a singular, very large pyramid image of
+    overview (practical? Maybe, maybe not, but would look coolest in the viewer).
+    """
+    def __init__(self, well_scan_radius, x_spacing, y_spacing, n_x, n_y, scope, tile_dir, tile_spacing=None,
+                 dwelltime=1, background=0, evtLog=False, trigger=False, base_tile_size=256):
+        """
+        Creates a new pyramid for each well due to performance constraints.
+
+        Parameters
+        ----------
+        well_scan_radius: float
+            radius to scan within each well [um]
+        x_well_spacing: float
+            center-to-center spacing of each well along x [um]
+        y_well_spacing: float
+            center-to-center spacing of each well along y [um]
+        n_x: int
+            number of rows along x to tile
+        n_y: int
+            number of columns along y to tile
+        scope: PYME.Acquire.microscope
+        tile_dir: str
+            directory to store all pyramids
+        tile_spacing: float
+            distance between tile 'pixels', i.e. center-to-center distance between the individual tiles.
+        dwelltime
+        background
+        evtLog
+        trigger
+        base_tile_size
+        """
+
+        self.well_scan_radius = well_scan_radius
+        self.x_spacing = x_spacing
+        self.y_spacing = y_spacing
+        self.n_x = n_x
+        self.n_y = n_y
+
+        self.scope = scope
+        self.tile_dir = tile_dir
+
+        self.set_well_positions()
+
+        # store the individual tiler settings
+        self.tile_spacing = tile_spacing
+        self.dwelltime = dwelltime
+        self.background = background
+        self.evt_log = evtLog
+        self.trigger = trigger
+        self.base_tile_size = base_tile_size
+
+        self.ind = 0
+
+    def set_well_positions(self):
+        """
+        Establish x,y center positions of each well to scan. Making the current microscope position the center of the
+        (0, 0) well, which is also the min x, min y well.
+
+        """
+        self.curr_pos = self.scope.GetPos()
+
+        x_wells = np.arange(0, self.n_x * self.x_spacing)
+        y_wells = np.arange(0, self.n_y * self.y_spacing)
+
+        self._x_wells = []
+        self._y_wells = np.repeat(y_wells, self.n_x)
+        # zig-zag with turns along x
+        for xi in range(self.n_y):
+            if xi % 2:
+                self._x_wells.extend(x_wells[::-1])
+            else:
+                self._x_wells.extend(x_wells)
+        self._x_wells = np.asarray(self._x_wells)
+
+        # add the current scope position offset
+        self._x_wells += self.curr_pos[0]
+        self._y_wells += self.curr_pos[1]
+
+        self.max_ind = self.n_x * self.n_y
+
+    def start_next(self):
+        if self.ind < self.max_ind:
+            self.scope.state.setItems({'Positioning.x': self._x_wells[self.ind],
+                                       'Positioning.y': self._y_wells[self.ind]},
+                                      stopCamera=True)  # stop cam to make sure the next tiler gets the right center pos
+
+            tile_dir = os.path.join(self.tile_dir, 'well_%d' % self.ind)
+            tiler = CircularTiler(self.scope, tile_dir, self.well_scan_radius, self.tile_spacing, self.dwelltime,
+                                  self.background, self.evt_log, self.trigger, self.base_tile_size, False)
+            tiler.start()
+            self.ind += 1
+            tiler.on_stop.connect(self.start_next())  # todo - is it problematic not ot call disconnect?
+
+
+    def start(self):
+        self.start_next()
         

--- a/PYME/Acquire/Utils/tiler.py
+++ b/PYME/Acquire/Utils/tiler.py
@@ -242,19 +242,30 @@ class MultiwellCircularTiler(object):
         self.max_ind = self.n_x * self.n_y
 
     def start_next(self):
+        try:
+            self.tiler.on_stop.disconnect()
+        except:
+            pass
+
         if self.ind < self.max_ind:
             self.scope.state.setItems({'Positioning.x': self._x_wells[self.ind],
                                        'Positioning.y': self._y_wells[self.ind]},
                                       stopCamera=True)  # stop cam to make sure the next tiler gets the right center pos
 
             tile_dir = os.path.join(self.tile_dir, 'well_%d' % self.ind)
-            tiler = CircularTiler(self.scope, tile_dir, self.well_scan_radius, self.tile_spacing, self.dwelltime,
+            self.tiler = CircularTiler(self.scope, tile_dir, self.well_scan_radius, self.tile_spacing, self.dwelltime,
                                   self.background, self.evt_log, self.trigger, self.base_tile_size, False)
-            tiler.start()
+            self.tiler.start()
             self.ind += 1
-            tiler.on_stop.connect(self.start_next())  # todo - is it problematic not ot call disconnect?
+            self.tiler.on_stop.connect(self.start_next())  # todo - is it problematic not ot call disconnect?
 
 
     def start(self):
         self.start_next()
+
+    def stop(self):
+        try:
+            self.tiler.stop()
+        except AttributeError:
+            pass
         

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -259,3 +259,6 @@ class MultiwellTilePanel(TilePanel):
         # self.scope.tiler.on_stop.connect(self._on_stop)
         # self.scope.tiler.progress.connect(self._update)
         self.scope.tiler.start()
+
+    def OnStop(self, event=None):
+        self.scope.tiler.stop()

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -189,58 +189,58 @@ class MultiwellTilePanel(TilePanel):
 
         vsizer = wx.BoxSizer(wx.VERTICAL)
 
-        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
-        hsizer2.Add(wx.StaticText(self, -1, 'Save to:'), 0, wx.ALL, 2)
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, 'Save to:'), 0, wx.ALL, 2)
         self.tDestination = wx.TextCtrl(self, -1, value='')
-        hsizer2.Add(self.tDestination, 1, wx.ALL | wx.EXPAND, 2)
-        vsizer.Add(hsizer2, 0, wx.EXPAND, 0)
+        hsizer.Add(self.tDestination, 1, wx.ALL | wx.EXPAND, 2)
+        vsizer.Add(hsizer, 0, wx.EXPAND, 0)
 
-        # hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
+        # hsizer = wx.BoxSizer(wx.HORIZONTAL)
         # self.pProgress = wx.Gauge(self, -1, range=100)
-        # hsizer2.Add(self.pProgress, 1, wx.ALL | wx.EXPAND, 2)
-        # vsizer.Add(hsizer2, 0, wx.EXPAND, 0)
+        # hsizer.Add(self.pProgress, 1, wx.ALL | wx.EXPAND, 2)
+        # vsizer.Add(hsizer, 0, wx.EXPAND, 0)
 
-        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
-        hsizer2.Add(wx.StaticText(self, -1, 'Well Scan radius [\u03BCm]:'), 0, wx.ALL, 2)
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, 'Well Scan radius [\u03BCm]:'), 0, wx.ALL, 2)
         self.radius_um = wx.TextCtrl(self, -1, value='%.1f' % 250)
-        hsizer2.Add(self.radius_um, 0, wx.ALL, 2)
-        vsizer.Add(hsizer2)
+        hsizer.Add(self.radius_um, 0, wx.ALL, 2)
+        vsizer.Add(hsizer)
 
-        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
-        hsizer2.Add(wx.StaticText(self, -1, '# wells x:'), 0, wx.ALL, 2)
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, '# wells x:'), 0, wx.ALL, 2)
         self.n_x = wx.TextCtrl(self, -1, value='%d' % 3)
-        hsizer2.Add(self.n_x, 0, wx.ALL, 2)
-        vsizer.Add(hsizer2)
+        hsizer.Add(self.n_x, 0, wx.ALL, 2)
+        vsizer.Add(hsizer)
 
-        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
-        hsizer2.Add(wx.StaticText(self, -1, 'x cent. dist [mm]:'), 0, wx.ALL, 2)
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, 'x cent. dist [mm]:'), 0, wx.ALL, 2)
         self.x_spacing_mm = wx.TextCtrl(self, -1, value='%.1f' % 3)
-        hsizer2.Add(self.x_spacing_mm, 0, wx.ALL, 2)
-        vsizer.Add(hsizer2)
+        hsizer.Add(self.x_spacing_mm, 0, wx.ALL, 2)
+        vsizer.Add(hsizer)
 
-        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
-        hsizer2.Add(wx.StaticText(self, -1, '# wells y:'), 0, wx.ALL, 2)
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, '# wells y:'), 0, wx.ALL, 2)
         self.n_y = wx.TextCtrl(self, -1, value='%d' % 3)
-        hsizer2.Add(self.n_y, 0, wx.ALL, 2)
-        vsizer.Add(hsizer2)
+        hsizer.Add(self.n_y, 0, wx.ALL, 2)
+        vsizer.Add(hsizer)
 
-        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
-        hsizer2.Add(wx.StaticText(self, -1, 'y cent. dist [mm]:'), 0, wx.ALL, 2)
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, 'y cent. dist [mm]:'), 0, wx.ALL, 2)
         self.y_spacing_mm = wx.TextCtrl(self, -1, value='%.1f' % 3)
-        hsizer2.Add(self.y_spacing_mm, 0, wx.ALL, 2)
-        vsizer.Add(hsizer2)
+        hsizer.Add(self.y_spacing_mm, 0, wx.ALL, 2)
+        vsizer.Add(hsizer)
 
-        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
 
         self.bGo = wx.Button(self, -1, 'Go')
         # self.bGo.Disable()
         self.bGo.Bind(wx.EVT_BUTTON, self.OnGo)
-        hsizer2.Add(self.bGo, 0, wx.ALL, 2)
+        hsizer.Add(self.bGo, 0, wx.ALL, 2)
         self.bStop = wx.Button(self, -1, 'Stop')
         self.bStop.Disable()
         self.bStop.Bind(wx.EVT_BUTTON, self.OnStop)
-        hsizer2.Add(self.bStop, 0, wx.ALL, 2)
-        vsizer.Add(hsizer2)
+        hsizer.Add(self.bStop, 0, wx.ALL, 2)
+        vsizer.Add(hsizer)
 
         self.SetSizerAndFit(vsizer)
 
@@ -248,11 +248,14 @@ class MultiwellTilePanel(TilePanel):
     def OnGo(self, event=None):
         trigger = hasattr(self.scope.cam, 'FireSoftwareTrigger')
 
-        self.scope.tiler = tiler.MultiwellCircularTiler() # fixme
+        self.scope.tiler = tiler.MultiwellCircularTiler(float(self.radius_um.GetValue()),
+            float(self.x_spacing_mm.GetValue()) * 1e3, float(self.y_spacing_mm.GetValue()) * 1e3,
+            int(self.n_x.GetValue()), int(self.n_y.GetValue()), self.scope, self.tDestination.GetValue(),
+            trigger=trigger)
 
         self.bStop.Enable()
         self.bGo.Disable()
 
-        self.scope.tiler.on_stop.connect(self._on_stop)
+        # self.scope.tiler.on_stop.connect(self._on_stop)
         # self.scope.tiler.progress.connect(self._update)
         self.scope.tiler.start()

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -177,3 +177,82 @@ class CircularTilePanel(TilePanel):
         self.scope.tiler.on_stop.connect(self._on_stop)
         self.scope.tiler.progress.connect(self._update)
         self.scope.tiler.start()
+
+
+class MultiwellTilePanel(TilePanel):
+    def __init__(self, parent, scope):
+        wx.Panel.__init__(self, parent)
+
+        self.scope = scope
+
+        self._gui_proc = None
+
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+
+        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer2.Add(wx.StaticText(self, -1, 'Save to:'), 0, wx.ALL, 2)
+        self.tDestination = wx.TextCtrl(self, -1, value='')
+        hsizer2.Add(self.tDestination, 1, wx.ALL | wx.EXPAND, 2)
+        vsizer.Add(hsizer2, 0, wx.EXPAND, 0)
+
+        # hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
+        # self.pProgress = wx.Gauge(self, -1, range=100)
+        # hsizer2.Add(self.pProgress, 1, wx.ALL | wx.EXPAND, 2)
+        # vsizer.Add(hsizer2, 0, wx.EXPAND, 0)
+
+        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer2.Add(wx.StaticText(self, -1, 'Well Scan radius [\u03BCm]:'), 0, wx.ALL, 2)
+        self.radius_um = wx.TextCtrl(self, -1, value='%.1f' % 250)
+        hsizer2.Add(self.radius_um, 0, wx.ALL, 2)
+        vsizer.Add(hsizer2)
+
+        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer2.Add(wx.StaticText(self, -1, '# wells x:'), 0, wx.ALL, 2)
+        self.n_x = wx.TextCtrl(self, -1, value='%d' % 3)
+        hsizer2.Add(self.n_x, 0, wx.ALL, 2)
+        vsizer.Add(hsizer2)
+
+        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer2.Add(wx.StaticText(self, -1, 'x cent. dist [mm]:'), 0, wx.ALL, 2)
+        self.x_spacing_mm = wx.TextCtrl(self, -1, value='%.1f' % 3)
+        hsizer2.Add(self.x_spacing_mm, 0, wx.ALL, 2)
+        vsizer.Add(hsizer2)
+
+        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer2.Add(wx.StaticText(self, -1, '# wells y:'), 0, wx.ALL, 2)
+        self.n_y = wx.TextCtrl(self, -1, value='%d' % 3)
+        hsizer2.Add(self.n_y, 0, wx.ALL, 2)
+        vsizer.Add(hsizer2)
+
+        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer2.Add(wx.StaticText(self, -1, 'y cent. dist [mm]:'), 0, wx.ALL, 2)
+        self.y_spacing_mm = wx.TextCtrl(self, -1, value='%.1f' % 3)
+        hsizer2.Add(self.y_spacing_mm, 0, wx.ALL, 2)
+        vsizer.Add(hsizer2)
+
+        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
+
+        self.bGo = wx.Button(self, -1, 'Go')
+        # self.bGo.Disable()
+        self.bGo.Bind(wx.EVT_BUTTON, self.OnGo)
+        hsizer2.Add(self.bGo, 0, wx.ALL, 2)
+        self.bStop = wx.Button(self, -1, 'Stop')
+        self.bStop.Disable()
+        self.bStop.Bind(wx.EVT_BUTTON, self.OnStop)
+        hsizer2.Add(self.bStop, 0, wx.ALL, 2)
+        vsizer.Add(hsizer2)
+
+        self.SetSizerAndFit(vsizer)
+
+
+    def OnGo(self, event=None):
+        trigger = hasattr(self.scope.cam, 'FireSoftwareTrigger')
+
+        self.scope.tiler = tiler.MultiwellCircularTiler() # fixme
+
+        self.bStop.Enable()
+        self.bGo.Disable()
+
+        self.scope.tiler.on_stop.connect(self._on_stop)
+        # self.scope.tiler.progress.connect(self._update)
+        self.scope.tiler.start()


### PR DESCRIPTION
Sets things up to run many circular tilers at preset spacing. Tested with the simulator (didn't think it worth adding the init script for it though).

Currently set up to produce a tilepyramid for each well individually, and not open any tileviewers afterwards. Would be very cool to open up an entire multiwell plate in the viewer, but I think the smart way to do this would be to create a shortcut to building a large tile when you know most of it will be zero's.