### PR TITLE
Alias VisGUI to PYMEVisualize

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/Users/zachcm/miniconda3/envs/pyme/bin/python"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/zachcm/miniconda3/envs/pyme/bin/python"
-}

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -487,7 +487,6 @@ if __name__ == '__main__':
     main()
     mProfile.report()
 
-
 def ipython_visgui(filename=None, **kwargs):
     import PYME.config
     
@@ -500,4 +499,5 @@ def ipython_visgui(filename=None, **kwargs):
     visFr.Show()
     return visFr
     
-    
+def ipython_pymevisualize(filename=None, **kwargs):
+    return ipython_visgui(filename, **kwargs)

--- a/PYME/LMVis/__init__.py
+++ b/PYME/LMVis/__init__.py
@@ -38,4 +38,4 @@ The VisGUI can be launched using the `VisGUI` script.
 
 """
 
-from . import VisGUI as PYMEVisualize
+from .VisGUI import ipython_pymevisualize, ipython_visgui

--- a/PYME/LMVis/__init__.py
+++ b/PYME/LMVis/__init__.py
@@ -37,3 +37,5 @@ Plugins are located in :py:mod:`PYME.LMVis.Extras`.
 The VisGUI can be launched using the `VisGUI` script.
 
 """
+
+from . import VisGUI as PYMEVisualize

--- a/PYME/LMVis/__init__.py
+++ b/PYME/LMVis/__init__.py
@@ -37,5 +37,3 @@ Plugins are located in :py:mod:`PYME.LMVis.Extras`.
 The VisGUI can be launched using the `VisGUI` script.
 
 """
-
-from .VisGUI import ipython_pymevisualize, ipython_visgui

--- a/PYME/resources/gnome/pyme-dh5view.desktop
+++ b/PYME/resources/gnome/pyme-dh5view.desktop
@@ -1,6 +1,6 @@
 
 [Desktop Entry]
-Name=Data Viewer
+Name=PYMEImage
 Comment=View (and analyse) raw data
 Exec=dh5view.py
 Icon=eog

--- a/PYME/resources/gnome/pyme-visgui.desktop
+++ b/PYME/resources/gnome/pyme-visgui.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=VisGUI
+Name=PYMEVisualize
 Comment=Generate images from pont position data
 Exec=VisGUI.py %f
 Icon=eog

--- a/conda-recipes/python-microscopy/entry_points.yaml
+++ b/conda-recipes/python-microscopy/entry_points.yaml
@@ -3,6 +3,7 @@ entry_points:
     - PYMEImage = PYME.DSView.dsviewer:main
     - PYMEAcquire = PYME.Acquire.PYMEAcquire:main
     - VisGUI = PYME.LMVis.VisGUI:main
+    - PYMEVisualize = PYME.LMVis.VisGUI:main
     - PYMEBatch = PYME.recipes.batchProcess:main
     - bakeshop = PYME.recipes.bakeshop:main
     - PYMEDataServer = PYME.cluster.HTTPDataServer:main

--- a/conda-recipes/python-microscopy/menu-windows.json
+++ b/conda-recipes/python-microscopy/menu-windows.json
@@ -15,7 +15,7 @@
                 "script": "${PREFIX}/Scripts/dh5view.exe",
                 "scriptarguments": [],
 
-                "name": "dh5view",
+                "name": "PYMEImage",
                 "workdir": "${USERPROFILE}",
                 "icon": "${MENU_DIR}/pmanal.ico",
                 "desktop": true,
@@ -26,7 +26,7 @@
                 "script": "${PREFIX}/Scripts/VisGUI.exe",
                 "scriptarguments": [],
 
-                "name": "VisGUI",
+                "name": "PYMEVisualize",
                 "workdir": "${USERPROFILE}",
                 "icon": "${MENU_DIR}/pmvis.ico",
                 "desktop": true,

--- a/conda-recipes/python-microscopy/menu-windows.json
+++ b/conda-recipes/python-microscopy/menu-windows.json
@@ -15,7 +15,7 @@
                 "script": "${PREFIX}/Scripts/dh5view.exe",
                 "scriptarguments": [],
 
-                "name": "PYMEImage",
+                "name": "PYMEImage (dh5view)",
                 "workdir": "${USERPROFILE}",
                 "icon": "${MENU_DIR}/pmanal.ico",
                 "desktop": true,

--- a/conda-recipes/python-microscopy/menu-windows.json
+++ b/conda-recipes/python-microscopy/menu-windows.json
@@ -26,7 +26,7 @@
                 "script": "${PREFIX}/Scripts/VisGUI.exe",
                 "scriptarguments": [],
 
-                "name": "PYMEVisualize",
+                "name": "PYMEVisualize (VisGUI)",
                 "workdir": "${USERPROFILE}",
                 "icon": "${MENU_DIR}/pmvis.ico",
                 "desktop": true,


### PR DESCRIPTION
Addresses issue #216.

**Is this a bugfix or an enhancement?**
Enhancement

**Proposed changes:**
- Entry point and import aliases to access `VisGUI` as `PYMEVisualize`
- Alias for Jupyter notebook functionality to access `ipython_visgui` as `ipython_pymevisualize`
- Entry point aliases to access `dh5view` as `PYMEImage` (there is no `import dh5view`)

**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [x] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
