### PR TITLE
ensure we have an absolute path for non-cluster filenames in PYMEImage

### DIFF
--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -212,6 +212,8 @@ class ImageStack(object):
         self.events = events  #events
 
         self.queueURI = queueURI
+        if filename is not None and not filename.lower().startswith('pyme-cluster'):
+            filename = os.path.abspath(filename)
         self.filename = filename
 
         self.haveGUI = haveGUI

--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -212,8 +212,12 @@ class ImageStack(object):
         self.events = events  #events
 
         self.queueURI = queueURI
-        if filename is not None and not filename.lower().startswith('pyme-cluster'):
+        
+        if filename is not None os.path.exists(filename): # is a real filename on disk, rather than a schemified one e.g. pyme-cluster://
+            # make the filename fully resolved rather than relative to the directory we launched from (if we launched with a partial filename)
+            # TODO: does this belong here, or should this logic be elsewhere
             filename = os.path.abspath(filename)
+            
         self.filename = filename
 
         self.haveGUI = haveGUI


### PR DESCRIPTION
Addresses issue #392 .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
us os.path.abspath to be an absolute path for non-cluster filenames






**Checklist:**

- [ ] Tested with numpy=1.14

1.16, 1.19
- [ ] Tested on python 2.7 and 3.6

3.6 and 3.7
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.1 and 4.0
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
