### PR TITLE
py2 zip returns list of tuple, py3 returns zip object which can't be directly json serialized

### DIFF
--- a/PYME/IO/h5File.py
+++ b/PYME/IO/h5File.py
@@ -109,7 +109,7 @@ class H5File(h5rFile.H5RFile):
         elif filename == 'events.json':
             try:
                 events = self._h5file.root.Events[:]
-                return json.dumps(zip(events['EventName'], events['EventDescr'], events['Time']))
+                return json.dumps(list(zip(events['EventName'], events['EventDescr'], events['Time'])))
             except AttributeError:
                 raise IOError('File has no events')
             #raise NotImplementedError('reading events not yet implemented')


### PR DESCRIPTION
should also work on py2:
```
Python 2.7.18 |Anaconda, Inc.| (default, Apr 23 2020, 17:44:47) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import json
>>> zip([0], [1], [2])
[(0, 1, 2)]
>>> list(zip([0], [1], [2]))
[(0, 1, 2)]

```