### PR TITLE
Bakeshop OnBake can't bake - missing description for ComputationInProgress

### DIFF
--- a/PYME/recipes/recipeGui.py
+++ b/PYME/recipes/recipeGui.py
@@ -792,7 +792,7 @@ class BatchFrame(wx.Frame, wx.FileDropTarget):
         from PYME.ui import progress
         
         try:
-            with progress.ComputationInProgress(self):
+            with progress.ComputationInProgress(self, 'Batch Analysis'):
                 if not len(self.inputFiles) == len(self.inputFiles2):
                     batchProcess.bake(self.rm.activeRecipe, {'input':self.inputFiles}, out_dir, num_procs=num_procs)
                 else:


### PR DESCRIPTION
Addresses issue 
```
Traceback (most recent call last):
  File "c:\users\bergamot\code\python-microscopy\PYME\recipes\recipeGui.py", line 797, in OnBake
    batchProcess.bake(self.rm.activeRecipe, {'input':self.inputFiles}, out_dir, num_procs=num_procs)
TypeError: __init__() missing 1 required positional argument: 'short_description'
```