### PR TITLE
marginal gains when checking for series name collisions using httpspooler

### DIFF
--- a/PYME/Acquire/HTTPSpooler.py
+++ b/PYME/Acquire/HTTPSpooler.py
@@ -97,7 +97,7 @@ def exists(seriesName):
     """
     Check for PYME Cluster Series or h5 file on the cluster so we don't end up
     with degenerate file stubs.
-    
+
     Parameters
     ----------
     seriesName : str
@@ -309,12 +309,5 @@ class Spooler(sp.Spooler):
         self._dPoll = False
     
     def FlushBuffer(self):
-        # each item in the post-queue will be pushed to a single dataserver,
-        # keep things relatively spread out
-        for chunk in chunk_buffer(self._buffer, self.buflen):
-            self._postQueue.put(chunk)
+        self._postQueue.put(self._buffer)
         self._buffer = []
-
-def chunk_buffer(buffer, chunk_size):
-        for ind in range(0, len(buffer), chunk_size):
-            yield buffer[ind:ind + chunk_size]

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -212,8 +212,7 @@ class SpoolController(object):
             # special case for HTTP spooling.  Make sure 000\series.pcs -> 000/series.pcs
             pyme_cluster = self.dirname + '/' + fn.replace('\\', '/')
             logger.debug('Looking for %s (.pcs or .h5) on cluster' % pyme_cluster)
-            return HTTPSpooler.exists(pyme_cluster + '.pcs') or HTTPSpooler.exists(pyme_cluster + '.h5')
-            #return (fn + '.h5/') in HTTPSpooler.clusterIO.listdir(self.dirname)
+            return HTTPSpooler.exists(pyme_cluster)
         else:
             local_h5 = os.sep.join([self.dirname, fn + '.h5'])
             logger.debug('Looking for %s on local machine' % local_h5)

--- a/PYME/IO/clusterIO.py
+++ b/PYME/IO/clusterIO.py
@@ -554,6 +554,41 @@ def exists(name, serverfilter=local_serverfilter):
     """
     return (len(locate_file(name, serverfilter, True)) > 0) or isdir(name, serverfilter)
 
+def series_exists(relative_name, serverfilter=local_serverfilter):
+    """
+    Performance version of `exists` when checking for multiple extensions of the
+    same base filename. Checks for PYME Cluster Series (.pcs) and .h5
+    
+    Parameters
+    ----------
+    relative_name : str
+        data server relative path and filename without extension
+    serverfilter : str
+        name of the cluster (optional)
+    exts : iterator
+        extensions (str) to check for. 
+
+    Returns
+    -------
+    exists : bool
+        True if file exists, else False
+
+    """
+    # get the directory listing one time:
+    dirname, filename = os.path.split(relative_name)
+    name = (dirname)
+    serverfilter = (serverfilter)
+    
+    d_list = set(listdirectory(name, serverfilter).keys())
+    
+    if len(d_list) < 1:
+        # trivial case
+        return False
+    
+    # check permutations of our filename
+    return ((filename + '.pcs') in d_list) or ((filename + '.h5') in d_list)
+
+
 class _StatResult(object):
     def __init__(self, file_info):
         self.st_size = file_info.size


### PR DESCRIPTION
Addresses issue #314, but not really since we know that exists separate of spooling, just reduces a little dataserver overhead on each spool, which never hurts and we'd kind of talked about doing anyway

**Is this a bugfix or an enhancement?**
marginal enhancement

**Proposed changes:**
- add `clusterIO.series_exists` call to check for either pcs or h5 files with a single directory listing rather than 2x `clusterIO.isdir` and 2x single directory listings. Also use a set for faster membership checks if the directory is pretty full.


**Checklist:**
- [x] works
```
DEBUG:PYME.Acquire.SpoolController:Looking for Andrew/2020_7_9/000/9_7_series_00001 (.pcs or .h5) on cluster

('currSlide:', [None])
DEBUG:PYME.Acquire.HTTPSpooler:Starting spooling: Andrew/2020_7_9/000/9_7_series_00001.h5

'http://127.0.0.1:55533/__aggregate_h5/Andrew/2020_7_9/000/9_7_series_00001.h5/metadata.json'
DEBUG:PYME.Acquire.Spooler:Disconnecting from frame source

DEBUG:PYME.Acquire.Spooler:Frame source should be disconnected

DEBUG:PYME.Acquire.HTTPSpooler:Stopping spooling Andrew/2020_7_9/000/9_7_series_00001.h5

'http://127.0.0.1:55533/__aggregate_h5/Andrew/2020_7_9/000/9_7_series_00001.h5/final_metadata.json'
'http://127.0.0.1:55533/__aggregate_h5/Andrew/2020_7_9/000/9_7_series_00001.h5/events.json'
DEBUG:PYME.Acquire.SpoolController:Looking for Andrew/2020_7_9/000/9_7_series_00001 (.pcs or .h5) on cluster

ERROR:PYME.Acquire.ui.HDFSpoolFrame:IO error whilst spooling
Traceback (most recent call last):
  File "/Users/Andrew/code/python-microscopy/PYME/Acquire/ui/HDFSpoolFrame.py", line 469, in OnBStartSpoolButton
    self.spoolController.StartSpooling(fn, #stack=stack, #compLevel = compLevel,
  File "/Users/Andrew/code/python-microscopy/PYME/Acquire/SpoolController.py", line 291, in StartSpooling
    raise IOError('A series with the same name already exists')
OSError: A series with the same name already exists
Traceback (most recent call last):
  File "/Users/Andrew/code/python-microscopy/PYME/Acquire/ui/HDFSpoolFrame.py", line 469, in OnBStartSpoolButton
    self.spoolController.StartSpooling(fn, #stack=stack, #compLevel = compLevel,
  File "/Users/Andrew/code/python-microscopy/PYME/Acquire/SpoolController.py", line 291, in StartSpooling
    raise IOError('A series with the same name already exists')
OSError: A series with the same name already exists

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/Andrew/code/python-microscopy/PYME/Acquire/ui/HDFSpoolFrame.py", line 475, in OnBStartSpoolButton
    ans = wx.MessageBox(str(e.message), 'Error', wx.OK)
AttributeError: 'OSError' object has no attribute 'message'

```

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

## whitespace changes
 - I removed a commented clusterIO.exists line under the one I changed in `SpoolController`. I think it's justifiable and won't overly burden your review @David-Baddeley but I'm OK with us adding it back if you like.
- accidentally committed a totally unnecessary 'fix' to a non-existent problem in `HTTPSpooler.FlushBuffer`. Sorry I didn't back it out elegantly and now there are whitespace changes. Hopefully OK (they were indented two spaces instead of four... and I had forgotten that)

