### PR TITLE
fix regression in RulePusher finding non-local ruleservers

### DIFF
--- a/PYME/cluster/HTTPRulePusher.py
+++ b/PYME/cluster/HTTPRulePusher.py
@@ -51,7 +51,7 @@ def _getTaskQueueURI(n_retries=2):
         local_queues = [q for q in queueURLs if compName in q]
         logger.debug('local_queues: %s' % local_queues)
         return queueURLs[local_queues[0]]
-    except KeyError:
+    except (KeyError, IndexError):
         #if there is no local distributor, choose one at random
         logger.info('no local rule server, choosing one at random')
         return random.choice(list(queueURLs.values()))


### PR DESCRIPTION
Addresses issue # .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
catch the error we get when there are no local ruleservers so we can find the non-locals





**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
