### PR TITLE
inherit/init bugfix in CircularTiler

### DIFF
--- a/PYME/Acquire/Utils/tiler.py
+++ b/PYME/Acquire/Utils/tiler.py
@@ -108,7 +108,7 @@ class Tiler(pointScanner.PointScanner):
         self.on_stop.send(self)
         self.progress.send(self)
 
-class CircularTiler(Tiler):
+class CircularTiler(Tiler, pointScanner.CircularPointScanner):
     def __init__(self, scope, tile_dir, max_radius_um=100, tile_spacing=None, dwelltime=1, background=0, evtLog=False,
                  trigger=False, base_tile_size=256, return_to_start=True):
         """
@@ -123,9 +123,10 @@ class CircularTiler(Tiler):
         pixel_radius = int(max_radius_um / tile_spacing.mean())
         logger.debug('Circular tiler target radius in units of (overlapped) FOVs: %d' % pixel_radius)
 
-        pointScanner.CircularPointScanner(scope, pixel_radius, tile_spacing, 
-                                          dwelltime, background, False, evtLog, 
-                                          trigger=trigger, stop_on_complete=True,
+        pointScanner.CircularPointScanner.__init__(self, scope, pixel_radius,
+                                          tile_spacing, dwelltime, background, 
+                                          False, evtLog, trigger=trigger, 
+                                          stop_on_complete=True,
                                           return_to_start=return_to_start)
         
         self._tiledir = tile_dir


### PR DESCRIPTION
Addresses issue introduced in #399 where we instantiate a circular point scanner rather than inheriting/initializing. I'm not super sure how this snuck in given I've tested circular tiler recently to e.g. look at fixing #386, and this bug crashes the tiler immediately. I might have abandoned a local commit or something - sorry

**Is this a bugfix or an enhancement?**
bugfix
```
Traceback (most recent call last):
  File "c:\users\bergamot\code\python-microscopy\PYME\Acquire\ui\tile_panel.py", line 182, in OnGo
    self.scope.tiler.start()
  File "c:\users\bergamot\code\python-microscopy\PYME\Acquire\Utils\tiler.py", line 49, in start
    self._gen_weights()
  File "c:\users\bergamot\code\python-microscopy\PYME\Acquire\Utils\tiler.py", line 39, in _gen_weights
    sh = self.scope.frameWrangler.currentFrame.shape[:2]
AttributeError: 'CircularTiler' object has no attribute 'scope'
```

**Proposed changes:**
- inherit priority to Tiler, but also inherit circular point scanner and initialize it to mimic tiler initializing normal point scanner






**Checklist:**

- [ ] Tested with numpy=1.14

1.19
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.1
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
