### PR TITLE
make standard acquisitiontasks panels optional

### DIFF
--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -51,7 +51,7 @@ from PYME.Acquire.ui import HDFSpoolFrame
 
 from PYME.Acquire import microscope
 from PYME.Acquire import protocol
-
+from PYME import config
 from PYME.IO import MetaDataHandler
 #from PYME.IO.FileUtils import nameUtils
 import six
@@ -275,16 +275,17 @@ class PYMEMainFrame(AUIFrame):
             self.time1.WantNotification.append(self.pos_sl.update)
 
             self.AddTool(self.pos_sl, 'Positioning')
-
-            self.seq_d = seqdialog.seqPanel(self, self.scope)
-            self.AddAqTool(self.seq_d, 'Z-Stack', pinned=False)
-            #self.seq_d.Show()
+            
+            if config.get('acquiremainframe-default_acq_tools', True):
+                self.seq_d = seqdialog.seqPanel(self, self.scope)
+                self.AddAqTool(self.seq_d, 'Z-Stack', pinned=False)
+                #self.seq_d.Show()
         
         for t in self.toolPanels:
             #print(t)
             self.AddTool(*t)
             
-        if self.scope.cam.CamReady():
+        if self.scope.cam.CamReady() and config.get('acquiremainframe-default_acq_tools', True):
             self.pan_spool = HDFSpoolFrame.PanSpool(self, self.scope)
             self.AddAqTool(self.pan_spool, 'Time/Blinking series', pinned=False, folded=False)
             


### PR DESCRIPTION
Addresses issue artistic differences / different use cases

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- allow users to specify if they want the standard z-stack and Time / Blinking series panels rather than always adding them



**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.x
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?

