### PR TITLE
refactor HTTPRulePusher calls so they share single entry point

### DIFF
--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -399,13 +399,13 @@ class SpoolController(object):
                 subprocess.Popen('%s %s' % (dh5view_cmd, self.spooler.getURL()), shell=True)
      
     def launch_cluster_analysis(self):
-        from PYME.cluster import HTTPRulePusher
+        from PYME.cluster.HTTPRulePusher import HTTPRulePusher
         
-        seriesName = self.spooler.getURL()
+        series_name = self.spooler.getURL()
         try:
-            HTTPRulePusher.launch_localize(self.scope.analysisSettings.analysisMDH, seriesName)
+            HTTPRulePusher(series_name, self.scope.analysisSettings.analysisMDH)
         except:
-            logger.exception('Error launching analysis for %s' % seriesName)
+            logger.exception('Error launching analysis for %s' % series_name)
 
 
     def SetProtocol(self, protocolName=None, reloadProtocol=True):

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -311,22 +311,13 @@ class AnalysisController(object):
 
     def pushImagesCluster(self, image):
         from PYME.cluster import HTTPRulePusher
-        #resultsFilename = _verifyResultsFilename(genResultFileName(image.seriesName))
-        resultsFilename = _verifyClusterResultsFilename(genClusterResultFileName(image.seriesName))
-        logging.debug('Results file: ' + resultsFilename)
-
-        #debugPrint('Results file = %s' % resultsFilename)
 
         self.resultsMdh = MetaDataHandler.NestedClassMDHandler(self.analysisMDH)
         self.resultsMdh['DataFileID'] = fileID.genDataSourceID(image.dataSource)
 
-        self.pusher = HTTPRulePusher.HTTPRulePusher(dataSourceID=image.seriesName,
-                                                    metadata=self.resultsMdh, resultsFilename=resultsFilename)
+        self.pusher = HTTPRulePusher.HTTPRulePusher(image.seriesName, self.resultsMdh)
 
-        self.queueName = self.pusher.queueID
-        self.results_filename = resultsFilename
-
-        debugPrint('Queue created')
+        debugPrint('Localization rule-pusher created')
 
         #self.onImagesPushed.send(self)
             

--- a/PYME/cluster/clusterUI/localization/views.py
+++ b/PYME/cluster/clusterUI/localization/views.py
@@ -144,10 +144,7 @@ def localize(request, analysisModule='LatGaussFitFR'):
     
         for seriesName in seriesToLaunch:
             try:
-                if USE_RULES:
-                    HTTPRulePusher.launch_localize(analysisMDH, seriesName)
-                else:
-                    HTTPTaskPusher.launch_localize(analysisMDH, seriesName)
+                HTTPRulePusher.HTTPRulePusher(seriesName, analysisMDH)
             except:
                 logger.exception('Error launching analysis for %s' % seriesName)
                 

--- a/PYME/experimental/dcimgSpoolShim.py
+++ b/PYME/experimental/dcimgSpoolShim.py
@@ -168,7 +168,7 @@ class DCIMGSpoolShim(object):
             self.mdh.setEntry('Analysis.subtractBackground', True)
             self.mdh.setEntry('Analysis.GPUPCTBackground', True)
             cluster_filename = 'pyme-cluster://%s/%s' % (clusterIO.local_serverfilter, self.spooler.seriesName)
-            HTTPRulePusher.launch_localize(analysisMDH=self.mdh, seriesName=cluster_filename)
+            HTTPRulePusher.HTTPRulePusher(cluster_filename, self.mdh)
 
         #remove the metadata generator
         MetaDataHandler.provideStartMetadata.remove(self.metadataSource)


### PR DESCRIPTION
additionally:
- pulls startAt/current frame number from analysis metadata rather than making it up
- removes some superfluous unused parameters of `HTTPRulePusher.__init__`
- moves copy of events from datasource to localization results file to after rule pushing is complete (such that events will be complete)