### PR TITLE
allow nameUtils to be imported when running from non-user process

### DIFF
--- a/PYME/IO/FileUtils/nameUtils.py
+++ b/PYME/IO/FileUtils/nameUtils.py
@@ -39,8 +39,10 @@ def getUsername():
         import win32api
         return '_'.join(win32api.GetUserName().split(' '))
     else: # OSX / linux
+        import getpass
         #return os.getlogin() #broken when not runing from command line
-        return os.environ.get('USER', 'nobody')
+        #return os.environ.get('USER', 'nobody')
+        return getpass.getuser()
 
 
 dtn = datetime.datetime.now()

--- a/PYME/IO/FileUtils/nameUtils.py
+++ b/PYME/IO/FileUtils/nameUtils.py
@@ -38,9 +38,7 @@ def getUsername():
     if sys.platform == 'win32':
         import win32api
         return '_'.join(win32api.GetUserName().split(' '))
-    if sys.platform.startswith('darwin'):
-        return os.environ['USER']
-    else: #linux
+    else: # OSX / linux
         #return os.getlogin() #broken when not runing from command line
         return os.environ.get('USER', 'nobody')
 


### PR DESCRIPTION
Addresses issue #342 .

**Is this a bugfix or an enhancement?**
bugfix

**Proposed changes:**
- note that OSX can also hit no 'USER' key in `os.environ` and treat it like linux in that respect.


**Note Also**
Rather than `nobody` for user, if I call `os.getlogin()` when 'USER' key is not defined I get `root`. I see the note for linux that `os.getlogin` is broken from non-user processes, though I wonder if this has changed in recent python versions. I don't think this is terribly important in any event, and `nobody` is certainly fine by me.

**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
