### PR TITLE
Add (optional) offset display slider to focus lock gui

### DIFF
--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -178,7 +178,7 @@ def focus_keys(MainFrame, scope):
     from PYME.Acquire.Hardware import focusKeys
     from PYME.Acquire.ui.focus_lock_gui import FocusLockPanel
     fk = focusKeys.FocusKeys(MainFrame, scope.piFoc)
-    panel = FocusLockPanel(MainFrame, scope.focus_lock, scope.piFoc)
+    panel = FocusLockPanel(MainFrame, scope.focus_lock, offset_piezo=scope.piFoc)
     MainFrame.camPanels.append((panel, 'Focus Lock'))
     MainFrame.time1.WantNotification.append(panel.refresh)
 

--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -178,7 +178,7 @@ def focus_keys(MainFrame, scope):
     from PYME.Acquire.Hardware import focusKeys
     from PYME.Acquire.ui.focus_lock_gui import FocusLockPanel
     fk = focusKeys.FocusKeys(MainFrame, scope.piFoc)
-    panel = FocusLockPanel(MainFrame, scope.focus_lock)
+    panel = FocusLockPanel(MainFrame, scope.focus_lock, scope.piFoc)
     MainFrame.camPanels.append((panel, 'Focus Lock'))
     MainFrame.time1.WantNotification.append(panel.refresh)
 

--- a/PYME/Acquire/ui/focus_lock_gui.py
+++ b/PYME/Acquire/ui/focus_lock_gui.py
@@ -31,13 +31,14 @@ class FocusLockPanel(wx.Panel):
         sizer_1.Add(hsizer, 0, wx.EXPAND, 0)
 
         if self.offset_piezo is not None:
-            pos = self.offset_piezo.GetPos()
-            self._offset_slider = wx.Slider(self, -1, 100 * pos, 
-                                           100 * self.offset_piezo.GetMin(), 
-                                           100 * self.offset_piezo.GetMax(), 
+            offset, offset_range = self._get_offset_and_range()
+
+            self._offset_slider = wx.Slider(self, -1, 100 * (offset - offset_range[0]), 
+                                           0, 
+                                           100 * (offset_range[1] - offset_range[0]), 
                                            size=wx.Size(100, -1),
                                            style=wx.SL_HORIZONTAL)
-            self._offset_label = wx.StaticBox(self, -1, u'%s - %2.3f %s' % ('offset', pos, u'\u03BCm'))
+            self._offset_label = wx.StaticBox(self, -1, u'%s - %2.3f %s' % ('offset', offset, u'\u03BCm'))
             
             hsizer = wx.BoxSizer(wx.HORIZONTAL)
             hsizer.Add(self._offset_slider, 0, wx.ALL, 2)
@@ -45,6 +46,16 @@ class FocusLockPanel(wx.Panel):
             sizer_1.Add(hsizer, 0, wx.EXPAND, 0)
 
         self.SetSizerAndFit(sizer_1)
+    
+    def _get_offset_and_range(self):
+        target = self.offset_piezo.GetTargetPos()
+        offset = self.offset_piezo.GetOffset()
+        min_pos, max_pos = self.offset_piezo.GetMin(), self.offset_piezo.GetMax()
+        #  basePiezo position - offset = OffsetPiezo position
+        min_offset = -(target + min_pos)
+        max_offset = max_pos - target
+
+        return offset, (min_offset, max_offset)
 
     def OnToggleLock(self, event):
         self.servo.ToggleLock()
@@ -58,10 +69,9 @@ class FocusLockPanel(wx.Panel):
     def refresh(self):
         self.lock_checkbox.SetValue(bool(self.servo.lock_enabled))
         if self.offset_piezo is not None:
-            pos = self.offset_piezo.GetOffset()
+            offset, offset_range = self._get_offset_and_range()
 
-            self._offset_slider.SetValue(int(100 * pos))
-            self._offset_slider.SetMin(100 * self.offset_piezo.GetMin())
-            self._offset_slider.SetMax(100 * self.offset_piezo.GetMax())
-            
-            self._offset_label.SetLabel(u'%s - %2.3f %s' % ('offset', pos, u'\u03BCm'))
+            self._offset_slider.SetValue(int(100 * (offset - offset_range[0])))
+            self._offset_slider.SetMin(0)
+            self._offset_slider.SetMax(100 * (offset_range[1] - offset_range[0]))
+            self._offset_label.SetLabel(u'%s - %2.3f %s' % ('offset', offset, u'\u03BCm'))

--- a/PYME/Acquire/ui/focus_lock_gui.py
+++ b/PYME/Acquire/ui/focus_lock_gui.py
@@ -40,8 +40,8 @@ class FocusLockPanel(wx.Panel):
             self._offset_label = wx.StaticBox(self, -1, u'%s - %2.3f %s' % ('offset', pos, u'\u03BCm'))
             
             hsizer = wx.BoxSizer(wx.HORIZONTAL)
-            hsizer.Add(self.offset_slider, 0, wx.ALL, 2)
-            hsizer.Add(self.offset_label, 0, wx.ALL, 2)
+            hsizer.Add(self._offset_slider, 0, wx.ALL, 2)
+            hsizer.Add(self._offset_label, 0, wx.ALL, 2)
             sizer_1.Add(hsizer, 0, wx.EXPAND, 0)
 
         self.SetSizerAndFit(sizer_1)

--- a/PYME/Acquire/ui/focus_lock_gui.py
+++ b/PYME/Acquire/ui/focus_lock_gui.py
@@ -2,9 +2,16 @@
 import wx
 
 class FocusLockPanel(wx.Panel):
-    def __init__(self, parent, focus_PID, winid=-1):
+    def __init__(self, parent, focus_PID, winid=-1, offset_piezo=None):
+        """
+        Parameters
+        ----------
+        offset_piezo : PYME.Acquire.Hardware.Piezos.offsetPiezoREST.OffsetPiezo
+            offset piezo; only used to display current offset
+        """
         wx.Panel.__init__(self, parent, winid)
         self.servo = focus_PID
+        self.offset_piezo = offset_piezo
 
         sizer_1 = wx.BoxSizer(wx.VERTICAL)
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -23,6 +30,20 @@ class FocusLockPanel(wx.Panel):
 
         sizer_1.Add(hsizer, 0, wx.EXPAND, 0)
 
+        if self.offset_piezo is not None:
+            pos = self.offset_piezo.GetPos()
+            self._offset_slider = wx.Slider(self, -1, 100 * pos, 
+                                           100 * self.offset_piezo.GetMin(), 
+                                           100 * self.offset_piezo.GetMax(), 
+                                           size=wx.Size(100, -1),
+                                           style=wx.SL_HORIZONTAL)
+            self._offset_label = wx.StaticBox(self, -1, u'%s - %2.3f %s' % ('offset', pos, u'\u03BCm'))
+            
+            hsizer = wx.BoxSizer(wx.HORIZONTAL)
+            hsizer.Add(self.offset_slider, 0, wx.ALL, 2)
+            hsizer.Add(self.offset_label, 0, wx.ALL, 2)
+            sizer_1.Add(hsizer, 0, wx.EXPAND, 0)
+
         self.SetSizerAndFit(sizer_1)
 
     def OnToggleLock(self, event):
@@ -36,3 +57,11 @@ class FocusLockPanel(wx.Panel):
 
     def refresh(self):
         self.lock_checkbox.SetValue(bool(self.servo.lock_enabled))
+        if self.offset_piezo is not None:
+            pos = self.offset_piezo.GetOffset()
+
+            self._offset_slider.SetValue(int(100 * pos))
+            self._offset_slider.SetMin(100 * self.offset_piezo.GetMin())
+            self._offset_slider.SetMax(100 * self.offset_piezo.GetMax())
+            
+            self._offset_label.SetLabel(u'%s - %2.3f %s' % ('offset', pos, u'\u03BCm'))

--- a/PYME/Acquire/ui/focus_lock_gui.py
+++ b/PYME/Acquire/ui/focus_lock_gui.py
@@ -73,4 +73,4 @@ class FocusLockPanel(wx.Panel):
             self._offset_slider.SetValue(int(100 * (offset - offset_range[0])))
             self._offset_slider.SetMin(0)
             self._offset_slider.SetMax(100 * (offset_range[1] - offset_range[0]))
-            self._offset_label.SetLabel(u'%s - %2.3f %s' % ('offset', offset, u'\u03BCm'))
+            self._offset_label.SetLabel(u'%s: %2.3f %s' % ('offset', offset, u'\u03BCm'))

--- a/PYME/Acquire/ui/focus_lock_gui.py
+++ b/PYME/Acquire/ui/focus_lock_gui.py
@@ -38,11 +38,10 @@ class FocusLockPanel(wx.Panel):
                                            100 * (offset_range[1] - offset_range[0]), 
                                            size=wx.Size(100, -1),
                                            style=wx.SL_HORIZONTAL)
-            self._offset_label = wx.StaticBox(self, -1, u'%s - %2.3f %s' % ('offset', offset, u'\u03BCm'))
+            self._offset_label = wx.StaticBox(self, -1, u'%s: %2.3f %s' % ('offset', offset, u'\u03BCm'))
             
-            hsizer = wx.BoxSizer(wx.HORIZONTAL)
-            hsizer.Add(self._offset_slider, 0, wx.ALL, 2)
-            hsizer.Add(self._offset_label, 0, wx.ALL, 2)
+            hsizer = wx.StaticBoxSizer(self._offset_label, wx.HORIZONTAL)
+            hsizer.Add(self._offset_slider, 1, wx.ALL|wx.EXPAND, 0)
             sizer_1.Add(hsizer, 0, wx.EXPAND, 0)
 
         self.SetSizerAndFit(sizer_1)


### PR DESCRIPTION
Addresses issue having to open the shell to check what the offset is / how close we are to running out of piezo range.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- add a slider to display the focus lock offset. Sliding it doesn't set the offset, and it snaps back to where it belongs each time the gui updates.
-use it in htsms. leave out of htsms_focus_lock for now

snazzy examples, with target position of 50 (and basePiezo range of [0, 100]):
![image](https://user-images.githubusercontent.com/31105780/88100611-c3ca2c00-cb6a-11ea-8971-e5018260e3ab.png)
and negative offsets
![image](https://user-images.githubusercontent.com/31105780/88100689-e3615480-cb6a-11ea-97b3-a3c6f7fa8a06.png)







**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [x] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
