### PR TITLE
z-stack dwell time gui

### DIFF
--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -433,6 +433,7 @@ class SpoolController(object):
             
             self.protocolZ = pmod.PROTOCOL_STACK
             self.protocolZ.filename = protocolName
+            self.z_dwell = self.protocolZ.dwellTime
             
     def SetSpoolMethod(self, method):
         """Set the spooling method

--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -280,7 +280,8 @@ class PanSpool(afp.foldingPane):
         self.AddNewElement(self._protocol_pan())
 
         clp = afp.collapsingPane(self, caption='Z stepping ...')
-        clp.AddNewElement(seqdialog.seqPanel(clp, self.scope, mode='sequence'))
+        self._seq_panel = seqdialog.seqPanel(clp, self.scope, mode='sequence')
+        clp.AddNewElement(self._seq_panel)
         self.AddNewElement(clp)
         self.seq_pan = clp
 
@@ -561,6 +562,7 @@ class PanSpool(afp.foldingPane):
             self.spoolController.SetProtocol(pname)
             # do this after setProtocol so that an error in SetProtocol avoids setting the new name
             self.stAqProtocol.SetLabel(pname)
+            self._seq_panel.UpdateDisp()  # update display of e.g. z_dwell
 
         pDlg.Destroy()
 

--- a/PYME/Acquire/ui/seqdialog.py
+++ b/PYME/Acquire/ui/seqdialog.py
@@ -172,7 +172,7 @@ class seqPanel(wx.Panel):
 
         #hsizer.Add(sNSlices, 1, 0, 0)
         vsizer.Add(hsizer, 0, wx.EXPAND|wx.BOTTOM, 5)
-        
+
         if not (self.mode == 'sequence'):
             hsizer = wx.BoxSizer(wx.HORIZONTAL)
             self.stMemory = wx.StaticText(self, -1, '')
@@ -187,6 +187,14 @@ class seqPanel(wx.Panel):
             hsizer.Add(self.bLive, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5, 0)
     
             vsizer.Add(hsizer, 0, wx.EXPAND, 0)
+        else:
+            # sequence mode doesn't have dwell functionality yet
+            hsizer = wx.BoxSizer(wx.HORIZONTAL)
+            hsizer.Add(wx.StaticText(self, -1, 'Dwell [frames]:'), 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 0)
+            self.t_zdwell = wx.TextCtrl(self, -1, value=str(self.scope.spoolController.z_dwell), size=(75,-1))
+            self.t_zdwell.Bind(wx.EVT_KILL_FOCUS, self.OnDwellKillFocus)
+            hsizer.Add(self.t_zdwell, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+            vsizer.Add(hsizer, 0, wx.EXPAND|wx.BOTTOM, 5)
 
         self.SetSizerAndFit(vsizer)
 
@@ -378,7 +386,10 @@ class seqPanel(wx.Panel):
         self.UpdateDisp()
 
         event.Skip()
-
+    
+    def OnDwellKillFocus(self, wx_event):
+        self.scope.spoolController.z_dwell = int(self.t_zdwell.GetValue())
+        wx_event.Skip()
         
 
     def UpdateDisp(self):
@@ -416,6 +427,8 @@ class seqPanel(wx.Panel):
         
         if not self.mode == 'sequence':
             self.stMemory.SetLabel('Mem: %2.1f MB' % (self.scope.cam.GetPicWidth()*self.scope.cam.GetPicHeight()*self.stackSettings.GetSeqLength()*2*1/(1024.0*1024.0)))
+        else:
+            self.t_zdwell.SetValue(str(self.scope.spoolController.z_dwell))
 
 
 class SeqProgressPanel(wx.Panel):


### PR DESCRIPTION
Addresses issue #318.

**Is this a bugfix or an enhancement?**
both, mostly enhancement
**Proposed changes:**
- add `Dwell [frames]:` text entry to sequence panel in HDFSpoolFrame
- update `SpoolController.z_dwell` with the `protocolZ.dwellTime` attribute on setting protocol through the gui


NOTE: as is, this does not affect the `Z-Stack` acquisition panel, owing to the if `mode == 'sequence'` check. A later enhancement to `PYME.Acquire.stackSettings.StackSettings` would make this simple, but at the moment `StackSettings` has no dwell-time support, and I haven't had it ok'd by @David-Baddeley to add one.

![Screen Shot 2020-07-13 at 1 09 28 PM](https://user-images.githubusercontent.com/31105780/87332794-2471bd00-c50a-11ea-8d74-af3e1540775c.png)


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [x] Does this change how users interact with the software? How will these changes be communicated?

Sort of, as issue #318 points out the behavior was recently changed to ignore protocol dwellTime parameters, which until recently was the only way to set the dwell time. The default protocol-dwellTime-adopting behavior is restored in this PR, and the ability to override it through the gui is added.

- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
