### PR TITLE
Cast mat columns to native byte order

### DIFF
--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -588,7 +588,7 @@ class MatfileColumnSource(TabularBase):
         if not key in self._keys:
             raise KeyError('Key (%s) not found' % key)
         
-        return self.res[key][sl].squeeze()
+        return self.res[key][sl].astype('f4').squeeze()
     
     def getInfo(self):
         return 'Text Data Source\n\n %d points' % len(self.res['x'])


### PR DESCRIPTION
Addresses issue #330.

**Is this a bugfix or an enhancement?**
Bugfix, option 2 from #330

**Proposed changes:**
- Cast .mat columns to native byte order to match missing pipeline ds keys, which are in native byte order


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
