### PR TITLE
Convert display name for mean and Gaussian curvature from H and K to …

### DIFF
--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -231,7 +231,7 @@ cdef class TriangleMesh(TrianglesBase):
         self.vertex_normals
 
         # Properties we can visualize
-        self.vertex_properties = ['x', 'y', 'z', 'component', 'boundary', 'singular', 'H', 'K']
+        self.vertex_properties = ['x', 'y', 'z', 'component', 'boundary', 'singular', 'mean_curvature', 'gaussian_curvature']
 
         self.fix_boundary = True  # Hold boundary edges in place
 
@@ -313,13 +313,13 @@ cdef class TriangleMesh(TrianglesBase):
         return self.vertices[:,2]
 
     @property
-    def H(self):
+    def mean_curvature(self):
         if self._H is None:
             self.calculate_curvatures()
         return self._H
     
     @property
-    def K(self):
+    def gaussian_curvature(self):
         if self._K is None:
             self.calculate_curvatures()
         return self._K

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -231,7 +231,7 @@ cdef class TriangleMesh(TrianglesBase):
         self.vertex_normals
 
         # Properties we can visualize
-        self.vertex_properties = ['x', 'y', 'z', 'component', 'boundary', 'singular', 'mean_curvature', 'gaussian_curvature']
+        self.vertex_properties = ['x', 'y', 'z', 'component', 'boundary', 'singular', 'curvature_mean', 'curvature_gaussian']
 
         self.fix_boundary = True  # Hold boundary edges in place
 
@@ -313,13 +313,13 @@ cdef class TriangleMesh(TrianglesBase):
         return self.vertices[:,2]
 
     @property
-    def mean_curvature(self):
+    def curvature_mean(self):
         if self._H is None:
             self.calculate_curvatures()
         return self._H
     
     @property
-    def gaussian_curvature(self):
+    def curvature_gaussian(self):
         if self._K is None:
             self.calculate_curvatures()
         return self._K


### PR DESCRIPTION
…mean_curvature and gaussian_curvature

Addresses issue # .

**Is this a bugfix or an enhancement?**

**Proposed changes:**







**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
