### PR TITLE
Update requirements.txt so recipe panels can open without crashing on pip installs

### DIFF
--- a/PYME/misc/depGraph.py
+++ b/PYME/misc/depGraph.py
@@ -6,7 +6,6 @@ Created on Mon Mar  9 21:56:18 2015
 """
 import numpy as np
 import toposort
-import networkx as nx
 # import pylab
 import matplotlib.pyplot as plt
 import matplotlib.cm
@@ -15,6 +14,8 @@ from six.moves import xrange
 import six
 
 def makeGraph(dg):
+    import networkx as nx
+    
     G = nx.DiGraph()
     for k, v in dg.items():
         for e in v:

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ pandas
 pyyaml
 psutil
 
-#docutils
+docutils
 #sphinx
 ujson
 jinja2


### PR DESCRIPTION
Addresses issue (none filed).

**Is this a bugfix or an enhancement?**
bugfix

**Proposed changes:**
- differ `networkx` import in PYME/misc/depGraph.py until it is called (in a function I don't think we use anywhere)
- add docutils back into requirements.txt as it is needed to display docs in any of the recipe ui's. While technically not necessary to run the program, I think it's a pretty small dependency and very helpful to users






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x ] Does this maintain backwards compatibility with old data?
- [x] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
