### PR TITLE
Fixes to make Dumbell3DFitR work

### DIFF
--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -267,7 +267,7 @@ class FitResultsSource(TabularBase):
 
 
     def keys(self):
-        return self._keys + list(self.transkeys.keys())
+        return list(self._keys) + list(self.transkeys.keys())
 
     def __getitem__(self, keys):
         key, sl = self._getKeySlice(keys)

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -259,7 +259,7 @@ class FitResultsSource(TabularBase):
         #allow access using unnested original names
         # TODO???? - replace key translation with a np.view call?
         #self._keys = unNestDtype(self.fitResults.dtype.descr)
-        self._keys = unnest_dtype(self.fitResults.dtype).names
+        self._keys = list(unnest_dtype(self.fitResults.dtype).names)
         
         #or shorter aliases
         self._set_transkeys()
@@ -267,7 +267,7 @@ class FitResultsSource(TabularBase):
 
 
     def keys(self):
-        return list(self._keys) + list(self.transkeys.keys())
+        return self._keys + list(self.transkeys.keys())
 
     def __getitem__(self, keys):
         key, sl = self._getKeySlice(keys)

--- a/PYME/localization/FitFactories/Dumbell3DFitR.py
+++ b/PYME/localization/FitFactories/Dumbell3DFitR.py
@@ -34,7 +34,7 @@ from PYME.Analysis._fithelpers import FitModelWeighted, FitModelWeightedJac
 # Model functions
 def f_dumbell3d(p, X, Y, Z):
     """Pair of 3D Gaussian model functions with linear background
-     - parameter vector [A, x0, y0, z0, x1, y1, z1, sigma_xy, sigma_z, background]
+     - parameter vector [A, x0, y0, z0, x1, y1, z1, wxy, wz, background]
      Note: Assumes sames sigma for both Gaussian (dumbell). """
     A, x0, y0, z0, x1, y1, z1, sxy, sz, b = p
         
@@ -50,12 +50,12 @@ fresultdtype=[('tIndex', '<i4'),
               ('fitResults', [('A', '<f4'),
                               ('x0', '<f4'),('y0', '<f4'),('z0', '<f4'),
                               ('x1', '<f4'),('y1', '<f4'),('z1', '<f4'),
-                              ('sigma_xy', '<f4'),('sigma_z','<f4'),
+                              ('wxy', '<f4'),('wz','<f4'),
                               ('background', '<f4')]),
               ('fitError', [('A', '<f4'),
                             ('x0', '<f4'),('y0', '<f4'),('z0', '<f4'),
                             ('x1', '<f4'),('y1', '<f4'),('z1', '<f4'),
-                            ('sigma_xy', '<f4'),('sigma_z','<f4'), 
+                            ('wxy', '<f4'),('wz','<f4'), 
                             ('background', '<f4')]),
               ('length', '<f4'),
               ('resultCode', '<i4'), 
@@ -135,8 +135,8 @@ class Dumbell3DFitFactory(FFBase.FitFactory):
                            x0-rand_x,       # x1
                            y0-rand_y,       # y1
                            z0-rand_z,       # z1
-                           sxy,             # sigma_xy
-                           2.5*sxy,         # sigma_z
+                           sxy,             # wxy
+                           2.5*sxy,         # wz
                            dataMean.min()]  # background
 
         # do the fit

--- a/PYME/localization/FitFactories/FFBase.py
+++ b/PYME/localization/FitFactories/FFBase.py
@@ -128,7 +128,7 @@ class FFBase(object):
         #generate grid to evaluate function on
         X = vx * (np.mgrid[xslice] + self.roi_offset[0])
         Y = vy * (np.mgrid[yslice] + self.roi_offset[1])
-        Z = vz * (np.mgrid[yslice])
+        Z = vz * (np.mgrid[zslice])
     
         return X, Y, Z, dataROI, bgROI, sigma, xslice, yslice, zslice
 


### PR DESCRIPTION
Addresses three issues:

* `FFBase.get3DROIAtPoint` slices `z` using `yslice`
* `self._keys` from `Dumbell3DFitR` returns a `tuple` (I expect other fitters do this too)

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-10-3dee89596212> in <module>
      2 from PYME.IO import tabular
      3 res_t = tabular.FitResultsSource(res)
----> 4 res_t.toDataFrame().to_csv('my_data.csv')

~/Code/python-microscopy/PYME/IO/tabular.py in toDataFrame(self, keys)
     59         import pandas as pd
     60         if keys is None:
---> 61             keys = self.keys()
     62 
     63         d = {}

~/Code/python-microscopy/PYME/IO/tabular.py in keys(self)
    268 
    269     def keys(self):
--> 270         return self._keys + list(self.transkeys.keys())
    271 
    272     def __getitem__(self, keys):

TypeError: can only concatenate tuple (not "list") to tuple
```
* Underscores are implictly used for nesting in `FitResults`, so my `sigma_xy` and `sigma_z` variables cause problems
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-10-3dee89596212> in <module>
      2 from PYME.IO import tabular
      3 res_t = tabular.FitResultsSource(res)
----> 4 res_t.toDataFrame().to_csv('my_data.csv')

~/Code/python-microscopy/PYME/IO/tabular.py in toDataFrame(self, keys)
     64 
     65         for k in keys:
---> 66             v = self.__getitem__(k)
     67             if np.ndim(v) == 1:
     68                 d[k] = v

~/Code/python-microscopy/PYME/IO/tabular.py in __getitem__(self, keys)
    288             return self.fitResults[k[0]][k[1]][sl]
    289         elif len(k) == 3:
--> 290             return self.fitResults[k[0]][k[1]][k[2]][sl]
    291         else:
    292             raise KeyError("Don't know about deeper nesting yet")

ValueError: no field of name sigma
```

**Is this a bugfix or an enhancement?**

**Proposed changes:**
* Make `FFBase.get3DROIAtPoint` slice `z` using `zslice`
* Cast `self._keys` explicitly to a list. There are probably better ways to fix this (e.g. ensure `unnest_dtype` returns a list, but I didn't want to touch that function since I'm not sure it's supposed to return a list. It would be nice if this function had a docstring indicating what it's supposed to return. In general, it would be nice if all functions at least indicated input/output types), but this works.
* Change `sigma_xy` and `sigma_z` to `wxy`, `wz`, as in `Gauss3DFitR`


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
