### PR TITLE
Unify shell name and intro text

### DIFF
--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -127,8 +127,8 @@ class PYMEMainFrame(AUIFrame):
 
         self.sh = wx.py.shell.Shell(id=-1,
               parent=self, size=wx.Size(-1, -1), style=0, locals=self.__dict__,
-              introText='PYMEAcquire - note that help, license etc below is for Python, not PYME\n\n')
-        self.AddPage(self.sh, caption='Console')
+              introText='PYMEAcquire - note that help, license, etc. below is for Python, not PYME\n\n')
+        self.AddPage(self.sh, caption='Shell')
 
         self.CreateToolPanel(getattr(options, 'gui_mode', 'default'))
 

--- a/PYME/DSView/modules/shell.py
+++ b/PYME/DSView/modules/shell.py
@@ -20,6 +20,7 @@
 #
 ##################
 
+import weakref
 import wx.py.shell
 from PYME import config
 
@@ -27,12 +28,12 @@ def Plug(dsviewer):
     sh = wx.py.shell.Shell(id=-1,
                            parent=dsviewer, pos=wx.Point(0, 0), size=wx.Size(618, 451), style=0, locals=dsviewer.__dict__,
                            startupScript=config.get('dh5View-console-startup-file', None),
-              introText='note that help, license etc below is for Python, not PYME\n\n')
+              introText='PYMEImage - note that help, license, etc. below is for Python, not PYME\n\n')
 
     sh.Execute('from pylab import *')
     sh.Execute('from scipy import ndimage')
     sh.Execute('from PYME.DSView import View3D, ViewIm3D')
 
-    dsviewer.AddPage(page=sh, select=False, caption='Console')
+    dsviewer.AddPage(page=sh, select=False, caption='Shell')
 
-    dsviewer.sh = sh
+    dsviewer.sh = weakref.proxy(sh)

--- a/PYME/DSView/modules/shell.py
+++ b/PYME/DSView/modules/shell.py
@@ -20,7 +20,6 @@
 #
 ##################
 
-import weakref
 import wx.py.shell
 from PYME import config
 
@@ -36,4 +35,4 @@ def Plug(dsviewer):
 
     dsviewer.AddPage(page=sh, select=False, caption='Shell')
 
-    dsviewer.sh = weakref.proxy(sh)
+    dsviewer.sh = sh

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -114,7 +114,7 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
         self.sh = wx.py.shell.Shell(id=-1,
                                     parent=self, size=wx.Size(-1, -1), style=0, locals=self.__dict__,
                                     startupScript=config.get('VisGUI-console-startup-file', None),
-              introText='PYME console - note that help, license etc below is for Python, not PySMI\n\n')
+              introText='PYMEVisualize - note that help, license, etc. below is for Python, not PYME\n\n')
 
         #self._mgr.AddPane(self.sh, aui.AuiPaneInfo().
         #                  Name("Shell").Caption("Console").Centre().CloseButton(False).CaptionVisible(False))


### PR DESCRIPTION
Addresses issue # .

**Is this a bugfix or an enhancement?**
Enhancement

**Proposed changes:**
- Unify shell name and intro text across pymevisualize, pymeimage, pymeacquire




**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
