### PR TITLE
Make Save Current View save as single extension

### DIFF
--- a/PYME/DSView/modules/visgui.py
+++ b/PYME/DSView/modules/visgui.py
@@ -65,7 +65,7 @@ class visGuiExtras:
     def OnExport(self, event):
         #ivp = self.notebook.GetPage(self.notebook.GetSelection())
         ivp = self.dsviewer.GetSelectedPage()
-        fname = wx.FileSelector('Save Current View', default_extension='.tif', wildcard="Supported Image Files (*.tif, *.bmp, *.gif, *.jpg, *.png)|*.tif, *.bmp, *.gif, *.jpg, *.png", flags = wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
+        fname = wx.FileSelector('Save Current View', default_extension='.tif', wildcard="Supported Image Files (*.tif, *.bmp, *.gif, *.jpg, *.png)|*.tif;*.bmp;*.gif;*.jpg;*.png", flags = wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
 
         if not fname == "":
             ext = os.path.splitext(fname)[-1]


### PR DESCRIPTION
Addresses issue `View>Export Current View` in `PYMEImage` currently saves files as `<filename>.tif, *.bmp, *.gif, *.jpg, *.png.<your extension>` as a file of type `<your extension>`.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Correct the `FileSelector` syntax to let the user optionally choose a single extension.

**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
