### PR TITLE
Create CameraControlFrame as general GUI class for camera controls

### DIFF
--- a/PYME/Acquire/Hardware/CameraControlFrame.py
+++ b/PYME/Acquire/Hardware/CameraControlFrame.py
@@ -99,6 +99,9 @@ class EnumPropertyControl(wx.Panel, PropertyControl):
 ######## Property controls based on PYME.Acquire.Hardware.Camera class    
 class ModePropertyControl(EnumPropertyControl):
     def __init__(self, target='_mode'):
+        """
+        List of available camera modes, grabbed from the Camera base class.
+        """
         from PYME.Acquire.Hardware.Camera import Camera
         modes = [x for x in dir(Camera) if x.startswith('MODE_')]
         choices = sorted(modes, key=lambda x: getattr(Camera, x))
@@ -106,6 +109,18 @@ class ModePropertyControl(EnumPropertyControl):
 
     def set_target_value(self):
         self.cam.SetAcquisitionMode(self.cChoice.GetSelection())
+
+
+######## Example replacement for legacy property control for ATBool
+class ATBoolPropertyControl(wx.CheckBox, PropertyControl):
+    """
+    Property control for ATBools (see PYME.Acquire.Hardware.AndorNeo.ZylaControlPanel).
+    """
+    def set_target_value(self):
+        self.target.setValue(self.GetValue())
+
+    def update(self):
+        self.SetValue(self.target.getValue())
 
 ######## Camera control
 class CameraControlFrame(wx.Panel):

--- a/PYME/Acquire/Hardware/CameraControlFrame.py
+++ b/PYME/Acquire/Hardware/CameraControlFrame.py
@@ -30,8 +30,12 @@ class PropertyControl:
             def update(self):
                 # Tell us how our wx.SomeElement should look, based on the value of self.target
     """
-    def __init__(self, target):
+    def __init__(self, target, display_name=None):
         self.target = target  # String
+        if display_name is None:
+            self._display_name = self.target
+        else:
+            self._display_name = display_name
     
     def Init(self, parent):
         self.parent=parent
@@ -55,7 +59,7 @@ class BoolPropertyControl(wx.CheckBox, PropertyControl):
     Property control for True/False values.
     """
     def Init(self, parent):
-        wx.CheckBox.__init__(self, parent, -1, self.target)
+        wx.CheckBox.__init__(self, parent, -1, self._display_name)
         self.Bind(wx.EVT_CHECKBOX, self.onChange) 
         PropertyControl.Init(self, parent)
 
@@ -70,8 +74,8 @@ class EnumPropertyControl(wx.Panel, PropertyControl):
     """
     Property control for list of values.
     """
-    def __init__(self, target, choices=None):
-        PropertyControl.__init__(self, target)
+    def __init__(self, target, choices=None, display_name=None):
+        PropertyControl.__init__(self, target, display_name)
         if type(choices) == str:
             # Assume camera property
             self._choices = getattr(self.cam, choices)
@@ -81,7 +85,7 @@ class EnumPropertyControl(wx.Panel, PropertyControl):
     def Init(self, parent):
         wx.Panel.__init__(self, parent)
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
-        hsizer.Add(wx.StaticText(self, -1, self.target), 1, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
+        hsizer.Add(wx.StaticText(self, -1, self._display_name), 1, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
         
         self.cChoice = wx.Choice(self, -1, size = [100,-1])
         self.cChoice.Bind(wx.EVT_CHOICE, self.onChange)
@@ -98,14 +102,14 @@ class EnumPropertyControl(wx.Panel, PropertyControl):
 
 ######## Property controls based on PYME.Acquire.Hardware.Camera class    
 class ModePropertyControl(EnumPropertyControl):
-    def __init__(self, target='_mode'):
+    def __init__(self, target='_mode', display_name=None):
         """
         List of available camera modes, grabbed from the Camera base class.
         """
         from PYME.Acquire.Hardware.Camera import Camera
         modes = [x for x in dir(Camera) if x.startswith('MODE_')]
         choices = sorted(modes, key=lambda x: getattr(Camera, x))
-        EnumPropertyControl.__init__(self, target, choices)
+        EnumPropertyControl.__init__(self, target, choices, display_name)
 
     def set_target_value(self):
         self.cam.SetAcquisitionMode(self.cChoice.GetSelection())

--- a/PYME/Acquire/Hardware/CameraControlFrame.py
+++ b/PYME/Acquire/Hardware/CameraControlFrame.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Aug 21 10:29:38 2020
+
+@author: zacsimile
+"""
+
+import wx
+
+# Built from PYME.Acquire.Hardware.AndorNeo.ZylaControlPanel, but with a twist.
+
+
+######## Base property controls
+class PropertyControl:
+    """
+    Default for controlling camera properties. Restarts frameWrangler
+    as settings are changed. Designed to be mixed with a wx element.
+
+    Usage is
+
+        MyControl(wx.SomeElement, PropertyControl):
+            def Init(self, parent):
+                # wx initialization
+                # bind wx event to self.onChange, indicates when to update the camera property
+                PropertyControl.Init(self, parent)
+
+            def set_target_value(self):
+                # Tell us how to set the value of self.target from the wx element
+
+            def update(self):
+                # Tell us how our wx.SomeElement should look, based on the value of self.target
+    """
+    def __init__(self, target):
+        self.target = target  # String
+    
+    def Init(self, parent):
+        self.parent=parent
+        self.cam=self.parent.cam
+        self.update()
+
+    def onChange(self, event=None):
+        self.parent.scope.frameWrangler.stop()
+        self.set_target_value()
+        self.parent.scope.frameWrangler.start()
+        self.parent.update()
+
+    def set_target_value(self):
+        raise NotImplementedError('This function should be over-ridden in derived class')
+
+    def update(self):
+        raise NotImplementedError('This function should be over-ridden in derived class')
+
+class BoolPropertyControl(wx.CheckBox, PropertyControl):
+    """
+    Property control for True/False values.
+    """
+    def Init(self, parent):
+        wx.CheckBox.__init__(self, parent, -1, self.target)
+        self.Bind(wx.EVT_CHECKBOX, self.onChange) 
+        PropertyControl.Init(self, parent)
+
+    def set_target_value(self):
+        setattr(self.cam, self.target, self.GetValue())
+
+    def update(self):
+        self.SetValue(getattr(self.cam, self.target))
+
+
+class EnumPropertyControl(wx.Panel, PropertyControl):
+    """
+    Property control for list of values.
+    """
+    def __init__(self, target, choices=None):
+        PropertyControl.__init__(self, target)
+        if type(choices) == str:
+            # Assume camera property
+            self._choices = getattr(self.cam, choices)
+        elif type(choices) == list:
+            self._choices = choices
+
+    def Init(self, parent):
+        wx.Panel.__init__(self, parent)
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, self.target), 1, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
+        
+        self.cChoice = wx.Choice(self, -1, size = [100,-1])
+        self.cChoice.Bind(wx.EVT_CHOICE, self.onChange)
+        hsizer.Add(self.cChoice, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
+        self.SetSizerAndFit(hsizer)
+        PropertyControl.Init(self, parent)
+
+    def set_target_value(self):
+        setattr(self.cam, self.target, self.cChoice.GetSelection())
+
+    def update(self):
+        self.cChoice.SetItems(self._choices)
+        self.cChoice.SetSelection(getattr(self.cam, self.target))
+
+######## Property controls based on PYME.Acquire.Hardware.Camera class    
+class ModePropertyControl(EnumPropertyControl):
+    def __init__(self, target='_mode'):
+        from PYME.Acquire.Hardware.Camera import Camera
+        modes = [x for x in dir(Camera) if x.startswith('MODE_')]
+        choices = sorted(modes, key=lambda x: getattr(Camera, x))
+        EnumPropertyControl.__init__(self, target, choices)
+
+    def set_target_value(self):
+        self.cam.SetAcquisitionMode(self.cChoice.GetSelection())
+
+######## Camera control
+class CameraControlFrame(wx.Panel):
+    """
+    Base class for camera controls. Usage is 
+
+
+        ctrls = [BoolControl('SpuriousNoiseFilter'),
+                etc.]
+        MyCamControl = CamControl(parent, cam, scope, ctrls)
+
+    """
+    def _init_ctrls(self):
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+
+        for c in self._ctrls:
+            c.Init(self)
+            vsizer.Add(c, 0, wx.EXPAND|wx.ALL, 2)
+        
+        self.SetSizerAndFit(vsizer)
+        
+    def __init__(self, parent, cam, scope, ctrls):
+        wx.Panel.__init__(self, parent)
+        
+        self.cam = cam
+        self.scope = scope
+
+        self._ctrls = ctrls
+        
+        self._init_ctrls()
+        
+    def update(self):
+        for c in self._ctrls:
+            c.update()

--- a/PYME/Acquire/Hardware/CameraControlFrame.py
+++ b/PYME/Acquire/Hardware/CameraControlFrame.py
@@ -112,7 +112,7 @@ class ModePropertyControl(EnumPropertyControl):
 
 
 ######## Example replacement for legacy property control for ATBool
-class ATBoolPropertyControl(wx.CheckBox, PropertyControl):
+class ATBoolPropertyControl(BoolPropertyControl):
     """
     Property control for ATBools (see PYME.Acquire.Hardware.AndorNeo.ZylaControlPanel).
     """

--- a/PYME/Acquire/Hardware/CameraControlFrame.py
+++ b/PYME/Acquire/Hardware/CameraControlFrame.py
@@ -128,7 +128,7 @@ class CameraControlFrame(wx.Panel):
     Base class for camera controls. Usage is 
 
 
-        ctrls = [BoolControl('SpuriousNoiseFilter'),
+        ctrls = [BoolPropertyControl('SpuriousNoiseFilter'),
                 etc.]
         MyCamControl = CamControl(parent, cam, scope, ctrls)
 


### PR DESCRIPTION
Currently we need to create custom camera controls per API. With this new class, you can throw the following into any init file

```
from PYME.Acquire.Hardware.CameraControlFrame import ModePropertyControl, CameraControlFrame
ctrls = [ModePropertyControl()]
scope.camControls['PcoEdge42LT'] = CameraControlFrame(MainFrame, scope.cam, scope, ctrls)
```

and get

![camera_control_snip](https://user-images.githubusercontent.com/1263313/90922853-a92de180-e3ba-11ea-84f1-6ca4a26de4b9.PNG)

The more controls there are in the `ctrls` list, the more appear in the GUI. We'll obviously need to add a few more base variable options to get all the camera controls working (e.g. because of how SDK3 works we need a specific `ATBoolPropertyControl` that inherits from `BoolPropertyControl`), but they should be 1-2 lines of code apiece and then work for cameras using that particular variable type generally. This should be good for quickly adding camera controls to new scopes.

**Is this a bugfix or an enhancement?**
Enhancement

**Proposed changes:**
- Refactor `PYME.Acquire.Hardware.AndorNeo.ZylaControlPanel` to base classes



**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
