### PR TITLE
a dict editor / view we need for hdfoutput

### DIFF
--- a/PYME/recipes/output.py
+++ b/PYME/recipes/output.py
@@ -353,9 +353,10 @@ class HDFOutput(OutputModule):
         from PYME.ui.custom_traits_editors import DictChoiceStrEditor
 
         inputs, outputs, params = self.get_params()
-
-        return View([Item(tn, editor=DictChoiceStrEditor(choices=self._namespace_keys)) for tn in inputs], 
-                    buttons=['OK', 'Cancel'])
+        
+        return View([Item(tn, editor=DictChoiceStrEditor(choices=self._namespace_keys)) for tn in inputs] +
+                    [Item('_'),] +
+                    self._view_items(params), buttons=['OK', 'Cancel'])
 
 
 

--- a/PYME/recipes/output.py
+++ b/PYME/recipes/output.py
@@ -343,19 +343,20 @@ class HDFOutput(OutputModule):
                 v = namespace[name]
                 v.to_hdf(out_filename, tablename=h5_name, metadata=getattr(v, 'mdh', None))
 
-    # @property
-    # def default_view(self):
-    #     from traitsui.api import View, Item, Group
-    #     from PYME.ui.custom_traits_editors import CBEditor
-    #
-    #     editable = self.class_editable_traits()
-    #     inputs = [tn for tn in editable if tn.startswith('input')]
-    #     outputs = [tn for tn in editable if tn.startswith('output')]
-    #     params = [tn for tn in editable if not (tn in inputs or tn in outputs or tn.startswith('_'))]
-    #
-    #     return View([Item(tn) for tn in inputs] + [Item('_'), ] +
-    #                 [Item(tn) for tn in params] + [Item('_'), ] +
-    #                 [Item(tn) for tn in outputs], buttons=['OK', 'Cancel'])
+    @property
+    def default_view(self):
+        import wx
+        if wx.GetApp() is None:
+            return None
+        
+        from traitsui.api import View, Item
+        from PYME.ui.custom_traits_editors import DictChoiceStrEditor
+
+        inputs, outputs, params = self.get_params()
+
+        return View([Item(tn, editor=DictChoiceStrEditor(choices=self._namespace_keys)) for tn in inputs], 
+                    buttons=['OK', 'Cancel'])
+
 
 
 @register_module('ReportOutput')

--- a/PYME/ui/custom_traits_editors.py
+++ b/PYME/ui/custom_traits_editors.py
@@ -48,7 +48,7 @@ class _CBEditor (Editor):
                 n = choices.index(self.value)
                 self.control.SetSelection(n)
             except ValueError:
-                self.control.SetValue(self.value)
+                self.control.SetValue(str(self.value))
 
         return
     
@@ -113,7 +113,240 @@ class FilterEditor(BasicEditorFactory):
 
     datasource = Instance(tabular.TabularBase)
 
+class DictChoiceStrEditDialog(wx.Dialog):
+    def __init__(self, parent, mode='new', possibleKeys=(), key='', val=''):
+        wx.Dialog.__init__(self, parent, title='Edit ...')
 
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        
+        hsizer.Add(wx.StaticText(self, -1, 'Input:'), 0, 
+                   wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        
+        self.cbKey = wx.ComboBox(self, -1, value=key, 
+                                 choices=sorted(possibleKeys), 
+                                 style=wx.CB_DROPDOWN, size=(150, -1))
+
+        if not mode == 'new':
+            self.cbKey.Enable(False)
+
+        hsizer.Add(self.cbKey, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        vsizer.Add(hsizer, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, 'Table_Name:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+
+        self.tVal = wx.TextCtrl(self, -1, val, size=(140, -1))
+        
+
+        hsizer.Add(self.tVal, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+
+        vsizer.Add(hsizer, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+
+        
+        btSizer = wx.StdDialogButtonSizer()
+
+        btn = wx.Button(self, wx.ID_OK)
+        btn.SetDefault()
+
+        btSizer.AddButton(btn)
+
+        btn = wx.Button(self, wx.ID_CANCEL)
+
+        btSizer.AddButton(btn)
+
+        btSizer.Realize()
+
+        vsizer.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+
+        self.SetSizer(vsizer)
+        vsizer.Fit(self)
+
+
+class DictChoiceStrPanel(wx.Panel):
+    def __init__(self, parent, filterKeys, choices=None, unique_vals=True):
+        """
+
+        Parameters
+        ----------
+        parent : wx.Window
+
+        filterKeys : dict
+            Dictionary keys
+
+        dataSource : function
+            function to call to get the current data source
+        """
+        wx.Panel.__init__(self, parent)
+
+        self.filterKeys = filterKeys
+        self._choices = choices
+        self._unique_vals = unique_vals
+
+        
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+
+        self.lFiltKeys = wx.ListCtrl(self, -1, style=wx.LC_REPORT | wx.LC_SINGLE_SEL | wx.SUNKEN_BORDER, size=(-1, 25*(max(len(self.filterKeys.keys())+1, 5))))
+        self.lFiltKeys.InsertColumn(0, 'Input')
+        self.lFiltKeys.InsertColumn(1, 'Table Name')
+
+        self.populate()
+
+        self.lFiltKeys.SetColumnWidth(0, 150)  # wx.LIST_AUTOSIZE)
+        self.lFiltKeys.SetColumnWidth(1, 150)  #wx.LIST_AUTOSIZE)
+
+        # only do this part the first time so the events are only bound once
+        if not hasattr(self, "ID_FILT_ADD"):
+            self.ID_FILT_ADD = wx.NewId()
+            self.ID_FILT_DELETE = wx.NewId()
+            self.ID_FILT_EDIT = wx.NewId()
+
+            self.Bind(wx.EVT_MENU, self.OnFilterAdd, id=self.ID_FILT_ADD)
+            self.Bind(wx.EVT_MENU, self.OnFilterDelete, id=self.ID_FILT_DELETE)
+            self.Bind(wx.EVT_MENU, self.OnFilterEdit, id=self.ID_FILT_EDIT)
+
+        # for wxMSW
+        self.lFiltKeys.Bind(wx.EVT_COMMAND_RIGHT_CLICK, self.OnFilterListRightClick)
+        # for wxGTK
+        self.lFiltKeys.Bind(wx.EVT_RIGHT_UP, self.OnFilterListRightClick)
+
+        self.lFiltKeys.Bind(wx.EVT_LIST_ITEM_SELECTED, self.OnFilterItemSelected)
+        self.lFiltKeys.Bind(wx.EVT_LIST_ITEM_DESELECTED, self.OnFilterItemDeselected)
+        self.lFiltKeys.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.OnFilterEdit)
+        
+        vsizer.Add(self.lFiltKeys, 1, wx.ALL|wx.EXPAND, 0)
+        self.SetSizerAndFit(vsizer)
+        
+    def update(self, filter_keys, choices):
+        self.filterKeys = filter_keys
+        self._choices = choices
+        self.populate()
+
+    def populate(self):
+        self.lFiltKeys.DeleteAllItems()
+        ind = 0
+        for key, value in self.filterKeys.items():
+            ind = self.lFiltKeys.InsertStringItem(ind+1, key)
+            self.lFiltKeys.SetStringItem(ind, 1, value)
+
+    @property
+    def choices(self):
+        if self._choices is None:
+            return None
+        elif callable(self._choices):
+            #support passing data source as a callable
+            return self._choices()
+        else:
+            return self._choices
+
+    def OnFilterListRightClick(self, event):
+        x = event.GetX()
+        y = event.GetY()
+
+        item, flags = self.lFiltKeys.HitTest((x, y))
+
+        menu = wx.Menu()
+        menu.Append(self.ID_FILT_ADD, "Add")
+
+        if item != wx.NOT_FOUND and flags & wx.LIST_HITTEST_ONITEM:
+            self.currentFilterItem = item
+            self.lFiltKeys.Select(item)
+
+            menu.Append(self.ID_FILT_DELETE, "Delete")
+            menu.Append(self.ID_FILT_EDIT, "Edit")
+
+        # Popup the menu.  If an item is selected then its handler
+        # will be called before PopupMenu returns.
+        self.PopupMenu(menu)
+        menu.Destroy()
+
+    def OnFilterItemSelected(self, event):
+        self.currentFilterItem = event.GetIndex()
+        event.Skip()
+
+    def OnFilterItemDeselected(self, event):
+        self.currentFilterItem = None
+        event.Skip()
+
+    def OnFilterAdd(self, event):
+        import sys
+
+        try:
+            possibleKeys = list(self.choices)
+        except:
+            possibleKeys = []
+
+        dlg = DictChoiceStrEditDialog(self, mode='new', 
+                                      possibleKeys=possibleKeys)
+
+        ret = dlg.ShowModal()
+
+        if ret == wx.ID_OK:
+            val = str(dlg.tVal.GetValue())
+            key = str(dlg.cbKey.GetValue())
+
+            if key == '':
+                return
+            elif self._unique_vals and (val in self.filterKeys.values()):
+                raise UserWarning('Please choose a unique Table Name')
+
+            self.filterKeys[key] = val
+
+            ind = self.lFiltKeys.InsertStringItem(sys.maxsize, key)
+            self.lFiltKeys.SetStringItem(ind, 1, val)
+
+        dlg.Destroy()
+
+    def OnFilterDelete(self, event):
+        it = self.lFiltKeys.GetItem(self.currentFilterItem)
+        self.lFiltKeys.DeleteItem(self.currentFilterItem)
+        self.filterKeys.pop(it.GetText())
+
+    def OnFilterEdit(self, event):
+        key = str(self.lFiltKeys.GetItem(self.currentFilterItem).GetText())
+        val = self.filterKeys[key]
+        
+        dlg = DictChoiceStrEditDialog(self, mode='edit', key=key, val=val)
+
+        ret = dlg.ShowModal()
+
+        if ret == wx.ID_OK:
+            val = str(dlg.tVal.GetValue())
+            if self._unique_vals and (val in self.filterKeys.values()):
+                raise UserWarning('Please choose a unique Table Name')
+            self.filterKeys[key] = val
+            self.lFiltKeys.SetStringItem(self.currentFilterItem, 1, val)
+
+        dlg.Destroy()
+
+class _DictChoiceStrEditor(Editor):
+    def init(self, parent):
+        """
+        Finishes initializing the editor by creating the underlying widget.
+        """
+        from PYME.LMVis.filterPane import FilterPanel
+
+
+        self.control = DictChoiceStrPanel(parent, filterKeys=self.value, 
+                                          choices=self.factory.choices)
+
+
+    def update_editor(self):
+        """
+        Updates the editor when the object trait changes externally to the
+        editor.
+        """
+        if self.value:
+            self.control.populate()
+    
+    def dispose(self):
+        self.control = None
+        # super(Editor, self).dispose()
+        super().dispose()
+
+class DictChoiceStrEditor(BasicEditorFactory):
+    klass = _DictChoiceStrEditor
+    choices = List()
 
 from . import editList
 

--- a/PYME/ui/custom_traits_editors.py
+++ b/PYME/ui/custom_traits_editors.py
@@ -207,8 +207,10 @@ class DictChoiceStrPanel(wx.Panel):
 
         # for wxMSW
         self.lFiltKeys.Bind(wx.EVT_COMMAND_RIGHT_CLICK, self.OnFilterListRightClick)
+        self.lFiltKeys.Bind(wx.EVT_COMMAND_LEFT_CLICK, self.OnFilterListRightClick)
         # for wxGTK
         self.lFiltKeys.Bind(wx.EVT_RIGHT_UP, self.OnFilterListRightClick)
+        self.lFiltKeys.Bind(wx.EVT_LEFT_UP, self.OnFilterListRightClick)
 
         self.lFiltKeys.Bind(wx.EVT_LIST_ITEM_SELECTED, self.OnFilterItemSelected)
         self.lFiltKeys.Bind(wx.EVT_LIST_ITEM_DESELECTED, self.OnFilterItemDeselected)


### PR DESCRIPTION
Addresses issue #404 #278 .

**Is this a bugfix or an enhancement?**
yes
**Proposed changes:**
- fix type error in #404 
- add DictChoiceStrEditor and use it for HDFOutput default view, as suggested in #278 



**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):
1. So you click add HDFOutput <img width="1215" alt="Screen Shot 2020-08-12 at 12 11 33 PM" src="https://user-images.githubusercontent.com/31105780/90040057-789cc800-dc95-11ea-8778-282eb6ed1950.png">
2. Then you click the table <img width="1213" alt="Screen Shot 2020-08-12 at 12 11 42 PM" src="https://user-images.githubusercontent.com/31105780/90040107-8e11f200-dc95-11ea-9311-70ee5fbde405.png">
3. Then you choose what you want to save using a normal recipe input dropdown <img width="1215" alt="Screen Shot 2020-08-12 at 12 11 53 PM" src="https://user-images.githubusercontent.com/31105780/90040218-af72de00-dc95-11ea-82fd-6c0bd123d376.png">
4.  type in what you want for the table name <img width="1216" alt="Screen Shot 2020-08-12 at 12 12 01 PM" src="https://user-images.githubusercontent.com/31105780/90040279-c31e4480-dc95-11ea-9b47-bf1cdb7fb498.png">
5. and boom, you're a hero <img width="1220" alt="Screen Shot 2020-08-12 at 12 12 08 PM" src="https://user-images.githubusercontent.com/31105780/90040352-d5987e00-dc95-11ea-835d-8e45522fbf2b.png">
6. but you're a flawed hero, so you try to save another item to the same name COLLISION! <img width="1216" alt="Screen Shot 2020-08-12 at 12 12 21 PM" src="https://user-images.githubusercontent.com/31105780/90040461-f4971000-dc95-11ea-8644-e61bca0d4ca3.png">
7. but we added a flag for the editor to put up unique value guard-rails <img width="1215" alt="Screen Shot 2020-08-12 at 12 12 40 PM" src="https://user-images.githubusercontent.com/31105780/90040543-11334800-dc96-11ea-83ef-6cc80b97426d.png">
8. and check it out the thing is still functional, so if you decide to give up and just add what you had you still can <img width="1216" alt="Screen Shot 2020-08-12 at 12 12 52 PM" src="https://user-images.githubusercontent.com/31105780/90040658-37f17e80-dc96-11ea-8cac-95c9401a3c69.png">


**note**
some of the code could be nicer: some camelCaseNamesAreRippedFromFilterPanel, and we might not want this all slapped into the custom traits editors file. _BUT_ this fixes multiple bugs which break the current gui, and the fact we've left it broken so long indicates a certain lack of excitement for sprucing it up further.