### PR TITLE
organize PYMEVisualize open/save into open/open extra/save

### DIFF
--- a/PYME/LMVis/Extras/snapshot.py
+++ b/PYME/LMVis/Extras/snapshot.py
@@ -63,4 +63,4 @@ def save_snapshot(canvas):
 
 
 def Plug(vis_fr):
-    vis_fr.AddMenuItem('View', 'Save Snapshot', lambda e: save_snapshot(vis_fr.glCanvas))
+    vis_fr.AddMenuItem('File>Save', 'View Snapshot', lambda e: save_snapshot(vis_fr.glCanvas))

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -255,12 +255,12 @@ class VisGUICore(object):
         if not subMenu:
             self.AddMenuItem('File>Open Extra', "Raw/Prebleach Data", self.OnOpenRaw)
             self.AddMenuItem('File>Open Extra', "Channel", self.OnOpenChannel)
-            
+
+        self.AddMenuItem('File', itemType='separator')
         self.AddMenuItem('File>Save', 'Filtered Localizations', self.OnSave)
         
         if not subMenu:
-            # self.AddMenuItem('File', itemType='separator')
-            self.AddMenuItem('File>Save', "Save Measurements", self.OnSaveMeasurements)
+            self.AddMenuItem('File>Save', "Measurements", self.OnSaveMeasurements)
 
             self.AddMenuItem('File', itemType='separator')
 

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -253,8 +253,8 @@ class VisGUICore(object):
 
         self.AddMenuItem('File', '&Open', self.OnOpenFile)
         if not subMenu:
-            self.AddMenuItem('File>Open Extra', "Raw/Prebleach Data", self.OnOpenRaw)
-            self.AddMenuItem('File>Open Extra', "Channel", self.OnOpenChannel)
+            self.AddMenuItem('File', "Open Raw/Prebleach Data", self.OnOpenRaw)
+            self.AddMenuItem('File', "Open Extra Channel", self.OnOpenChannel)
 
         self.AddMenuItem('File', itemType='separator')
         self.AddMenuItem('File>Save', 'Filtered Localizations', self.OnSave)

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -253,14 +253,14 @@ class VisGUICore(object):
 
         self.AddMenuItem('File', '&Open', self.OnOpenFile)
         if not subMenu:
-            self.AddMenuItem('File', "Open &Raw/Prebleach Data", self.OnOpenRaw)
-            self.AddMenuItem('File', "Open Extra &Channel", self.OnOpenChannel)
+            self.AddMenuItem('File>Open Extra', "Raw/Prebleach Data", self.OnOpenRaw)
+            self.AddMenuItem('File>Open Extra', "Channel", self.OnOpenChannel)
             
-        self.AddMenuItem('File', 'Save filtered localizations', self.OnSave)
+        self.AddMenuItem('File>Save', 'Filtered Localizations', self.OnSave)
         
         if not subMenu:
-            self.AddMenuItem('File', itemType='separator')
-            self.AddMenuItem('File', "&Save Measurements", self.OnSaveMeasurements)
+            # self.AddMenuItem('File', itemType='separator')
+            self.AddMenuItem('File>Save', "Save Measurements", self.OnSaveMeasurements)
 
             self.AddMenuItem('File', itemType='separator')
 


### PR DESCRIPTION
- move extra open items into a submenu
- move all save items into a submenu
- move snapshot save from 'View' to 'File>Save'
- consistent CapsCase on 'File' menu items

![Screen Shot 2020-05-11 at 12 31 20 PM](https://user-images.githubusercontent.com/31105780/81586315-52f4df80-9383-11ea-9843-487f3253fd89.png)
![Screen Shot 2020-05-11 at 12 30 21 PM](https://user-images.githubusercontent.com/31105780/81586281-47a1b400-9383-11ea-9cec-e2ca92c4051f.png)
