### PR TITLE
Visgui pylab farewell

### DIFF
--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -535,7 +535,7 @@ class MatfileSource(TabularBase):
 class MatfileColumnSource(TabularBase):
     _name = "Matlab Column Source"
     
-    def __init__(self, filename, columnnames=None):
+    def __init__(self, filename):
         """ Input filter for use with matlab data where the each column is in a separate variable.
         Relies on variables having suitable column names - columns named x, y, z, t, and probe (if multi-colour) should
         be present.
@@ -546,29 +546,6 @@ class MatfileColumnSource(TabularBase):
         self.res = scipy.io.loadmat(filename)  # TODO: evaluate why these are cast as floats
         
         self._keys = [k for k in self.res.keys() if not k.startswith('_')]
-
-        # Check for multicolor
-        test_shape = self.res[self._keys[0]].shape
-        n_channels = 1
-        multicolor = test_shape[1] > test_shape[0]
-        if multicolor:
-            n_channels = test_shape[1]
-            if columnnames is None:
-                columnnames = self._keys
-
-        # Mapping for multicolor, channels
-        if columnnames is not None:
-            tmp_res = {}
-            for i, k in enumerate(self._keys):
-                if multicolor:
-                    tmp_res[columnnames[i]] = np.hstack([self.res[k].squeeze()[_i].squeeze() for _i in range(n_channels)])
-                else:
-                    tmp_res[columnnames[i]] = self.res[k]
-            if multicolor:
-                tmp_res['probe'] = np.hstack([np.ones(self.res[self._keys[0]].squeeze()[_i].shape[0])*_i for _i in range(n_channels)])
-                columnnames.append('probe')
-            self.res = tmp_res
-            self._keys = columnnames
     
     def keys(self):
         return self._keys
@@ -582,7 +559,7 @@ class MatfileColumnSource(TabularBase):
     
     def getInfo(self):
         return 'Text Data Source\n\n %d points' % len(self.res['x'])
-    
+
 
 @deprecated_name('recArrayInput')
 class RecArraySource(TabularBase):

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -560,6 +560,19 @@ class MatfileColumnSource(TabularBase):
     def getInfo(self):
         return 'Text Data Source\n\n %d points' % len(self.res['x'])
 
+class MatfileMultiColumnSource(MatfileColumnSource):
+    def __init__(self, filename):
+        MatfileColumnSource.__init__(self, filename)
+        
+        # Unwrap multiple channels in self.res
+        tmp_res = {}
+        for k in self._keys:
+            tmp_res[k] = np.vstack(self.res[k][0]).squeeze()
+        n_channels = self.res[self._keys[0]][0].shape[0]
+        tmp_res['probe'] = np.vstack(self.res[self._keys[0]][0]*np.zeros(n_channels)+np.arange(n_channels)).squeeze()
+        self._keys.append('probe')
+
+        self.res = tmp_res
 
 @deprecated_name('recArrayInput')
 class RecArraySource(TabularBase):

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -535,7 +535,7 @@ class MatfileSource(TabularBase):
 class MatfileColumnSource(TabularBase):
     _name = "Matlab Column Source"
     
-    def __init__(self, filename):
+    def __init__(self, filename, columnnames=None):
         """ Input filter for use with matlab data where the each column is in a separate variable.
         Relies on variables having suitable column names - columns named x, y, z, t, and probe (if multi-colour) should
         be present.
@@ -546,6 +546,13 @@ class MatfileColumnSource(TabularBase):
         self.res = scipy.io.loadmat(filename)  # TODO: evaluate why these are cast as floats
         
         self._keys = [k for k in self.res.keys() if not k.startswith('_')]
+
+        if columnnames is not None:
+            tmp_res = {}
+            for i, k in enumerate(self._keys):
+                tmp_res[columnnames[i]] = self.res[k]
+            self.res = tmp_res
+            self._keys = columnnames
     
     def keys(self):
         return self._keys

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -39,7 +39,7 @@ import sys
 
 import matplotlib
 matplotlib.use('wxagg')
-import pylab
+# import pylab
 
 from PYME import config
 from PYME.misc import extraCMaps
@@ -238,7 +238,8 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
         while len(self.pipeline.filesToClose) > 0:
             self.pipeline.filesToClose.pop().close()
 
-        pylab.close('all')
+        # pylab.close('all')
+        matplotlib.pyplot.close('all')
         self._cleanup()
 
 

--- a/PYME/LMVis/importTextDialog.py
+++ b/PYME/LMVis/importTextDialog.py
@@ -270,6 +270,7 @@ class ImportMatDialog(wx.Dialog):
 class ImportMatlabDialog(ColumnMappingDialog):
     # MATLAB importer with variable mapping
     fileType = 'MATLAB'
+    multichannel = False  # Is out matlab source multichannel?
 
     def _parse_header(self, file):
         import numpy as np
@@ -289,6 +290,7 @@ class ImportMatlabDialog(ColumnMappingDialog):
         for k in colNames:
             if mf[k].shape[1] > mf[k].shape[0]:
                 # Multicolor
+                self.multichannel = True
                 dataLines.append(mf[k][0,0][:10].squeeze())
             else:
                 dataLines.append(mf[k][:10].squeeze())
@@ -296,3 +298,6 @@ class ImportMatlabDialog(ColumnMappingDialog):
 
         self.colNames = colNames
         self.dataLines = dataLines
+
+    def GetMultichannel(self):
+        return self.multichannel

--- a/PYME/LMVis/importTextDialog.py
+++ b/PYME/LMVis/importTextDialog.py
@@ -295,7 +295,11 @@ class ImportMatlabDialog(ImportDialog):
 
         dataLines = []
         for k in colNames:
-            dataLines.append(mf[k][:10].squeeze())
+            if mf[k].shape[1] > mf[k].shape[0]:
+                # Multicolor
+                dataLines.append(mf[k][0,0][:10].squeeze())
+            else:
+                dataLines.append(mf[k][:10].squeeze())
         dataLines = np.array(dataLines).T.astype(str).tolist()
 
         return colNames, dataLines

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -674,7 +674,7 @@ class Pipeline:
                 #old style matlab import
                 ds = tabular.MatfileSource(filename, kwargs['FieldNames'], kwargs['VarName'])
             else:
-                ds = tabular.MatfileColumnSource(filename)
+                ds = tabular.MatfileColumnSource(filename, kwargs['FieldNames'])
                 
 
         elif os.path.splitext(filename)[1] == '.csv':

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -674,7 +674,10 @@ class Pipeline:
                 #old style matlab import
                 ds = tabular.MatfileSource(filename, kwargs['FieldNames'], kwargs['VarName'])
             else:
-                ds = tabular.MatfileColumnSource(filename, kwargs['FieldNames'])
+                if 'FieldNames' in kwargs.keys():
+                    ds = tabular.MatfileColumnSource(filename, kwargs['FieldNames'])
+                else:
+                    ds = tabular.MatfileColumnSource(filename)
                 
 
         elif os.path.splitext(filename)[1] == '.csv':

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -674,11 +674,12 @@ class Pipeline:
                 #old style matlab import
                 ds = tabular.MatfileSource(filename, kwargs['FieldNames'], kwargs['VarName'])
             else:
-                if 'FieldNames' in kwargs.keys():
-                    ds = tabular.MatfileColumnSource(filename, kwargs['FieldNames'])
-                else:
-                    ds = tabular.MatfileColumnSource(filename)
+                ds = tabular.MatfileColumnSource(filename)
                 
+                # check for column name mapping
+                field_names = kwargs.get('FieldNames', None)
+                if field_names:
+                    ds = tabular.MappingFilter(ds, **{new_field : old_field for new_field, old_field in zip(field_names, ds.keys())})
 
         elif os.path.splitext(filename)[1] == '.csv':
             #special case for csv files - tell np.loadtxt to use a comma rather than whitespace as a delimeter

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -674,11 +674,16 @@ class Pipeline:
                 #old style matlab import
                 ds = tabular.MatfileSource(filename, kwargs['FieldNames'], kwargs['VarName'])
             else:
-                ds = tabular.MatfileColumnSource(filename)
+                if kwargs['Multichannel']:
+                    ds = tabular.MatfileMultiColumnSource(filename)
+                else:
+                    ds = tabular.MatfileColumnSource(filename)
                 
                 # check for column name mapping
                 field_names = kwargs.get('FieldNames', None)
                 if field_names:
+                    if kwargs['Multichannel']:
+                        field_names.append('probe')  # don't forget to copy this field over
                     ds = tabular.MappingFilter(ds, **{new_field : old_field for new_field, old_field in zip(field_names, ds.keys())})
 
         elif os.path.splitext(filename)[1] == '.csv':

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -704,6 +704,7 @@ class VisGUICore(object):
 
                     args['FieldNames'] = dlg.GetFieldNames()
                     args['PixelSize'] = dlg.GetPixelSize()
+                    args['Multichannel'] = dlg.GetMultichannel()
                 
                     dlg.Destroy()
     

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -673,11 +673,10 @@ class VisGUICore(object):
         
             mf = loadmat(filename)
             if ('x' not in mf.keys()) or ('y' not in mf.keys()):
-                # This at least has some weird variable names
+                # This MATLAB file has some weird variable names
 
-                if (len(mf.keys()) < 3):
-                    # Bewersdorf-style .mat where each variable is in a separate column
-                    # and the variables are all stored within another variable (MATLAB struct)
+                if (len([k for k in mf.keys() if not k.startswith('_')]) < 3):
+                    # All the data is probably packed in a single variable
                     dlg = importTextDialog.ImportMatDialog(self, [k for k in mf.keys() if not k.startswith('__')])
                     ret = dlg.ShowModal()
                 
@@ -695,7 +694,7 @@ class VisGUICore(object):
                     # We have to map the field names
                     from PYME.LMVis import importTextDialog
 
-                    dlg = importTextDialog.ImportMatlabDialog(self, filename)
+                    dlg = importTextDialog.ImportMatlabDialog(self, mf)
 
                     ret = dlg.ShowModal()
                 

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -703,6 +703,7 @@ class VisGUICore(object):
                         return #we cancelled
 
                     args['FieldNames'] = dlg.GetFieldNames()
+                    args['PixelSize'] = dlg.GetPixelSize()
                 
                     dlg.Destroy()
     


### PR DESCRIPTION
Together, these imports crash the Jupyter notebook kernel:

```
import matplotlib
matplotlib.use('wxagg')
import pylab
```

If we comment out `matplotlib.use('wxagg')` or `import pylab`, everything runs fine. To fix this, I've switched our only use of `pylab` in `VisGUI.py` to an equivalent `matplotlib` call. 