### PR TITLE
allow protocol filename to be set

### DIFF
--- a/PYME/Acquire/protocol.py
+++ b/PYME/Acquire/protocol.py
@@ -33,6 +33,9 @@ from sys import maxsize as maxint
 #minimal protocol which does nothing
 class Protocol:
     def __init__(self, filename=None):
+        # NOTE: .filename attribute is currently set in the spool controller, and will over-ride the filename passed to the constructor.
+        # The filename parameter exists to allow setting the filename in protocols which are not instantiated through the spool controller, and
+        # requires passing __name__ to the constructor in the protocol itself. Both solutions are a bit gross, and may be revisited in the future.
         self.filename = filename
 
     def Init(self, spooler):

--- a/PYME/Acquire/protocol.py
+++ b/PYME/Acquire/protocol.py
@@ -32,9 +32,8 @@ from sys import maxsize as maxint
 
 #minimal protocol which does nothing
 class Protocol:
-    filename=None
-    def __init__(self):
-        pass
+    def __init__(self, filename=None):
+        self.filename = filename
 
     def Init(self, spooler):
         pass
@@ -100,9 +99,10 @@ def SetContinuousMode(contMode):
 
 
 class TaskListProtocol(Protocol):
-    def __init__(self, taskList, metadataEntries = [], preflightList=[]):
+    def __init__(self, taskList, metadataEntries = [], preflightList=[], 
+                 filename=None):
         self.taskList = taskList
-        Protocol.__init__(self)
+        Protocol.__init__(self, filename)
         self.listPos = 0
 
         self.metadataEntries = metadataEntries
@@ -146,7 +146,7 @@ class TaskListProtocol(Protocol):
 
 class ZStackTaskListProtocol(TaskListProtocol):
     def __init__(self, taskList, startFrame, dwellTime, metadataEntries=[], preflightList=[], randomise=False,
-                 slice_order='saw', require_camera_restart=True):
+                 slice_order='saw', require_camera_restart=True, filename=None):
         """
 
         Parameters
@@ -171,7 +171,8 @@ class ZStackTaskListProtocol(TaskListProtocol):
         require_camera_restart: bool
             Flag to toggle restarting the camera/frameWrangler on each step (True) or leave the camera running (False)
         """
-        TaskListProtocol.__init__(self, taskList, metadataEntries, preflightList)
+        TaskListProtocol.__init__(self, taskList, metadataEntries, preflightList,
+                                  filename)
         
         self.startFrame = startFrame
         self.dwellTime = dwellTime


### PR DESCRIPTION
Addresses issue spoolcontroller state preservation discussed in #285, and need to pair protocols with analysis chains in #372. 

Issue is that `scope.spoolController.protocol.filename` won't necessarily be the protocol / protocol filename for the current series, and it might not even be set, however `scope.spoolController.spooler.protocol.filename` would track and preserve the sanctity of our spoolcontroller state so startspooling doesn't disrupt it. However, it is currently just `None`

**Is this a bugfix or an enhancement?**
kind of a bugfix, protocol.filename was always None
**Proposed changes:**
- add for-now-optional filename input to protocol task lists







**Checklist:**

- [ ] Tested with numpy=1.14

1.18
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.1
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
