### PR TITLE
Update PYMEVisualize entry point

### DIFF
--- a/conda-recipes/python-microscopy/entry_points.yaml
+++ b/conda-recipes/python-microscopy/entry_points.yaml
@@ -3,7 +3,7 @@ entry_points:
     - PYMEImage = PYME.DSView.dsviewer:main
     - PYMEAcquire = PYME.Acquire.PYMEAcquire:main
     - VisGUI = PYME.LMVis.VisGUI:main
-    - PYMEVisualize = PYME.LMVis.VisGUI:main
+    - PYMEVis = PYME.LMVis.VisGUI:main
     - PYMEBatch = PYME.recipes.batchProcess:main
     - bakeshop = PYME.recipes.bakeshop:main
     - PYMEDataServer = PYME.cluster.HTTPDataServer:main


### PR DESCRIPTION
Re: private conversation, update `PYMEVisualize` entry point to `PYMEVis`.

**Is this a bugfix or an enhancement?**
Neither

**Proposed changes:**



**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
