### PR TITLE
Get PYMEImage SPT workflow working again

### DIFF
--- a/PYME/Analysis/Tracking/trackUtils.py
+++ b/PYME/Analysis/Tracking/trackUtils.py
@@ -41,10 +41,13 @@ class FeaturePlot(object):
             return ''
             
         data = self.clump[key]
+
+        if len(data.shape) > 2:
+            return ''
             
         plt.ioff()
         f = plt.figure(figsize=(6,2))
-        
+
         if 't' in self.clump.keys():        
             plt.plot(self.clump['t'], data)
         else:

--- a/PYME/Analysis/Tracking/trackUtils.py
+++ b/PYME/Analysis/Tracking/trackUtils.py
@@ -42,7 +42,9 @@ class FeaturePlot(object):
             
         data = self.clump[key]
 
-        if len(data.shape) > 2:
+        if len(data.shape) >= 2:
+            # FIXME - handle this better. Potentially a kymograph for ndim==2?
+            # FIXME - warn???
             return ''
             
         plt.ioff()

--- a/PYME/Analysis/graphing_filters.py
+++ b/PYME/Analysis/graphing_filters.py
@@ -255,7 +255,7 @@ def movieplot2(clump, image):
                 else:
                     scMax = img.max()
                 
-                print(x_0, y_0, img.shape, img_out.shape, i)
+                # print(x_0, y_0, img.shape, img_out.shape, i)
                 
                 img_out[x_0:(x_0 + roiSize), y_0:(y_0 + roiSize), 0] = np.clip(255. * img.T / scMax, 0, 255).astype(
                     'uint8')

--- a/PYME/Analysis/graphing_filters.py
+++ b/PYME/Analysis/graphing_filters.py
@@ -235,7 +235,7 @@ def movieplot2(clump, image):
             contours = None
         
         for i in range(clump.nEvents):
-            k = np.floor(i / 10)
+            k = int(np.floor(i / 10))
             l = i % 10
             
             y_0 = l * (roiSize + 2)
@@ -255,7 +255,7 @@ def movieplot2(clump, image):
                 else:
                     scMax = img.max()
                 
-                #print x_0, y_0, img.shape, img_out.shape, i
+                print(x_0, y_0, img.shape, img_out.shape, i)
                 
                 img_out[x_0:(x_0 + roiSize), y_0:(y_0 + roiSize), 0] = np.clip(255. * img.T / scMax, 0, 255).astype(
                     'uint8')

--- a/PYME/DSView/modules/particleTracking.py
+++ b/PYME/DSView/modules/particleTracking.py
@@ -57,8 +57,10 @@ class TrackList(wx.ListCtrl):
         # for wxGTK
         self.Bind(wx.EVT_RIGHT_UP, self.OnListRightClick)
 
-        self._attr_disabled = wx.ListItemAttr(wx.LIGHT_GREY)
-        self._attr_enabled = wx.ListItemAttr(wx.BLACK)
+        self._attr_disabled = wx.ListItemAttr()
+        self._attr_disabled.SetTextColour(wx.LIGHT_GREY)
+        self._attr_enabled = wx.ListItemAttr()
+        self._attr_enabled.SetTextColour(wx.BLACK)
 
         
         #self.SetItemCount(100)

--- a/PYME/DSView/modules/particleTracking.py
+++ b/PYME/DSView/modules/particleTracking.py
@@ -70,9 +70,9 @@ class TrackList(wx.ListCtrl):
         
     def OnGetItemText(self, item, col):
         if col == 0:
-            return self.clumps[item].clumpID
+            return str(self.clumps[item].clumpID)
         if col == 1:
-            return self.clumps[item].nEvents
+            return str(self.clumps[item].nEvents)
         elif col == 2:
             return str(self.clumps[item].enabled)
         else:
@@ -262,10 +262,10 @@ class ParticleTrackingView(HasTraits, Plugin):
         self.list.SetClumps(self.clumps)
         
     def OnSelectTrack(self, event):
-        self.selectedTrack = self.clumps[event.m_itemIndex]
+        self.selectedTrack = self.clumps[event.GetIndex()]
         #template = env.get_template('trackView.html')
         #self.trackview.SetPage(template.render(clump=self.selectedTrack, img=self.dsviewer.image), '')
-        self.trackview.LoadURL(htmlServe.getURL() + 'tracks/trackDetail?trackNum=%d' % event.m_itemIndex)
+        self.trackview.LoadURL(htmlServe.getURL() + 'tracks/trackDetail?trackNum=%d' % event.GetIndex())
         #self.trackview.SetPage(self.trackDetail(event.m_itemIndex), '')
 
     @cherrypy.expose

--- a/PYME/recipes/Recipes/pre_particleTracking.yaml
+++ b/PYME/recipes/Recipes/pre_particleTracking.yaml
@@ -11,6 +11,11 @@
     method: mean
     mode: reflect
     offset: -0.5
+    outputName: skf_mask
+    processFramesIndividually: true
+- FractionalThreshold:
+    inputName: skf_mask
+    fractionThreshold: 0.5
     outputName: mask
     processFramesIndividually: true
 - Label:

--- a/PYME/recipes/Recipes/pre_particleTracking.yaml
+++ b/PYME/recipes/Recipes/pre_particleTracking.yaml
@@ -1,3 +1,10 @@
+- GaussianFilter:
+    inputName: input
+    outputName: filtered_image
+    processFramesIndividually: true
+    sigmaX: 1.0
+    sigmaY: 1.0
+    sigmaZ: 1.0
 - SKF_threshold_local:
     block_size: 11.0
     inputName: filtered_image
@@ -6,13 +13,6 @@
     offset: -0.5
     outputName: mask
     processFramesIndividually: true
-- GaussianFilter:
-    inputName: input
-    outputName: filtered_image
-    processFramesIndividually: true
-    sigmaX: 1.0
-    sigmaY: 1.0
-    sigmaZ: 1.0
 - Label:
     inputName: mask
     minRegionPixels: 10

--- a/PYME/recipes/Recipes/pre_particleTracking.yaml
+++ b/PYME/recipes/Recipes/pre_particleTracking.yaml
@@ -1,0 +1,25 @@
+- SKF_threshold_local:
+    block_size: 11.0
+    inputName: filtered_image
+    method: mean
+    mode: reflect
+    offset: -0.5
+    outputName: mask
+    processFramesIndividually: true
+- GaussianFilter:
+    inputName: input
+    outputName: filtered_image
+    processFramesIndividually: true
+    sigmaX: 1.0
+    sigmaY: 1.0
+    sigmaZ: 1.0
+- Label:
+    inputName: mask
+    minRegionPixels: 10
+    outputName: labels
+    processFramesIndividually: true
+- Measure2D:
+    inputIntensity: input
+    inputLabels: labels
+    measureContour: true
+    outputName: output

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -9,7 +9,7 @@ Created on Mon May 25 17:02:04 2015
 #import wx
 import six
 
-from PYME.recipes.traits import HasTraits, Float, List, Bool, Int, CStr, Enum, File, on_trait_change, Input, Output
+from PYME.recipes.traits import HasTraits, Float, List, Bool, Int, CStr, Enum, File, on_trait_change, Input, Output, IntFloat
     
     #for some reason traitsui raises SystemExit when called from sphinx on OSX
     #This is due to the framework build problem of anaconda on OSX, and also

--- a/PYME/recipes/skfilters.py
+++ b/PYME/recipes/skfilters.py
@@ -5,7 +5,7 @@ Created on Fri Feb 20 17:11:05 2015
 @author: david
 """
 from .base import register_module, ModuleBase, Filter
-from .traits import Input, Output, Float, Enum, CStr, Bool, Int, IntFloat
+from .traits import Input, Output, Float, Enum, CStr, Bool, Int, _IntFloat
 from scipy import ndimage
 
 
@@ -119,7 +119,7 @@ for filtName in skFilterNames:
             elif argTypes[a] == 'int':
                 paramString += '%s = Int(%s)\n    ' % (a, argDefaults[a])
             elif argTypes[a] == 'int_float':
-                paramString += '%s = IntFloat(%s)\n    ' % (a, argDefaults[a])
+                paramString += '%s = _IntFloat(%s)\n    ' % (a, argDefaults[a])
 
         doc = filt.__doc__
                 

--- a/PYME/recipes/skfilters.py
+++ b/PYME/recipes/skfilters.py
@@ -5,7 +5,7 @@ Created on Fri Feb 20 17:11:05 2015
 @author: david
 """
 from .base import register_module, ModuleBase, Filter
-from .traits import Input, Output, Float, Enum, CStr, Bool, Int
+from .traits import Input, Output, Float, Enum, CStr, Bool, Int, IntFloat
 from scipy import ndimage
 
 
@@ -74,12 +74,12 @@ for filtName in skFilterNames:
         argspec = inspect.getfullargspec(filt)
     except AttributeError:  # python 2
         argspec = inspect.getargspec(filt)
-    
+
     if len(argspec.args) > 0:
         args = argspec.args[1:]
         
         if len(args) > 0:
-            argTypes = {a: 'float' for a in args}
+            argTypes = {a: 'int_float' for a in args}
             argDefaults = {a: 0.0 for a in args}
             
             #print filtName, argspec
@@ -98,7 +98,7 @@ for filtName in skFilterNames:
                         argTypes[a] = 'dict'
                     elif isinstance(ad, bool):
                         argTypes[a] = 'bool'
-                    elif isinstance(ad, int):
+                    elif isinstance(ad, int) and (ad != 0):
                         argTypes[a] = 'int'
             
             #disregard parameters which need another image for now        
@@ -118,6 +118,8 @@ for filtName in skFilterNames:
                 paramString += '%s = Bool(%s)\n    ' % (a, argDefaults[a])
             elif argTypes[a] == 'int':
                 paramString += '%s = Int(%s)\n    ' % (a, argDefaults[a])
+            elif argTypes[a] == 'int_float':
+                paramString += '%s = IntFloat(%s)\n    ' % (a, argDefaults[a])
 
         doc = filt.__doc__
                 

--- a/PYME/recipes/tracking.py
+++ b/PYME/recipes/tracking.py
@@ -135,6 +135,8 @@ class TrackFeatures(ModuleBase):
         #self.clumps = clumps        
         # pipeline.clumps = clumps
 
+        # FIXME - is this the right thing to be adding (and under the right name?) Does the pipeline (As used in dsviewer)
+        # actually support multiple data sources in a meaningful way? Consider fixing DSView/modules/particleTracking and removing this function completely.
         pipeline.addDataSource('clumps', clumpInfo)
         
         return clumps

--- a/PYME/recipes/tracking.py
+++ b/PYME/recipes/tracking.py
@@ -92,7 +92,9 @@ class TrackFeatures(ModuleBase):
         pipe = {}
         pipe.update(clumpInfo)
         pipe.update(objects)
-        pipe = pd.DataFrame(pipe)
+        # pipe = pd.DataFrame(pipe)
+        from PYME.IO.tabular import DictSource
+        pipe = DictSource(pipe)
         
         if 'mdh' in dir(objects):
             #propagate metadata
@@ -105,7 +107,8 @@ class TrackFeatures(ModuleBase):
         else:
             clumps = [c for c in clumps.all if (c.nEvents > self.minTrackLength) ]
 
-        clumpInfo = pd.DataFrame(clumpInfo)
+        # clumpInfo = pd.DataFrame(clumpInfo)
+        clumpInfo = DictSource(clumpInfo)
         
         if 'mdh' in dir(objects):
             #propagate metadata
@@ -125,12 +128,14 @@ class TrackFeatures(ModuleBase):
         into the pipeline (used when called from PYME.DSView.modules.particleTracking)"""
         clumpInfo, clumps = self.Track(pipeline)
 
-        pipeline.addColumn('clumpIndex', clumpInfo['clumpIndex'])
-        pipeline.addColumn('clumpSize', clumpInfo['clumpSize'])
-        pipeline.addColumn('trackVelocity', clumpInfo['trackVelocity'])
+        # pipeline.addColumn('clumpIndex', clumpInfo['clumpIndex'])
+        # pipeline.addColumn('clumpSize', clumpInfo['clumpSize'])
+        # pipeline.addColumn('trackVelocity', clumpInfo['trackVelocity'])
         
         #self.clumps = clumps        
-        pipeline.clumps = clumps
+        # pipeline.clumps = clumps
+
+        pipeline.addDataSource('clumps', clumpInfo)
         
         return clumps
 

--- a/PYME/recipes/traits.py
+++ b/PYME/recipes/traits.py
@@ -33,7 +33,10 @@ class FileOrURI(File):
         # FIXME
         return value
 
-class IntFloat(BaseFloat):
+class _IntFloat(BaseFloat):
+    # WARNING: This is a fudge used in skimage wrapping. It should not be used unless absolutely necessary and might dissappear if and when we 
+    # find a better replacement. Has a 'private' (leading underscore) name to discourage use.
+    # TODO - Can we inherit from Float instead to eliminate the `set()` method?
     default_value = 0.0
     info_text = 'Frankenstein to deal with automatic introspection'
 

--- a/PYME/recipes/traits.py
+++ b/PYME/recipes/traits.py
@@ -1,5 +1,6 @@
 """ Shim to give us a uniform way of importing traits (and replacing them if needed in the future)"""
 from __future__ import absolute_import
+import numpy as np
 
 try:
     from enthought.traits.api import *
@@ -31,3 +32,19 @@ class FileOrURI(File):
         # Traitsui hangs up if a file doesn't validate correctly and doesn't allow selecting a replacement - disable validation for now :(
         # FIXME
         return value
+
+class IntFloat(BaseFloat):
+    default_value = 0.0
+    info_text = 'Frankenstein to deal with automatic introspection'
+
+    def set(self, obj, name, value):
+        setattr(self, name, value)
+        self.set_value(obj, name, value)
+
+    def get(self, obj, name):
+        val = self.get_value(obj, name)
+        if val is None:
+            val = self.default_value
+        if val == np.round(val):
+            val = int(val)
+        return val


### PR DESCRIPTION
Everything I needed to do to get the steps outlined in PYME_tracking_workflow.pdf working again. `movieplot2` still isn't plotting contours correctly. 

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Fix `skfilter` imports by shimming py2 int/float behavior into py3 (see #376)
- Update wx calls in particeTracking.py
- Create a new version of `STED_COP3.yaml` that uses `skimage.filters.threshold_local` instead of the removed `threshold_adaptive`, and add a `FractionalThreshold` to convert its output to a mask 
- Adjust how the clump information is injected into the pipeline
- Fix `ListEvent` index grabbing
- Float/int fix for slicing in py3


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
