### PR TITLE
allow httpspooler buflen to be configured

### DIFF
--- a/PYME/Acquire/HTTPSpooler.py
+++ b/PYME/Acquire/HTTPSpooler.py
@@ -126,7 +126,7 @@ class Spooler(sp.Spooler):
         self.clusterFilter = kwargs.get('serverfilter', CLUSTERID)
         self._buffer = []
         
-        self.buflen = config.get('http-chunk-size', 50)
+        self.buflen = config.get('httpspooler-chunksize', 50)
         
         self._postQueue = Queue.Queue(QUEUE_MAX_SIZE)
         self._dPoll = True

--- a/PYME/Acquire/HTTPSpooler.py
+++ b/PYME/Acquire/HTTPSpooler.py
@@ -126,7 +126,7 @@ class Spooler(sp.Spooler):
         self.clusterFilter = kwargs.get('serverfilter', CLUSTERID)
         self._buffer = []
         
-        self.buflen = 50
+        self.buflen = config.get('http-chunk-size', 50)
         
         self._postQueue = Queue.Queue(QUEUE_MAX_SIZE)
         self._dPoll = True


### PR DESCRIPTION
Enhancement as discussed with David this week. Configuring a longer buffer length in `HTTPSpooler` will increase data locality when spooling to multiple servers and localizing with sliding-window background estimation. Too long and you start losing out on the advantages of multiple servers.