### PR TITLE
Ripleys tweaks

### DIFF
--- a/PYME/Analysis/points/ripleys.py
+++ b/PYME/Analysis/points/ripleys.py
@@ -73,9 +73,6 @@ def ripleys_k_from_mask_points(x, y, xu, yu, n_bins, bin_size, mask_area, z=None
     return bb, K
 
 def points_from_mask(mask, sampling, three_d = True, coord_origin=(0,0,0)):
-    if three_d and mask.data.shape[2] < 2:
-        raise RuntimeError('Need to use a 3D mask for a 3D point cloud.')
-
     vx, vy, vz = mask.voxelsize
     x0_m, y0_m, z0_m = mask.origin
     x0_p, y0_p, z0_p = coord_origin

--- a/PYME/Analysis/points/ripleys.py
+++ b/PYME/Analysis/points/ripleys.py
@@ -75,7 +75,7 @@ def ripleys_k_from_mask_points(x, y, xu, yu, n_bins, bin_size, mask_area, z=None
 def points_from_mask(mask, sampling, three_d = True, coord_origin=(0,0,0)):
     vx, vy, vz = mask.voxelsize
     x0_m, y0_m, z0_m = mask.origin
-    x0_p, y0_p, z0_p = coord_origin
+    # x0_p, y0_p, z0_p = coord_origin
 
     if (vz < 1e-12) and not three_d:
         vz = 1 #dummy value to prevent div by zero when calculating strides we don't use
@@ -90,8 +90,8 @@ def points_from_mask(mask, sampling, three_d = True, coord_origin=(0,0,0)):
         # generate uniformly sampled coordinates on mask
         xu, yu, zu = np.mgrid[0:bool_mask.shape[0]:stride_x, 0:bool_mask.shape[1]:stride_y,
                      0:bool_mask.shape[2]:stride_z]
-        xu, yu, zu = vx * xu[bool_mask] + x0_m - x0_p, vy * yu[bool_mask] + y0_m - y0_p, vz * zu[
-            bool_mask] + z0_m - z0_p
+        xu, yu, zu = vx * xu[bool_mask] + x0_m, vy * yu[bool_mask] + y0_m, vz * zu[
+            bool_mask] + z0_m
         
         mask_area = bool_mask.sum() * vx * vy * vz
     else:
@@ -102,7 +102,7 @@ def points_from_mask(mask, sampling, three_d = True, coord_origin=(0,0,0)):
         
         zu = None
         xu, yu = np.mgrid[0:bool_mask.shape[0]:stride_x, 0:bool_mask.shape[1]:stride_y]
-        xu, yu = vx * xu[bool_mask] + x0_m - x0_p, vy * yu[bool_mask] + y0_m - y0_p
+        xu, yu = vx * xu[bool_mask] + x0_m, vy * yu[bool_mask] + y0_m
         mask_area = bool_mask.sum() * vx * vy
         
     return xu, yu, zu, mask_area

--- a/PYME/Analysis/points/ripleys.py
+++ b/PYME/Analysis/points/ripleys.py
@@ -73,6 +73,9 @@ def ripleys_k_from_mask_points(x, y, xu, yu, n_bins, bin_size, mask_area, z=None
     return bb, K
 
 def points_from_mask(mask, sampling, three_d = True, coord_origin=(0,0,0)):
+    if three_d and mask.data.shape[2] < 2:
+        raise RuntimeError('Need to use a 3D mask for a 3D point cloud.')
+
     vx, vy, vz = mask.voxelsize
     x0_m, y0_m, z0_m = mask.origin
     x0_p, y0_p, z0_p = coord_origin

--- a/PYME/Analysis/points/ripleys.py
+++ b/PYME/Analysis/points/ripleys.py
@@ -75,7 +75,7 @@ def ripleys_k_from_mask_points(x, y, xu, yu, n_bins, bin_size, mask_area, z=None
 def points_from_mask(mask, sampling, three_d = True, coord_origin=(0,0,0)):
     vx, vy, vz = mask.voxelsize
     x0_m, y0_m, z0_m = mask.origin
-    # x0_p, y0_p, z0_p = coord_origin
+    x0_p, y0_p, z0_p = coord_origin
 
     if (vz < 1e-12) and not three_d:
         vz = 1 #dummy value to prevent div by zero when calculating strides we don't use
@@ -90,8 +90,8 @@ def points_from_mask(mask, sampling, three_d = True, coord_origin=(0,0,0)):
         # generate uniformly sampled coordinates on mask
         xu, yu, zu = np.mgrid[0:bool_mask.shape[0]:stride_x, 0:bool_mask.shape[1]:stride_y,
                      0:bool_mask.shape[2]:stride_z]
-        xu, yu, zu = vx * xu[bool_mask] + x0_m, vy * yu[bool_mask] + y0_m, vz * zu[
-            bool_mask] + z0_m
+        xu, yu, zu = vx * xu[bool_mask] + x0_m - x0_p, vy * yu[bool_mask] + y0_m - y0_p, vz * zu[
+            bool_mask] + z0_m - z0_p
         
         mask_area = bool_mask.sum() * vx * vy * vz
     else:
@@ -102,7 +102,7 @@ def points_from_mask(mask, sampling, three_d = True, coord_origin=(0,0,0)):
         
         zu = None
         xu, yu = np.mgrid[0:bool_mask.shape[0]:stride_x, 0:bool_mask.shape[1]:stride_y]
-        xu, yu = vx * xu[bool_mask] + x0_m, vy * yu[bool_mask] + y0_m
+        xu, yu = vx * xu[bool_mask] + x0_m - x0_p, vy * yu[bool_mask] + y0_m - y0_p
         mask_area = bool_mask.sum() * vx * vy
         
     return xu, yu, zu, mask_area

--- a/PYME/Analysis/points/ripleys.py
+++ b/PYME/Analysis/points/ripleys.py
@@ -167,8 +167,7 @@ def ripleys_k(x, y, n_bins, bin_size, mask=None, bbox=None, z=None, threaded=Fal
 
 def ripleys_l(bb, K, d=2):
     """
-    Normalizes Ripley's K-function to an L-function such that L > 0 indicates
-    clustering and L < 0 indicates dispersion.
+    Normalizes Ripley's K-function to an L-function.
 
     Parameters
     ----------
@@ -180,7 +179,6 @@ def ripleys_l(bb, K, d=2):
         d : int
             Dimension of the input data to calculate K (2 or 3).
     """
-    bin_size = np.diff(bb)[0]
     if d == 2:
         # Normalize 2D
         L = np.sqrt(K/np.pi)
@@ -190,6 +188,26 @@ def ripleys_l(bb, K, d=2):
     else:
         raise ValueError('Please enter a valid dimension.')
 
-    L -= bb+bin_size
-
     return bb, L
+
+def ripleys_h(bb, K, d=2):
+    """
+    Normalizes Ripley's K-function to an H-function such that  > 0 indicates
+    clustering and H < 0 indicates dispersion.
+
+    Parameters
+    ----------
+        bb : np.array
+            Histogram bins associated with K.
+        K : np.array
+            Ripley's K-function, calculated from 
+            PYME.Analysis.points.spatial_descriptive.ripleys_k
+        d : int
+            Dimension of the input data to calculate K (2 or 3).
+    """
+    bb, L = ripleys_l(bb, K, d)
+
+    bin_size = np.diff(bb)[0]
+    H = L - bb+bin_size
+
+    return bb, H

--- a/PYME/Analysis/points/ripleys.py
+++ b/PYME/Analysis/points/ripleys.py
@@ -103,7 +103,7 @@ def points_from_mask(mask, sampling, three_d = True, coord_origin=(0,0,0)):
         zu = None
         xu, yu = np.mgrid[0:bool_mask.shape[0]:stride_x, 0:bool_mask.shape[1]:stride_y]
         xu, yu = vx * xu[bool_mask] + x0_m - x0_p, vy * yu[bool_mask] + y0_m - y0_p
-        mask_area = bool_mask.sum() * vx * vy * vz
+        mask_area = bool_mask.sum() * vx * vy
         
     return xu, yu, zu, mask_area
     

--- a/PYME/LMVis/Extras/QPobjectSegment.py
+++ b/PYME/LMVis/Extras/QPobjectSegment.py
@@ -54,7 +54,7 @@ class QPObjectSegmenter:
 
         dlg = wx.SingleChoiceDialog(
                 None, 'choose the image which contains labels', 'Use Segmentation',
-                dsviewer.openViewers.keys(),
+                list(dsviewer.openViewers.keys()),
                 wx.CHOICEDLG_STYLE
                 )
 

--- a/PYME/LMVis/Extras/clusterAnalysis.py
+++ b/PYME/LMVis/Extras/clusterAnalysis.py
@@ -396,7 +396,7 @@ class ClusterAnalyser:
 
     def OnRipleys(self, event=None, mask=None):
         """
-        Run's  masked Ripley's K or L on the current dataset.
+        Run's  masked Ripley's K, L or H on the current dataset.
         """
         from PYME.recipes.pointcloud import Ripleys
         import matplotlib.pyplot as plt
@@ -411,16 +411,15 @@ class ClusterAnalyser:
     
             fig = plt.figure()
             ax = fig.add_subplot(111)
-            if r.normalization == 'L':
+            if r.normalization == 'L' or r.normalization == 'H':
                 ax.axhline(y=0, c='k', linestyle='--')
-                ax.set_ylabel('L')
             else:
                 if np.count_nonzero(pipeline['z']) == 0:
                     ax.plot(result['bins'], np.pi * (result['bins'] + r.binSize) ** 2, c='k', linestyle='--')
                 else:
                     ax.plot(result['bins'], np.pi * (4.0 / 3.0) * np.pi * (result['bins'] + r.binSize) ** 3,
                             c='k', linestyle='--')
-                ax.set_ylabel('K')
+            ax.set_ylabel(r.normalization)
             ax.plot(result['bins'], result['vals'], c='r')
             ax.set_xlabel('Distance (nm)')
 

--- a/PYME/LMVis/Extras/clusterAnalysis.py
+++ b/PYME/LMVis/Extras/clusterAnalysis.py
@@ -421,7 +421,7 @@ class ClusterAnalyser:
                     ax.plot(result['bins'], np.pi * (4.0 / 3.0) * np.pi * (result['bins'] + r.binSize) ** 3,
                             c='k', linestyle='--')
                 ax.set_ylabel('K')
-            ax.scatter(result['bins'], result['vals'], s=0.1, c='r')
+            ax.plot(result['bins'], result['vals'], c='r')
             ax.set_xlabel('Distance (nm)')
 
             

--- a/PYME/recipes/pointcloud.py
+++ b/PYME/recipes/pointcloud.py
@@ -272,7 +272,7 @@ class Ripleys(ModuleBase):
             if mask.data.shape[2] < 2:
                 raise RuntimeError('Need a 3D mask to run in 3D. Generate a 3D mask or select 2D.')
             three_d = True
-        if self.dimension == '2D':
+        else:
             if mask.data.shape[2] > 1:
                 raise RuntimeError('Need a 2D mask.')
             three_d = False

--- a/PYME/recipes/pointcloud.py
+++ b/PYME/recipes/pointcloud.py
@@ -251,11 +251,12 @@ class Ripleys(ModuleBase):
     inputPositions = Input('input')
     inputMask = Input('')
     outputName = Output('ripleys')
-    normalization = Enum(['K', 'L'])
+    normalization = Enum(['K', 'L', 'H'])
     nbins = Int(50)
     binSize = Float(50.)
     sampling = Float(5.)
     threaded = Bool(False)
+    dimension = Enum(['2D', '3D'])
     
     def execute(self, namespace):
         from PYME.Analysis.points import ripleys
@@ -263,8 +264,18 @@ class Ripleys(ModuleBase):
         
         points_real = namespace[self.inputPositions]
         mask = namespace.get(self.inputMask, None)
-        
-        three_d = np.count_nonzero(points_real['z']) > 0
+
+        # three_d = np.count_nonzero(points_real['z']) > 0
+        if self.dimension == '3D':
+            if np.count_nonzero(points_real['z']) == 0:
+                raise RuntimeError('Need a 3D dataset')
+            if mask.data.shape[2] < 2:
+                raise RuntimeError('Need a 3D mask to run in 3D. Generate a 3D mask or select 2D.')
+            three_d = True
+        if self.dimension == '2D':
+            if mask.data.shape[2] > 1:
+                raise RuntimeError('Need a 2D mask.')
+            three_d = False
         
         try:
             origin_coords = MetaDataHandler.origin_nm(points_real.mdh)
@@ -284,6 +295,10 @@ class Ripleys(ModuleBase):
             d = 3 if three_d else 2
             bb, L = ripleys.ripleys_l(bb, K, d)
             res = tabular.DictSource({'bins': bb, 'vals': L})
+        elif self.normalization == 'H':
+            d = 3 if three_d else 2
+            bb, H = ripleys.ripleys_h(bb, K, d)
+            res = tabular.DictSource({'bins': bb, 'vals': H})
         else:
             res = tabular.DictSource({'bins': bb, 'vals': K})
         


### PR DESCRIPTION
GUI and nomenclature (L vs. H)  tweaks. Fix to 2D voxel size. Fix for mask/image registration.

Re: registration fix. I have a real data example where

```
Mask origin: 33524.79315970354, 26741.4607524257, 0
Coord origin: 47520.0, 0.0, 0
```

Subtracting the coordinate origin from the mask origin resulted in a massive shift of mask points away from the real data, causing Ripley's to indicate dispersion where there is none. We didn't notice this on generated data (wormlike chain) because their coordinate origin is `(0,0,0)`.