### PR TITLE
Dataserver get tabular part endpoint

### DIFF
--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -756,6 +756,7 @@ class LMAnalyser2(object):
 
     def _refresh_analysis_cluster(self):
         import requests
+        from io import BytesIO
         try:
             # import cPickle on py2
             import cPickle as pickle
@@ -766,7 +767,8 @@ class LMAnalyser2(object):
         newNumAnalysed = int(queueInfo[self.analysisController.pusher._ruleID]['tasksCompleted'])
         if newNumAnalysed > self.numAnalysed:
             self.numAnalysed = newNumAnalysed
-            newResults = pickle.loads(requests.get(self.analysisController.pusher.resultsURI.replace('__aggregate_h5r/', '') + '/FitResults.npy?from=%d' % len(self.fitResults)).content)
+            cont = requests.get(self.analysisController.pusher.resultsURI.replace('__aggregate_h5r/', '') + '/FitResults.npy?from=%d' % len(self.fitResults)).content
+            newResults = np.load(BytesIO(cont))
             self._add_new_results(newResults)
         
 

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -766,7 +766,7 @@ class LMAnalyser2(object):
         newNumAnalysed = int(queueInfo[self.analysisController.pusher._ruleID]['tasksCompleted'])
         if newNumAnalysed > self.numAnalysed:
             self.numAnalysed = newNumAnalysed
-            newResults = pickle.loads(requests.get(self.analysisController.pusher.resultsURI.replace('__aggregate_h5r/', '') + '/FitResults?from=%d' % len(self.fitResults)).content)
+            newResults = pickle.loads(requests.get(self.analysisController.pusher.resultsURI.replace('__aggregate_h5r/', '') + '/FitResults.npy?from=%d' % len(self.fitResults)).content)
             self._add_new_results(newResults)
         
 

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -767,8 +767,14 @@ class LMAnalyser2(object):
         newNumAnalysed = int(queueInfo[self.analysisController.pusher._ruleID]['tasksCompleted'])
         if newNumAnalysed > self.numAnalysed:
             self.numAnalysed = newNumAnalysed
+            
+            # load from server as pickle (try this instead of numpy loading to get around np.load slowness if performance is an issue)
+            #newResults = pickle.loads(requests.get(self.analysisController.pusher.resultsURI.replace('__aggregate_h5r/', '') + '/FitResults?from=%d' % len(self.fitResults)).content)
+            
+            # load from server as .npy
             cont = requests.get(self.analysisController.pusher.resultsURI.replace('__aggregate_h5r/', '') + '/FitResults.npy?from=%d' % len(self.fitResults)).content
             newResults = np.load(BytesIO(cont))
+            
             self._add_new_results(newResults)
         
 

--- a/PYME/IO/clusterResults.py
+++ b/PYME/IO/clusterResults.py
@@ -126,12 +126,14 @@ def format_results(data_raw, URI=''):
             df = pd.DataFrame(data_raw)
             data = df.to_csv()
     
-    elif URI.endswith('.json'):
+    elif URI.endswith('.json') or isinstance(data_raw, MetaDataHandler.MDHandlerBase):  # todo - do we need to keep this metadatahandler special case?
         output_format = 'text/json'
         if isinstance(data_raw, bytes):
             data = data_raw
         elif isinstance(data_raw, str):
             data = data_raw.encode()
+        elif hasattr(data_raw, 'to_JSON'):
+            data = data_raw.to_JSON().encode()
         else:
             import pandas as pd
             df = pd.DataFrame(data_raw)
@@ -154,10 +156,6 @@ def format_results(data_raw, URI=''):
     elif isinstance(data_raw, np.ndarray):
         #very reluctantly use pickle to serialize numpy arrays rather than the better .npy format as reading .npy is really slow.
         data = data_raw.dumps()
-    
-    elif isinstance(data_raw, MetaDataHandler.MDHandlerBase):
-        output_format = 'text/json'
-        data = data_raw.to_JSON().encode()
     
     else:
         logging.warning('No handler for data type found, using pickle')

--- a/PYME/IO/clusterResults.py
+++ b/PYME/IO/clusterResults.py
@@ -111,7 +111,9 @@ def pickResultsServer(filename, serverfilter=clusterIO.local_serverfilter):
 
 
 def format_results(data_raw, URI=''):
-    # translate data into wire format
+    """
+    translate data into wire format
+    """
     output_format = None
     
     if URI.endswith('.csv') or URI.endswith('.txt') or URI.endswith('.log'):
@@ -134,6 +136,9 @@ def format_results(data_raw, URI=''):
             data = data_raw.encode()
         elif hasattr(data_raw, 'to_JSON'):
             data = data_raw.to_JSON().encode()
+        elif isinstance(data_raw, np.ndarray):
+            from PYME.IO.tabular import unnest_recarray_to_json
+            data = unnest_recarray_to_json(data_raw).encode()
         else:
             import pandas as pd
             df = pd.DataFrame(data_raw)

--- a/PYME/IO/clusterResults.py
+++ b/PYME/IO/clusterResults.py
@@ -110,7 +110,7 @@ def pickResultsServer(filename, serverfilter=clusterIO.local_serverfilter):
 
 
 
-def format_results(URI, data_raw):
+def format_results(data_raw, URI=''):
     # translate data into wire format
     output_format = None
     
@@ -167,7 +167,7 @@ def format_results(URI, data_raw):
     return data, output_format
 
 def fileResults(URI, data_raw):
-    data, output_format = format_results(URI, data_raw)
+    data, output_format = format_results(data_raw, URI)
 
     #now do URI translation
     if '__aggregate' in URI and URI.startswith('PYME-CLUSTER') or URI.startswith('pyme-cluster'):

--- a/PYME/IO/clusterResults.py
+++ b/PYME/IO/clusterResults.py
@@ -136,11 +136,12 @@ def format_results(data_raw, URI=''):
             data = data_raw.encode()
         elif hasattr(data_raw, 'to_JSON'):
             data = data_raw.to_JSON().encode()
-        elif isinstance(data_raw, np.ndarray):
-            from PYME.IO.tabular import unnest_recarray_to_json
-            data = unnest_recarray_to_json(data_raw).encode()
         else:
             import pandas as pd
+            if isinstance(data_raw, np.ndarray):
+                from PYME.IO.tabular import unnest_dtype
+                data_raw = data_raw.view(unnest_dtype(data_raw.dtype))
+            
             df = pd.DataFrame(data_raw)
             data = df.to_json().encode()
     

--- a/PYME/IO/clusterResults.py
+++ b/PYME/IO/clusterResults.py
@@ -128,7 +128,7 @@ def format_results(data_raw, URI=''):
             df = pd.DataFrame(data_raw)
             data = df.to_csv()
     
-    elif URI.endswith('.json') or isinstance(data_raw, MetaDataHandler.MDHandlerBase):  # todo - do we need to keep this metadatahandler special case?
+    elif URI.endswith('.json'):
         output_format = 'text/json'
         if isinstance(data_raw, bytes):
             data = data_raw
@@ -161,6 +161,12 @@ def format_results(data_raw, URI=''):
     elif isinstance(data_raw, np.ndarray):
         #very reluctantly use pickle to serialize numpy arrays rather than the better .npy format as reading .npy is really slow.
         data = data_raw.dumps()
+    
+    elif isinstance(data_raw, MetaDataHandler.MDHandlerBase):
+        # NB - this may be redundant as we usually request metadata.json which will get caught and handled by the .endswith('json') cas above
+        # keeping for now in case we want to change default metadata handling and/or also support .xml or .md formats
+        output_format = 'text/json'
+        data = data_raw.to_JSON().encode()
     
     else:
         logging.warning('No handler for data type found, using pickle')

--- a/PYME/IO/h5rFile.py
+++ b/PYME/IO/h5rFile.py
@@ -154,6 +154,21 @@ class H5RFile(object):
             self.appendQueues[tablename].append(data)
 
     def getTableData(self, tablename, _slice):
+        """
+        Retrieves a tables.table.Table from the file and returns it as a structured numpy array
+
+        Parameters
+        ----------
+        tablename: str
+            name of table to return
+        _slice: slice
+            slice object to index the table
+
+        Returns
+        -------
+        table_part: numpy.ndarray
+
+        """
         with tablesLock:
             try:
                 table = getattr(self._h5file.root, tablename)

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -250,6 +250,8 @@ class FitResultsSource(TabularBase):
             self.fitResults.sort(order='tIndex')
 
         #allow access using unnested original names
+        # TODO - replace with unnest_dtype(self.fitResults.dtype).names
+        # TODO???? - replace key translation with a np.view call?
         self._keys = unNestDtype(self.fitResults.dtype.descr)
         
         #or shorter aliases

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -572,6 +572,9 @@ class MatfileColumnSource(TabularBase):
 
 @deprecated_name('recArrayInput')
 class RecArraySource(TabularBase):
+    """
+    Source for flat recarrays. To create a recarray with nested elements see NestedRecArraySource
+    """
     _name = 'RecArray Source'
     def __init__(self, recordArray):
         self.recArray = recordArray
@@ -593,9 +596,14 @@ class RecArraySource(TabularBase):
 
 
 class NestedRecArraySource(TabularBase):
+    """
+    Source for nested structured arrays as one would get if they slice a FitResults table. Mimics the nesting/unnesting
+    keys used in FitResultsSource
+    """
     _name = 'NestedRecArraySource'
     def __init__(self, array, translate_pipeline_keys=False):
-        self._array = array[:]  # if array is tables.table.Table instead of numpy array, slice it to convert
+        # table Tables need to be sliced to convert to array
+        self._array = array[:] if type(array) is tables.table.Table else array
         self._keys = unNestDtype(self._array.dtype.descr)
 
         self.transkeys = {}

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -53,6 +53,51 @@ def deprecated_name(name):
         return cls
     
     return _dec
+
+def get_unnested(fit_results, unnested_key, sl=slice(None)):
+    k = unnested_key.split('_')
+
+    if len(k) == 1:  # TODO: evaluate why these are cast as floats
+        return fit_results[k[0]][sl]
+    elif len(k) == 2:
+        return fit_results[k[0]][k[1]][sl]
+    elif len(k) == 3:
+        return fit_results[k[0]][k[1]][k[2]][sl]
+    else:
+        raise KeyError("Don't know about deeper nesting yet")
+
+def unnest_recarray(array, return_slice=slice(None)):
+    """
+    Flatten a FitResults-type structured array, such that we can easily convert to json, etc
+    Parameters
+    ----------
+    array: tables.table.Table or numpy.ndarray
+        array of whatever structure, keys will be unnested splitting on underscores, and all columns must be the same
+        length.
+    return_slice: slice
+        slice object to only return part of a datasource, if desired.
+
+    Returns
+    -------
+    a: numpy.ndarray
+        flattened numpy array with original data types for each column and names unnested with underscores.
+
+    """
+    a = array[:] if type(array) == tables.table.Table else array
+    keys, types = unNestDtype(a.dtype.descr), unnest_dtype(a.dtype.descr)
+    unnested = np.empty(len(a), dtype=list(zip(keys, types)))
+    for k in keys:
+        unnested[k] = get_unnested(a, k, return_slice)
+    return unnested
+
+def unnest_recarray_to_json(array, keys=None, return_slice=slice(None)):
+    import json
+    keys = keys if keys != None else unNestDtype(array.dtype.descr)
+    print(keys)
+    d = {}
+    for k in keys:
+        d[k] = get_unnested(array, k, return_slice).tolist()
+    return json.dumps(d)
     
 
 
@@ -208,6 +253,15 @@ def unNestDtype(descr, parent=''):
             unList += unNestDtype(n[1], parent + n[0] + '_')
     return unList
 
+def unnest_dtype(descr):
+    dt = []
+    for node in descr:
+        if isinstance(node, tuple) and len(node) == 2 and isinstance(node[1], str):
+            dt.append(node[1])
+        else:
+            dt += unnest_dtype(node[1])
+    return dt
+
 @deprecated_name('fitResultsSource')
 class FitResultsSource(TabularBase):
     _name = "recarrayfi Source"
@@ -257,9 +311,12 @@ class FitResultsSource(TabularBase):
         else:
             raise KeyError("Don't know about deeper nesting yet")
 
-
     def getInfo(self):
         return 'PYME h5r Data Source\n\n %d points' % self.fitResults.shape[0]
+
+    def to_JSON(self, keys=None, return_slice=slice(None)):
+        return unnest_fitresults_recarray_to_json(self.fitResults, keys, return_slice)
+
 
 
 class _BaseHDFSource(FitResultsSource):

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -758,9 +758,7 @@ class Pipeline:
         self.filename = filename
         
         if ds is None:
-            #load from file
-            print(filename)
-            type(filename)
+            # load from file or cluster
             if (filename.upper()).startswith('PYME-CLUSTER'):
                 ds = self._ds_from_cluster(filename)
             else:

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -696,37 +696,6 @@ class Pipeline:
 
         return ds
 
-    def _ds_from_cluster(self, uri):
-        from PYME.IO import clusterIO
-        from PYME.IO.tabular import DictSource
-        s = clusterIO._getSession(uri)
-
-        ext = '.h5r' if '.h5r' in uri else '.hdf'
-        try:
-            table_name = uri.split(ext)[1]
-        except IndexError:
-            table_name = 'FitResults'
-
-        server_filter = uri.split('://')[1].split('/')[0]
-        filename = uri.split('://%s/' % server_filter)[1].strip('/' + table_name)
-
-        loc = clusterIO.locate_file(filename, server_filter, return_first_hit=True)[0][0]
-
-        r = s.get(loc + '/' + table_name)
-        if r.status_code != 200:
-            raise IOError('Error retrieving %s from %s' % (uri, loc))
-        resp = r.json()
-        ds = DictSource({k: np.asarray(v) for k, v in resp.items()})
-        try:
-            r = s.get(loc + '/' + 'Metadata')
-            self.mdh.update(r.json())
-        except:
-            logger.warning('No metadata found for %s' % uri)
-
-        # todo - get events
-
-        return ds
-
     def OpenFile(self, filename= '', ds = None, **kwargs):
         """Open a file - accepts optional keyword arguments for use with files
         saved as .txt and .mat. These are:
@@ -758,11 +727,10 @@ class Pipeline:
         self.filename = filename
         
         if ds is None:
-            # load from file or cluster
-            if (filename.upper()).startswith('PYME-CLUSTER'):
-                ds = self._ds_from_cluster(filename)
-            else:
-                ds = self._ds_from_file(filename, **kwargs)
+            from PYME.IO import unifiedIO
+            # load from file(/cluster, downloading a copy of the file if needed)
+            with unifiedIO.local_or_temp_filename(filename) as fn:
+                ds = self._ds_from_file(fn, **kwargs)
 
             
         #wrap the data source with a mapping so we can fiddle with things

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -730,6 +730,10 @@ class Pipeline:
             from PYME.IO import unifiedIO
             # load from file(/cluster, downloading a copy of the file if needed)
             with unifiedIO.local_or_temp_filename(filename) as fn:
+                # TODO - check that loading isn't lazy (i.e. we need to make a copy of data in memory whilst in the
+                # context manager in order to be safe with unifiedIO and cluster data). From a quick look, it would seem
+                # that _ds_from_file() copies the data, but potentially keeps the file open which could be problematic.
+                # This won't effect local file loading even if loading is lazy (i.e. shouldn't cause a regression)
                 ds = self._ds_from_file(fn, **kwargs)
 
             

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -727,7 +727,8 @@ class Pipeline:
         self.filename = filename
         
         if ds is None:
-            from PYME.IO import unifiedIO
+            from PYME.IO import unifiedIO # TODO - what is the launch time penalty here for importing clusterUI and finding a nameserver?
+            
             # load from file(/cluster, downloading a copy of the file if needed)
             with unifiedIO.local_or_temp_filename(filename) as fn:
                 # TODO - check that loading isn't lazy (i.e. we need to make a copy of data in memory whilst in the

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -713,17 +713,17 @@ class Pipeline:
         loc = clusterIO.locate_file(filename, server_filter, return_first_hit=True)[0][0]
 
         r = s.get(loc + '/' + table_name)
-        # if r.status_code == 200:
-        print(r.json().keys())
+        if r.status_code != 200:
+            raise IOError('Error retrieving %s from %s' % (uri, loc))
         resp = r.json()
         ds = DictSource({k: np.asarray(v) for k, v in resp.items()})
         try:
             r = s.get(loc + '/' + 'Metadata')
-            print(r.json())
             self.mdh.update(r.json())
         except:
-            import traceback
-            traceback.format_exc()
+            logger.warning('No metadata found for %s' % uri)
+
+        # todo - get events
 
         return ds
 

--- a/PYME/cluster/HTTPDataServer.py
+++ b/PYME/cluster/HTTPDataServer.py
@@ -567,7 +567,7 @@ class PYMEHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
                 return self.list_h5(path)
             else:
                 return self.get_h5_part(path)
-        elif '.h5r' in self.path or '.hdf' in self.path:
+        elif '.h5r/' in self.path or '.hdf/' in self.path:
             return self.get_tabular_part(path)
 
         ctype = self.guess_type(path)

--- a/PYME/cluster/HTTPDataServer.py
+++ b/PYME/cluster/HTTPDataServer.py
@@ -689,11 +689,10 @@ class PYMEHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         Parameters
         ----------
         path: str
-            path to an hdf or h5r file on the dataserver computer. Specific parts of the file can be accessed by
-            appending, e.g. /Metadata, for a resulting `path` of something like folder/test.h5r/Metadata. The 'part' of
-            the file returned defaults to FitResults if unspecified, and can additionally include a slice to take before
-            returning. In other words, a `path` of 'folder/test.h5r/FitResultsslice(0,100,None)' will return the first
-            hundred elements of the FitResults table in test.h5r.
+            path to an hdf or h5r file on the dataserver computer. Append the part of the file to read after the file
+            extension, e.g. .h5r/Events. Return format (for arrays) can additionally be specified, as can slices
+            using the following syntax: test.h5r/FitResults.json?from=0&to=100. Supported array formats include json and
+            npy.
 
         Returns
         -------
@@ -704,6 +703,16 @@ class PYMEHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         from PYME.IO.tabular import NestedRecArraySource
         from PYME.IO import h5rFile
         ext = '.h5r' if '.h5r' in path else '.hdf'
+        filename, details = path.split(ext + '/')
+        filename = filename + ext  # path to file on dataserver disk
+        query = urlparse.urlparse(details).query
+        details = details.strip('?' + query)
+        if '.' in details:
+            part, return_type = details.split('.')
+        else:
+            part, return_type = details, ''
+
+
         try:
             filename, part = path.split(ext)
             ctype = self.guess_type(filename + ext)

--- a/PYME/cluster/HTTPDataServer.py
+++ b/PYME/cluster/HTTPDataServer.py
@@ -729,7 +729,7 @@ class PYMEHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
 
             f, length = self._string_to_file(wire_data)
             self.send_response(200)
-            self.send_header("Content-type", output_format if output_format else 'application/octet-stream')
+            self.send_header("Content-Type", output_format if output_format else 'application/octet-stream')
             self.send_header("Content-Length", length)
             #self.send_header("Last-Modified", self.date_time_string(fs.st_mtime))
             self.end_headers()

--- a/PYME/cluster/HTTPDataServer.py
+++ b/PYME/cluster/HTTPDataServer.py
@@ -728,7 +728,7 @@ class PYMEHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
 
             f, length = self._string_to_file(wire_data)
             self.send_response(200)
-            self.send_header("Content-type", output_format)
+            self.send_header("Content-type", output_format if output_format else 'application/octet-stream')
             self.send_header("Content-Length", length)
             #self.send_header("Last-Modified", self.date_time_string(fs.st_mtime))
             self.end_headers()

--- a/PYME/cluster/HTTPDataServer.py
+++ b/PYME/cluster/HTTPDataServer.py
@@ -721,11 +721,9 @@ class PYMEHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
                 else:
                     # figure out if we have any slicing to do
                     query = urlparse.parse_qs(query)
-                    try:
-                        return_slice = slice(int(query['from'][0]), int(query['to'][0]))
-                    except KeyError:  # no slicing
-                        return_slice = slice(None)
-                    wire_data, output_format = clusterResults.format_results(h5f.getTableData(part, return_slice),
+                    start = int(query.get('from', [0])[0])
+                    end = None if 'to' not in query.keys() else int(query['to'][0])
+                    wire_data, output_format = clusterResults.format_results(h5f.getTableData(part, slice(start, end)),
                                                                              '.' + return_type)
 
             f, length = self._string_to_file(wire_data)

--- a/PYME/cluster/HTTPDataServer.py
+++ b/PYME/cluster/HTTPDataServer.py
@@ -569,7 +569,8 @@ class PYMEHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
             else:
                 return self.get_h5_part(path)
         elif '.h5r/' in self.path or '.hdf/' in self.path:
-            return self.get_tabular_part(path)
+            # throw the query back on to our fully resolved path
+            return self.get_tabular_part(path + '?' + urlparse.urlparse(self.path).query)
 
         ctype = self.guess_type(path)
         try:


### PR DESCRIPTION
Adds a nested recarray source to PYME tabular, with a to_json method such that we can read/slice part of a table and return it as json. Submitting this PR early for feedback.

This would be a precursor to a tabular.HTTPSource which would have a polling flag to update periodically as localizations are added for live preview. In the mean time I implemented a simplistic load for visgui (which does not allow slicing during retrieval or viewing part of a tabular other than 'FitResults').

Events would be nice to handle using a base class with a to_json method. At the moment I haven't done anything there.