### PR TITLE
No more matplotlib debugs

### DIFF
--- a/PYME/Analysis/processLogger.py
+++ b/PYME/Analysis/processLogger.py
@@ -58,6 +58,8 @@ class ContextLayer(object):
         dt = np.dtype(reca.dtype.descr + recb.dtype.descr)
         #print dt
         
+        # FIXME: this is gross (a workaround as old versions of np.concatenate didn't work with structured arrays). 
+        # Is this fixed in more recent numpy versions???? 
         return np.fromstring(bytes(reca.data[:])+ bytes(recb.data[:]), dt)
         
     def AddRecord(self, table, record):

--- a/PYME/Analysis/processLogger.py
+++ b/PYME/Analysis/processLogger.py
@@ -58,7 +58,7 @@ class ContextLayer(object):
         dt = np.dtype(reca.dtype.descr + recb.dtype.descr)
         #print dt
         
-        return np.fromstring(reca.data[:]+ recb.data[:], dt)
+        return np.fromstring(bytes(reca.data[:])+ bytes(recb.data[:]), dt)
         
     def AddRecord(self, table, record):
         self.parent.AddRecord(table, self._reccat(self.contextInfo, record))

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -57,6 +57,8 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 logging.getLogger('matplotlib.font_manager').setLevel(logging.ERROR) #clobber unhelpful matplotlib debug messages
+logging.getLogger('matplotlib.backends.backend_wx').setLevel(logging.ERROR)
+logging.getLogger('PIL.PngImagePlugin').setLevel(logging.ERROR)
 
 from PYME.ui import MetadataTree
 from PYME.recipes import recipeGui


### PR DESCRIPTION
Addresses issue

```
 Error whilst running Analysis>Photophysics>Estimate decay lifetimes
==============================================
python-microscopy=20.07.22
python=3.6.10, platform=darwin
numpy=1.16.6, wx=4.0.4 osx-cocoa (phoenix) wxWidgets 3.0.5

Traceback
=========
Traceback (most recent call last):
  File "/Users/zachcm/Code/python-microscopy/PYME/ui/progress.py", line 107, in func
    return fcn(*args, **kwargs)
  File "/Users/zachcm/Code/python-microscopy/PYME/LMVis/Extras/photophysics.py", line 38, in OnCalcDecays
    kinModels.fitDecay(pipeline)
  File "/Users/zachcm/Code/python-microscopy/PYME/Analysis/BleachProfile/kinModels.py", line 254, in colfcnwrap
    retc = fcn(colourFilter, metadata, chanNames[i], i)
  File "/Users/zachcm/Code/python-microscopy/PYME/Analysis/BleachProfile/kinModels.py", line 289, in fitDecay
    PL.AddRecord('/Photophysics/Decay/e2mod', munge_res(e2mod, res, mse=mse, ch2=ch2))
  File "/Users/zachcm/Code/python-microscopy/PYME/Analysis/processLogger.py", line 72, in AddRecord
    self.currentContext.AddRecord(table, record)
  File "/Users/zachcm/Code/python-microscopy/PYME/Analysis/processLogger.py", line 64, in AddRecord
    self.parent.AddRecord(table, self._reccat(self.contextInfo, record))
  File "/Users/zachcm/Code/python-microscopy/PYME/Analysis/processLogger.py", line 61, in _reccat
    return np.fromstring(reca.data[:]+ recb.data[:], dt)
TypeError: unsupported operand type(s) for +: 'memoryview' and 'memoryview'
```

and a bunch of debug statements

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Cast `ndarray` to `bytes`
- Remove some more debug statements


Ideally we'd change these logging statements to 

```
logging.getLogger('matplotlib').setLevel(logging.ERROR)
logging.getLogger('PIL').setLevel(logging.ERROR)
```

I think that we're just playing whack-a-mole with which submodules we want to silence at the moment.






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
