### PR TITLE
Execute PointFeaturesPairwiseDist recipe

### DIFF
--- a/PYME/LMVis/Extras/objectMeasurements.py
+++ b/PYME/LMVis/Extras/objectMeasurements.py
@@ -122,6 +122,8 @@ class ObjectMeasurer:
             m.edit_no_invalidate()
        
             pipeline.recipe.add_module(m)
+            pipeline.recipe.execute()
+            
             pipeline.selectDataSource(m.outputName)
             
             if m.PCA:


### PR DESCRIPTION
Missing `recipe.execute()` call was causing errors when trying to select the output data source.