### PR TITLE
spool panel gui consistency improvements

### DIFF
--- a/PYME/Acquire/Protocols/htsms-calibration.py
+++ b/PYME/Acquire/Protocols/htsms-calibration.py
@@ -8,7 +8,6 @@ taskList = [
     T(0, scope.focus_lock.DisableLock),
     T(maxint, scope.turnAllLasersOff),
     # T(maxint, scope.focus_lock.EnableLock),
-    # T(maxint, scope.spoolController.LaunchAnalysis)
 ]
 
 metaData = [

--- a/PYME/Acquire/Protocols/htsms-flow.py
+++ b/PYME/Acquire/Protocols/htsms-flow.py
@@ -7,8 +7,7 @@ taskList = [
     T(0, scope.focus_lock.DisableLock),
     # T(8000, scope.l560.TurnOn),
     # T(maxint, scope.turnAllLasersOff),
-    T(maxint, scope.focus_lock.EnableLock),
-    T(maxint, scope.spoolController.LaunchAnalysis)  # todo - add this back in
+    T(maxint, scope.focus_lock.EnableLock)
 ]
 
 metaData = [

--- a/PYME/Acquire/Protocols/htsms-staggered.py
+++ b/PYME/Acquire/Protocols/htsms-staggered.py
@@ -7,8 +7,7 @@ taskList = [
     T(0, scope.focus_lock.DisableLock),
     T(8000, scope.l560.TurnOn),
     T(maxint, scope.turnAllLasersOff),
-    T(maxint, scope.focus_lock.EnableLock),
-    T(maxint, scope.spoolController.LaunchAnalysis)
+    T(maxint, scope.focus_lock.EnableLock)
 ]
 
 metaData = [

--- a/PYME/Acquire/Protocols/htsms-two-color.py
+++ b/PYME/Acquire/Protocols/htsms-two-color.py
@@ -7,8 +7,7 @@ taskList = [
     T(-1, scope.l560.TurnOn),
     T(0, scope.focus_lock.DisableLock),
     T(maxint, scope.turnAllLasersOff),
-    T(maxint, scope.focus_lock.EnableLock),
-    T(maxint, scope.spoolController.LaunchAnalysis)
+    T(maxint, scope.focus_lock.EnableLock)
 ]
 
 metaData = [

--- a/PYME/Acquire/ui/AnalysisSettingsUI.py
+++ b/PYME/Acquire/ui/AnalysisSettingsUI.py
@@ -28,20 +28,25 @@ class AnalysisSettingsPanel(wx.Panel):
         self.fitFactories = PYME.localization.FitFactories.resFitFactories
 
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.cbLocalizeInRealTime = wx.CheckBox(self, -1, 'Localize in real time')
+        self.cbLocalizeInRealTime.SetValue(False)
+        self.cbLocalizeInRealTime.Bind(wx.EVT_CHECKBOX, lambda e: self.analysisSettings.SetPropagate(e.IsChecked()))
+        hsizer.Add(self.cbLocalizeInRealTime, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        vsizer.Add(hsizer, 0, wx.EXPAND | wx.ALL, 4)
 
+        # todo - uncomment once we've got pymevisualize opening / get_h5r_part with slice
+        # hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        # self.cbVisualizeLive = wx.CheckBox(self, -1, 'PYMEVisualize live view')
+        # self.cbVisualizeLive.SetValue(False)
+        # hsizer.Add(self.cbVisualizeLive, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+        # vsizer.Add(hsizer, 0, wx.EXPAND | wx.ALL, 4)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
         hsizer.Add(wx.StaticText(self, -1, 'Type:'), 0,wx.RIGHT|wx.ALIGN_CENTER_VERTICAL, 5)
         self.cFitType = wx.Choice(self, -1, choices = ['{:<35} - {:} '.format(f, PYME.localization.FitFactories.useFor[f]) for f in self.fitFactories], size=(110, -1))
-        #self.cFitType.SetSelection(self.fitFactories.index('LatGaussFitFR'))
         self.cFitType.Bind(wx.EVT_CHOICE, self.OnFitModuleChanged)
         
         hsizer.Add(self.cFitType, 1, wx.ALIGN_CENTER_VERTICAL, 0)
-        vsizer.Add(hsizer, 0, wx.EXPAND|wx.ALL, 4)
-        
-        hsizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.cbLogSettings = wx.CheckBox(self, -1, 'Save analysis settings to metadata')
-        self.cbLogSettings.SetValue(False)
-        self.cbLogSettings.Bind(wx.EVT_CHECKBOX, lambda e : self.analysisSettings.SetPropagate(e.IsChecked()))
-        hsizer.Add(self.cbLogSettings, 1, wx.ALIGN_CENTER_VERTICAL, 0)
         vsizer.Add(hsizer, 0, wx.EXPAND|wx.ALL, 4)
         
         self.SetSizerAndFit(vsizer)

--- a/PYME/Acquire/ui/AnalysisSettingsUI.py
+++ b/PYME/Acquire/ui/AnalysisSettingsUI.py
@@ -28,7 +28,7 @@ class AnalysisSettingsPanel(wx.Panel):
         self.fitFactories = PYME.localization.FitFactories.resFitFactories
 
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.cbLocalizeInRealTime = wx.CheckBox(self, -1, 'Localize in real time')
+        self.cbLocalizeInRealTime = wx.CheckBox(self, -1, 'Auto-start localization')
         self.cbLocalizeInRealTime.SetValue(False)
         self.cbLocalizeInRealTime.Bind(wx.EVT_CHECKBOX, lambda e: self.analysisSettings.SetPropagate(e.IsChecked()))
         hsizer.Add(self.cbLocalizeInRealTime, 1, wx.ALIGN_CENTER_VERTICAL, 0)

--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -131,7 +131,7 @@ class PanSpool(afp.foldingPane):
         spoolDirSizer.Add(hsizer, 0, wx.LEFT | wx.RIGHT | wx.EXPAND, 0)
     
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.stSpoolDirName = wx.StaticText(pan, -1, 'Save images in: Blah Blah', size=wx.Size(136, -1))
+        self.stSpoolDirName = wx.StaticText(pan, -1, 'Save images in:', size=wx.Size(136, -1))
         hsizer.Add(self.stSpoolDirName, 5, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, 5)
     
         self.bSetSpoolDir = wx.Button(pan, -1, 'Set', style=wx.BU_EXACTFIT)
@@ -259,7 +259,7 @@ class PanSpool(afp.foldingPane):
     
         hsizer.Add(self.bStopSpooling, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
     
-        self.bAnalyse = wx.Button(self.spoolProgPan, -1, 'Analyse', style=wx.BU_EXACTFIT)
+        self.bAnalyse = wx.Button(self.spoolProgPan, -1, 'Open Series', style=wx.BU_EXACTFIT)
         self.bAnalyse.Enable(False)
         self.bAnalyse.Bind(wx.EVT_BUTTON, self.OnBAnalyse)
     

--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -293,7 +293,7 @@ class PanSpool(afp.foldingPane):
         self.AddNewElement(clp)
 
         #analysis settings
-        clp = afp.collapsingPane(self, caption='Real time analysis ...')
+        clp = afp.collapsingPane(self, caption='Automatic analysis ...')
 
         self.scope.analysisSettings = AnalysisSettingsUI.AnalysisSettings() #Move me???
 

--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -259,11 +259,11 @@ class PanSpool(afp.foldingPane):
     
         hsizer.Add(self.bStopSpooling, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
     
-        self.bAnalyse = wx.Button(self.spoolProgPan, -1, 'Open Series', style=wx.BU_EXACTFIT)
-        self.bAnalyse.Enable(False)
-        self.bAnalyse.Bind(wx.EVT_BUTTON, self.OnBAnalyse)
+        self.open_button = wx.Button(self.spoolProgPan, -1, 'Open', style=wx.BU_EXACTFIT)
+        self.open_button.Enable(False)
+        self.open_button.Bind(wx.EVT_BUTTON, lambda e: self.spoolController.open_current_series())
     
-        hsizer.Add(self.bAnalyse, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        hsizer.Add(self.open_button, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
     
         spoolProgSizer.Add(hsizer, 0, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL, 0)
     
@@ -483,7 +483,9 @@ class PanSpool(afp.foldingPane):
             
     def OnSpoolingStarted(self, **kwargs):
         if self.spoolController.spoolType in ['Queue', 'Cluster']:
-            self.bAnalyse.Enable()
+            self.open_button.Enable()
+        else:
+            self.open_button.Disable()
 
         self.bStartSpool.Enable(False)
         #self.bStartStack.Enable(False)
@@ -504,6 +506,8 @@ class PanSpool(afp.foldingPane):
         """GUI callback to stop spooling."""
         self.spoolController.StopSpooling()
         #self.OnSpoolingStopped()
+        if self.spoolController.spoolType == 'File':
+            self.open_button.Enable()
         
     def OnSpoolingStopped(self, **kwargs):
         self.bStartSpool.Enable(True)
@@ -516,8 +520,9 @@ class PanSpool(afp.foldingPane):
         self.UpdateFreeSpace()
 
     def OnBAnalyse(self, event):
+        import warnings
+        warnings.warn('OnBAnalyse is deprecated, use scope.spoolController.open_current_series() instead')
         self.spoolController.LaunchAnalysis()
-        
     
     def _tick(self, **kwargs):
         wx.CallAfter(self.Tick)


### PR DESCRIPTION
- makes the autostart-analysis checkbox text more readable and accurate since we also use it to toggle dh5view -g 
- changes 'Analyse' button to 'Open', deprecating OnBAnalyse but leaving it effectively alone for those currently calling it through protocols
- remove `spoolController.LaunchLocalize` calls from htsms protocols now that the checkbox takes care of it