### PR TITLE
Covert weakref.proxy to weakref.ref

### DIFF
--- a/PYME/DSView/modules/_base.py
+++ b/PYME/DSView/modules/_base.py
@@ -16,11 +16,11 @@ class Plugin(object):
     """
     
     def __init__(self, dsviewer):
-        self._dsviewer = weakref.proxy(dsviewer)
+        self._dsviewer = weakref.ref(dsviewer)
     
     @property
     def dsviewer(self):
-        return self._dsviewer # type: PYME.DSView.dsviewer
+        return self._dsviewer() # type: PYME.DSView.dsviewer
         
     @property
     def do(self):


### PR DESCRIPTION
Addresses issue #356.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
Convert `weakref.proxy` to `weakref.ref`. My understanding is `weakref.proxy` prevents us from having to explicitly dereference when we want to use the `weakref`ed object. However, since we access this object strictly through the `dsviewer` property of plugin, we have the opportunity to deference every time we need the object. For some reason, this works better than proxy.






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
