### PR TITLE
Measure clusters 3d fix

### DIFF
--- a/PYME/Analysis/points/cluster_morphology.py
+++ b/PYME/Analysis/points/cluster_morphology.py
@@ -171,9 +171,6 @@ def measure_3d(x, y, z, output=None):
     #principle axes
     u, s, v = np.linalg.svd(np.vstack([x_c, y_c, z_c]).T)
 
-    print(x_c.shape, y_c.shape, z_c.shape)
-    print(s.shape)
-
     standard_deviations = s / np.sqrt(N - 1)  # with bessel's correction
     for i in range(3):
         output['axis%d' % i] = v[i]

--- a/PYME/Analysis/points/cluster_morphology.py
+++ b/PYME/Analysis/points/cluster_morphology.py
@@ -144,7 +144,9 @@ def measure_3d(x, y, z, output=None):
     N = len(x)
     output['count'] = N
     if N < 3:
-        raise UserWarning('measure_3D can only be used on clusters of size 3 or larger')
+        import warnings
+        warnings.warn('measure_3D can only be used on clusters of size 3 or larger', UserWarning)
+        return
     
     #centroid
     xc, yc, zc = x.mean(), y.mean(), z.mean()
@@ -168,6 +170,9 @@ def measure_3d(x, y, z, output=None):
 
     #principle axes
     u, s, v = np.linalg.svd(np.vstack([x_c, y_c, z_c]).T)
+
+    print(x_c.shape, y_c.shape, z_c.shape)
+    print(s.shape)
 
     standard_deviations = s / np.sqrt(N - 1)  # with bessel's correction
     for i in range(3):

--- a/PYME/recipes/localisations.py
+++ b/PYME/recipes/localisations.py
@@ -633,7 +633,7 @@ class MeasureClusters3D(ModuleBase):
         if np.min(inp[self.labelKey]) < 0:
             raise UserWarning('This module expects 0-label for unclustered points, and no negative labels')
 
-        labels = inp[self.labelKey]
+        labels = inp[self.labelKey].astype(np.int)
         I = np.argsort(labels)
         I = I[labels[I] > 0]
         


### PR DESCRIPTION
If you try to run `Analysis>Clustering>Measure Clusters` you get the following traceback.

```
Traceback (most recent call last):
  File "/Users/zachcm/Code/python-microscopy/PYME/recipes/base.py", line 641, in execute
    m.execute(self.namespace)
  File "/Users/zachcm/Code/python-microscopy/PYME/recipes/localisations.py", line 648, in execute
    measurements = np.zeros(maxLabel, cmorph.measurement_dtype)
TypeError: 'numpy.float32' object cannot be interpreted as an integer
```

If you fix this and then try to run `Analysis>Clustering>Measure Clusters` and any of the clusters are of size <3, the context manager stops the run and you get the following traceback.

```
Traceback (most recent call last):
  File "/Users/zachcm/Code/python-microscopy/PYME/recipes/base.py", line 641, in execute
    m.execute(self.namespace)
  File "/Users/zachcm/Code/python-microscopy/PYME/recipes/localisations.py", line 663, in execute
    cmorph.measure_3d(x, y, z, output=measurements[cluster_index])
  File "/Users/zachcm/Code/python-microscopy/PYME/Analysis/points/cluster_morphology.py", line 147, in measure_3d
    raise UserWarning('measure_3D can only be used on clusters of size 3 or larger')
UserWarning: measure_3D can only be used on clusters of size 3 or larger
```

Unrelated: how do we display the results of "Measure Clusters"?

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Explicitly cast labels to integer
- Create a warning and then exit `measure_3d` function if cluster of size <3 is passed. This lets us keep looping through clusters in `OnMeasureClusters`. An alternative would be to wrap `measure_3d` calls in a `try` block.


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
