### PR TITLE
fix bug for now-legacy dsview plugs

### DIFF
--- a/PYME/DSView/modules/__init__.py
+++ b/PYME/DSView/modules/__init__.py
@@ -125,7 +125,7 @@ def loadModule(modName, dsviewer):
     if ret is not None:
         if isinstance(ret, dict):
             # either track named outputs [legacy]
-            for k, v in ret:
+            for k, v in ret.items():
                 setattr(dsviewer, k, weakref.proxy(v))
         else:
             # or track module data under module name.


### PR DESCRIPTION
Addresses issue # .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
fix plugging legacy (e.g. LMAnalysis) dsview modules are loaded

with printing to display the module name and variable `ret`:
```
(pyme) C:\Users\Bergamot>dh5view pyme-cluster:///Bergamot/2020_7_14/000/14_7_series_B.pcs
INFO:numexpr.utils:Note: NumExpr detected 12 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
INFO:numexpr.utils:NumExpr defaulting to 8 threads.
c:\users\bergamot\code\python-microscopy\PYME\misc\extraCMaps.py:73: MatplotlibDeprecationWarning:
The revcmap function was deprecated in Matplotlib 3.2 and will be removed two minor releases later. Use Colormap.reversed() instead.
  cmapdat_r = cm.revcmap(ndat[cmapname])
Starting main loop
Loading data
filename == pyme-cluster:///Bergamot/2020_7_14/000/14_7_series_B.pcs
c:\users\bergamot\code\python-microscopy\PYME\DSView\dsviewer.py:140: wxPyDeprecationWarning: Call to deprecated item. Use Append instead.
  tmp_menu.AppendMenu(-1, 'Save &Results', self.save_menu)
WARNING:PYME.DSView.modules:Plugin [arrayView] injects into dsviewer namespace, could result in circular references
WARNING:PYME.DSView.modules:Plugin [shell] injects into dsviewer namespace, could result in circular references
0
WARNING:PYME.DSView.modules:Plugin [metadataView] injects into dsviewer namespace, could result in circular references
0
WARNING:PYME.DSView.modules:Plugin [eventView] injects into dsviewer namespace, could result in circular references
Trying to load 3rd party recipe module pyme_rcnn.recipe_modules.rcnn_segment
Loaded 3rd party recipe module pyme_rcnn.recipe_modules.rcnn_segment
0
WARNING:PYME.DSView.modules:Plugin [recipes] injects into dsviewer namespace, could result in circular references
WARNING:PYME.DSView.modules:Plugin [LMAnalysis] injects into dsviewer namespace, could result in circular references
{'LMAnalyser': <PYME.DSView.modules.LMAnalysis.LMAnalyser2 object at 0x000001C1A8049208>}
<module 'PYME.DSView.modules.LMAnalysis' from 'c:\\users\\bergamot\\code\\python-microscopy\\PYME\\DSView\\modules\\LMAnalysis.py'>
Traceback (most recent call last):
  File "C:\Users\Bergamot\Anaconda2\envs\pyme\lib\site-packages\wx\core.py", line 3259, in <lambda>
    lambda event: event.callable(*event.args, **event.kw) )
  File "c:\users\bergamot\code\python-microscopy\PYME\DSView\dsviewer.py", line 455, in LoadData
    vframe = DSViewFrame(im, None, im.filename, mode = mode)
  File "c:\users\bergamot\code\python-microscopy\PYME\DSView\dsviewer.py", line 167, in __init__
    modules.loadMode(self.mode, self)
  File "c:\users\bergamot\code\python-microscopy\PYME\DSView\modules\__init__.py", line 150, in loadMode
    loadModule(m, dsviewer)
  File "c:\users\bergamot\code\python-microscopy\PYME\DSView\modules\__init__.py", line 130, in loadModule
    for k, v in ret:
ValueError: too many values to unpack (expected 2)
```





**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
