### PR TITLE
Enable `AndSave` in PYMEImage `RunCurrentRecipeAndSave`

### DIFF
--- a/PYME/DSView/modules/recipes.py
+++ b/PYME/DSView/modules/recipes.py
@@ -97,7 +97,13 @@ class RecipePlugin(recipeGui.RecipeManager, Plugin):
                 self.outp = self.activeRecipe.execute(input=self.image)
                 
                 if saveResults:
-                    self.activeRecipe.save() #FIXME - set context
+                    dir_dialog = wx.DirDialog(None, 'Set output directory', style=wx.FD_OPEN)
+                    succ = dir_dialog.ShowModal()
+                    if (succ == wx.ID_OK):
+                        output_dir = dir_dialog.GetPath()
+                        file_stub = os.path.splitext(os.path.split(self.image.filename)[-1])[0]
+                        self.activeRecipe.save({'output_dir': output_dir, 
+                                                'file_stub': file_stub})
                     
                     
             def _display_output_image(outp):


### PR DESCRIPTION
Addresses issue dh5view recipe has 'run and save' option which has no context to save

```
 Error whilst running Recipes>Run Current Recipe and Save    Shift+F5
==============================================
python-microscopy=20.07.29
python=3.6.10, platform=win32
numpy=1.16.6, wx=4.0.4 msw (phoenix) wxWidgets 3.0.5
Traceback
=========
Traceback (most recent call last):
  File "c:\users\bergamot\code\python-microscopy\PYME\ui\progress.py", line 107, in func
    return fcn(*args, **kwargs)
  File "c:\users\bergamot\code\python-microscopy\PYME\DSView\modules\recipes.py", line 88, in RunCurrentRecipeAndSave
    self.RunCurrentRecipe(saveResults=True)
  File "c:\users\bergamot\code\python-microscopy\PYME\DSView\modules\recipes.py", line 100, in RunCurrentRecipe
    self.activeRecipe.save() #FIXME - set context
  File "c:\users\bergamot\code\python-microscopy\PYME\recipes\base.py", line 857, in save
    mod.save(self.namespace, context)
  File "c:\users\bergamot\code\python-microscopy\PYME\recipes\output.py", line 329, in save
    out_filename = self.filePattern.format(**context)
KeyError: 'output_dir'

```
**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
wxdialog to have user select directory for output






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.1
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
