### PR TITLE
Spharm mayavi to builtin

### DIFF
--- a/PYME/Analysis/points/spherical_harmonics.py
+++ b/PYME/Analysis/points/spherical_harmonics.py
@@ -236,6 +236,15 @@ def icosahedron_mesh(n_subdivision=1):
            /    \    ==>   v3----v5
           /      \         / \  / \
          v1------v2       v1--v4--v2
+
+    Returns
+    -------
+        azimuth : np.array
+            Azimuth of mesh vertices [0, 2*pi].
+        zenith : np.array
+            Zenith of mesh vertices [0, pi].
+        faces : np.array
+            20 x 3, counterclockwise triangles denoting mesh faces.
     """
     
     # First, generate the icosahedron

--- a/PYME/Analysis/points/spherical_harmonics.py
+++ b/PYME/Analysis/points/spherical_harmonics.py
@@ -197,6 +197,97 @@ def scaled_shell_from_hdf(hdf_file, table_name='harmonic_shell'):
 
     return shell
 
+def generate_icosahedron():
+    """
+    Generate an icosahedron in spherical coordinates.
+    
+    Returns
+    -------
+        azimuth : np.array
+            Length 12, azimuth of icosahedron vertices [0, 2*pi].
+        zenith : np.array
+            Length 12, zenith of icosahedron vertices [0, pi].
+        faces : np.array
+            20 x 3, counterclockwise triangles denoting icosahedron faces.
+    """
+    t = np.arctan(0.5)+np.pi/2
+    zenith = np.hstack([0, np.array(5*[np.pi-t,t]).ravel(), np.pi])  # [0, pi]
+    azimuth = np.hstack([0, np.arange(0, 2*np.pi, np.pi/5), 0])   # [0, 2*pi]
+    idxs = np.arange(len(zenith))[1:-1]
+    upper_middle_strip = np.vstack([[v0,v1,v2] for v0,v1,v2 in 
+                                    zip(idxs[::2],idxs[1::2],np.roll(idxs[::2],-1))])
+    lower_middle_strip = np.vstack([[v0,v1,v2] for v0,v1,v2 in 
+                                    zip(np.roll(idxs[::2],-1),idxs[1::2],np.roll(idxs[1::2],-1))])
+    upper_cap = np.vstack([[v0,v1,v2] for v0,v1,v2 in 
+                        zip(np.zeros(5),idxs[::2],np.roll(idxs[::2],-1))])
+    lower_cap = np.vstack([[v0,v1,v2] for v0,v1,v2 in 
+                        zip(11*np.ones(5),np.roll(idxs[1::2],-1),idxs[1::2])])
+    faces = np.vstack([upper_cap, upper_middle_strip, lower_middle_strip, lower_cap]).astype(np.int)
+    
+    return azimuth, zenith, faces
+
+def icosahedron_mesh(n_subdivision=1):
+    """
+    Return an icosahedron subdivided n_subdivision times. This provides a
+    quasi-regular sampling of the unit sphere.
+    
+            v0               v0
+            /  \             /  \
+           /    \    ==>   v3----v5
+          /      \         / \  / \
+         v1------v2       v1--v4--v2
+    """
+    
+    # First, generate the icosahedron
+    azimuth, zenith, faces = generate_icosahedron()
+    
+    if n_subdivision < 1:
+        # We don't need to do anything
+        return azimuth, zenith, faces
+    
+    # Convert pole azimuth to np.nan so we can ignore pole azimuth (irrelevant, detrimental)
+    azimuth[0], azimuth[-1] = np.nan, np.nan
+    
+    # Make azimuth and zenith complex numbers (to deal with phase wrapping)
+    azimuth, zenith = np.exp(1j*azimuth), np.exp(1j*zenith)
+    
+    for k in range(n_subdivision):
+        # Average each edge to get new vertex at the center of each face v0,v1,v2
+        az_v3 = np.nanmean(azimuth[faces[:,[0,1]]],axis=1)
+        az_v4 = np.nanmean(azimuth[faces[:,[1,2]]],axis=1)
+        az_v5 = np.nanmean(azimuth[faces[:,[2,0]]],axis=1)
+        new_az = np.hstack([az_v3, az_v4, az_v5])
+        ze_v3 = np.nanmean(zenith[faces[:,[0,1]]],axis=1)
+        ze_v4 = np.nanmean(zenith[faces[:,[1,2]]],axis=1)
+        ze_v5 = np.nanmean(zenith[faces[:,[2,0]]],axis=1)
+        new_ze = np.hstack([ze_v3, ze_v4, ze_v5])
+        
+        # Create new vertices, eliminating duplicates (there should be two of each 
+        # new vertex, one from each face sharing an edge)
+        new_v, new_idxs = np.unique(np.vstack([new_az,new_ze]).T, axis=0, return_inverse=True)
+        new_idxs += len(azimuth)
+        new_idxs = new_idxs.reshape(3,-1).T  # v3 = new_idxs[:,0], v4 = new_idxs[:,1], v5 = new_idxs[:,2]
+        
+        # Create new faces (4 faces per old face)
+        f0 = np.vstack([faces[:,0], new_idxs[:,0], new_idxs[:,2]]).T
+        f1 = np.vstack([faces[:,1], new_idxs[:,1], new_idxs[:,0]]).T
+        f2 = np.vstack([faces[:,2], new_idxs[:,2], new_idxs[:,1]]).T
+        faces = np.vstack([f0,f1,f2,new_idxs]).astype(np.int)
+        
+        # Append the new vertices to azimuth
+        azimuth = np.hstack([azimuth, new_v[:,0]])
+        zenith = np.hstack([zenith, new_v[:,1]])
+    
+    # Restore poles to azimuth 0 for future conversion to real coordinates
+    azimuth[np.isnan(azimuth)] = 0
+    
+    # Back to angles with you
+    azimuth, zenith = np.angle(azimuth), np.angle(zenith)
+    azimuth[azimuth<0] = azimuth[azimuth<0]+2*np.pi  # wrap to [0, 2*pi]
+    zenith = np.abs(zenith) # wrap to [0, pi]
+        
+    return azimuth, zenith, faces
+
 
 class ScaledShell(object):
     data_type = [
@@ -343,22 +434,17 @@ class ScaledShell(object):
             zenith step size for generating vector in plane of the shell [radians], by default 0.1
         """
 
-        # Compute surface points as grid, with each point adjacent in angular space,
-        # staggered by d_zenith/2 to generate triangles directly
-        zenith, azimuth = np.mgrid[0:(np.pi + d_zenith):d_zenith, 0:(2 * np.pi + d_zenith):d_zenith]
+        # Convert d_zenith to closest subdivision >= d_zenith (limited control due to icosahedon subdivision)
+        # Mean initial d_zenith is 2*pi/5, so solve for (2*pi/10)^n_subdivision = d_zenith
+        n_subdivision = int(np.ceil(np.log(d_zenith)/(np.log(np.pi)-np.log(5))))
+
+        # Quasi-regular sample points on a unit sphere with icosahedron subdivision
+        azimuth, zenith, faces = icosahedron_mesh(n_subdivision)
+        # Map points onto shell radius 
         xs, ys, zs = self.get_fitted_shell(azimuth, zenith)
 
         # Create vertices 
         vertices = np.vstack([xs.ravel(), ys.ravel(), zs.ravel()]).T   # Row-major ravel
-        # Index faces as two oppositely-would triangles per grid square
-        f_list = np.arange(len(vertices))
-        l = xs.shape[1]
-        tri1 = np.vstack([[v0,v1,v2] for v0,v1,v2 in zip(f_list[1:], f_list, f_list[l:])])
-        tri2 = np.vstack([[v0,v1,v2] for v0,v1,v2 in zip(f_list[1:], f_list[l:], f_list[(l+1):])])
-        # Stitch boundaries
-        # stitch1 = np.vstack([[v0,v1,v2] for v0,v1,v2 in zip(f_list[::l], f_list[(l-1)::l], f_list[(2*l-1)::l])])
-        # stitch2 = np.vstack([[v0,v1,v2] for v0,v1,v2 in zip(f_list[::l], f_list[(2*l-1)::l], f_list[(2*l)::l])])
-        faces = np.vstack([tri1, tri2]) #, stitch1, stitch2])
 
         return vertices.astype(np.float32), faces.astype(np.int32)
 

--- a/PYME/Analysis/points/spherical_harmonics.py
+++ b/PYME/Analysis/points/spherical_harmonics.py
@@ -353,9 +353,12 @@ class ScaledShell(object):
         # Index faces as two oppositely-would triangles per grid square
         f_list = np.arange(len(vertices))
         l = xs.shape[1]
-        tri1 = np.vstack([[x,y,z] for x,y,z in zip(f_list[1:], f_list, f_list[l:])])
-        tri2 = np.vstack([[x,y,z] for x,y,z in zip(f_list[1:], f_list[l:], f_list[(l+1):])])
-        faces = np.vstack([tri1, tri2])
+        tri1 = np.vstack([[v0,v1,v2] for v0,v1,v2 in zip(f_list[1:], f_list, f_list[l:])])
+        tri2 = np.vstack([[v0,v1,v2] for v0,v1,v2 in zip(f_list[1:], f_list[l:], f_list[(l+1):])])
+        # Stitch boundaries
+        # stitch1 = np.vstack([[v0,v1,v2] for v0,v1,v2 in zip(f_list[::l], f_list[(l-1)::l], f_list[(2*l-1)::l])])
+        # stitch2 = np.vstack([[v0,v1,v2] for v0,v1,v2 in zip(f_list[::l], f_list[(2*l-1)::l], f_list[(2*l)::l])])
+        faces = np.vstack([tri1, tri2]) #, stitch1, stitch2])
 
         return vertices.astype(np.float32), faces.astype(np.int32)
 

--- a/PYME/Analysis/points/spherical_harmonics.py
+++ b/PYME/Analysis/points/spherical_harmonics.py
@@ -352,8 +352,9 @@ class ScaledShell(object):
         vertices = np.vstack([xs.ravel(), ys.ravel(), zs.ravel()]).T   # Row-major ravel
         # Index faces as two oppositely-would triangles per grid square
         f_list = np.arange(len(vertices))
-        tri1 = np.vstack([[x,y,z] for x,y,z in zip(f_list[1:], f_list, f_list[:-xs.shape[1]]+xs.shape[1])])
-        tri2 = np.vstack([[x,y,z] for x,y,z in zip(f_list[1:], f_list[:-xs.shape[1]]+xs.shape[1], f_list[1:-xs.shape[1]-1]+xs.shape[1])])
+        l = xs.shape[1]
+        tri1 = np.vstack([[x,y,z] for x,y,z in zip(f_list[1:], f_list, f_list[l:])])
+        tri2 = np.vstack([[x,y,z] for x,y,z in zip(f_list[1:], f_list[l:], f_list[(l+1):])])
         faces = np.vstack([tri1, tri2])
 
         return vertices.astype(np.float32), faces.astype(np.int32)

--- a/PYME/LMVis/Extras/spherical_harmonics.py
+++ b/PYME/LMVis/Extras/spherical_harmonics.py
@@ -50,7 +50,6 @@ class SphericalHarmonicShellManager(object):
         # Add a surface rendering
         v, f = shell.get_mesh_vertices_faces(self.d_angle)        
         surf = triangle_mesh.TriangleMesh(v, f)
-        surf.repair()  # Deal with cuts at theta=0, phi=0
         self.pipeline.dataSources['shell_surface'] = surf
 
         layer = TriangleRenderLayer(self.pipeline, dsname='shell_surface', method='shaded', cmap = 'C')
@@ -91,7 +90,6 @@ class SphericalHarmonicShellManager(object):
 
         v, f = shell.get_mesh_vertices_faces(self.d_angle)        
         surf = triangle_mesh.TriangleMesh(v, f)
-        surf.repair()  # Deal with cuts at theta=0, phi=0
         self.pipeline.dataSources['shell_surface'] = surf
 
         layer = TriangleRenderLayer(self.pipeline, dsname='shell_surface', method='shaded', cmap = 'C')

--- a/PYME/LMVis/Extras/spherical_harmonics.py
+++ b/PYME/LMVis/Extras/spherical_harmonics.py
@@ -23,6 +23,8 @@ class SphericalHarmonicShellManager(object):
 
     def OnCalcHarmonicRepresentation(self, wx_event):
         from PYME.recipes import surface_fitting
+        import PYME.experimental._triangle_mesh as triangle_mesh
+        from PYME.LMVis.layers.mesh import TriangleRenderLayer
         recipe = self.pipeline.recipe
         recipe.trait_set(execute_on_invalidation=False)
 
@@ -45,12 +47,23 @@ class SphericalHarmonicShellManager(object):
         self.pipeline.addDataSource('shell_mapped', shell_mapped)
         self.pipeline.selectDataSource('shell_mapped')
 
+        # Add a surface rendering
+        v, e = shell.get_mesh_vertices_edges(self.d_angle)        
+        surf = triangle_mesh.TriangleMesh(v, edges=e)
+        self.pipeline.dataSources['shell_surface'] = surf
+
+        layer = TriangleRenderLayer(self.pipeline, dsname='shell_surface', method='shaded', cmap = 'C')
+        self.vis_frame.add_layer(layer)
+
         self.vis_frame.RefreshView()
 
     def OnLoadHarmonicRepresentation(self, wx_event):
         import wx
         from PYME.IO import tabular, FileUtils
         from PYME.Analysis.points.spherical_harmonics import scaled_shell_from_hdf
+        import PYME.experimental._triangle_mesh as triangle_mesh
+        from PYME.LMVis.layers.mesh import TriangleRenderLayer
+
         fdialog = wx.FileDialog(None, 'Load Spherical Harmonic Representation', wildcard='Harmonic shell (*.hdf)|*.hdf',
                                 style=wx.OPEN, defaultDir=FileUtils.nameUtils.genShiftFieldDirectoryPath())
         succ = fdialog.ShowModal()
@@ -75,10 +88,17 @@ class SphericalHarmonicShellManager(object):
         self.pipeline.addDataSource('shell%d_mapped' % shell_number, points)
         self.pipeline.selectDataSource('shell%d_mapped' % shell_number)
 
+        v, e = shell.get_mesh_vertices_edges(self.d_angle)        
+        surf = triangle_mesh.TriangleMesh(v, edges=e)
+        self.pipeline.dataSources['shell_surface'] = surf
+
+        layer = TriangleRenderLayer(self.pipeline, dsname='shell_surface', method='shaded', cmap = 'C')
+        self.vis_frame.add_layer(layer)
+
         self.vis_frame.RefreshView()
         # self.vis_frame.CreateFoldPanel()
 
-        shell._visualize_shell(self.d_angle, (points['x'], points['y'], points['z']))
+        # shell._visualize_shell(self.d_angle, (points['x'], points['y'], points['z']))
 
 def Plug(vis_frame):
     vis_frame.shell_manager= SphericalHarmonicShellManager(vis_frame)

--- a/PYME/LMVis/Extras/spherical_harmonics.py
+++ b/PYME/LMVis/Extras/spherical_harmonics.py
@@ -48,8 +48,8 @@ class SphericalHarmonicShellManager(object):
         self.pipeline.selectDataSource('shell_mapped')
 
         # Add a surface rendering
-        v, e = shell.get_mesh_vertices_edges(self.d_angle)        
-        surf = triangle_mesh.TriangleMesh(v, edges=e)
+        v, f = shell.get_mesh_vertices_faces(self.d_angle)        
+        surf = triangle_mesh.TriangleMesh(v, f)
         self.pipeline.dataSources['shell_surface'] = surf
 
         layer = TriangleRenderLayer(self.pipeline, dsname='shell_surface', method='shaded', cmap = 'C')
@@ -88,8 +88,8 @@ class SphericalHarmonicShellManager(object):
         self.pipeline.addDataSource('shell%d_mapped' % shell_number, points)
         self.pipeline.selectDataSource('shell%d_mapped' % shell_number)
 
-        v, e = shell.get_mesh_vertices_edges(self.d_angle)        
-        surf = triangle_mesh.TriangleMesh(v, edges=e)
+        v, f = shell.get_mesh_vertices_faces(self.d_angle)        
+        surf = triangle_mesh.TriangleMesh(v, f)
         self.pipeline.dataSources['shell_surface'] = surf
 
         layer = TriangleRenderLayer(self.pipeline, dsname='shell_surface', method='shaded', cmap = 'C')

--- a/PYME/LMVis/Extras/spherical_harmonics.py
+++ b/PYME/LMVis/Extras/spherical_harmonics.py
@@ -50,6 +50,7 @@ class SphericalHarmonicShellManager(object):
         # Add a surface rendering
         v, f = shell.get_mesh_vertices_faces(self.d_angle)        
         surf = triangle_mesh.TriangleMesh(v, f)
+        surf.repair()  # Deal with cuts at theta=0, phi=0
         self.pipeline.dataSources['shell_surface'] = surf
 
         layer = TriangleRenderLayer(self.pipeline, dsname='shell_surface', method='shaded', cmap = 'C')
@@ -90,6 +91,7 @@ class SphericalHarmonicShellManager(object):
 
         v, f = shell.get_mesh_vertices_faces(self.d_angle)        
         surf = triangle_mesh.TriangleMesh(v, f)
+        surf.repair()  # Deal with cuts at theta=0, phi=0
         self.pipeline.dataSources['shell_surface'] = surf
 
         layer = TriangleRenderLayer(self.pipeline, dsname='shell_surface', method='shaded', cmap = 'C')

--- a/PYME/LMVis/Extras/spherical_harmonics.py
+++ b/PYME/LMVis/Extras/spherical_harmonics.py
@@ -65,7 +65,7 @@ class SphericalHarmonicShellManager(object):
         from PYME.LMVis.layers.mesh import TriangleRenderLayer
 
         fdialog = wx.FileDialog(None, 'Load Spherical Harmonic Representation', wildcard='Harmonic shell (*.hdf)|*.hdf',
-                                style=wx.OPEN, defaultDir=FileUtils.nameUtils.genShiftFieldDirectoryPath())
+                                style=wx.FD_OPEN, defaultDir=FileUtils.nameUtils.genShiftFieldDirectoryPath())
         succ = fdialog.ShowModal()
         if (succ == wx.ID_OK):
             path = fdialog.GetPath()

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -948,7 +948,7 @@ cdef class TriangleMesh(TrianglesBase):
         self._chalfedges[_edge].next = -1
         self._chalfedges[_edge].prev = -1
         self._chalfedges[_edge].length = -1
-        self._chalfedges[_edge].component = -15
+        self._chalfedges[_edge].component = -1
 
         self._halfedge_vacancies.append(_edge)
 

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -529,9 +529,7 @@ cdef class TriangleMesh(TrianglesBase):
             edges = np.vstack([faces[:,[0,1]], faces[:,[1,2]], faces[:,[2,0]]])
             n_faces = len(faces)
         else:
-            # Assume manifold, use Euler characteristic
-            print('n_edges: {}'.format(len(edges)))
-            n_faces = int(len(edges)/3.0)
+            n_faces = int(np.ceil(len(edges)/3.0))
 
         # Now order them...
         n_edges = len(edges)

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -157,7 +157,7 @@ cdef class TriangleMesh(TrianglesBase):
     cdef object _H
     cdef object _K
 
-    def __init__(self, vertices=None, faces=None, mesh=None, **kwargs):
+    def __init__(self, vertices=None, faces=None, edges=None, mesh=None, **kwargs):
         """
         Base class for triangle meshes stored using halfedge data structure. 
         Expects STL-like input.
@@ -166,9 +166,14 @@ cdef class TriangleMesh(TrianglesBase):
         ----------
             vertices : np.array
                 N x 3 array of Euclidean points.
-            faces : np .array
+            faces : np.array
                 M x 3 array of vertex indices indicating triangle connectivity.
                 Expects STL redundancy.
+            edges : np.array
+                P x 2 array of edges, indicating connectivity. Each index 
+                references a vertex. Optional.
+            mesh : PYME.experimental._triangle_mesh.TriangleMesh
+                Mesh, usually for copying, optional.
         """
         if mesh is not None:
             import copy
@@ -207,10 +212,13 @@ cdef class TriangleMesh(TrianglesBase):
             self._halfedge_vacancies = []
             
             print('initializing halfedges ...')
-            print('vertices.shape = %s, faces.shape = %s' % (vertices.shape, faces.shape))
+            if faces is not None:
+                print('vertices.shape = %s, faces.shape = %s' % (vertices.shape, faces.shape))
+            elif edges is not None:
+                print('vertices.shape = %s, edges.shape = %s' % (vertices.shape, edges.shape))
             if vertices.shape[0] >= MAX_VERTEX_COUNT:
                 raise RuntimeError('Maximum vertex count is %d, mesh has %d' % (MAX_VERTEX_COUNT, vertices.shape[0]))
-            self._initialize_halfedges(vertices, faces)
+            self._initialize_halfedges(vertices, faces, edges)
             print('done initializing halfedges')
 
         # Representation of faces by triplets of vertices
@@ -245,7 +253,7 @@ cdef class TriangleMesh(TrianglesBase):
         # Set fix_boundary, etc.
         for key, value in kwargs.items():
             setattr(self, key, value)
-
+        
     def __getitem__(self, k):
         # this defers evaluation of the properties until we actually access them, 
         # as opposed to the mappings which stored the values on class creation.
@@ -496,7 +504,7 @@ cdef class TriangleMesh(TrianglesBase):
     def _set_cvertices(self, vertex_d[:] vertices):
         self._cvertices = &vertices[0]
 
-    def _initialize_halfedges(self, vertices, faces):
+    def _initialize_halfedges(self, vertices, faces=None, edges=None):
         """
         Accepts unordered vertices, indices parameterization of a triangular 
         mesh from an STL file and converts to topologically-connected halfedge
@@ -508,62 +516,70 @@ cdef class TriangleMesh(TrianglesBase):
                 N x 3 array of Euclidean points.
             faces : np .array
                 M x 3 array of vertex indices indicating triangle connectivity. 
-                Expects STL redundancy.
+                Expects STL redundancy. Optional.
+            edges : np.array
+                P x 2 array of edges, indicating connectivity. Each index 
+                references a vertex. Optional.
         """
-        if vertices is not None and faces is not None:
-            # Unordered halfedges
+        if (vertices is None) or ((faces is None) and (edges is None)):
+            raise RuntimeError('Mesh generation requires vertices and faces or vertices and edges.')
+
+        # Unordered halfedges
+        if edges is None:
             edges = np.vstack([faces[:,[0,1]], faces[:,[1,2]], faces[:,[2,0]]])
-
-            # Now order them...
             n_faces = len(faces)
-            n_edges = len(edges)
-            j = np.arange(n_faces)
-            
-            self._halfedges = np.zeros(n_edges, dtype=HALFEDGE_DTYPE)
-            self._set_chalfedges(self._halfedges)
-
-            self._halfedges[:] = -1  # initialize everything to -1 to start with
-
-            self._halfedges['vertex'] = edges[:, 1]
-            
-            self._faces = np.zeros(n_faces, dtype=FACE_DTYPE)
-            # Flatten to address cython view problem
-            self._flat_faces = self._faces.view(FACE_DTYPE2)
-            # Set up c views to arrays
-            self._set_cfaces(self._flat_faces)
-            self._faces[:] = -1  # initialize everything to -1 to start with
-
-            # Sort the edges lo->hi so we can arrange them uniquely
-            # Convert to list of tuples for use with dictionary
-            edges_packed = [tuple(e) for e in np.sort(edges, axis=1)]
-
-
-            print('iterating edges')
-            # Use a dictionary to keep track of which edges are already assigned twins
-            d = {}
-            for i, e in enumerate(edges_packed):
-                if e in d:
-                    idx = d.pop(e)
-                    if self._halfedges['vertex'][idx] == self._halfedges['vertex'][i]:
-                        # Don't assign a halfedge to multivalent edges
-                        continue
-                        
-                    self._halfedges['twin'][idx] = i
-                    self._halfedges['twin'][i] = idx
-                else:
-                    d[e] = i
-
-            self._halfedges['face'] = np.hstack([j, j, j])
-            self._halfedges['next'] = np.hstack([j+n_faces, j+2*n_faces, j])
-            self._halfedges['prev'] = np.hstack([j+2*n_faces, j, j+n_faces])
-            self._halfedges['length'] = np.linalg.norm(self._vertices['position'][self._halfedges['vertex']] - self._vertices['position'][self._halfedges['vertex'][self._halfedges['prev']]], axis=1)
-            
-            # Set the vertex halfedges (multiassignment, but should be fine)
-            self._vertices['halfedge'][self._halfedges['vertex']] = self._halfedges['next']
-
-            self._faces['halfedge'] = j  # Faces are defined by associated halfedges
         else:
-            raise ValueError('Mesh does not contain vertices and faces.')
+            # Assume manifold, use Euler characteristic
+            print('n_edges: {}'.format(len(edges)))
+            n_faces = int(len(edges)/3.0)
+
+        # Now order them...
+        n_edges = len(edges)
+        j = np.arange(n_faces)
+        
+        self._halfedges = np.zeros(n_edges, dtype=HALFEDGE_DTYPE)
+        self._set_chalfedges(self._halfedges)
+
+        self._halfedges[:] = -1  # initialize everything to -1 to start with
+
+        self._halfedges['vertex'] = edges[:, 1]
+        
+        self._faces = np.zeros(n_faces, dtype=FACE_DTYPE)
+        # Flatten to address cython view problem
+        self._flat_faces = self._faces.view(FACE_DTYPE2)
+        # Set up c views to arrays
+        self._set_cfaces(self._flat_faces)
+        self._faces[:] = -1  # initialize everything to -1 to start with
+
+        # Sort the edges lo->hi so we can arrange them uniquely
+        # Convert to list of tuples for use with dictionary
+        edges_packed = [tuple(e) for e in np.sort(edges, axis=1)]
+
+
+        print('iterating edges')
+        # Use a dictionary to keep track of which edges are already assigned twins
+        d = {}
+        for i, e in enumerate(edges_packed):
+            if e in d:
+                idx = d.pop(e)
+                if self._halfedges['vertex'][idx] == self._halfedges['vertex'][i]:
+                    # Don't assign a halfedge to multivalent edges
+                    continue
+                    
+                self._halfedges['twin'][idx] = i
+                self._halfedges['twin'][i] = idx
+            else:
+                d[e] = i
+
+        self._halfedges['face'] = np.hstack([j, j, j])
+        self._halfedges['next'] = np.hstack([j+n_faces, j+2*n_faces, j])
+        self._halfedges['prev'] = np.hstack([j+2*n_faces, j, j+n_faces])
+        self._halfedges['length'] = np.linalg.norm(self._vertices['position'][self._halfedges['vertex']] - self._vertices['position'][self._halfedges['vertex'][self._halfedges['prev']]], axis=1)
+        
+        # Set the vertex halfedges (multiassignment, but should be fine)
+        self._vertices['halfedge'][self._halfedges['vertex']] = self._halfedges['next']
+
+        self._faces['halfedge'] = j  # Faces are defined by associated halfedges
 
     def _update_face_normals(self, f_idxs):
         """

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -948,7 +948,7 @@ cdef class TriangleMesh(TrianglesBase):
         self._chalfedges[_edge].next = -1
         self._chalfedges[_edge].prev = -1
         self._chalfedges[_edge].length = -1
-        self._chalfedges[_edge].component = -1
+        self._chalfedges[_edge].component = -15
 
         self._halfedge_vacancies.append(_edge)
 
@@ -2326,6 +2326,12 @@ cdef class TriangleMesh(TrianglesBase):
         self._fill_holes()
 
         self._manifold = None
+
+        # Now we gotta recalculate the normals
+        self._faces['normal'][:] = -1
+        self._vertices['normal'][:] = -1
+        self.face_normals
+        self.vertex_normals
 
     def to_stl(self, filename):
         """

--- a/PYME/experimental/triangle_mesh_utils.c
+++ b/PYME/experimental/triangle_mesh_utils.c
@@ -163,7 +163,7 @@ static PyObject *update_vertex_neighbors(PyObject *self, PyObject *args)
         // If we hit a boundary, try the reverse direction, 
         // starting from orig_idx
         // twin now becomes prev
-        if ((twin_idx == -1) && (curr_idx != -1))
+        if ((twin_idx == -1) && (curr_idx != -1) && (i < NEIGHBORSIZE))
         {
             // Ideally we sweep through the neighbors in a continuous fashion,
             // so we'll reverse the order of all the edges so far.


### PR DESCRIPTION
Adresses issue #83 / PR #197 .

**Is this a bugfix or an enhancement?**

Bugfixes and enhancement!

**Proposed changes:**

- Critical fix to `triangle_mesh_utils.c`
- Move spharm surface rendering from `mayavi` to built-in
- Fix style argument for OnLoadHarmonicRepresentation FileDialog
- Add normal re-calculation to `TriangleMesh.repair()` method

**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [x] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
