### PR TITLE
_get_dye_ratios_from_metadata dye name encoding fix

### DIFF
--- a/PYME/recipes/localisations.py
+++ b/PYME/recipes/localisations.py
@@ -187,9 +187,9 @@ class ProcessColour(ModuleBase):
         seen_structures = []
     
         for structure, dye in labels:
-            #info might be unicode - encode to a standard string to keep traits happy
-            structure = structure.encode()
-            dye = dye.encode()
+            #info might be unicode - convert to a standard string to keep traits happy
+            structure = str(structure)
+            dye = str(dye)
             
             if structure in seen_structures:
                 strucname = structure + '_1'


### PR DESCRIPTION
Encoding caused `_get_dye_ratios_from_metadata` to search, for example, a dict ` {'A647': 0.85, 'A680': 0.87, 'A750': 0.11, 'A700': 0.3, 'CF770': 0.11}` for a key `b'A750'`.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Swap `encode` for a `str` call to still cast unicode to string on py2 and prevent key renaming on py3.






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
