### PR TITLE
Photo fix its

### DIFF
--- a/PYME/Analysis/BleachProfile/kinModels.py
+++ b/PYME/Analysis/BleachProfile/kinModels.py
@@ -315,7 +315,7 @@ def fitDecay(colourFilter, metadata, channame='', i=0):
         
         b = 0.5*(1+erf(res[0][2]))*Nm
     
-        plt.figtext(.4,.8 -.05*i, channame + '\t$\\tau = %3.2fs,\\;b = %3.2f$' % (res[0][1], b/res[0][0]), size=18, color=colours[i])
+        plt.figtext(.4,.8 -.05*i, channame + '\t$\\tau = %3.2fs,\\;b = %3.2f$' % (res[0][1], b/res[0][0]), size=18, color=colours[i], verticalalignment='top', horizontalalignment='left')
 
     return 0
 
@@ -356,7 +356,7 @@ def fitOnTimes(colourFilter, metadata, channame='', i=0):
         plt.ylim((1, plt.ylim()[1]))
         plt.title('Event Duration - CAUTION: unreliable if $\\tau <\\sim$ exposure time')
     
-        plt.figtext(.6,.8 -.05*i, channame + '\t$\\tau = %3.4fs$' % (res[0][1], ), size=18, color=colours[i])
+        plt.figtext(.4,.8 -.05*i, channame + '\t$\\tau = %3.4fs$' % (res[0][1], ), size=18, color=colours[i], verticalalignment='top', horizontalalignment='left')
     return 0
 
 
@@ -390,7 +390,7 @@ def fitFluorBrightness(colourFilter, metadata, channame='', i=0, rng = None, qui
         plt.title('Event Intensity - CAUTION - unreliable if evt. duration $>\\sim$ exposure time')
         #print res[0][2]
     
-        plt.figtext(.4,.8 -.05*i, channame + '\t$N_{det} = %3.0f\\;\\lambda = %3.0f$\n\t$Ph.mean = %3.0f$' % (res[0][1], res[0][3], nPh.mean()), size=18, color=colours[i])
+        plt.figtext(.4,.8 -.05*i, channame + '\t$N_{det} = %3.0f\\;\\lambda = %3.0f$\n\t$Ph.mean = %3.0f$' % (res[0][1], res[0][3], nPh.mean()), size=18, color=colours[i], verticalalignment='top', horizontalalignment='left')
 
     return [channame, res[0][3], NEvents]
 

--- a/PYME/LMVis/Extras/particleTracking.py
+++ b/PYME/LMVis/Extras/particleTracking.py
@@ -54,7 +54,7 @@ class ParticleTracker:
     #
     #     dlg.Destroy()
         
-    def OnFindClumps(self, event):
+    def OnFindClumps(self, event=None):
         import PYME.Analysis.points.DeClump.deClumpGUI as deClumpGUI
         #import PYME.Analysis.points.DeClump.deClump as deClump
         import PYME.Analysis.Tracking.trackUtils as trackUtils
@@ -84,7 +84,7 @@ class ParticleTracker:
 
         dlg.Destroy()
 
-    def OnTrackMolecules(self, event):
+    def OnTrackMolecules(self, event=None):
         import PYME.Analysis.points.DeClump.deClumpGUI as deClumpGUI
         #import PYME.Analysis.points.DeClump.deClump as deClump
         import PYME.Analysis.Tracking.trackUtils as trackUtils
@@ -134,7 +134,7 @@ class ParticleTracker:
         
         #dlg.Destroy()
 
-    def OnCalcMSDs(self,event):
+    def OnCalcMSDs(self, event=None):
         #TODO - move this logic to reports - like dh5view module
         # import pylab
         import matplotlib.pyplot as plt
@@ -197,7 +197,7 @@ class ParticleTracker:
 
         pipeline.Rebuild()
         
-    def _OnCoalesce(self, event):
+    def _OnCoalesce(self, event=None):
         from PYME.IO import tabular
         from PYME.Analysis.points.DeClump import pyDeClump
         
@@ -217,7 +217,7 @@ class ParticleTracker:
 
         #self.visFr.CreateFoldPanel() #TODO: can we capture this some other way?
         
-    def OnCoalesce(self, event):
+    def OnCoalesce(self, event=None):
         #with progress.ComputationInProgress(self.visFr, 'coalescing consecutive appearances'):
         from PYME.recipes import localisations
         recipe = self.visFr.pipeline.recipe
@@ -228,7 +228,7 @@ class ParticleTracker:
         self.visFr.pipeline.selectDataSource('coalesced')
         #self.visFr.CreateFoldPanel() #TODO: can we capture this some other way?
 
-    def OnCalcWidths(self,event):
+    def OnCalcWidths(self, event=None):
         #FIXME - this is probably broken on modern VisGUI
         from scipy.stats import binned_statistic
 
@@ -271,4 +271,4 @@ class ParticleTracker:
 
 def Plug(visFr):
     """Plugs this module into the gui"""
-    ParticleTracker(visFr)
+    visFr.particleTracker = ParticleTracker(visFr)

--- a/PYME/LMVis/Extras/photophysics.py
+++ b/PYME/LMVis/Extras/photophysics.py
@@ -38,7 +38,11 @@ class DecayAnalyser:
         kinModels.fitDecay(pipeline)
         kinModels.fitFluorBrightness(pipeline)
         #kinModels.fitFluorBrightnessT(pipeline)
-        kinModels.fitOnTimes(pipeline)
+        if 'clumpSize' in pipeline.keys():
+            kinModels.fitOnTimes(pipeline)
+        else:
+            import warnings
+            warnings.warn('To fit on times, first run Corrections>Chaining>Find consecutive appearances and Corrections>Chaining>Clump consecutive appearances.', UserWarning)
         
 
     def OnRetrieveIntensitySteps(self, event):

--- a/PYME/LMVis/Extras/photophysics.py
+++ b/PYME/LMVis/Extras/photophysics.py
@@ -35,15 +35,14 @@ class DecayAnalyser:
         
         pipeline = self.visFr.pipeline
 
+        if 'clumpSize' not in pipeline.keys():
+            # Clump 
+            self.visFr.particleTracker.OnFindClumps()
+
         kinModels.fitDecay(pipeline)
         kinModels.fitFluorBrightness(pipeline)
         #kinModels.fitFluorBrightnessT(pipeline)
-        if 'clumpSize' in pipeline.keys():
-            kinModels.fitOnTimes(pipeline)
-        else:
-            import warnings
-            warnings.warn('To fit on times, first run Corrections>Chaining>Find consecutive appearances and Corrections>Chaining>Clump consecutive appearances.', UserWarning)
-        
+        kinModels.fitOnTimes(pipeline)
 
     def OnRetrieveIntensitySteps(self, event):
         from PYME.Analysis import piecewiseMapping


### PR DESCRIPTION
Addresses issue: display alignment of photophysical variables in plots was off. Error was thrown every time we tried to run photophysics even though 2/3 photophysics measurements work just fine.

**Is this a bugfix or an enhancement?**
Bugfix/enhancement

**Proposed changes:**
- Fix alignment in display of photophysical constants
- Don't throw an Error/Traceback if you run Analysis>Photophysics without clumping





**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
