### PR TITLE
reflection focus lock tweaks: reset PID internals when we lose measurement

### DIFF
--- a/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
+++ b/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
@@ -248,6 +248,10 @@ class ReflectedLinePIDFocusLock(PID):
 
         Returns
         -------
+        success : bool
+            Whether the fit converged
+        peak_position : float
+            center position of the reflection on the camera [pix]
 
         """
         crop_start = np.argmax(profile) - int(0.5 * self._fit_roi_size)
@@ -255,15 +259,15 @@ class ReflectedLinePIDFocusLock(PID):
         results, success = self._fitter.fit(self._roi_position[:stop - start], profile[start:stop])
         if not success:
             logger.debug('Focus lock fit error')
-            return success, results[1] + start
+        return results[1] + start, success
 
     def on_frame(self, **kwargs):
         # get focus position
         profile = self.scope.frameWrangler.currentFrame.squeeze().sum(axis=0).astype(float)
         if self.subtraction_profile is not None:
-            success, peak_position = self.find_peak(profile - self.subtraction_profile)
+            peak_position, success = self.find_peak(profile - self.subtraction_profile)
         else:
-            success, peak_position = self.find_peak(profile)
+            peak_position, success = self.find_peak(profile)
 
         if not success:
             # restart the integration / derivatives so we don't go wild when we


### PR DESCRIPTION
**Is this a bugfix or an enhancement?**
little of both
**Proposed changes:**
- reset PID internals if we lose measurement - this gets done automatically when we toggle the lock, but if we just lose the reflection for a bit we integrate over a longer time, etc. if we don't reset
- avoid ever setting the position to nan. Shouldn't matter for offset sliders in the main microscope program, but this avoids us trying to plot nans when we plot the peak position over time



**Checklist:**

- [ ] Tested with numpy=1.14

1.18
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.1
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
