### PR TITLE
Fix vertical recipe display on python 3

### DIFF
--- a/PYME/recipes/recipeLayout.py
+++ b/PYME/recipes/recipeLayout.py
@@ -201,7 +201,7 @@ def layout_vertical(dg, rdg):
                     _descend(child, dg, rdg)
     
     for t_i in ts:
-        for n in sorted(list(t_i)):
+        for n in sorted(list(t_i), key=lambda x: x if isinstance(x,str) else x.__class__.__name__):
             if not n in ordered:
                 ordered.append(n)
                 _descend(n, dg, rdg)


### PR DESCRIPTION
Addresses issue #246.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
-Fix sorted() call in recipe layout to work on objects for py3


**Checklist:**

- [ ] Tested with numpy=1.14
- [x] Tested on python 2.7 and 3.6
- [x] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
