### PR TITLE
Add title to FRC plot window

### DIFF
--- a/PYME/Analysis/Colocalisation/correlationCoeffs.py
+++ b/PYME/Analysis/Colocalisation/correlationCoeffs.py
@@ -138,6 +138,9 @@ def fourier_ring_correlation(imA, imB, voxelsize=[1.0, 1.0], window=False):
     bn2, bm2, bs2 = binAvg.binAvg(R, np.fft.fftshift((H2 * H2.conjugate()).real), rB)
     
     plt.figure()
+
+    fig = plt.gcf()
+    fig.canvas.set_window_title('Fourier Ring Correlation')
     
     ax = plt.gca()
     


### PR DESCRIPTION
Addresses issue # .

**Is this a bugfix or an enhancement?**
Enhacement

**Proposed changes:**
Add a title to the FRC plot window (instead of just calling it `Figure 1`). It would be good to title the second window as well, but I don't know what to call it. Best title I've come up with so far is `Fit Intercept`. Thoughts?






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
