### PR TITLE
Better contour plotting

### DIFF
--- a/PYME/Analysis/graphing_filters.py
+++ b/PYME/Analysis/graphing_filters.py
@@ -282,7 +282,7 @@ def movieplot2(clump, image):
             
             if not contours is None:
                 xc, yc = contours[i].T
-                plt.plot(xc - xp + 20, yc - yp + 20, c='b')#plt.cm.hsv(clump.clumpID/16.))
+                plt.plot(xc - xp + roiHalfSize + y_0, yc - yp + roiHalfSize + x_0, c='b')#plt.cm.hsv(clump.clumpID/16.))
         
         if img_out.shape[2] <= 1:
             plt.imshow(img_out.squeeze(), interpolation='nearest', cmap=plt.cm.gray, clim=[0, 255])


### PR DESCRIPTION
Addresses issue all the contours plot in the upper-left plot only (see screenshot).

Before this fix:
<img width="912" alt="before_spt" src="https://user-images.githubusercontent.com/1263313/89330566-736cc700-d65e-11ea-9697-d89bb7ed2493.png">

After this fix:
<img width="912" alt="after_spt" src="https://user-images.githubusercontent.com/1263313/89330578-7798e480-d65e-11ea-9a84-49ae058a5e3f.png">

For a lot of SPT plots, this works. For some, the plots are still wonky, and I'm not sure why. Way more work this fix then worked before though (zero).

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Center contours on their respective images with `x0`, `y0`






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
