### PR TITLE
Let the PointScanner stop_on_complete stop tile_triggered acquisition

### DIFF
--- a/PYME/Acquire/Protocols/tile_triggered.py
+++ b/PYME/Acquire/Protocols/tile_triggered.py
@@ -174,7 +174,7 @@ T(1, ps.start),
 #T(maxint, ps.stop),
 #T(maxint, scope.EnableJoystick, True),
 #T(maxint, SetContinuousMode, True),
-# T(maxint, MainFrame.pan_spool.OnBAnalyse, None),
+T(maxint, MainFrame.pan_spool.OnBAnalyse, None),
 ]
 
 #optional - metadata entries

--- a/PYME/Acquire/Protocols/tile_triggered.py
+++ b/PYME/Acquire/Protocols/tile_triggered.py
@@ -42,6 +42,7 @@ if 'splitting'in dir(scope.cam) and scope.cam.splitting =='up_down':
 # TODO - squash this file and add triggering as option to standard tile protocol
 ps = PointScanner(scope, pixels = [10,10], pixelsize=numpy.array([tsx*.7, tsy*.7]), dwelltime=1, avg=False,
                   evtLog = True, sync=True,trigger=True, stop_on_complete=True)
+ps.on_stop.connect(scope.spoolController.StopSpooling)
 
 class SFGenPlotPanel(PlotPanel):
     def draw(self):

--- a/PYME/Acquire/Protocols/tile_triggered.py
+++ b/PYME/Acquire/Protocols/tile_triggered.py
@@ -142,15 +142,6 @@ class ShiftfieldPreviewDialog(wx.Dialog):
         ps.genCoords()
         self.EndModal(True)
 
-
-def stop():
-    #scope.frameWrangler.stop()
-    ps.stop()
-    MainFrame.pan_spool.OnBStopSpoolingButton(None)
-
-
-stopTask = T(500, stop)
-
 def ShowSFDialog():
     #ps.pixelsize[0] = float(scope.cam.GetPicWidth())
     vsx, vsy = scope.GetPixelSize()
@@ -163,10 +154,6 @@ def ShowSFDialog():
     dlg = ShiftfieldPreviewDialog()
     ret = dlg.ShowModal()
     dlg.Destroy()
-
-    #stop after one full scan
-    stopTask.when = 2 + 1*ps.imsize
-    print((stopTask.when))
 
 
 

--- a/PYME/Acquire/Protocols/tile_triggered.py
+++ b/PYME/Acquire/Protocols/tile_triggered.py
@@ -41,7 +41,7 @@ if 'splitting'in dir(scope.cam) and scope.cam.splitting =='up_down':
     tsy *= 0.5
 # TODO - squash this file and add triggering as option to standard tile protocol
 ps = PointScanner(scope, pixels = [10,10], pixelsize=numpy.array([tsx*.7, tsy*.7]), dwelltime=1, avg=False,
-                  evtLog = True, sync=True,trigger=True)
+                  evtLog = True, sync=True,trigger=True, stop_on_complete=True)
 
 class SFGenPlotPanel(PlotPanel):
     def draw(self):
@@ -183,11 +183,11 @@ T(-1, ShowSFDialog),
 #T(1, SetCameraShutter, True),
 T(1, ps.start),
 #T(30, MainFrame.pan_spool.OnBAnalyse, None),
-stopTask,
+# stopTask,
 #T(maxint, ps.stop),
 #T(maxint, scope.EnableJoystick, True),
 #T(maxint, SetContinuousMode, True),
-T(maxint, MainFrame.pan_spool.OnBAnalyse, None),
+# T(maxint, MainFrame.pan_spool.OnBAnalyse, None),
 ]
 
 #optional - metadata entries

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -430,7 +430,7 @@ class SpoolController(object):
     def rel_dirname(self):
         return self._sep.join(self._subdir)
 
-    def StopSpooling(self):
+    def StopSpooling(self, **kwargs):
         """GUI callback to stop spooling."""
         self.spooler.StopSpool()
         

--- a/PYME/Acquire/Utils/pointScanner.py
+++ b/PYME/Acquire/Utils/pointScanner.py
@@ -27,6 +27,7 @@ import threading
 import numpy as np
 from PYME.Acquire import eventLog
 import uuid
+import dispatch
 import logging
 logger = logging.getLogger(__name__)
 
@@ -61,6 +62,7 @@ class PointScanner(object):
         
         self.running = False
         self._uuid = uuid.uuid4()
+        self.on_stop = dispatch.Signal()
 
     def genCoords(self):
         self.currPos = self.scope.GetPos()
@@ -238,6 +240,8 @@ class PointScanner(object):
             logger.exception('Could not disconnect pointScanner tick from frameWrangler.onFrame')
     
         self.scope.frameWrangler.stop()
+
+        self.on_stop.send(self)
         
         if self._return_to_start:
             logger.debug('Returning home : %s' % self.currPos)


### PR DESCRIPTION
For fast triggered acquisitions we actually want to let the pointScanner stop itself, especially if we start caring about, e.g. `return_to_start`, otherwise we run over and add laser-off frames to the start position of our overview (which nicely average that to zero).

Related to tile pyramid construction and chained analysis (#360 ) and  tiler stopping / returning as we specify (#350 / #355 )

**Proposed changes:**
- add an `on_stop` dispatch signal to `PointScanner`, which gets called immediately after disconnecting from frameWrangler.
- change `SpoolController.StopSpooling` to accept **kwargs so we can call it from a dispatch send. Note StopSpooling is supposed to be the GUI callback for  `SpoolController.StopSpool`


@David-Baddeley I left the GUI stuff in for now. I think for queuing overviews I'll add a scanner as an attribute of the scope in the MultiwellTilePanel initialization, add a protocol which uses that pointscanner, and add a checkbox for the panel to toggle actionqueue or all-in-one-go options. So I won't use tile_triggered protocol exactly (unless you want me to check for an existing scope-attribute pointscanner in tile_triggered, move the gui stuff into preflight, and kill the OnBAnalyse call?), but the ability to stop spool nicely from an acquisition is the reason I'm submitting this PR.


**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

- [ ] Does this change how users interact with the software? How will these changes be communicated?

David and I added the tile_triggered protocol a year ago. Not sure that anyone is using it.

