### PR TITLE
force views to list in MultiviewCameraMixin

### DIFF
--- a/PYME/Acquire/Hardware/Camera.py
+++ b/PYME/Acquire/Hardware/Camera.py
@@ -953,7 +953,7 @@ class MultiviewCameraMixin(object):
 
             Parameters
             ----------
-            views: List
+            views: list
                 views to activate. Should be integers which can be used to index self.multiview_info
 
             Returns
@@ -965,6 +965,7 @@ class MultiviewCameraMixin(object):
             again. This is not special to this function, but rather anytime SetROI gets called.
 
             """
+            views = list(views)  # tuple(int) isn't iterable, make sure we avoid it
             # set the camera FOV to be just large enough so we do most of the cropping where it is already optimized
             self.x_origins, self.y_origins = zip(*[self.view_origins[view] for view in views])
             chip_x_min, chip_x_max = min(self.x_origins), max(self.x_origins)


### PR DESCRIPTION
`views` input to `enable_multiview` should always be iterable. trying to enable a single view, e.g. with `enable_views(0)` or `enable_views((0))` fails.

**Is this a bugfix or an enhancement?**
slight enhancement

**Proposed changes:**
type `views` input as list






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.1
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
