### PR TITLE
Display units in voxSizeDialog

### DIFF
--- a/PYME/DSView/voxSizeDialog.py
+++ b/PYME/DSView/voxSizeDialog.py
@@ -31,7 +31,7 @@ class VoxSizeDialog(wx.Dialog):
         #sizer2 = wx.BoxSizer(wx.HORIZONTAL)
 
         sizer2 = wx.BoxSizer(wx.HORIZONTAL)
-        sizer2.Add(wx.StaticText(self, -1, u'x [\u03BCm]:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        sizer2.Add(wx.StaticText(self, -1, u'x\u00A0[\u00B5m]:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
         self.tVoxX = wx.TextCtrl(self, -1, '0.08')
 
         sizer2.Add(self.tVoxX, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
@@ -39,7 +39,7 @@ class VoxSizeDialog(wx.Dialog):
         sizer1.Add(sizer2, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 0)
 
         sizer2 = wx.BoxSizer(wx.HORIZONTAL)
-        sizer2.Add(wx.StaticText(self, -1, u'y [\u03BCm]:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        sizer2.Add(wx.StaticText(self, -1, u'y\u00A0[\u00B5m]:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
         self.tVoxY = wx.TextCtrl(self, -1, '0.08')
 
         sizer2.Add(self.tVoxY, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
@@ -47,7 +47,7 @@ class VoxSizeDialog(wx.Dialog):
         sizer1.Add(sizer2, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 0)
 
         sizer2 = wx.BoxSizer(wx.HORIZONTAL)
-        sizer2.Add(wx.StaticText(self, -1, u'z [\u03BCm]:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        sizer2.Add(wx.StaticText(self, -1, u'z\u00A0[\u00B5m]:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
         self.tVoxZ = wx.TextCtrl(self, -1, '0.2')
 
         sizer2.Add(self.tVoxZ, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)


### PR DESCRIPTION
Addresses issue the [um] part of x, y, and z wasn't showing up (py3/wx4).

**Is this a bugfix or an enhancement?**
Bugfix 

**Proposed changes:**
- Convert space to space character (fixed display)
- Convert mu character to Windows-accepted mu character (re: #367)




**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
