### PR TITLE
fix intfloat import

### DIFF
--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -9,7 +9,7 @@ Created on Mon May 25 17:02:04 2015
 #import wx
 import six
 
-from PYME.recipes.traits import HasTraits, Float, List, Bool, Int, CStr, Enum, File, on_trait_change, Input, Output, IntFloat
+from PYME.recipes.traits import HasTraits, Float, List, Bool, Int, CStr, Enum, File, on_trait_change, Input, Output, _IntFloat
     
     #for some reason traitsui raises SystemExit when called from sphinx on OSX
     #This is due to the framework build problem of anaconda on OSX, and also


### PR DESCRIPTION
Assuming `_IntFloat` is the desired name
```
_________________________________________________________________ ERROR collecting tests/PYME/recipes/test_measurement.py _________________________________________________________________
ImportError while importing test module '/Users/Andrew/code/python-microscopy/tests/PYME/recipes/test_measurement.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
PYME/recipes/test_measurement.py:4: in <module>
    from PYME.recipes import measurement, base, tablefilters
../PYME/recipes/measurement.py:9: in <module>
    from .base import ModuleBase, register_module, Filter
../PYME/recipes/base.py:12: in <module>
    from PYME.recipes.traits import HasTraits, Float, List, Bool, Int, CStr, Enum, File, on_trait_change, Input, Output, IntFloat
E   ImportError: cannot import name 'IntFloat'
_________________________________________________________________ ERROR collecting tests/PYME/recipes/test_processing.py __________________________________________________________________
ImportError while importing test module '/Users/Andrew/code/python-microscopy/tests/PYME/recipes/test_processing.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
PYME/recipes/test_processing.py:2: in <module>
    from PYME.recipes.base import ModuleCollection
../PYME/recipes/base.py:12: in <module>
    from PYME.recipes.traits import HasTraits, Float, List, Bool, Int, CStr, Enum, File, on_trait_change, Input, Output, IntFloat
E   ImportError: cannot import name 'IntFloat'
```