### PR TITLE
Installation tweaks

### DIFF
--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -69,7 +69,7 @@ environment and enter
     conda install javabridge
     conda install python-bioformats
 
-**Caveat:** This feature is currently in development. If ``conda`` packages for ``javabridge`` and ``bioformats`` don't work, try pip. 
+**Caveat:** This feature is currently in development. If ``conda`` packages for ``javabridge`` and ``bioformats`` don't work, try ``pip``. 
 
 Verify installation
 *******************

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -61,8 +61,18 @@ On OSX, use ``/path/to/conda/environment/python.app/Contents/MacOS/python setup.
 Enable bioformats data importers
 ================================
 
-Install a JAVA JDK or JRE. Open a command prompt in the installation ``conda`` 
-environment and enter
+Download and install `JAVA JDK 1.8 <https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html>`_. 
+Note that you may need to create an account to access the installer. Open a command prompt in the installation ``conda`` 
+environment.
+
+If you are on Windows, enter
+
+.. code-block:: bash
+
+    set MSSdk=1
+    set DISTUTILS_USE_SDK=1
+
+Otherwise (or subsequently, if on Windows) enter
 
 .. code-block:: bash
 
@@ -73,12 +83,11 @@ If you'd prefer to install via ``conda``, instead enter
 
 .. code-block:: bash
 
-    conda install -c conda-forge javabridge
+    conda install -c free javabridge
     conda install -c bioconda bioformats
 
-**Caveat:** pip is the only installation route confirmed to work. 
-
-
+**Caveat:** ``pip`` is the only installation route confirmed to work. Installation issues on ``pip``
+are likely caused by ``javabridge`` and addressed at `https://pythonhosted.org/javabridge/installation.html <https://pythonhosted.org/javabridge/installation.html>`_.
 
 Verify installation
 *******************

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -57,37 +57,19 @@ This assumes a basic familiarity with python and conda. We maintain a conda meta
 
 On OSX, use ``/path/to/conda/environment/python.app/Contents/MacOS/python setup.py develop`` instead  of ``python setup.py develop`` so that the PYME programs can access the screen. 
 
-
 Enable bioformats data importers
 ================================
 
 Download and install `JAVA JDK 1.8 <https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html>`_. 
 Note that you may need to create an account to access the installer. Open a command prompt in the installation ``conda`` 
-environment.
-
-If you are on Windows, enter
+environment and enter
 
 .. code-block:: bash
 
-    set MSSdk=1
-    set DISTUTILS_USE_SDK=1
+    conda install javabridge
+    conda install python-bioformats
 
-Otherwise (or subsequently, if on Windows) enter
-
-.. code-block:: bash
-
-    pip install javabridge
-    pip install python-bioformats
-
-If you'd prefer to install via ``conda``, instead enter
-
-.. code-block:: bash
-
-    conda install -c free javabridge
-    conda install -c bioconda bioformats
-
-**Caveat:** ``pip`` is the only installation route confirmed to work. Installation issues on ``pip``
-are likely caused by ``javabridge`` and addressed at `https://pythonhosted.org/javabridge/installation.html <https://pythonhosted.org/javabridge/installation.html>`_.
+**Caveat:** This feature is currently in development. If conda packages for javabridge and bioformats don't work, try pip. 
 
 Verify installation
 *******************

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -69,7 +69,7 @@ environment and enter
     conda install javabridge
     conda install python-bioformats
 
-**Caveat:** This feature is currently in development. If conda packages for javabridge and bioformats don't work, try pip. 
+**Caveat:** This feature is currently in development. If ``conda`` packages for ``javabridge`` and ``bioformats`` don't work, try pip. 
 
 Verify installation
 *******************

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -27,7 +27,7 @@ Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. note::
 
-    **Which python version?** We are currently in the process of switching the default install from python 2.7 to python 3. As of 2020/8/6 the python 3 packages are not in the above conda channel, but that should change shortly. The python2.7 version is better tested, but most of the core functionality now runs on python 3 as well.
+    **Which python version?** We are currently in the process of switching the default install from python 2.7 to python 3. As of 2020/8/6 the python 3 packages are not in the above conda channel, but that should change shortly. The python 2.7 version is better tested, but most of the core functionality now runs on python 3 as well.
 
 
 Updating
@@ -66,10 +66,17 @@ environment and enter
 
 .. code-block:: bash
 
-    conda install javabridge
-    conda install python-bioformats
+    pip install javabridge
+    pip install python-bioformats
 
-**Caveat:** This currently only works on OSX. If conda packages for javabridge and bioformats don't work, try pip. 
+If you'd prefer to install via ``conda``, instead enter
+
+.. code-block:: bash
+
+    conda install -c conda-forge javabridge
+    conda install -c bioconda bioformats
+
+**Caveat:** pip is the only installation route confirmed to work. 
 
 
 
@@ -140,7 +147,7 @@ If installing in a tricky evironment, you can manually edit requirements.txt bef
 
 .. rubric:: Footnotes
 
-.. [#anacondaprompt] On OSX or linux this is the command prompt. On Windows, this is accessed from the "Miniconda" or "PYME" folder in the start menu.
+.. [#anacondaprompt] On OSX or linux this is the terminal. On Windows, this is accessed from the "Miniconda" or "PYME" folder in the start menu.
 
 
 


### PR DESCRIPTION
The javabridge/bioformats install instructions don't work as-is.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Fix the conda install calls for bioformats/javabridge
- Replace with pip as the recommended installation route since that's the only route I've ever gotten to work


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
