### PR TITLE
pointScanner stop_on_complete, return_to_start, and dwellTime+trigger fix

### DIFF
--- a/PYME/Acquire/Utils/pointScanner.py
+++ b/PYME/Acquire/Utils/pointScanner.py
@@ -213,9 +213,9 @@ class PointScanner(object):
                     eventLog.logEvent('ScannerXPos', '%3.6f' % self.scope.state['Positioning.x'])
                     eventLog.logEvent('ScannerYPos', '%3.6f' % self.scope.state['Positioning.y'])
 
-                if cam_trigger:
-                    #logger.debug('Firing camera trigger')
-                    self.scope.cam.FireSoftwareTrigger()
+            if cam_trigger:
+                self.scope.cam.FireSoftwareTrigger()
+                if self.evtLog:
                     eventLog.logEvent('StartAq',"")
 #
         #

--- a/PYME/Acquire/Utils/pointScanner.py
+++ b/PYME/Acquire/Utils/pointScanner.py
@@ -190,7 +190,7 @@ class PointScanner(object):
                     self.image[callN % self.nx, int((callN % (self.image.size))/self.nx)] = self.scope.currentFrame.mean() - self.background
                     self.view.Refresh()
             
-            if self.callNum >= self.dwellTime * self.imsize:
+            if self.callNum >= self.dwellTime * self.imsize - 1:
                 # we've acquired the last frame
                 if self._stop_on_complete:
                     self._stop()

--- a/PYME/Acquire/Utils/pointScanner.py
+++ b/PYME/Acquire/Utils/pointScanner.py
@@ -214,6 +214,7 @@ class PointScanner(object):
                     eventLog.logEvent('ScannerYPos', '%3.6f' % self.scope.state['Positioning.y'])
 
             if cam_trigger:
+                #logger.debug('Firing camera trigger')
                 self.scope.cam.FireSoftwareTrigger()
                 if self.evtLog:
                     eventLog.logEvent('StartAq',"")

--- a/PYME/Acquire/Utils/pointScanner.py
+++ b/PYME/Acquire/Utils/pointScanner.py
@@ -189,6 +189,12 @@ class PointScanner(object):
                 if self.avg:
                     self.image[callN % self.nx, int((callN % (self.image.size))/self.nx)] = self.scope.currentFrame.mean() - self.background
                     self.view.Refresh()
+            
+            if self.callNum >= self.dwellTime * self.imsize:
+                # we've acquired the last frame
+                if self._stop_on_complete:
+                    self._stop()
+                    return
 
             if ((self.callNum +1) % self.dwellTime) == 0:
                 #move piezo
@@ -211,10 +217,6 @@ class PointScanner(object):
                     #logger.debug('Firing camera trigger')
                     self.scope.cam.FireSoftwareTrigger()
                     eventLog.logEvent('StartAq',"")
-                    
-            if (int(self.callNum/self.dwellTime)) > self.imsize:
-                if self._stop_on_complete:
-                    self._stop()
 #
         #
         #if self.sync:


### PR DESCRIPTION
Addresses issue #350.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- when we're finished,if stop_on_complete is true then  call stop() before moving to the 'next' position.
- if we're running in trigger mode, fire the trigger on each call, not just on calls that move the stage (i.e. don't ignore dwellTime)
- don't log StartAq's unless we're logging events






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
