### PR TITLE
return empty fitResult on pre-StartAt tasks

### DIFF
--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -396,6 +396,10 @@ class fitTask(taskDef.Task):
     def __call__(self, gui=False, taskQueue=None):
         global dBuffer, bBuffer, dataSourceID, nTasksProcessed
         
+        # short-circuit if a task is generated for a frame pre-StartAt
+        if 'Analysis.StartAt' in self.md.keys() and self.index < self.md['Analysis.StartAt']:
+            return fitResult(self, [], [])
+        
         #create a local copy of the metadata        
         md = copy.copy(self.md)
         md.tIndex = self.index

--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -397,7 +397,9 @@ class fitTask(taskDef.Task):
         global dBuffer, bBuffer, dataSourceID, nTasksProcessed
         
         # short-circuit if a task is generated for a frame pre-StartAt
-        if 'Analysis.StartAt' in self.md.keys() and self.index < self.md['Analysis.StartAt']:
+        # FIXME - we should never generate tasks for these frames.
+        if self.index < self.md.get('Analysis.StartAt', 0):
+            logger.error("Frame index is less than 'Analysis.StartAt', frame should not have been released for analysis. Skipping to avoid potential buffer errors.")
             return fitResult(self, [], [])
         
         #create a local copy of the metadata        


### PR DESCRIPTION
Addresses issues related to #272, but refactored into more digestable chunks.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
Allow tasks to be generated for frames pre StartAt, which simplifies indexing in ruleserver/tasks generation and removes localization metadata peeking in ruleserver. 


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
