### PR TITLE
Extract pupil fix

### DIFF
--- a/PYME/Analysis/PSFGen/fourierHNA.py
+++ b/PYME/Analysis/PSFGen/fourierHNA.py
@@ -352,8 +352,8 @@ def ExtractPupil(ps, zs, dx, lamb=488, NA=1.3, n=1.51, nIters=50, size=5e3, inte
     
     sx = ps.shape[0]
     sy = ps.shape[1]
-    ox = (X.shape[0] - sx) / 2
-    oy = (X.shape[1] - sy) / 2
+    ox = int((X.shape[0] - sx) / 2)
+    oy = int((X.shape[1] - sy) / 2)
     ex = ox + sx
     ey = oy + sy
     

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -27,7 +27,7 @@ Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. note::
 
-    **Which python version?** We are currently in the process of switching the default install from python 2.7 to python 3. As of 2020/8/6 the python 3 packages are not in the above conda channel, but that should change shortly. The python2.7 version is better tested, but most of the core functionality now runs on python 3 as well.
+    **Which python version?** We are currently in the process of switching the default install from python 2.7 to python 3. As of 2020/8/6 the python 3 packages are not in the above conda channel, but that should change shortly. The python 2.7 version is better tested, but most of the core functionality now runs on python 3 as well.
 
 
 Updating
@@ -66,10 +66,17 @@ environment and enter
 
 .. code-block:: bash
 
-    conda install javabridge
-    conda install python-bioformats
+    pip install javabridge
+    pip install python-bioformats
 
-**Caveat:** This currently only works on OSX. If conda packages for javabridge and bioformats don't work, try pip. 
+If you'd prefer to install via ``conda``, instead enter
+
+.. code-block:: bash
+
+    conda install -c conda-forge javabridge
+    conda install -c bioconda bioformats
+
+**Caveat:** pip is the only installation route confirmed to work. 
 
 
 
@@ -140,7 +147,7 @@ If installing in a tricky evironment, you can manually edit requirements.txt bef
 
 .. rubric:: Footnotes
 
-.. [#anacondaprompt] On OSX or linux this is the command prompt. On Windows, this is accessed from the "Miniconda" or "PYME" folder in the start menu.
+.. [#anacondaprompt] On OSX or linux this is the terminal. On Windows, this is accessed from the "Miniconda" or "PYME" folder in the start menu.
 
 
 


### PR DESCRIPTION
Addresses issue

```
 Error whilst running Processing>Extract &Pupil Function
==============================================
python-microscopy=20.07.29
python=3.6.10, platform=darwin
numpy=1.16.6, wx=4.0.4 osx-cocoa (phoenix) wxWidgets 3.0.5

Traceback
=========
Traceback (most recent call last):
  File "/Users/zachcm/Code/python-microscopy/PYME/ui/progress.py", line 107, in func
    return fcn(*args, **kwargs)
  File "/Users/zachcm/Code/python-microscopy/PYME/DSView/modules/psfTools.py", line 279, in OnExtractPupil
    pupil = fourierHNA.ExtractPupil(self.image.data[:,:,:], z_, vs.x, self.wavelength, self.NA, nIters=self.iterations, size=self.pupilSize, intermediateUpdates=self.intermediateUpdates)
  File "/Users/zachcm/Code/python-microscopy/PYME/Analysis/PSFGen/fourierHNA.py", line 388, in ExtractPupil
    pj = prop_j[ox:ex, oy:ey]
TypeError: slice indices must be integers or None or have an __index__ method
```

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Explicitly cast slice integers to int






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
