### PR TITLE
py3 compat fix for new ruleserver ui

### DIFF
--- a/PYME/cluster/cluster_of_one.py
+++ b/PYME/cluster/cluster_of_one.py
@@ -74,7 +74,7 @@ class ClusterOfOne(object):
         from . import distribution
         ns = sqlite_ns.getNS('_pyme-taskdist')
         ruleservers = distribution.getDistributorInfo(ns)
-        webbrowser.open_new_tab(ruleservers.values()[0])
+        webbrowser.open_new_tab(list(ruleservers.values())[0])
             
             
     def shutdown(self):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/miniconda3/bin/pymeclusterofone", line 11, in <module>
    load_entry_point('PYME', 'console_scripts', 'PYMEClusterOfOne')()
  File "/Users/Andrew/code/python-microscopy/PYME/cluster/cluster_of_one.py", line 178, in main
    cluster.launch(gui=options.ui, clusterUI=options.clusterui)
  File "/Users/Andrew/code/python-microscopy/PYME/cluster/cluster_of_one.py", line 100, in launch
    self._launch_ruleserver_ui()
  File "/Users/Andrew/code/python-microscopy/PYME/cluster/cluster_of_one.py", line 77, in _launch_ruleserver_ui
    webbrowser.open_new_tab(ruleservers.values()[0])
TypeError: 'dict_values' object does not support indexing
```