### PR TITLE
Offset piezo / focus lock performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,6 @@ The intention of this file is to be easier to parse than the PR / commit history
 
 ## Changes
 
-**FIXVERSION** - socket keep-alives in OffsetPiezoClient and RLPIDFocusLockClient
-
 **20.07.08** - created CHANGELOG.md (changes before here are incomplete)
 
 **20.07.07** - improved dsviewer plugin API - see PYME.DSView.modules.loadModule() docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The intention of this file is to be easier to parse than the PR / commit history
 
 ## Changes
 
+**FIXVERSION** - socket keep-alives in OffsetPiezoClient and RLPIDFocusLockClient
+
 **20.07.08** - created CHANGELOG.md (changes before here are incomplete)
 
 **20.07.07** - improved dsviewer plugin API - see PYME.DSView.modules.loadModule() docs

--- a/PYME/Acquire/ExecTools.py
+++ b/PYME/Acquire/ExecTools.py
@@ -190,6 +190,14 @@ class GUIInitTask(object):
         self.codeObj = codeObj
 
     def run(self, parent, scope):
+        """
+
+        Parameters
+        ----------
+        parent : PYME.Acquire.acquiremainframe.PYMEMainFrame, wx.Frame
+        scope : PYME.Acquire.microscope.microscope
+        
+        """
         global defGlobals
         global defLocals
         #try:

--- a/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
+++ b/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
@@ -108,53 +108,54 @@ class OffsetPiezoClient(PiezoBase):
         self.name = name
         
         self.urlbase = 'http://%s:%d' % (host, port)#,self.name)
+        self._session = requests.Session()
 
     def MoveTo(self, iChannel, fPos, bTimeOut=True):
-        return requests.get(self.urlbase + '/MoveTo?iChannel=%d&fPos=%3.3f' % (iChannel, fPos))
+        return self._session.get(self.urlbase + '/MoveTo?iChannel=%d&fPos=%3.3f' % (iChannel, fPos))
 
     def MoveRel(self, iChannel, incr, bTimeOut=True):
-        return requests.get(self.urlbase + '/MoveRel?iChannel=%d&incr=%3.3f' % (iChannel, incr))
+        return self._session.get(self.urlbase + '/MoveRel?iChannel=%d&incr=%3.3f' % (iChannel, incr))
 
     def GetPos(self, iChannel=0):
-        res = requests.get(self.urlbase + '/GetPos?iChannel=%d' % (iChannel, ))
+        res = self._session.get(self.urlbase + '/GetPos?iChannel=%d' % (iChannel, ))
         return float(res.json())
 
     def GetTargetPos(self, iChannel=0):
-        res = requests.get(self.urlbase + '/GetTargetPos?iChannel=%d' % (iChannel,))
+        res = self._session.get(self.urlbase + '/GetTargetPos?iChannel=%d' % (iChannel,))
         return float(res.json())
 
     def GetMin(self, iChan=1):
-        res = requests.get(self.urlbase + '/GetMin?iChan=%d' % (iChan,))
+        res = self._session.get(self.urlbase + '/GetMin?iChan=%d' % (iChan,))
         return float(res.json())
 
     def GetMax(self, iChan=1):
-        res = requests.get(self.urlbase + '/GetMax?iChan=%d' % (iChan,))
+        res = self._session.get(self.urlbase + '/GetMax?iChan=%d' % (iChan,))
         return float(res.json())
 
     def GetFirmwareVersion(self):
-        res = requests.get(self.urlbase + '/GetFirmwareVersion')
+        res = self._session.get(self.urlbase + '/GetFirmwareVersion')
         return str(res.json())
 
     def GetOffset(self):
-        res = requests.get(self.urlbase + '/GetOffset')
+        res = self._session.get(self.urlbase + '/GetOffset')
         return float(res.json())
 
     def SetOffset(self, offset):
-        return requests.get(self.urlbase + '/SetOffset?offset=%3.3f' % (offset))
+        return self._session.get(self.urlbase + '/SetOffset?offset=%3.3f' % (offset))
 
     def CorrectOffset(self, shim):
-        return requests.get(self.urlbase + '/CorrectOffset?correction=%3.3f' % (shim))
+        return self._session.get(self.urlbase + '/CorrectOffset?correction=%3.3f' % (shim))
 
     def LogShifts(self, dx, dy, dz, active=True):
-        res = requests.get(self.urlbase + '/LogShifts?dx=%3.3f&dy=%3.3f&dz=%3.3f&active=%d'% (dx, dy, dz, active))
+        res = self._session.get(self.urlbase + '/LogShifts?dx=%3.3f&dy=%3.3f&dz=%3.3f&active=%d'% (dx, dy, dz, active))
         return float(res.json())
 
     def OnTarget(self):
-        res = requests.get(self.urlbase + '/OnTarget')
+        res = self._session.get(self.urlbase + '/OnTarget')
         return bool(res.json())
 
     def LogFocusCorrection(self, offset):
-        res = requests.get(self.urlbase + '/LogFocusCorrection?offset=%3.3f' % (offset,))
+        self._session.get(self.urlbase + '/LogFocusCorrection?offset=%3.3f' % (offset,))
 
 def generate_offset_piezo_server(offset_piezo_base_class):
     """

--- a/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
+++ b/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
@@ -286,29 +286,30 @@ class RLPIDFocusLockClient(object):
         self.name = name
 
         self.base_url = 'http://%s:%d' % (host, port)
+        self._session = requests.Session()
 
     @property
     def lock_enabled(self):
         return self.LockEnabled()
 
     def LockEnabled(self):
-        response = requests.get(self.base_url + '/LockEnabled')
+        response = self._session.get(self.base_url + '/LockEnabled')
         return bool(response.json())
 
     def EnableLock(self):
-        return requests.get(self.base_url + '/EnableLock')
+        return self._session.get(self.base_url + '/EnableLock')
 
     def DisableLock(self):
-        return requests.get(self.base_url + '/DisableLock')
+        return self._session.get(self.base_url + '/DisableLock')
 
     def GetPeakPosition(self):
-        response = requests.get(self.base_url + '/GetPeakPosition')
+        response = self._session.get(self.base_url + '/GetPeakPosition')
         return float(response.json())
 
     def ChangeSetpoint(self, setpoint=None):
         if setpoint is None:
             setpoint = self.GetPeakPosition()
-        return requests.get(self.base_url + '/ChangeSetpoint?setpoint=%3.3f' % (setpoint,))
+        return self._session.get(self.base_url + '/ChangeSetpoint?setpoint=%3.3f' % (setpoint,))
 
     def ToggleLock(self):
         if self.lock_enabled:
@@ -317,7 +318,7 @@ class RLPIDFocusLockClient(object):
             self.EnableLock()
 
     def SetSubtractionProfile(self):
-        return requests.get(self.base_url + '/SetSubtractionProfile')
+        return self._session.get(self.base_url + '/SetSubtractionProfile')
 
 
 class RLPIDFocusLockServer(webframework.APIHTTPServer, ReflectedLinePIDFocusLock):

--- a/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
+++ b/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
@@ -198,13 +198,13 @@ class ReflectedLinePIDFocusLock(PID):
         if self.mode == 'time':
             self.StartPolling()
         else:
-            self.scope.frameWrangler.onFrame.connect(self.on_frame)
+            self.scope.frameWrangler.onFrameGroup.connect(self.on_frame)
 
     def deregister(self):
         if self.mode == 'time':
             self.StopPolling()
         else:
-            self.scope.frameWrangler.onFrame.disconnect(self.on_frame)
+            self.scope.frameWrangler.onFrameGroup.disconnect(self.on_frame)
 
     @webframework.register_endpoint('/ToggleLock', output_is_json=False)
     def ToggleLock(self):

--- a/PYME/Acquire/Scripts/init_htsms_focus_lock.py
+++ b/PYME/Acquire/Scripts/init_htsms_focus_lock.py
@@ -65,11 +65,15 @@ def focus_lock(MainFrame, scope):
     from PYME.ui import fastGraph
     from PYME.Acquire.Hardware.focus_locks.reflection_focus_lock import RLPIDFocusLockServer
     from PYME.Acquire.ui.focus_lock_gui import FocusLockPanel
-    scope.focus_lock = RLPIDFocusLockServer(scope, scope.piFoc, p=-0.075, i=-0.0025, d=-0.002, sample_time=0.005)
+    sample_time = 0.005
+    scope.focus_lock = RLPIDFocusLockServer(scope, scope.piFoc, 
+                                            p=-0.075, i=-0.0025, d=-0.002, 
+                                            sample_time=sample_time)
     scope.focus_lock.register()
     panel = FocusLockPanel(MainFrame, scope.focus_lock)
     MainFrame.camPanels.append((panel, 'Focus Lock'))
     MainFrame.time1.WantNotification.append(panel.refresh)
+    scope.frameWrangler._polling_interval = sample_time
 
     # # display dark-subtracted profile
     # fg = fastGraph.FastGraphPanel(MainFrame, -1, np.arange(10), np.arange(10))

--- a/PYME/Acquire/Scripts/init_htsms_focus_lock.py
+++ b/PYME/Acquire/Scripts/init_htsms_focus_lock.py
@@ -34,9 +34,8 @@ def cam(scope):
     scope.cam.SetGainBoost(False)  # shouldn't be needed, but make sure it is off
     scope.cam.SetGain(1)  # we really don't need any extra gain, this defaults to 10 on startup
     scope.cam.SetROI(289, 827, 1080, 1008)
-    # With our laser at a stable operating current we saturate easily, set integ low. Can't get frame rate higher than
-    # 300 Hz, so try and get a low integ and 250 frame rate
-    scope.cam.SetIntegTime(0.005)
+    # Can't get frame rate higher than ~297 Hz for the current ROI, so default to just under that
+    scope.cam.SetIntegTime(0.0035)  # [s]
 
 #PIFoc
 @init_hardware('PIFoc')
@@ -65,15 +64,18 @@ def focus_lock(MainFrame, scope):
     from PYME.ui import fastGraph
     from PYME.Acquire.Hardware.focus_locks.reflection_focus_lock import RLPIDFocusLockServer
     from PYME.Acquire.ui.focus_lock_gui import FocusLockPanel
-    sample_time = 0.005
-    scope.focus_lock = RLPIDFocusLockServer(scope, scope.piFoc, 
-                                            p=-0.075, i=-0.0025, d=-0.002, 
-                                            sample_time=sample_time)
+    ku = -1.2  # ziegler-nichols 'ultimate' gain for my system
+    tu = 7  # [frames], roughly the period, when we're running camera/frameWrangler polling at 3.5 ms
+    # Stick with a PI tune for now
+    kp = 0.45 * ku
+    ki = 0.54 * ku / tu
+    scope.focus_lock = RLPIDFocusLockServer(scope, scope.piFoc,  p=kp, i=ki, d=0, sample_time=0.0035)
     scope.focus_lock.register()
     panel = FocusLockPanel(MainFrame, scope.focus_lock)
     MainFrame.camPanels.append((panel, 'Focus Lock'))
     MainFrame.time1.WantNotification.append(panel.refresh)
-    scope.frameWrangler._polling_interval = sample_time
+    # we don't benefit at all from multiple frames piling up in a polling interval, so try and match the camera cycle
+    scope.frameWrangler._polling_interval = 0.0035
 
     # # display dark-subtracted profile
     # fg = fastGraph.FastGraphPanel(MainFrame, -1, np.arange(10), np.arange(10))
@@ -88,23 +90,23 @@ def focus_lock(MainFrame, scope):
     # MainFrame.time1.WantNotification.append(refresh_profile)
 
     # # display setpoint / error over time
-    # n = 500
-    # # setpoint = np.zeros(n)
-    # position = np.ones(n) * scope.focus_lock.peak_position
-    # time = np.arange(n)
+    n = 500
+    # setpoint = np.zeros(n)
+    position = np.ones(n) * scope.focus_lock.peak_position
+    time = np.arange(n)
+
+    position_plot = fastGraph.FastGraphPanel(MainFrame, -1, time, position)
+    MainFrame.AddPage(page=position_plot, select=False, caption='Position')
     #
-    # position_plot = fastGraph.FastGraphPanel(MainFrame, -1, time, position)
-    # MainFrame.AddPage(page=position_plot, select=False, caption='Position')
-    #
-    # def refresh_position(*args, **kwargs):
-    #     position[:-1] = position[1:]
-    #     # if the position can't be found, replace nan with zero
-    #     position[-1] = np.nan_to_num(scope.focus_lock.peak_position)
-    #     time[:-1] = time[1:]
-    #     time[-1] = scope.focus_lock._last_time
-    #     position_plot.SetData(time, position)
-    #
-    # MainFrame.time1.WantNotification.append(refresh_position)
+    def refresh_position(*args, **kwargs):
+        position[:-1] = position[1:]
+        # if the position can't be found, replace nan with zero
+        position[-1] = np.nan_to_num(scope.focus_lock.peak_position)
+        # time[:-1] = time[1:]  # commenting out to leave time in units of frameWrangler.onFrameGroups for readability
+        # time[-1] = scope.focus_lock._last_time
+        position_plot.SetData(time, position)
+
+    MainFrame.time1.WantNotification.append(refresh_position)
 
 
 #must be here!!!

--- a/PYME/Acquire/frameWrangler.py
+++ b/PYME/Acquire/frameWrangler.py
@@ -54,6 +54,31 @@ import threading
 #sfrom PYME.ui import mytimer
 
 class FrameWrangler(object):
+    """
+    Grabs frames from the camera buffers
+
+    Notes
+    -----
+    dispatch Signals are used to allow other files to listen to key events 
+    happinging within the acquisition.
+
+    Attributes
+    ----------
+    onFrame : dispatch.Signal
+        Called once per new-frame appearing in our buffer; used to pass
+        frame data to e.g. spoolers. Note that while onFrame gets called once
+        per new frame, the new frames are only checked for once per polling
+        cycle, meaning that this event will be fired N-times for each 
+        `onFrameGroup` event.
+    onFrameGroup : dispatch.Signal
+        Called on each new frame group (once per polling interval) - use for 
+        updateing GUIs etc.
+    onStop : dispatch.Signal
+    _polling_interval : float
+        Length of time to sleep between loops in the polling thread. Defaults to
+        0.01, units of seconds.
+
+    """
     def __init__(self, _cam, _ds = None, event_loop=None):
         #wx.EvtHandler.__init__(self)
         #self.timer = wx.Timer(self)
@@ -105,7 +130,7 @@ class FrameWrangler(object):
 
         self._current_frame_lock = threading.Lock()
         self._poll_lock = threading.Lock()
-        
+        self._polling_interval = 0.01  # [s]
         self._poll_thread = threading.Thread(target=self._poll_loop)
         self._poll_thread.start()
         
@@ -221,18 +246,11 @@ class FrameWrangler(object):
                 #signal complete 
                 self.needExposureStart = True
 
-    def _poll_loop(self, sleep_interval=.01):
+    def _poll_loop(self):
         """
-        This loop runs in a background thread to continuously poll the camera and deal with frames as they arrive.
-
-        Parameters
-        ----------
-        sleep_interval : float
-            length of time to sleep within the polling thread
-
-        Returns
-        -------
-
+        This loop runs in a background thread to continuously poll the camera 
+        and deal with frames as they arrive. `FrameWrangler._polling_interval`
+        is used to set the delay between loops.
         """
         while (self._poll_camera):
             if (not self.cam.CamReady()):# and self.piezoReady())):
@@ -266,7 +284,7 @@ class FrameWrangler(object):
                     self.onExpReady()
                     self.n_frames_in_group += 1
         
-            time.sleep(sleep_interval)
+            time.sleep(self._polling_interval)
 
 
 

--- a/PYME/Acquire/frameWrangler.py
+++ b/PYME/Acquire/frameWrangler.py
@@ -74,9 +74,7 @@ class FrameWrangler(object):
         Called on each new frame group (once per polling interval) - use for 
         updateing GUIs etc.
     onStop : dispatch.Signal
-    _polling_interval : float
-        Length of time to sleep between loops in the polling thread. Defaults to
-        0.01, units of seconds.
+        Called when acquisition stops.
 
     """
     def __init__(self, _cam, _ds = None, event_loop=None):
@@ -130,7 +128,7 @@ class FrameWrangler(object):
 
         self._current_frame_lock = threading.Lock()
         self._poll_lock = threading.Lock()
-        self._polling_interval = 0.01  # [s]
+        self._polling_interval = 0.01  # time between calls to poll the camera [s]
         self._poll_thread = threading.Thread(target=self._poll_loop)
         self._poll_thread.start()
         

--- a/PYME/Acquire/microscope.py
+++ b/PYME/Acquire/microscope.py
@@ -313,6 +313,14 @@ class StateManager(object):
     
 
 class microscope(object):
+    """
+
+    Attributes
+    ----------
+    frameWrangler : PYME.Acquire.frameWrangler.FrameWrangler
+        Initialized in between hardware initializations and gui initializations.
+    
+    """
     def __init__(self):
         #list of tuples  of form (class, chan, name) describing the instaled piezo channels
         self.piezos = []


### PR DESCRIPTION
Addresses issue #313, maybe.

**Is this a bugfix or an enhancement?**
enhancement for the sake of bugfix

**Proposed changes:**
- use `request.Session.get` instead of `request.get` for socket keep-alives in `RLPIDFocusLockClient` 
- use `request.Session.get` instead of `request.get` for socket keep-alives in `OffsetPiezoClient` 
- connect focus lock to `frameWrangler.onFrameGroup` rather than `onFrame`
- make `frameWrangler` polling interval an attribute so we can change it if we like
- change `frameWrangler._polling_interval` in init_htsms_focus_lock
- move frameWrangler signal doc into docstring and clarify the part that I misunderstood earlier
- add minimal (typing) docstrings to `microscope` and `GUIInitTask` to aid linter/IDE shortcuts






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
