### PR TITLE
fix squiggle typo

### DIFF
--- a/PYME/DSView/DisplayOptionsPanel.py
+++ b/PYME/DSView/DisplayOptionsPanel.py
@@ -374,7 +374,7 @@ class OptionsPanel(wx.Panel):
         
     def OnSelectSquiggle(self, event):
         self.do.leftButtonAction = DisplayOpts.ACTION_SELECTION
-        self.do.selectionMode = DisplayOpts.SELECTION_SQUIGLE
+        self.do.selectionMode = DisplayOpts.SELECTION_SQUIGGLE
         self.do.showSelection = True
 
         #self.Refresh()

--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -272,7 +272,7 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
             if self.do.selectionMode == DisplayOpts.SELECTION_RECTANGLE:
                 dc.DrawRectangle(lx,ly, (hx-lx),(hy-ly))
                 
-            elif self.do.selectionMode == DisplayOpts.SELECTION_SQUIGLE:
+            elif self.do.selectionMode == DisplayOpts.SELECTION_SQUIGGLE:
                 if len(self.do.selection_trace) > 2:
                     x, y = numpy.array(self.do.selection_trace).T
                     pts = numpy.vstack(self._PixelToScreenCoordinates(x, y)).T

--- a/PYME/DSView/displayOptions.py
+++ b/PYME/DSView/displayOptions.py
@@ -56,7 +56,7 @@ class DisplayOpts(object):
     SLICE_XY, SLICE_XZ, SLICE_YZ = range(3)
 
     ACTION_POSITION, ACTION_SELECTION = range(2)
-    SELECTION_RECTANGLE, SELECTION_LINE, SELECTION_SQUIGLE = range(3)
+    SELECTION_RECTANGLE, SELECTION_LINE, SELECTION_SQUIGGLE = range(3)
 
     def __init__(self, datasource, xp=0, yp=0, zp=0, aspect=1):
         self.WantChangeNotification = []# MyWeakSet() #[]

--- a/PYME/DSView/modules/annotation.py
+++ b/PYME/DSView/modules/annotation.py
@@ -154,7 +154,7 @@ class Annotater(Plugin):
         
     
     def add_curved_line(self, event=None):
-        if self.do.selectionMode == self.do.SELECTION_SQUIGLE:
+        if self.do.selectionMode == self.do.SELECTION_SQUIGGLE:
             l = self.do.selection_trace
             if isinstance(l, np.ndarray):
                 l = l.tolist()
@@ -173,7 +173,7 @@ class Annotater(Plugin):
         self.dsviewer.Update()
 
     def add_filled_polygon(self, event=None):
-        if self.do.selectionMode == self.do.SELECTION_SQUIGLE:
+        if self.do.selectionMode == self.do.SELECTION_SQUIGGLE:
             l = self.do.selection_trace
             if isinstance(l, np.ndarray):
                 l = l.tolist()
@@ -218,7 +218,7 @@ class Annotater(Plugin):
             
     def snake_refine_trace(self, event=None, sender=None, **kwargs):
         print('Refining selection')
-        if self.lock_mode == 'None' or not self.do.selectionMode == self.do.SELECTION_SQUIGLE:
+        if self.lock_mode == 'None' or not self.do.selectionMode == self.do.SELECTION_SQUIGGLE:
             return
         else:
             try:

--- a/PYME/LMVis/imageView.py
+++ b/PYME/LMVis/imageView.py
@@ -154,7 +154,7 @@ class ImageViewPanel(wx.Panel):
             if self.do.selectionMode == DisplayOpts.SELECTION_RECTANGLE:
                 dc.DrawRectangle(lx,ly, (hx-lx),(hy-ly))
                 
-            elif self.do.selectionMode == DisplayOpts.SELECTION_SQUIGLE:
+            elif self.do.selectionMode == DisplayOpts.SELECTION_SQUIGGLE:
                 if len(self.do.selection_trace) > 2:
                     x, y = numpy.array(self.do.selection_trace).T
                     pts = numpy.vstack(self._PixelToScreenCoordinates(x, y)).T

--- a/PYME/LMVis/imageView2.py
+++ b/PYME/LMVis/imageView2.py
@@ -84,7 +84,7 @@ class ImageViewPanel(wx.Panel):
             if self.do.selectionMode == DisplayOpts.SELECTION_RECTANGLE:
                 dc.DrawRectangle(lx,ly, (hx-lx),(hy-ly))
                 
-            elif self.do.selectionMode == DisplayOpts.SELECTION_SQUIGLE:
+            elif self.do.selectionMode == DisplayOpts.SELECTION_SQUIGGLE:
                 if len(self.do.selection_trace) > 2:
                     x, y = numpy.array(self.do.selection_trace).T
                     pts = numpy.vstack(self._PixelToScreenCoordinates(x, y)).T


### PR DESCRIPTION
Addresses issue # .

Not filed as an issue yet but try plotting a profile with current PYME and you get an error about SELECTION_SQUIGGLE not being known.  This is because everywhere else the bogus name SELECTION_SQUIGLE is currently used.

**Is this a bugfix or an enhancement?**

Bugfix

**Proposed changes:**

Change the bogus SELECTION_SQUIGLE to SELECTION_SQUIGGLE everywhere.





**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [~ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes] My emacs may have added missing newlines in a few files??

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
