### PR TITLE
Max-duration arg for acquisition tasks and monitoring thread

### DIFF
--- a/PYME/Acquire/ActionManager.py
+++ b/PYME/Acquire/ActionManager.py
@@ -145,7 +145,7 @@ class ActionManager(object):
         """
         while self._monitoring:
             if self.currentTask is not None:
-                logger.debug('here, %f s until kill' % (self._cur_task_kill_time - time.time()))
+                #logger.debug('here, %f s until kill' % (self._cur_task_kill_time - time.time()))
                 if time.time() > self._cur_task_kill_time:
                     self.scope().turnAllLasersOff()
                     # pause and reset so we can start up again later


### PR DESCRIPTION
…to watch whether they've gone defunct / perform safety maneuvers

Addresses issue # .

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- add a `max_duration` kwarg to `ActionManager.QueueAction`, after which point the action can be regarded as failed/defunct/the microscope in a bad place/something going to catch fire.
- a thread which constantly checks whether we have an active task that has outlived itself.
- use the new `max_duration` arg during `actionUI._add_ROIs`
- add a column to the `actionUI.ActionList` and a text-entry box to allow use during gui add-tasks




I tested by throwing a method into microscope
```
    def sleep(self, delay=15):
        import time
        time.sleep(delay)
```
and adding it to the queue. Notably the lasers shut off, and the queue pauses, however the onQueueChanged signal (which connects to the `ActionUI` update method) does not have the effect I desired of changing 'pause' to 'resume' in the GUI. This is relatively minor, and I assume updating the queue won't hurt anyway in case we 'fix' that 'issue' later. Could also just remove it and assume if something gone horribly wrong, it's gone wrong enough you're just glad the lasers are off and your queue is paused on the backend.


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?

Discussed with David, additionally it came up that in the medium/longer term it would be nice to have a context manager defined in ActionManager which would be taken out by function calls we would like failures to pause/turn off lasers. Alternatively a server process with access to `microscope.turnAllLasersOff` might also be more universally call-able for those using hybrid PYME + ??? systems.

- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
