### PR TITLE
improving SpoolController (sub)directory handling

### DIFF
--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -78,9 +78,10 @@ class SpoolController(object):
         
         #dateDict = {'username' : win32api.GetUserName(), 'day' : dtn.day, 'month' : dtn.month, 'year':dtn.year}
         
-        self._user_dir = None
         self._base_dir = nameUtils.get_local_data_directory()
-        self._subdir = nameUtils.get_spool_subdir()
+        self._dirname = os.sep.join([self._base_dir, ] + nameUtils.get_spool_subdir())
+        self._cluster_dirname = self.get_cluster_dirname(self._dirname)
+
         self.seriesStub = defSeries % nameUtils.dateDict
 
         self.seriesCounter = 0
@@ -168,10 +169,11 @@ class SpoolController(object):
         
     @property
     def dirname(self):
-        if self.spoolType == 'Cluster':
-            dir = self.get_cluster_dirname(self._user_dir) if self._user_dir is not None else '/'.join(self._subdir)
-        else:
-            dir = self._user_dir if self._user_dir is not None else os.sep.join([self._base_dir, ] + self._subdir)
+        dir = self._dirname if self.spoolType != 'Cluster' else self._cluster_dirname
+        if config.get('acquire-spool_subdirectories', False):
+            # limit single directory size for (cluster) IO performance
+            subdir = '%03d' % int(self.seriesCounter/100)
+            dir = dir + self._sep + subdir
         return dir
 
     def get_cluster_dirname(self, dirname):
@@ -179,7 +181,7 @@ class SpoolController(object):
         dir = dirname.replace(self._base_dir + os.sep, '')
         # if we weren't below PYMEData dir, which probably isn't great, at least drop any windows nonsense
         dir = dir.split(':')[-1]
-        return unifiedIO.fix_name(dir.replace(os.sep, '/'))
+        return unifiedIO.verbose_fix_name(dir.replace(os.sep, '/'))
         
     @property
     def seriesName(self):
@@ -199,12 +201,7 @@ class SpoolController(object):
     
 
     def _GenSeriesName(self):
-        if config.get('acquire-spool_subdirectories', False):
-            # High-throughput performance optimization
-            # If true, add a layer of directories to limit the number of series saved in a single directory
-            return '%03d%s%s_%05d' % (int(self.seriesCounter/100), self._sep, self.seriesStub, self.seriesCounter)
-        else:
-            return self.seriesStub + '_' + numToAlpha(self.seriesCounter)
+        return self.seriesStub + '_' + numToAlpha(self.seriesCounter)
        
     def _checkOutputExists(self, fn):
         if self.spoolType == 'Cluster':
@@ -246,7 +243,9 @@ class SpoolController(object):
             
     def SetSpoolDir(self, dirname):
         """Set the directory we're spooling into"""
-        self._user_dir = dirname + os.sep
+        print('setting spool dir: %s' % dirname)
+        self._dirname = dirname
+        self._cluster_dirname = self.get_cluster_dirname(dirname)
         #if we've had to quit for whatever reason start where we left off
         self._update_series_counter()
             
@@ -261,8 +260,8 @@ class SpoolController(object):
             ext = '.pcs'
         else:
             ext = '.h5'
-            
-        return self._sep.join([self.dirname.rstrip(self._sep), fn + ext])
+        
+        return self._sep.join([self.dirname, fn + ext])
 
 
     def StartSpooling(self, fn=None, stack=None, compLevel=None, zDwellTime=None, doPreflightCheck=True, maxFrames=sys.maxsize,
@@ -356,8 +355,21 @@ class SpoolController(object):
         return lambda : not self.spooler.spoolOn
 
     @property
-    def rel_dirname(self):
-        return self._sep.join(self._subdir)
+    def display_dirname(self):
+        """ 
+        Returns a relative directory name for display in user interfaces
+
+        Returns
+        -------
+        dirname : str
+            current spool directory, relative to local PYMEData directory 
+            (ideally)
+        """
+        dirname = self.dirname
+        if self.spoolType == 'Cluster':
+            return dirname
+        else:
+            return dirname.replace(self._base_dir + os.sep, '')
 
     def StopSpooling(self):
         """GUI callback to stop spooling."""

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -174,6 +174,11 @@ class SpoolController(object):
             # limit single directory size for (cluster) IO performance
             subdir = '%03d' % int(self.seriesCounter/100)
             dir = dir + self._sep + subdir
+        
+        # make directories as needed, makedirs(dir, exist_ok=True) once py2 support is dropped
+        if (self.spoolType != 'Cluster') and (not os.path.exists(dir)):
+                os.makedirs(dir)
+
         return dir
 
     def get_cluster_dirname(self, dirname):
@@ -277,12 +282,6 @@ class SpoolController(object):
         cluster_h5 = self.cluster_h5 if cluster_h5 is None else cluster_h5
         fn = self.seriesName if fn in ['', None] else fn
         zDwellTime = self.z_dwell if zDwellTime is None else zDwellTime
-        
-        #make directories as needed
-        if not (self.spoolType == 'Cluster'):
-            dirname = os.path.split(self._get_queue_name(fn))[0]
-            if not os.path.exists(dirname):
-                os.makedirs(dirname)
 
         if self._checkOutputExists(fn): #check to see if data with the same name exists
             self.seriesCounter +=1

--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -339,7 +339,7 @@ class PanSpool(afp.foldingPane):
         self.spoolController.onSpoolStart.connect(self.OnSpoolingStarted)
         self.spoolController.onSpoolStop.connect(self.OnSpoolingStopped)
 
-        self.stSpoolDirName.SetLabel(self.spoolController.rel_dirname)
+        self.stSpoolDirName.SetLabel(self.spoolController.display_dirname)
         self.tcSpoolFile.SetValue(self.spoolController.seriesName)
         self.UpdateFreeSpace()
 
@@ -541,7 +541,7 @@ class PanSpool(afp.foldingPane):
         if not ndir == '':
             logger.debug('series name %s' % self.spoolController.seriesName)
             self.spoolController.SetSpoolDir(ndir)
-            self.stSpoolDirName.SetLabel(self.spoolController.dirname)
+            self.stSpoolDirName.SetLabel(self.spoolController.display_dirname)
             self.tcSpoolFile.SetValue(self.spoolController.seriesName)
             logger.debug('series name %s' % self.spoolController.seriesName)
 
@@ -572,7 +572,7 @@ class PanSpool(afp.foldingPane):
         
     def OnSpoolMethodChanged(self, event):
         self.spoolController.SetSpoolMethod(self._get_spool_method())
-        self.stSpoolDirName.SetLabel(self.spoolController.rel_dirname)
+        self.stSpoolDirName.SetLabel(self.spoolController.display_dirname)
         self.tcSpoolFile.SetValue(self.spoolController.seriesName)
 
         self.UpdateFreeSpace()

--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -515,6 +515,7 @@ class PanSpool(afp.foldingPane):
         self.stSpoolingTo.SetForegroundColour(wx.TheColourDatabase.Find('GREY'))
         self.stNImages.SetForegroundColour(wx.TheColourDatabase.Find('GREY'))
 
+        self.stSpoolDirName.SetLabel(self.spoolController.display_dirname)
         self.tcSpoolFile.SetValue(self.spoolController.seriesName)
         self.UpdateFreeSpace()
 


### PR DESCRIPTION
Addresses issue # .
PR #178 was partially helpful, but in our efforts to support file/queue/cluster as well as my subdirectory chunking stuff we got a little mixed up in `SpoolController.dirname`, `SpoolController.rel_dirname`, `SpoolController._base_dir`, `SpoolController._user_dir`, `SpoolController.get_cluster_dirname`, and `SpoolController._subdir` handling, which left us with a trailing '/' when spooling from windows where `os.sep != '/'` (but e.g. in `SpoolController._get_queue_name` we rstrip `SpoolController._sep` when we might have added an `os.sep` previously). Additionally, as mentioned in/a result of #178, the directory display in `HDFSpoolFrame` for `File` or `Queue` spool types was not incredibly useful because it tried to display the full path. 

The '//' issue lead to some pain checking if a file exists, because clusterIO would choke on the directory. See below for 'Bergamot/2020_7_3/super-secret/000//3_7_series_B.pcs'. 

```
DEBUG:PYME.Acquire.microscope:restarted framewrangler

fold
DEBUG:PYME.Acquire.ui.HDFSpoolFrame:series name 3_7_series_B

DEBUG:PYME.Acquire.SpoolController:Updating series counter

DEBUG:PYME.Acquire.SpoolController:Looking for Bergamot/2020_7_3/super-secret/000//3_7_series_B (.pcs or .h5) on cluster

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.10:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.2:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.3:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.1:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.4:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.7:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.8:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.5:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.9:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.9:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.2:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.8:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.1:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.3:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.10:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.7:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.4:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.5:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.10:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.2:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.3:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.1:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.4:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.7:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.8:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.5:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.9:15348/Bergamot/2020_7_3/super-secret/000//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.2:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.8:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.9:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.3:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.7:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.4:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.10:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.5:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.1:15348/Bergamot/2020_7_3/super-secret/000/' failed with error: 404

DEBUG:PYME.Acquire.ui.HDFSpoolFrame:series name 3_7_series_B

Warning: not keeping up with camera, giving up with 0 frames still in buffer
DEBUG:PYME.Acquire.ui.HDFSpoolFrame:series name 3_7_series_B

DEBUG:PYME.Acquire.SpoolController:Updating series counter

DEBUG:PYME.Acquire.SpoolController:Looking for Bergamot/2020_7_3/super-secret//3_7_series_B (.pcs or .h5) on cluster

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.10:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.2:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.3:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.1:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.4:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.7:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.8:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.5:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.9:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.2:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.8:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.5:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.9:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.3:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.4:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.10:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.1:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.7:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.10:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.2:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.3:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.1:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.4:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.7:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.8:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.5:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.9:15348/Bergamot/2020_7_3/super-secret//' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.7:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.8:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.3:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.2:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.10:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.5:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.1:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.4:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.IO.clusterIO:Request for b'http://10.150.7.9:15348/Bergamot/2020_7_3/super-secret/' failed with error: 404

DEBUG:PYME.Acquire.ui.HDFSpoolFrame:series name 3_7_series_B

Warning: not keeping up with camera, giving up with 0 frames still in buffer
```

**Is this a bugfix or an enhancement?**
sort of both I guess

**Proposed changes:**
- consolidate `_user_dir`, `_subdir` and `_dirname` into just `_dirname`, additionally keeping track of `_cluster_dirname` which is updated when we update `_dirname` using the existing `get_cluster_dirname` function.
- decide whether to return `_dirname` or `_cluster_dirname` in the `dirname` property getter.
- don't worry about adding separators to the end of `_dirname` upstream of `dirname` 
property.
- handle subdirectory chunking following PYME config `acquire-spool_subdirectories` flag in `dirname` property rather than in seriesName.
- change `rel_dirname` property to `display_dirname` - I can revert this if you like, @David-Baddeley . It was helpful for me to rename it when I started working on this and we had `rel_dirname` and `_sub_dir` at the same time.
- update display directory name in `HDFSpoolFrame` on spool stop so we display the right chunked directory if we're about to tick over into the next one.



**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [x] Does this change how users interact with the software? How will these changes be communicated?

I don't think anyone will panic, but displaying the relative directory (if under the PYMEData dir) after setting the spool directory instead of displaying the full path will be a change. It will still show the directory set though (e.g. if they made a subfolder or something) which I think makes it pretty clear things are OK.
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
