### PR TITLE
start `SpoolController._update_series_counter` from zero series

### DIFF
--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -272,6 +272,7 @@ class SpoolController(object):
         
     def _update_series_counter(self):
         logger.debug('Updating series counter')
+        self.seriesCounter = 0
         while self._checkOutputExists(self.seriesName):
             self.seriesCounter +=1
             self.seriesName = self._GenSeriesName()

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -273,6 +273,7 @@ class SpoolController(object):
     def _update_series_counter(self):
         logger.debug('Updating series counter')
         self.seriesCounter = 0
+        self.seriesName = self._GenSeriesName()
         while self._checkOutputExists(self.seriesName):
             self.seriesCounter +=1
             self.seriesName = self._GenSeriesName()


### PR DESCRIPTION
Addresses issue if you image a couple series, then change sample and change the spool directory correspondingly, you get left at the series counter / name from the old one, e.g. your first series in a new folder will be 8_7_series_ZB.

**Is this a bugfix or an enhancement?**
small enhancement
**Proposed changes:**
- when we update the series counter to make sure we don't override any files if we left off and restarted, start at zero so we also get the right number if we start a new folder.
  - Note we only call this function internally to spoolcontroller when we a) pull the first series name, b) set spool method, and c) set spool directory


**Question for future PRs/not**
Would zero padding the dates be OK? As a config option? Maybe another for just leaving the gen series name in numbers rather than letters?



**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]