### PR TITLE
reflection focus lock robustness improvement on signal loss

### DIFF
--- a/PYME/Acquire/Scripts/init_htsms_focus_lock.py
+++ b/PYME/Acquire/Scripts/init_htsms_focus_lock.py
@@ -69,7 +69,10 @@ def focus_lock(MainFrame, scope):
     # Stick with a PI tune for now
     kp = 0.45 * ku
     ki = 0.54 * ku / tu
-    scope.focus_lock = RLPIDFocusLockServer(scope, scope.piFoc,  p=kp, i=ki, d=0, sample_time=0.0035)
+    scope.focus_lock = RLPIDFocusLockServer(scope, scope.piFoc, p=kp, i=ki, d=0,
+                                            sample_time=0.0035, 
+                                            min_amp=10**5,
+                                            max_sigma=20.)
     scope.focus_lock.register()
     panel = FocusLockPanel(MainFrame, scope.focus_lock)
     MainFrame.camPanels.append((panel, 'Focus Lock'))

--- a/PYME/Acquire/stage_leveling.py
+++ b/PYME/Acquire/stage_leveling.py
@@ -71,9 +71,9 @@ class StageLeveler(object):
             scope position to be the smallest x, y position to queue (False)
         """
 
-        x = np.arange(0, x_length, x_spacing)
-        y = np.arange(0, y_length, y_spacing)
-        
+        x = np.arange(0, x_length, x_spacing, dtype=float)
+        y = np.arange(0, y_length, y_spacing, dtype=float)
+
         if center:
             x = x - (0.5 * x.max())
             y = y - (0.5 * y.max())

--- a/PYME/Acquire/stage_leveling.py
+++ b/PYME/Acquire/stage_leveling.py
@@ -53,7 +53,7 @@ class StageLeveler(object):
         """
         self._positions.append(self._scope.GetPos())
 
-    def add_grid(self, x_length, y_length, x_spacing, y_spacing):
+    def add_grid(self, x_length, y_length, x_spacing, y_spacing, center=True):
         """
         Add a grid of set spacings to the list of positions to scan when measuring offsets.
 
@@ -65,15 +65,19 @@ class StageLeveler(object):
         x_spacing : float
             x grid spacing, micrometers.
         y_spacing : float
-            y grid spacing, micrometers.
-
+            y grid spacing, micrometers.'
+        center : bool
+            center the grid on the current position (True) or take the current
+            scope position to be the smallest x, y position to queue (False)
         """
-        current = self._scope.GetPos()
-        x = np.arange(0, x_length, x_spacing)
-        x = x - (0.5 * x.max()) + current['x']
-        y = np.arange(0, y_length, y_spacing)
-        y = y - (0.5 * y.max()) + current['y']
 
+        x = np.arange(0, x_length, x_spacing)
+        y = np.arange(0, y_length, y_spacing)
+
+        current = self._scope.GetPos() if center else dict(x=0, y=0)
+        x = x - (0.5 * x.max()) + current['x']
+        y = y - (0.5 * y.max()) + current['y']
+        
         x_grid, y_grid = np.meshgrid(x, y, indexing='ij')
 
         self._positions.extend([{'x': xi, 'y': yi} for xi, yi in zip(x_grid.ravel(), y_grid.ravel())])

--- a/PYME/Acquire/stage_leveling.py
+++ b/PYME/Acquire/stage_leveling.py
@@ -73,10 +73,14 @@ class StageLeveler(object):
 
         x = np.arange(0, x_length, x_spacing)
         y = np.arange(0, y_length, y_spacing)
-
-        current = self._scope.GetPos() if center else dict(x=0, y=0)
-        x = x - (0.5 * x.max()) + current['x']
-        y = y - (0.5 * y.max()) + current['y']
+        
+        if center:
+            x = x - (0.5 * x.max())
+            y = y - (0.5 * y.max())
+        
+        current = self._scope.GetPos()
+        x += current['x']
+        y += current['y']
         
         x_grid, y_grid = np.meshgrid(x, y, indexing='ij')
 


### PR DESCRIPTION
allow simple thresholds on amplitude and sigma fit results to determine whether a fit is 'successful' and we can update the focus using the result

Addresses issue we have discussed in meetings.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- check against min amplitude and max sigma values when deciding if a fit was 'successful'
- save fit results as fitter attribute so we can debug things easily through the wx shell
- set initial peak position using half the current frame size rather than 512 magic number. This is just cosmetic for the position `fastGraph`
- make centering grid in `stage_leveling.StageLeveler.add_grid`  optional so you can queue from corner easily (rather than trying to guess the center which might be e.g. in between wells

**demo**
[fl-success-demo.zip](https://github.com/python-microscopy/python-microscopy/files/5104890/fl-success-demo.zip)




**Checklist:**

- [ ] Tested with numpy=1.14

1.19
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.1
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

not excessive I don't think

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?

kind of
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?