### PR TITLE
unpin numpy from 1.14 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 #PIP requirements
 #NB - this might be incomplete / buggy, the conda route is currently more reliable
 
-numpy==1.14.*
+numpy>=1.14.*
 scipy
 matplotlib
 wxpython

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-#PIP requirements
-#NB - this might be incomplete / buggy, the conda route is currently more reliable
+# PIP requirements
+# NB - this might be incomplete / buggy, the conda route is currently more reliable
+# 
 
-numpy>=1.14.*
+numpy>=1.14.* # we build and test against 1.14, but should work against any higher version. Try numpy==1.14.* if you run into issues.
 scipy
 matplotlib
 wxpython


### PR DESCRIPTION
We have tested numpy 1.16 on python 3 much more than 1.14, and the pin makes it harder for people to help us test py3
