### PR TITLE
recipes.acquisition.QueueAcquisition fixes

### DIFF
--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -184,10 +184,15 @@ def focus_keys(MainFrame, scope):
 
 @init_gui('Action manager')
 def action_manager(MainFrame, scope):
+    from PYME import config
     from PYME.Acquire.ui import actionUI
+    from PYME.Acquire.ActionManager import ActionManagerServer
 
     ap = actionUI.ActionPanel(MainFrame, scope.actions, scope)
     MainFrame.AddPage(ap, caption='Queued Actions')
+
+    ActionManagerServer(scope.actions, 9393, 
+                        config.get('actionmanagerserver-address', '127.0.0.1'))
 
 @init_hardware('tweeter')
 def tweeter(scope):

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -94,15 +94,16 @@ class QueueAcquisitions(OutputModule):
             positions = positions[::-1, :] if self.lifo else positions
         
         dest = self.action_server_url + '/queue_action'
+        session = requests.Session()
         for ri in range(positions.shape[0]):
             args = {'function_name': 'centre_roi_on', 
             'args': {'x': positions[ri, 0], 'y': positions[ri, 1]}, 
                     'timeout': self.timeout, 'nice': nices[2 * ri]}
-            requests.post(dest, data=json.dumps(args), 
+            session.post(dest, data=json.dumps(args), 
                           headers={'Content-Type': 'application/json'})
             
             args = {'function_name': 'spoolController.StartSpooling',
                     'args': self.spool_settings,
                     'timeout': self.timeout, 'nice': nices[2 * ri + 1]}
-            requests.post(dest, data=json.dumps(args), 
+            session.post(dest, data=json.dumps(args), 
                           headers={'Content-Type': 'application/json'})

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -84,7 +84,7 @@ class QueueAcquisitions(OutputModule):
             nices = np.linspace(self.nice_range[0], self.nice_range[1], 
                                 2 * len(positions))
         else:
-            nices = np.arange(2 * len(positions))
+            nices = np.arange(2 * len(positions), dtype=float)
         
         if self.optimize_path:
             from PYME.Analysis.points.traveling_salesperson import sort

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -88,7 +88,7 @@ class QueueAcquisitions(OutputModule):
         
         if self.optimize_path:
             from PYME.Analysis.points.traveling_salesperson import sort
-            start = len(positions) if self.lifo else 0
+            start = -1 if self.lifo else 0
             positions = sort.tsp_sort(positions, start)
         else:
             positions = positions[::-1, :] if self.lifo else positions

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -19,9 +19,6 @@ class QueueAcquisitions(OutputModule):
         PYME.IO.tabular containing 'x_um' and 'y_um' coordinates in units of 
         micrometers (preferred) *or* 'x' and 'y' coordinates in units of 
         nanometers.
-    position_units : CStr
-        Units the `input_positions` are in. Should be 'nm' for nanometers or 
-        'um' for micrometers. 'um' by default.
     action_server_url : CStr
         URL of the microscope-side action server process.
     spool_settings : DictStrAny


### PR DESCRIPTION
Addresses issues:
- `IndexError` in QueueAcquisitions if LIFO is True and optimize_path is True. Index should be -1, or len(positions) - 1, not len(positions).
- json not serializable error if user doesn't specify `nice_range`, as we fall back to using `[0, 2 * len(positions)]` and `len(positions)` can return `numpy.int32` for `tabular.HDFSource`s, apparently.
- `input_position` unit handling is inconsistent with `recipes.measurement`'s `TilePhysicalCoords`, `TravelingSalesperson`, and `IdentifyOverlappingROI`.
- `requests.post` serially called in a loop might as well use a keep-alive session, though this seems to work too well and if spun off from a local machine can get forcibly closed errors in the client, so add an option throttle parameter to queue at a pace

**Is this a bugfix or an enhancement?**
bugfixes

**Proposed changes:**
- fix LIFO/optimize_path start index
- type arange-generated Nice's as float so they json
- use `'x_um'` in um and `'x'` in nm convention for input positions, as we have done in other stage-position related recipe modules
- use a request session instead of serial posts
- add a throttle parameter to the queuing loop. Obviously this isn't a super performance move, but is configurable to zero and is preferable to dropping a (10000, 2) array onto the ActionManager all at once if you're already in the middle of acquisitions (which would use a server endpoint we haven't written yet).
- add the action manager server to the htsms scope





**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.1
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
