### PR TITLE
fix h5rfile appendToTable on python 3 / numpy >=1.14

### DIFF
--- a/PYME/IO/h5rFile.py
+++ b/PYME/IO/h5rFile.py
@@ -7,7 +7,6 @@ from PYME import config
 import numpy as np
 import traceback
 import collections
-import six
 
 #global lock across all instances of the H5RFile class as we can have problems across files
 tablesLock = threading.Lock()
@@ -118,7 +117,7 @@ class H5RFile(object):
                 table.append(data)
             except AttributeError:
                 # we don't have a table with that name - create one
-                if isinstance(data, six.string_types):
+                if isinstance(data, (bytes, str)) or isinstance(data, unicode):
                     table = self._h5file.create_vlarray(self._h5file.root, tablename, tables.VLStringAtom())
                     table.append(data)
                 else:


### PR DESCRIPTION
`isinstance(b'anything', six.string_types)` is `False` on py3 because `six.string_types` is just `(str,)`.

This would result in tables calling `numpy.rec.array(b'anything')` which fails (at least on numpy 1.14 and 1.18) due to the req that `numpy.fromstring` have a dtype or format argument.

The work-around was already in appendToTable, we just had to catch bytes on both py2 and py3. The replacement works on py2 and py3 thanks to the short-circuiting or.

Note this fixes one of the errors mentioned in issue #160.