### PR TITLE
Add sphinx back as a pip requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ pyyaml
 psutil
 
 docutils
-#sphinx
+sphinx
 ujson
 jinja2
 django==1.11.29


### PR DESCRIPTION
Addresses issue: From a fresh `pip` install, if you try to use the bakeshop in PYMEVisualize you can't add any recipe modules. Traceback:

```
Traceback (most recent call last):
  File "/Users/zachcm/Code/python-microscopy/PYME/recipes/recipeGui.py", line 266, in OnSelect
    from sphinx.util.docstrings import prepare_docstring
ModuleNotFoundError: No module named 'sphinx'
```

An alternative fix would be to wrap the docstring display stuff in a `try` block.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Add sphinx back as a `requirements.txt` dependency.

**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
