### PR TITLE
add scikits depends back into pip req's files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,8 @@ pyfftw #; python_version > '3.0'
 
 #mpld3
 cherrypy
-#scikit-image
-#scikit-learn
+scikit-image
+scikit-learn
 
 #FIXME for py3k
 #shapely [osx and py2k]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -21,8 +21,8 @@ pyfftw #; python_version > '3.0'
 
 #mpld3
 cherrypy
-#scikit-image
-#scikit-learn
+scikit-image
+scikit-learn
 
 #FIXME for py3k
 #shapely [osx and py2k]


### PR DESCRIPTION
At the moment the scikit-image dep missing causes some tests to fail (e.g. spherical_harmonics and coordinate_tools)

```
==================================== ERRORS ====================================
_____ ERROR collecting tests/PYME/Analysis/points/test_coordinate_tools.py _____
ImportError while importing test module '/home/vsts/work/1/s/tests/PYME/Analysis/points/test_coordinate_tools.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
PYME/Analysis/points/test_coordinate_tools.py:6: in <module>
    from skimage import morphology
E   ModuleNotFoundError: No module named 'skimage'
___ ERROR collecting tests/PYME/Analysis/points/test_spherical_harmonics.py ____
ImportError while importing test module '/home/vsts/work/1/s/tests/PYME/Analysis/points/test_spherical_harmonics.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
PYME/Analysis/points/test_spherical_harmonics.py:5: in <module>
    from skimage import morphology
E   ModuleNotFoundError: No module named 'skimage'

```
