### PR TITLE
launch workers using sys.executable

### DIFF
--- a/PYME/cluster/PYMERuleNodeServer.py
+++ b/PYME/cluster/PYMERuleNodeServer.py
@@ -7,7 +7,7 @@ import socket
 import subprocess
 import tempfile
 import time
-
+import sys
 import yaml
 from PYME import config as conf
 from PYME.misc import pyme_zeroconf, sqlite_ns
@@ -109,12 +109,12 @@ def main():
     nodeserverLog.debug('Launching worker processors')
     numWorkers = conf.get('nodeserver-num_workers', cpu_count())
 
-    workerProcs = [subprocess.Popen('python -m PYME.cluster.taskWorkerHTTP -s %d' % serverPort, shell=True, stdin=subprocess.PIPE)
+    workerProcs = [subprocess.Popen('%s -m PYME.cluster.taskWorkerHTTP -s %d' % (sys.executable, serverPort), shell=True, stdin=subprocess.PIPE)
                    for i in range(numWorkers -1)]
 
     #last worker has profiling enabled
     profiledir = os.path.join(nodeserver_log_dir, 'mProf')      
-    workerProcs.append(subprocess.Popen('python -m PYME.cluster.taskWorkerHTTP -s % d -p --profile-dir=%s' % (serverPort, profiledir), shell=True,
+    workerProcs.append(subprocess.Popen('%s -m PYME.cluster.taskWorkerHTTP -s % d -p --profile-dir=%s' % (sys.executable, serverPort, profiledir), shell=True,
                                         stdin=subprocess.PIPE))
 
     try:


### PR DESCRIPTION
Addresses issue trying to benchmark things using a profiler can result in bash command python not found

**Is this a bugfix or an enhancement?**
enhancement - works fine if you launch from terminal as user
**Proposed changes:**
- initialize taskWorkerHTTPs using `sys.executable` rather than `python`, as we do for e.g. the dataservers


**note**
Could also do this in test_discover and a few of the deprecated (eg normal nodeserver, distributor) files too if we like.






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
