### PR TITLE
Bring back mpld3 in requirements.txt since it's needed to launch PYME…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ toposort
 #pyfftw3; python_version < '3.0'
 pyfftw #; python_version > '3.0'
 
-#mpld3
+mpld3
 cherrypy
 scikit-image
 scikit-learn


### PR DESCRIPTION
…Visualize

Addresses issue #322.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Add `mpld3` back in as a `requirements.txt` requirement since it's needed to launch PYMEVisualize.






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
