### PR TITLE
avoid multiple frames on the same step after AverageFrameByZStep

### DIFF
--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -1747,6 +1747,9 @@ class AverageFramesByZStep(ModuleBase):
         else:
             #z values are provided as input
             z_vals = namespace[self.input_zvals][self.z_column_name]
+        
+        # later we will mash z with %3.3f, round here so we don't duplicate steps
+        z_vals = np.round(z_vals, decimals=3)
 
         # make sure everything is sorted. We'll carry the args to sort, rather than creating another full array
         frames_z_sorted = np.argsort(z_vals)

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -1749,6 +1749,7 @@ class AverageFramesByZStep(ModuleBase):
             z_vals = namespace[self.input_zvals][self.z_column_name]
         
         # later we will mash z with %3.3f, round here so we don't duplicate steps
+        # TODO - make rounding precision a parameter?
         z_vals = np.round(z_vals, decimals=3)
 
         # make sure everything is sorted. We'll carry the args to sort, rather than creating another full array


### PR DESCRIPTION
Addresses issue calculating z positions early in the module, then spoofing events with `'%3.3f'` can get close frames (e.g. if you imaged multiple cycles) counting as separate steps and being averaged separately, but having the same z position, which then breaks things downstream if the whole point was to get one frame per step, e.g. for `ResampleZ`.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- round to 3 decimal places (1 nm) early on so we associate/average the frames which we'll eventually call the same z






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]