### PR TITLE
turn lasers back on for each well in multiwell tiling

### DIFF
--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -115,23 +115,6 @@ def orca_cam_controls(MainFrame, scope):
     MainFrame.AddMenuItem('Camera', 'Set Multiview', lambda e: scope.state.setItem('Camera.Views', [0, 1, 2, 3]))
     MainFrame.AddMenuItem('Camera', 'Clear Multiview', lambda e: scope.state.setItem('Camera.Views', []))
 
-    # from PYME.Acquire.ui import multiview_panel
-    # mvp = multiview_panel.MultiviewPanel(MainFrame, scope)
-    # MainFrame.camPanels.append((mvp, 'Multiview Panel'))
-
-
-# @init_gui('Sample database')
-# def samp_db(MainFrame, scope):
-#     from PYME.Acquire import sampleInformation
-#     sampPan = sampleInformation.slidePanel(MainFrame)
-#     MainFrame.camPanels.append((sampPan, 'Current Slide'))
-
-# @init_gui('Analysis settings')
-# def anal_settings(MainFrame, scope):
-#     from PYME.Acquire.ui import AnalysisSettingsUI
-#     AnalysisSettingsUI.Plug(scope, MainFrame)
-
-
 @init_hardware('Lasers & Shutters')
 def lasers(scope):
     from PYME.Acquire.Hardware.Coherent import OBIS
@@ -182,20 +165,6 @@ def laser_controls(MainFrame, scope):
     MainFrame.time1.WantNotification.append(lsf.update)
     MainFrame.camPanels.append((lsf, 'Laser Powers'))
 
-# @init_hardware('Line scanner')
-# def line_scanner(scope):
-#     from PYME.experimental import scanner_control
-#     scope.line_scanner = scanner_control.ScannerController()
-
-# @init_gui('line scanner')
-# def line_scanner_gui(MainFrame, scope):
-#     from PYME.Acquire.ui import scanner_panel
-#     from PYME.experimental import scanner_control
-#
-#     scope.line_scanner = scanner_control.ScannerController()
-#     scp = scanner_panel.ScannerPanel(MainFrame.camPanel, scope.line_scanner)
-#     MainFrame.camPanels.append((scp, 'Line Scanner'))
-
 @init_gui('Multiview Selection')
 def multiview_selection(MainFrame, scope):
     from PYME.Acquire.ui import multiview_select
@@ -212,21 +181,6 @@ def focus_keys(MainFrame, scope):
     panel = FocusLockPanel(MainFrame, scope.focus_lock)
     MainFrame.camPanels.append((panel, 'Focus Lock'))
     MainFrame.time1.WantNotification.append(panel.refresh)
-
-#splitter
-# @init_gui('Splitter')
-# def splitter(MainFrame, scope):
-#     from PYME.Acquire.Hardware import splitter
-#     splt1 = splitter.Splitter(MainFrame, scope, scope.cameras['EMCCD'], flipChan = 1, dichroic = 'Unspecified' ,
-#                               transLocOnCamera = 'Top', flip=True, dir='up_down', constrain=False, cam_name='EMCCD')
-#     splt2 = splitter.Splitter(MainFrame, scope, scope.cameras['sCMOS'], flipChan = 1, dichroic = 'FF700-Di01' ,
-#                               transLocOnCamera = 'Right', flip=False, dir='left_right', constrain=False, cam_name='sCMOS')
-
-
-#InitGUI("""
-#from PYME.Acquire.Hardware import splitter
-#splt = splitter.Splitter(MainFrame, None, scope, scope.cam)
-#""")
 
 @init_gui('Action manager')
 def action_manager(MainFrame, scope):
@@ -255,7 +209,10 @@ def action_manager(MainFrame, scope):
     from PYME.Acquire.ui import tile_panel
 
     ap = tile_panel.CircularTilePanel(MainFrame, scope)
-    MainFrame.aqPanels.append((ap, 'Tiling'))
+    MainFrame.aqPanels.append((ap, 'Circular Tile Acquisition'))
+
+    ap = tile_panel.MultiwellTilePanel(MainFrame, scope)
+    MainFrame.aqPanels.append((ap, 'Multiwell Tile Acquisition'))
 
 #must be here!!!
 joinBGInit() #wait for anyhting which was being done in a separate thread

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -195,11 +195,6 @@ class MultiwellTilePanel(TilePanel):
         hsizer.Add(self.tDestination, 1, wx.ALL | wx.EXPAND, 2)
         vsizer.Add(hsizer, 0, wx.EXPAND, 0)
 
-        # hsizer = wx.BoxSizer(wx.HORIZONTAL)
-        # self.pProgress = wx.Gauge(self, -1, range=100)
-        # hsizer.Add(self.pProgress, 1, wx.ALL | wx.EXPAND, 2)
-        # vsizer.Add(hsizer, 0, wx.EXPAND, 0)
-
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
         hsizer.Add(wx.StaticText(self, -1, 'Well Scan radius [\u03BCm]:'), 0, wx.ALL, 2)
         self.radius_um = wx.TextCtrl(self, -1, value='%.1f' % 250)
@@ -248,10 +243,13 @@ class MultiwellTilePanel(TilePanel):
     def OnGo(self, event=None):
         trigger = hasattr(self.scope.cam, 'FireSoftwareTrigger')
 
+        # get laser states
+        laser_state = {k:v for k, v in dict(self.scope.state).items() if k.startswith('Laser')}
+
         self.scope.tiler = tiler.MultiwellCircularTiler(float(self.radius_um.GetValue()),
             float(self.x_spacing_mm.GetValue()) * 1e3, float(self.y_spacing_mm.GetValue()) * 1e3,
             int(self.n_x.GetValue()), int(self.n_y.GetValue()), self.scope, self.tDestination.GetValue(),
-            trigger=trigger)
+            trigger=trigger, laser_state=laser_state)
 
         self.bStop.Enable()
         self.bGo.Disable()


### PR DESCRIPTION
Addresses issue # .

**Is this a bugfix or an enhancement?**
bugfix - current behavior is that `pointScanner.stop` calls `microscope.turnAllLasersOff` after each well but we don't turn them back on when we start the next well.
**Proposed changes:**
- cache laser state on multiwell tile start
- set the laser state back to what it was initially
- add the multiwell tile panel to the htsms init
- remove commented out stuff in htsms init which has either never been used for this scope or is duplicated






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
