### PR TITLE
dictvalues py3 recipe gui related fixes

### DIFF
--- a/PYME/recipes/recipeGui.py
+++ b/PYME/recipes/recipeGui.py
@@ -161,7 +161,7 @@ class RecipePlotPanel(wxPlotPanel.PlotPanel):
                 
                 
                 
-        ipsv = np.array(node_positions.values())
+        ipsv = np.array(list(node_positions.values()))
         try:
             xmn, ymn = ipsv.min(0)
             xmx, ymx = ipsv.max(0)

--- a/PYME/ui/custom_traits_editors.py
+++ b/PYME/ui/custom_traits_editors.py
@@ -21,7 +21,7 @@ class _CBEditor (Editor):
 
         self.control = wx.ComboBox(parent,
                                    size=(120,-1),
-                                   style = wx.CB_DROPDOWN, value=self.value, choices=self.factory.choices)
+                                   style = wx.CB_DROPDOWN, value=str(self.value), choices=self.factory.choices)
         self.control.Bind(wx.EVT_COMBOBOX, self.text_changed)
         #self.control.Bind(wx.EVT_COMBOBOX_CLOSEUP, lambda e: print('foo'))
         self.control.Bind(wx.EVT_TEXT, self.text_changed)


### PR DESCRIPTION
Addresses issue trying to add a recipe module in bakeshop/recipeGUI can fail due to a dictvalues type error as mentioned in #278 and/or another sneaky type error:

here printing the type of `ipsv = np.array(node_positions.values())` before printing `ymn` and `ymx`
```
Disposing of CBEditor
dict_values([(0, 0.0), (1, 0.0)])
(1, 0.0)
(1, 0.0)
Traceback (most recent call last):
  File "C:\Users\Bergamot\Anaconda2\envs\pyme\lib\site-packages\wx\core.py", line 2228, in Notify
    self.notify()
  File "C:\Users\Bergamot\Anaconda2\envs\pyme\lib\site-packages\wx\core.py", line 3384, in Notify
    self.result = self.callable(*self.args, **self.kwargs)
  File "c:\users\bergamot\code\python-microscopy\PYME\recipes\recipeGui.py", line 491, in update
    self.recipePlot.draw()
  File "c:\users\bergamot\code\python-microscopy\PYME\recipes\recipeGui.py", line 171, in draw
    self.ax.set_ylim(ymn-1, ymx+1)
TypeError: unsupported operand type(s) for -: 'tuple' and 'int'
```

wrapping d.values in a np.array call changes behavior between 2 and 3
```
>>> d = {'a': 0, 'b': 1, 'c': 12}
>>> np.array(d.values()).min(0)
dict_values([0, 1, 12])
>>> np.array(list(d.values())).min(0)
0
```


**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**







**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
