### PR TITLE
Kill JVM so dh5view can close

### DIFF
--- a/PYME/DSView/dsviewer.py
+++ b/PYME/DSView/dsviewer.py
@@ -154,6 +154,7 @@ class DSViewFrame(AUIFrame):
         self.Bind(wx.EVT_MENU, self.OnSave, id=wx.ID_SAVE)
         self.Bind(wx.EVT_MENU, self.OnExport, id=wx.ID_SAVEAS)
         self.Bind(wx.EVT_CLOSE, self.OnCloseWindow)
+        self.Bind(wx.EVT_MENU, self.OnCloseWindow, id=wx.ID_EXIT)  # Needed to run through self.OnCloseWindow on a command+Q call
         
 
 		
@@ -355,7 +356,12 @@ class DSViewFrame(AUIFrame):
     def _cleanup(self):
         self.timer.Stop()
         del(self.image)
-        
+
+        # In case garbage collection didn't work, kill the Java VM so it can't
+        # hold the program open.
+        import javabridge
+        javabridge.kill_vm()
+
         AUIFrame._cleanup(self)
 
     def dsRefresh(self):

--- a/PYME/DSView/dsviewer.py
+++ b/PYME/DSView/dsviewer.py
@@ -357,14 +357,18 @@ class DSViewFrame(AUIFrame):
         else:
             self._cleanup()
 
+        if event == wx.ID_EXIT:
+            # Check if we need to do anything else with ID_EXIT
+            event.Skip()
+
     def _cleanup(self):
         self.timer.Stop()
         del(self.image)
 
-        # In case garbage collection didn't work, kill the Java VM so it can't
-        # hold the program open.
-        import javabridge
-        javabridge.kill_vm()
+        # In case garbage collection didn't work, check if we need to kill the Java VM 
+        # so it can't hold the program open.
+        from PYME.IO.DataSources.BioformatsDataSource import release_VM
+        release_VM()
 
         AUIFrame._cleanup(self)
 

--- a/PYME/DSView/dsviewer.py
+++ b/PYME/DSView/dsviewer.py
@@ -137,7 +137,7 @@ class DSViewFrame(AUIFrame):
         tmp_menu.AppendMenu(-1, 'Save &Results', self.save_menu)
         
         tmp_menu.AppendSeparator()
-        tmp_menu.Append(wx.ID_CLOSE, "Close", "", wx.ITEM_NORMAL)
+        tmp_menu.Append(wx.ID_CLOSE, "&Close", "", wx.ITEM_NORMAL)
         self.menubar.Append(tmp_menu, "File")
 
         self.view_menu = wx.Menu()
@@ -153,8 +153,12 @@ class DSViewFrame(AUIFrame):
         self.Bind(wx.EVT_MENU, self.OnOpen, id=wx.ID_OPEN)
         self.Bind(wx.EVT_MENU, self.OnSave, id=wx.ID_SAVE)
         self.Bind(wx.EVT_MENU, self.OnExport, id=wx.ID_SAVEAS)
-        self.Bind(wx.EVT_CLOSE, self.OnCloseWindow)
-        self.Bind(wx.EVT_MENU, self.OnCloseWindow, id=wx.ID_EXIT)  # Needed to run through self.OnCloseWindow on a command+Q call
+        # Closing needs three different bindings, each for a different way to
+        # close the program, to ensure the same cleanup operation happens
+        # rfor each method
+        self.Bind(wx.EVT_CLOSE, self.OnCloseWindow)  # Press the X button in the upper-left of the window
+        self.Bind(wx.EVT_MENU, self.OnCloseWindow, id=wx.ID_CLOSE)  # Choose Close from the File menu
+        self.Bind(wx.EVT_MENU, self.OnCloseWindow, id=wx.ID_EXIT)  # Command+Q
         
 
 		

--- a/PYME/DSView/dsviewer.py
+++ b/PYME/DSView/dsviewer.py
@@ -137,7 +137,7 @@ class DSViewFrame(AUIFrame):
         tmp_menu.AppendMenu(-1, 'Save &Results', self.save_menu)
         
         tmp_menu.AppendSeparator()
-        tmp_menu.Append(wx.ID_CLOSE, "&Close", "", wx.ITEM_NORMAL)
+        tmp_menu.Append(wx.ID_CLOSE, "Close", "", wx.ITEM_NORMAL)
         self.menubar.Append(tmp_menu, "File")
 
         self.view_menu = wx.Menu()

--- a/PYME/DSView/dsviewer.py
+++ b/PYME/DSView/dsviewer.py
@@ -155,7 +155,7 @@ class DSViewFrame(AUIFrame):
         self.Bind(wx.EVT_MENU, self.OnExport, id=wx.ID_SAVEAS)
         # Closing needs three different bindings, each for a different way to
         # close the program, to ensure the same cleanup operation happens
-        # rfor each method
+        # for each method
         self.Bind(wx.EVT_CLOSE, self.OnCloseWindow)  # Press the X button in the upper-left of the window
         self.Bind(wx.EVT_MENU, self.OnCloseWindow, id=wx.ID_CLOSE)  # Choose Close from the File menu
         self.Bind(wx.EVT_MENU, self.OnCloseWindow, id=wx.ID_EXIT)  # Command+Q


### PR DESCRIPTION
Addresses issue #277.

**Is this a bugfix or an enhancement?**

Bugfix.

**Proposed changes:**

- Force kill of Java VM on program exit
- Bind `wx.ID_EXIT` to close operations so same cleanup happens when you press `Ctrl+Q` as happens when you choose `File>Close`.
- Bind `wx.EVT` with `ID_CLOSE` to close operations so same cleanup happens when you chooose `File>Close`




**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
