### PR TITLE
Compute statistics on a Ripley's analysis

### DIFF
--- a/PYME/Analysis/points/ripleys.py
+++ b/PYME/Analysis/points/ripleys.py
@@ -90,7 +90,7 @@ def points_from_mask(mask, sampling, three_d=True, coord_origin=(0,0,0)):
             Offset in nm of the x, y, and z coordinates w.r.t. the camera 
             origin (used to make sure mask aligns)
     """
-    vx, vy, vz = mask.voxelsize
+    vx, vy, vz = mask.voxelsize_nm
     x0_m, y0_m, z0_m = mask.origin
     x0_p, y0_p, z0_p = coord_origin
 
@@ -142,11 +142,11 @@ def mc_points_from_mask(mask, n_points, three_d=True, coord_origin=(0,0,0)):
             Offset in nm of the x, y, and z coordinates w.r.t. the camera 
             origin (used to make sure mask aligns)
     """
-    vx, vy, vz = mask.voxelsize
+    vx, vy, vz = mask.voxelsize_nm
     x0_m, y0_m, z0_m = mask.origin
     x0_p, y0_p, z0_p = coord_origin
 
-    eps = 0.1  # scaling fudge factor
+    eps = 0.2  # scaling fudge factor
 
     if three_d:
         #convert mask to boolean image
@@ -228,6 +228,7 @@ def mc_sampling_statistics(K, n_points, n_bins, bin_size, mask, three_d,
     for _i in range(n_sim):
         print('Simulation {} ...'.format(_i))
         xm, ym, zm = mc_points_from_mask(mask, n_points, three_d, coord_origin)
+        print(xm.shape)
         _, K_arr[_i,:] = ripleys_k_from_mask_points(x=xm, y=ym, z=zm,
                                     xu=xu, yu=yu, zu=zu,
                                     n_bins=n_bins, bin_size=bin_size, mask_area=mask_area, 

--- a/PYME/Analysis/points/ripleys.py
+++ b/PYME/Analysis/points/ripleys.py
@@ -236,8 +236,8 @@ def mc_sampling_statistics(K, n_points, n_bins, bin_size, mask, three_d,
     # 
     # Definition of one-tailed p-value: we check the probability that our 
     # simulation K-values are greater than or equal to the real data 
-    # K-values given that we expect no relationship between the simulated
-    # and real distributions (null hypothesis)
+    # K-values given that we expect no the simulated and real values
+    # to be drawn from the same distributions (null hypothesis)
     p_clustered = ((K_arr>=K).sum(0) + 1)/(n_sim + 1)
     p_dispersed = ((K_arr<=K).sum(0) + 1)/(n_sim + 1)
     return K_min, K_max, p_clustered, p_dispersed

--- a/PYME/Analysis/points/ripleys.py
+++ b/PYME/Analysis/points/ripleys.py
@@ -72,7 +72,22 @@ def ripleys_k_from_mask_points(x, y, xu, yu, n_bins, bin_size, mask_area, z=None
     # return bins, K-function
     return bb, K
 
-def points_from_mask(mask, sampling, three_d = True, coord_origin=(0,0,0)):
+def points_from_mask(mask, sampling, three_d=True, coord_origin=(0,0,0)):
+    """
+    Calculate coordinate positions in nm from a regularly-sampled mask.
+
+    Parameters
+    ----------
+        mask : np.array
+            Mask image (array of 0s and 1s)
+        sampling : float
+            Sampling rate of mask image in nm.
+        three_d : bool
+            Return 2D or 3D coordinates
+        coord_origin : 3-tuple
+            Offset in nm of the x, y, and z coordinates w.r.t. the camera 
+            origin (used to make sure mask aligns)
+    """
     vx, vy, vz = mask.voxelsize
     x0_m, y0_m, z0_m = mask.origin
     x0_p, y0_p, z0_p = coord_origin
@@ -106,14 +121,72 @@ def points_from_mask(mask, sampling, three_d = True, coord_origin=(0,0,0)):
         mask_area = bool_mask.sum() * vx * vy
         
     return xu, yu, zu, mask_area
-    
 
-def ripleys_k(x, y, n_bins, bin_size, mask=None, bbox=None, z=None, threaded=False, sampling=5.0, coord_origin=(0,0,0)):
+def mc_points_from_mask(mask, n_points, three_d=True, coord_origin=(0,0,0)):
+    """
+    Calculate coordinate positions in nm from a Monte-Carlo-sampled mask.
+
+    Parameters
+    ----------
+        mask : np.array
+            Mask image (array of 0s and 1s)
+        n_points : int
+            Number of points to return.
+        three_d : bool
+            Return 2D or 3D coordinates
+        coord_origin : 3-tuple
+            Offset in nm of the x, y, and z coordinates w.r.t. the camera 
+            origin (used to make sure mask aligns)
+    """
+    vx, vy, vz = mask.voxelsize
+    x0_m, y0_m, z0_m = mask.origin
+    x0_p, y0_p, z0_p = coord_origin
+
+    eps = 0.1  # scaling fudge factor
+
+    if three_d:
+        #convert mask to boolean image
+        bool_mask = np.atleast_3d(mask.data[:, :, :, 0].squeeze()) > 0.5
+        mask_area = bool_mask.sum()
+
+        # Scale up number of points to simulate so we still have n_points left 
+        # after the Monte-Carlo rejection step
+        n_sim = int((np.prod(bool_mask.shape)/mask_area + eps)*n_points)
+        
+        # generate randomly sampled coordinates on mask
+        xu, yu, zu = (np.random.rand(n_sim,3)*[bool_mask.shape[0],bool_mask.shape[1],bool_mask.shape[2]]).T
+        # Find corresponding (xu, yu, zu) in the mesj
+        point_mask = bool_mask[xu.astype(int), yu.astype(int), zu.astype(int)]
+        # Monte-Carlo reject points outside of the mask and shift points inside to coordinate position
+        xu, yu, zu = vx * xu[point_mask] + x0_m - x0_p, vy * yu[
+            point_mask] + y0_m - y0_p, vz * zu[point_mask] + z0_m - z0_p
+        
+        mask_area *= vx * vy * vz
+    else:
+        bool_mask = mask.data[:, :, :, 0].squeeze() > 0.5
+        if bool_mask.ndim > 2:
+            raise RuntimeError('Trying to calculate 2D Ripleys with 3D mask')
+        mask_area = bool_mask.sum()
+
+        n_sim = int((np.prod(bool_mask.shape)/mask_area + eps)*n_points)
+        
+        zu = None
+        xu, yu = (np.random.rand(n_sim,2)*[bool_mask.shape[0],bool_mask.shape[1]]).T
+        point_mask = bool_mask[xu.astype(int), yu.astype(int)]
+        xu, yu = vx * xu[point_mask] + x0_m - x0_p, vy * yu[point_mask] + y0_m - y0_p
+        mask_area *= vx * vy
+
+    # Truncate
+    xu, yu, zu = xu[:n_points], yu[:n_points], zu[:n_points] if zu is not None else None
+
+    return xu, yu, zu, mask_area
+
+def ripleys_k(x, y, n_bins, bin_size, mask=None, bbox=None, z=None, threaded=False, mc=False, n_sim=100, sampling=5.0, coord_origin=(0,0,0)):
     """
     Ripley's K-function for examining clustering and dispersion of points within a
     region R, where R is defined by a mask (2D or 3D) of the data.
     
-    x : np.array
+        x : np.array
             x-position of raw data
         y : np.array
             y-position of raw data
@@ -124,15 +197,23 @@ def ripleys_k(x, y, n_bins, bin_size, mask=None, bbox=None, z=None, threaded=Fal
         mask : PYME.IO.image.ImageStack
             a mask of allowing the Ripleys to be computed within a given area
         bbox : optional, a tuple (x0, y0, x1, y1), or (x0, y0, z0, x1, y1, z1)
-            bounding box of the region to consider if no mask provided (defaults to min and max of supplied data)
+            bounding box of the region to consider if no mask provided 
+            (defaults to min and max of supplied data)
         z : optional, np.array
             z-position of raw data
         threaded : bool
             Calculate pairwise distances using multithreading (faster)
+        mc : bool
+            Monte-Carlo sampling of the structure to determine clustering/
+            dispersion probability.
+        n_sim : int
+            Number of Monte-Carlo simulations to run. More simulations = 
+            more statistical power.
         sampling : float
             spacing (in nm) of samples from mask / region.
         coord_origin : 3-tuple
-            Offset in nm of the x, y, and z coordinates w.r.t. the camera origin (used to make sure mask aligns)
+            Offset in nm of the x, y, and z coordinates w.r.t. the camera 
+            origin (used to make sure mask aligns)
 
     """
     three_d = z is not None
@@ -158,10 +239,27 @@ def ripleys_k(x, y, n_bins, bin_size, mask=None, bbox=None, z=None, threaded=Fal
     yu = yu.ravel()
     if zu is not None:
         zu = zu.ravel()
-            
-    return ripleys_k_from_mask_points(x=x, y=y, z=z,
+
+    bb, K = ripleys_k_from_mask_points(x=x, y=y, z=z,
                                       xu=xu, yu=yu, zu=zu,
                                       n_bins=n_bins, bin_size=bin_size, mask_area=mask_area, threaded=threaded)
+
+    if mc:
+        # Monte-Carlo simulations on the mask
+        K_arr = np.zeros((n_sim,len(K)))
+        for _i in range(n_sim):
+            xm, ym, zm, _ = mc_points_from_mask(mask, len(x), three_d, coord_origin)
+            _, K_arr[_i,:] = ripleys_k_from_mask_points(x=xm, y=ym, z=zm,
+                                      xu=xu, yu=yu, zu=zu,
+                                      n_bins=n_bins, bin_size=bin_size, mask_area=mask_area, threaded=threaded)
+        # Envelope
+        K_min = np.min(K_arr, axis=0)
+        K_max = np.max(K_arr, axis=0)
+        # Probability our original data is clustered
+        p_clustered = ((K_arr>=K).sum(0) + 1)/(n_sim + 1)
+        return bb, K, K_min, K_max, p_clustered
+    # Return the normal Ripleys
+    return bb, K
         
         
 

--- a/PYME/Analysis/points/ripleys.py
+++ b/PYME/Analysis/points/ripleys.py
@@ -239,7 +239,8 @@ def mc_sampling_statistics(K, n_points, n_bins, bin_size, mask, three_d,
     # K-values given that we expect no relationship between the simulated
     # and real distributions (null hypothesis)
     p_clustered = ((K_arr>=K).sum(0) + 1)/(n_sim + 1)
-    return K_min, K_max, p_clustered
+    p_dispersed = ((K_arr<=K).sum(0) + 1)/(n_sim + 1)
+    return K_min, K_max, p_clustered, p_dispersed
 
 def ripleys_k(x, y, n_bins, bin_size, mask=None, bbox=None, z=None, 
                 threaded=False, sampling=5.0, coord_origin=(0,0,0)):

--- a/PYME/LMVis/Extras/clusterAnalysis.py
+++ b/PYME/LMVis/Extras/clusterAnalysis.py
@@ -439,16 +439,22 @@ class ClusterAnalyser:
                 ax.plot(result['bins'], result['min'], c='k', linestyle=':')
                 ax.plot(result['bins'], result['max'], c='k', linestyle=':')
 
-                # Create a new plot for the p-values
-                fig_p = plt.figure()
-                ax_p = fig_p.add_subplot(111)
-                ax_p.plot(result['bins'], result['p'], c='k')
-                ax_p.set_xlabel('Distance (nm)')
-                ax_p.set_ylabel('P-value (clustered)')
-                ax_p.set_title('Clustering significance')
-                p_sig = 1.0/r.nsim
-                ax_p.axhline(y=p_sig, c='r', linestyle='--')  # Below this is clustered
-                ax_p.axhline(y=1-p_sig, c='r', linestyle='--')  # Above this is dispersed
+                # Create a new plot for the pc-values
+                fig_pc = plt.figure()
+                ax_pc = fig_pc.add_subplot(111)
+                ax_pc.plot(result['bins'], -np.log(result['pc']), c='k')
+                ax_pc.set_xlabel('Distance (nm)')
+                ax_pc.set_ylabel('Clustering significance (-log(p))')
+                p_sig = -np.log(1.0/r.nsim)
+                ax_pc.axhline(y=p_sig, c='r', linestyle='--')  # Above this is clustered
+
+                # Create a new plot for the pd-values
+                fig_pd = plt.figure()
+                ax_pd = fig_pd.add_subplot(111)
+                ax_pd.plot(result['bins'], -np.log(result['pd']), c='k')
+                ax_pd.set_xlabel('Distance (nm)')
+                ax_pd.set_ylabel('Dispersion significance (-log(p))')
+                ax_pd.axhline(y=p_sig, c='r', linestyle='--')  # Above this is dispersed
             
 
 def Plug(visFr):

--- a/PYME/LMVis/Extras/clusterAnalysis.py
+++ b/PYME/LMVis/Extras/clusterAnalysis.py
@@ -429,11 +429,26 @@ class ClusterAnalyser:
                 else:
                     ax.plot(result['bins'], np.pi * (4.0 / 3.0) * np.pi * (result['bins'] + r.binSize) ** 3,
                             c='k', linestyle='--')
+
             ax.set_ylabel(r.normalization)
             # Plot Ripley's K/L/H
             ax.plot(result['bins'], result['vals'], c='r')
             ax.set_xlabel('Distance (nm)')
+            if r.statistics:
+                # Plot envelope
+                ax.plot(result['bins'], result['min'], c='k', linestyle=':')
+                ax.plot(result['bins'], result['max'], c='k', linestyle=':')
 
+                # Create a new plot for the p-values
+                fig_p = plt.figure()
+                ax_p = fig_p.add_subplot(111)
+                ax_p.plot(result['bins'], result['p'], c='k')
+                ax_p.set_xlabel('Distance (nm)')
+                ax_p.set_ylabel('P-value (clustered)')
+                ax_p.set_title('Clustering significance')
+                p_sig = 1.0/r.nsim
+                ax_p.axhline(y=p_sig, c='r', linestyle='--')  # Below this is clustered
+                ax_p.axhline(y=1-p_sig, c='r', linestyle='--')  # Above this is dispersed
             
 
 def Plug(visFr):

--- a/PYME/LMVis/Extras/clusterAnalysis.py
+++ b/PYME/LMVis/Extras/clusterAnalysis.py
@@ -436,8 +436,7 @@ class ClusterAnalyser:
             ax.set_xlabel('Distance (nm)')
             if r.statistics:
                 # Plot envelope
-                ax.plot(result['bins'], result['min'], c='k', linestyle=':')
-                ax.plot(result['bins'], result['max'], c='k', linestyle=':')
+                ax.fill_between(result['bins'], result['min'], result['max'], color='k', alpha=0.25)
 
                 # Create a new plot for the pc-values
                 fig_pc = plt.figure()
@@ -445,8 +444,7 @@ class ClusterAnalyser:
                 ax_pc.plot(result['bins'], -np.log2(result['pc']), c='k')
                 ax_pc.set_xlabel('Distance (nm)')
                 ax_pc.set_ylabel('Clustering significance (-log(p))')
-                p_sig = -np.log2(1.0/r.nsim)
-                ax_pc.axhline(y=p_sig, c='r', linestyle='--')  # Above this is clustered
+                ax_pc.axhline(y=-np.log2(r.significance), c='r', linestyle='--')  # Above this is clustered
 
                 # Create a new plot for the pd-values
                 fig_pd = plt.figure()
@@ -454,7 +452,7 @@ class ClusterAnalyser:
                 ax_pd.plot(result['bins'], -np.log2(result['pd']), c='k')
                 ax_pd.set_xlabel('Distance (nm)')
                 ax_pd.set_ylabel('Dispersion significance (-log(p))')
-                ax_pd.axhline(y=p_sig, c='r', linestyle='--')  # Above this is dispersed
+                ax_pd.axhline(y=-np.log2(r.significance), c='r', linestyle='--')  # Above this is dispersed
             
 
 def Plug(visFr):

--- a/PYME/LMVis/Extras/clusterAnalysis.py
+++ b/PYME/LMVis/Extras/clusterAnalysis.py
@@ -442,16 +442,16 @@ class ClusterAnalyser:
                 # Create a new plot for the pc-values
                 fig_pc = plt.figure()
                 ax_pc = fig_pc.add_subplot(111)
-                ax_pc.plot(result['bins'], -np.log(result['pc']), c='k')
+                ax_pc.plot(result['bins'], -np.log2(result['pc']), c='k')
                 ax_pc.set_xlabel('Distance (nm)')
                 ax_pc.set_ylabel('Clustering significance (-log(p))')
-                p_sig = -np.log(1.0/r.nsim)
+                p_sig = -np.log2(1.0/r.nsim)
                 ax_pc.axhline(y=p_sig, c='r', linestyle='--')  # Above this is clustered
 
                 # Create a new plot for the pd-values
                 fig_pd = plt.figure()
                 ax_pd = fig_pd.add_subplot(111)
-                ax_pd.plot(result['bins'], -np.log(result['pd']), c='k')
+                ax_pd.plot(result['bins'], -np.log2(result['pd']), c='k')
                 ax_pd.set_xlabel('Distance (nm)')
                 ax_pd.set_ylabel('Dispersion significance (-log(p))')
                 ax_pd.axhline(y=p_sig, c='r', linestyle='--')  # Above this is dispersed

--- a/PYME/recipes/pointcloud.py
+++ b/PYME/recipes/pointcloud.py
@@ -317,21 +317,21 @@ class Ripleys(ModuleBase):
             origin_coords = (0, 0, 0)
         
         if self.three_d:
-            K_packed = ripleys.ripleys_k(x=points_real['x'], y=points_real['y'], z=points_real['z'],
+            bb, K = ripleys.ripleys_k(x=points_real['x'], y=points_real['y'], z=points_real['z'],
                                       mask=mask, n_bins=self.nbins, bin_size=self.binSize,
-                                      sampling=self.sampling, threaded=self.threaded, mc=self.statistics,
-                                      n_sim=self.nsim, coord_origin=origin_coords)
+                                      sampling=self.sampling, threaded=self.threaded, coord_origin=origin_coords)
         else:
-            K_packed = ripleys.ripleys_k(x=points_real['x'], y=points_real['y'],
+            bb, K = ripleys.ripleys_k(x=points_real['x'], y=points_real['y'],
                                       mask=mask, n_bins=self.nbins, bin_size=self.binSize,
-                                      sampling=self.sampling, threaded=self.threaded, mc=self.statistics,
-                                      n_sim=self.nsim, coord_origin=origin_coords)
+                                      sampling=self.sampling, threaded=self.threaded, coord_origin=origin_coords)
 
-        # Unpack
+        # Run MC simulations
         if self.statistics:
-            bb, K, K_min, K_max, p_clustered = K_packed
-        else:
-            bb, K = K_packed
+            K_min, K_max, p_clustered = ripleys.mc_sampling_statistics(K, mask=mask,
+                                                                        n_points=len(points_real['x']), n_bins=self.nbins, 
+                                                                        three_d=self.three_d, bin_size=self.binSize, 
+                                                                        n_sim=self.nsim, sampling=self.sampling, 
+                                                                        threaded=self.threaded, coord_origin=origin_coords)
         
         # Check for alternate Ripley's normalization
         norm_func = None

--- a/PYME/recipes/pointcloud.py
+++ b/PYME/recipes/pointcloud.py
@@ -327,7 +327,7 @@ class Ripleys(ModuleBase):
 
         # Run MC simulations
         if self.statistics:
-            K_min, K_max, p_clustered = ripleys.mc_sampling_statistics(K, mask=mask,
+            K_min, K_max, p_clustered, p_dispersed = ripleys.mc_sampling_statistics(K, mask=mask,
                                                                         n_points=len(points_real['x']), n_bins=self.nbins, 
                                                                         three_d=self.three_d, bin_size=self.binSize, 
                                                                         n_sim=self.nsim, sampling=self.sampling, 
@@ -356,10 +356,11 @@ class Ripleys(ModuleBase):
                 if self.normalization == 'dL' or self.normalization == 'dH':
                     # Truncate p_clustered for dL and dH to match size
                     p_clustered = p_clustered[1:-1]
+                    p_dispersed = p_dispersed[1:-1]
             bb = bb0
 
         if self.statistics:
-            res = tabular.DictSource({'bins': bb, 'vals': K, 'min': K_min, 'max': K_max, 'p': p_clustered})
+            res = tabular.DictSource({'bins': bb, 'vals': K, 'min': K_min, 'max': K_max, 'pc': p_clustered, 'pd': p_dispersed})
         else:
             res = tabular.DictSource({'bins': bb, 'vals': K})
         

--- a/tests/PYME/Analysis/points/test_ripleys.py
+++ b/tests/PYME/Analysis/points/test_ripleys.py
@@ -18,9 +18,9 @@ def test_ripleys_k_2d():
     A = 100**2
         
     bb, K = ripleys_k_from_mask_points(xu, yu, xu, yu, NBINS, BIN_SIZE, A,
-                      z=np.zeros_like(xu), zu=None, threaded=False)
+                      z=np.zeros_like(xu), area_per_mask_point=1, zu=None, threaded=False)
 
-    assert (np.sum((np.pi*(bb+BIN_SIZE)**2-K)**2) < 1e-4)
+    assert (np.sum((np.pi*bb**2-K)**2) < 1e-4)
 
 def test_ripleys_k_3d():
     from PYME.Analysis.points.ripleys import ripleys_k_from_mask_points
@@ -37,6 +37,6 @@ def test_ripleys_k_3d():
     A = 10**3
         
     bb, K = ripleys_k_from_mask_points(xu, yu, xu, yu, NBINS, BIN_SIZE, A,
-                      z=zu, zu=zu, threaded=False)
+                      area_per_mask_point=1, z=zu, zu=zu, threaded=False)
 
-    assert (np.sum(((4.0/3.0)*np.pi*(bb+BIN_SIZE)**3-K)**2) < 1e-4)
+    assert (np.sum(((4.0/3.0)*np.pi*bb**3-K)**2) < 1e-4)


### PR DESCRIPTION
Added Monte-Carlo simulations to Ripley's for statistical analysis of clustering. Ripley's now returns a simulation envelope and a significance graph (p-values). Example graphs with N=3 simulations from a standard worm-like chain with an extra Generate Events call are shown below. Also added some documentation.

<img width="708" alt="Screen Shot 2020-06-01 at 8 14 05 AM" src="https://user-images.githubusercontent.com/1263313/83408007-e304d280-a3df-11ea-8da8-dacf947d15a7.png">
<img width="752" alt="Screen Shot 2020-06-01 at 8 14 07 AM" src="https://user-images.githubusercontent.com/1263313/83408012-e4ce9600-a3df-11ea-88df-2ae69fca1820.png">