### PR TITLE
Point to correct location for colourFilter

### DIFF
--- a/PYME/LMVis/Extras/pointwiseColoc.py
+++ b/PYME/LMVis/Extras/pointwiseColoc.py
@@ -22,7 +22,7 @@ class PointwiseColocaliser:
         #mProfile.profileOn(['distColoc.py'])
         from PYME.Analysis.Colocalisation import distColoc
         #A vs B
-        distColoc.calcDistCorr(self.visFr.colourFilter, *(self.visFr.colourFilter.getColourChans()[::1]))
+        distColoc.calcDistCorr(self.visFr.pipeline.colourFilter, *(self.visFr.pipeline.colourFilter.getColourChans()[::1]))
         #B vs A
         #distColoc.calcDistCorr(self.visFr.colourFilter, *(self.visFr.colourFilter.getColourChans()[::-1]))
         #mProfile.report()


### PR DESCRIPTION
Addresses issue

```
Traceback (most recent call last):
  File "/Users/zachcm/Code/python-microscopy/PYME/ui/progress.py", line 107, in func
    return fcn(*args, **kwargs)
  File "/Users/zachcm/Code/python-microscopy/PYME/LMVis/Extras/pointwiseColoc.py", line 25, in OnPointwiseColoc
    distColoc.calcDistCorr(self.visFr.colourFilter, *(self.visFr.colourFilter.getColourChans()[::1]))
AttributeError: 'VisGUIFrame' object has no attribute 'colourFilter'
```

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
-Point to the correct location for the `colourFilter`







**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
