### PR TITLE
pass haveGUI kwarg in ImageStack init/attribute to ImageStack.Load

### DIFF
--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -229,7 +229,7 @@ class ImageStack(object):
         
         if (data is None):
             #if we've supplied data, use that, otherwise load from file
-            self.Load(filename, prompt=load_prompt)
+            self.Load(filename, prompt=load_prompt, haveGUI=self.haveGUI)
 
         #do the necessary munging to get the data in the format we want it        
         self.SetData(self.data)


### PR DESCRIPTION
Addresses issue `haveGUI` call passed into e.g. `ImageStack(filename=fn, haveGUI=False)` is ignored ~imediately in `ImageStack.Load`.

**Is this a bugfix or an enhancement?**
minor bugfix, the real problem I ran into when I saw this was just that I was passing in '' for the filename kwarg, but still I think we probably meant to pass haveGUI on through to Load (where it is only partially ignored if we have a filename already).

**Proposed changes:**
- pass haveGUI from ImageStack init kwarg to the ImageStack.Load call which happens inside said init call.
