### PR TITLE
include filename/url in clusterIO timeout/error logging

### DIFF
--- a/PYME/IO/clusterIO.py
+++ b/PYME/IO/clusterIO.py
@@ -779,7 +779,7 @@ def get_file(filename, serverfilter=local_serverfilter, numRetries=3, use_file_c
     nTries = 1
     while nTries < numRetries and len(locs) == 0:
         #retry, giving a little bit of time for the data servers to come up
-        logger.debug('Could not find file, retrying ...')
+        logger.debug('Could not find %s, retrying ...' % filename)
         time.sleep(1)
         nTries += 1
         locs = locate_file(filename, serverfilter, return_first_hit=True)
@@ -803,10 +803,10 @@ def get_file(filename, serverfilter=local_serverfilter, numRetries=3, use_file_c
         except (requests.Timeout, requests.ConnectionError) as e:
             # s.get sometimes raises ConnectionError instead of ReadTimeoutError
             # see https://github.com/requests/requests/issues/2392
-            logger.exception('Timeout on get file')
+            logger.exception('Timeout on get file %s' % url)
             logger.info('%d retries left' % (numRetries - nTries))
             if nTries == numRetries:
-                raise
+                raise e
 
     #s = _getSession(url)
     #r = s.get(url, timeout=.5)

--- a/PYME/IO/clusterIO.py
+++ b/PYME/IO/clusterIO.py
@@ -800,13 +800,13 @@ def get_file(filename, serverfilter=local_serverfilter, numRetries=3, use_file_c
             s = _getSession(url)
             r = s.get(url, timeout=.5)
             haveResult = True
-        except (requests.Timeout, requests.ConnectionError) as e:
+        except (requests.Timeout, requests.ConnectionError):
             # s.get sometimes raises ConnectionError instead of ReadTimeoutError
             # see https://github.com/requests/requests/issues/2392
             logger.exception('Timeout on get file %s' % url)
             logger.info('%d retries left' % (numRetries - nTries))
             if nTries == numRetries:
-                raise e
+                raise
 
     #s = _getSession(url)
     #r = s.get(url, timeout=.5)


### PR DESCRIPTION
Addresses issue # .

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- include filename/url in logging statements






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
