### PR TITLE
py3 hardtyping fix in progGraph

### DIFF
--- a/PYME/LMVis/progGraph.py
+++ b/PYME/LMVis/progGraph.py
@@ -42,7 +42,7 @@ class progPanel(wxPlotPanel.PlotPanel):
                 self.subplot1 = self.figure.add_axes([.14,.05,.85,.9])#self.figure.add_subplot( 211 )
                 self.subplot2 = self.subplot1.twinx()#self.figure.add_subplot( 212 )
 
-            a, ed = numpy.histogram(self.fitResults['tIndex'], self.Size[0]/2)
+            a, ed = numpy.histogram(self.fitResults['tIndex'], int(self.Size[0]/2))
             print((float(numpy.diff(ed[:2]))))
 
             self.subplot1.cla()


### PR DESCRIPTION
Addresses issue progress graph histogram tries to set number of bins to a float

```
Traceback (most recent call last):
  File "/Users/Andrew/code/python-microscopy/PYME/ui/mytimer.py", line 42, in Notify
    a()
  File "/Users/Andrew/code/python-microscopy/PYME/DSView/modules/LMAnalysis.py", line 713, in refresh_analysis
    self.progPan.draw()
  File "/Users/Andrew/code/python-microscopy/PYME/LMVis/progGraph.py", line 45, in draw
    a, ed = numpy.histogram(self.fitResults['tIndex'], self.Size[0]/2)
  File "/opt/miniconda3/lib/python3.6/site-packages/numpy/lib/histograms.py", line 790, in histogram
    bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights)
  File "/opt/miniconda3/lib/python3.6/site-packages/numpy/lib/histograms.py", line 423, in _get_bin_edges
    '`bins` must be an integer, a string, or an array')
TypeError: `bins` must be an integer, a string, or an array
DEBUG:PYME.DSView.modules.LMAnalysis:use_cluster: newStyle=True, tq=None
Traceback (most recent call last):
  File "/opt/miniconda3/lib/python3.6/site-packages/numpy/lib/histograms.py", line 420, in _get_bin_edges
    n_equal_bins = operator.index(bins)
TypeError: 'float' object cannot be interpreted as an integer

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/Andrew/code/python-microscopy/PYME/ui/mytimer.py", line 42, in Notify
    a()
  File "/Users/Andrew/code/python-microscopy/PYME/DSView/modules/LMAnalysis.py", line 713, in refresh_analysis
    self.progPan.draw()
  File "/Users/Andrew/code/python-microscopy/PYME/LMVis/progGraph.py", line 45, in draw
    a, ed = numpy.histogram(self.fitResults['tIndex'], self.Size[0]/2)
  File "/opt/miniconda3/lib/python3.6/site-packages/numpy/lib/histograms.py", line 790, in histogram
    bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights)
  File "/opt/miniconda3/lib/python3.6/site-packages/numpy/lib/histograms.py", line 423, in _get_bin_edges
    '`bins` must be an integer, a string, or an array')
TypeError: `bins` must be an integer, a string, or an array
DEBUG:PYME.DSView.modules.LMAnalysis:use_cluster: newStyle=True, tq=None
Traceback (most recent call last):
  File "/opt/miniconda3/lib/python3.6/site-packages/numpy/lib/histograms.py", line 420, in _get_bin_edges
    n_equal_bins = operator.index(bins)
TypeError: 'float' object cannot be interpreted as an integer

```

**Is this a bugfix or an enhancement?**
bugfix

**Proposed changes:**

type # bins as an int

**Note addressed in this PR**
Would be pretty nice to label the axes / add a legend
![Screen Shot 2020-07-18 at 3 31 02 PM](https://user-images.githubusercontent.com/31105780/87860472-b3684600-c90b-11ea-94ee-9d771d74d3a8.png)
