### PR TITLE
fix formating error in protocol event logging for tuple/list/etc

### DIFF
--- a/PYME/Acquire/protocol.py
+++ b/PYME/Acquire/protocol.py
@@ -129,7 +129,7 @@ class TaskListProtocol(Protocol):
         while not self.listPos >= len(self.taskList) and frameNum >= self.taskList[self.listPos].when:
             t = self.taskList[self.listPos]
             t.what(*t.params)
-            eventLog.logEvent('ProtocolTask', '%d, %s, ' % (frameNum, t.what.__name__) + ', '.join(['%s' % p for p in t.params]))
+            eventLog.logEvent('ProtocolTask', '%d, %s, ' % (frameNum, t.what.__name__) + ', '.join([str(p) for p in t.params]))
             self.listPos += 1
 
     def OnFinish(self):
@@ -137,7 +137,7 @@ class TaskListProtocol(Protocol):
             t = self.taskList[self.listPos]
             self.listPos += 1
             t.what(*t.params)
-            eventLog.logEvent('ProtocolTask', '%s, ' % ( t.what.__name__,) + ', '.join(['%s' % p for p in t.params]))
+            eventLog.logEvent('ProtocolTask', '%s, ' % ( t.what.__name__,) + ', '.join([str(p) for p in t.params]))
             
 
 


### PR DESCRIPTION
Addresses issue #403 

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
call str() rather than format str, see #403.






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.1
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
