### PR TITLE
tweaks to enable Sona with Zyla backend support

### DIFF
--- a/PYME/Acquire/Hardware/AndorNeo/AndorZyla.py
+++ b/PYME/Acquire/Hardware/AndorNeo/AndorZyla.py
@@ -131,7 +131,7 @@ class AndorBase(SDK3Camera, CameraMapMixin):
     class SimpleGainEnum(object):
         def __init__(self, cam):
             self.cam = cam
-            self.gainmodes = cam.PixelEncodingForGain.keys()
+            self.gainmodes = cam.SimplePreAmpGainControl.getAvailableValues()
             self.propertyName = 'SimpleGainMode'
             
         def getAvailableValues(self):
@@ -256,6 +256,11 @@ class AndorBase(SDK3Camera, CameraMapMixin):
                     raise RuntimeError('PixelEncodingForGain mode "%s" unknown bit depth (neither 12 nor 16 bit)' % (mode))
         else:
             self.PixelEncodingForGain = self.DefaultPixelEncodingForGain
+
+        # this instance is compatible with use in Zylacontrolpanel
+        # note we make this only once the camera has been initialised and PixelEncodingForGain been made
+        self.SimpleGainEnumInstance = self.SimpleGainEnum(self)
+
 
         self.FrameCount.setValue(1)
         self.CycleMode.setString(u'Continuous')
@@ -790,8 +795,7 @@ class AndorZyla(AndorBase):
         self.TemperatureControl = ATEnum()
         self.TemperatureStatus = ATEnum()
         self.SimplePreAmpGainControl = ATEnum()
-        # this instance is compatible with use in Zylacontrolpanel
-        self.SimpleGainEnumInstance = self.SimpleGainEnum(self)
+
         self.BitDepth = ATEnum()
         
         self.ActualExposureTime = ATFloat()

--- a/PYME/Acquire/Hardware/AndorNeo/AndorZyla.py
+++ b/PYME/Acquire/Hardware/AndorNeo/AndorZyla.py
@@ -126,6 +126,25 @@ class AndorBase(SDK3Camera, CameraMapMixin):
                 'SaturationThreshold' : (2**16 -1)
             }}}
 
+    # this class is compatible with the ATEnum object properties that are used in ZylaControlPanel
+    # we use it as a higher level alternative to setting gainmode and encoding directly
+    class SimpleGainEnum(object):
+        def __init__(self, cam):
+            self.cam = cam
+            self.gainmodes = cam.PixelEncodingForGain.keys()
+            self.propertyName = 'SimpleGainMode'
+            
+        def getAvailableValues(self):
+            return self.gainmodes
+
+        def setString(self,str):
+            self.cam.SetSimpleGainMode(str)
+
+        def getString(self):
+            return self.cam.GetSimpleGainMode()
+
+
+    
     @property
     def noise_properties(self):
         """return the noise properties for a the given camera
@@ -743,6 +762,11 @@ class AndorBase(SDK3Camera, CameraMapMixin):
         #return self.FrameRate.getValue()
         return self._frameRate
 
+    def TemperatureStatusText(self):
+        return "Zyla target T %s - %s" % (self.TemperatureControl.getString(),
+                                          self.TemperatureStatus.getString())
+
+
     def __del__(self):
         self.Shutdown()
         #self.compT.kill = True
@@ -766,7 +790,8 @@ class AndorZyla(AndorBase):
         self.TemperatureControl = ATEnum()
         self.TemperatureStatus = ATEnum()
         self.SimplePreAmpGainControl = ATEnum()
-
+        # this instance is compatible with use in Zylacontrolpanel
+        self.SimpleGainEnumInstance = self.SimpleGainEnum(self)
         self.BitDepth = ATEnum()
         
         self.ActualExposureTime = ATFloat()

--- a/PYME/Acquire/Hardware/AndorNeo/AndorZyla.py
+++ b/PYME/Acquire/Hardware/AndorNeo/AndorZyla.py
@@ -49,7 +49,7 @@ class AndorBase(SDK3Camera, CameraMapMixin):
     #MODE_CONTINUOUS = 1
     #MODE_SINGLE_SHOT = 0
 
-    DefaultPixelEncodingForGain = {'12-bit (low noise)': 'Mono12',
+    ZylaPixelEncodingForGain = {'12-bit (low noise)': 'Mono12',
                                    '12-bit (high well capacity)': 'Mono12',
                                    '16-bit (low noise & high well capacity)' : 'Mono16'
     }
@@ -246,6 +246,7 @@ class AndorBase(SDK3Camera, CameraMapMixin):
 
         # figure out preamp gain modes for this camera type
         if not self.CameraModel.getValue().startswith('SIM'):
+            # Special case for Sona cams
             self.PixelEncodingForGain = {}
             for mode in self.SimplePreAmpGainControl.getAvailableValues():
                 if mode.startswith('12'):
@@ -255,7 +256,8 @@ class AndorBase(SDK3Camera, CameraMapMixin):
                 else:
                     raise RuntimeError('PixelEncodingForGain mode "%s" unknown bit depth (neither 12 nor 16 bit)' % (mode))
         else:
-            self.PixelEncodingForGain = self.DefaultPixelEncodingForGain
+            # Assume Zyla
+            self.PixelEncodingForGain = self.ZylaPixelEncodingForGain
 
         # this instance is compatible with use in Zylacontrolpanel
         # note we make this only once the camera has been initialised and PixelEncodingForGain been made
@@ -768,6 +770,8 @@ class AndorBase(SDK3Camera, CameraMapMixin):
         return self._frameRate
 
     def TemperatureStatusText(self):
+        # TODO - rename (potentially when considering PEP8ing  / genral camera interface refactor)
+        # TODO - uniform interface for device status text across devices - should be more generic than temperature
         return "Zyla target T %s - %s" % (self.TemperatureControl.getString(),
                                           self.TemperatureStatus.getString())
 

--- a/PYME/Acquire/Hardware/AndorNeo/ZylaControlPanel.py
+++ b/PYME/Acquire/Hardware/AndorNeo/ZylaControlPanel.py
@@ -84,14 +84,14 @@ class ZylaControl(wx.Panel):
         self.cam = cam
         self.scope = scope
         
-        self.ctrls = [EnumControl(self, cam.SimplePreAmpGainControl, targetPropertyName='SimpleGainMode'),
+        self.ctrls = [EnumControl(self, cam.SimpleGainEnumInstance), # use enum class as it also sets pixel encoding
                       EnumControl(self, cam.PixelReadoutRate),
                       BoolControl(self, cam.SpuriousNoiseFilter),
                       BoolControl(self, cam.StaticBlemishCorrection),
-                      EnumControl(self, cam.CycleMode),
-                      EnumControl(self, cam.TemperatureStatus),]
+                      EnumControl(self, cam.CycleMode),]
 
-        if len(cam.TemperatureControl.getAvailableValues()) > 0: # need to check that Zyla has at least one mode
+
+        if len(cam.TemperatureControl.getAvailableValues()) > 1: # we only add this if there is a real choice
             self.ctrls.append(EnumControl(self, cam.TemperatureControl))
 
         self._init_ctrls()

--- a/PYME/Acquire/Hardware/AndorNeo/ZylaControlPanel.py
+++ b/PYME/Acquire/Hardware/AndorNeo/ZylaControlPanel.py
@@ -8,24 +8,26 @@ Created on Wed Apr 01 16:29:38 2015
 import wx
 
 class EnumControl(wx.Panel):
-    def __init__(self, parent, target, targetPropertyName=None):
+    def __init__(self, parent, target, display_name=None):
         wx.Panel.__init__(self, parent)
         self.scope = parent.scope
         self.parent = parent
         self.target = target
+        
         # this keyword allows us to override unwieldy property Names
-        if targetPropertyName is None:
-            self.targetPropertyName = target.propertyName
+        if display_name is None:
+            self.display_name = target.propertyName
         else:
-            self.targetPropertyName = targetPropertyName
+            self.display_name = display_name
             
+        # TODO - do we really need to support read only enums????
         try:
-            self.targetReadOnly = target.isReadOnly()
+            self._read_only = target.isReadOnly()
         except AttributeError:
-            self.targetReadOnly = False
+            self._read_only = False
         
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
-        hsizer.Add(wx.StaticText(self, -1, self.targetPropertyName), 1, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
+        hsizer.Add(wx.StaticText(self, -1, self.display_name), 1, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
         
         self.cChoice = wx.Choice(self, -1, size = [100,-1])
         self.cChoice.Bind(wx.EVT_CHOICE, self.onChange)
@@ -36,7 +38,7 @@ class EnumControl(wx.Panel):
         self.SetSizerAndFit(hsizer)
         
     def onChange(self, event=None):
-        if not self.targetReadOnly:
+        if not self._read_only:
             self.scope.frameWrangler.stop()
             self.target.setString(self.cChoice.GetStringSelection())
             self.scope.frameWrangler.start()

--- a/PYME/Acquire/Hardware/AndorNeo/ZylaControlPanel.py
+++ b/PYME/Acquire/Hardware/AndorNeo/ZylaControlPanel.py
@@ -8,14 +8,24 @@ Created on Wed Apr 01 16:29:38 2015
 import wx
 
 class EnumControl(wx.Panel):
-    def __init__(self, parent, target):
+    def __init__(self, parent, target, targetPropertyName=None):
         wx.Panel.__init__(self, parent)
         self.scope = parent.scope
         self.parent = parent
         self.target = target
+        # this keyword allows us to override unwieldy property Names
+        if targetPropertyName is None:
+            self.targetPropertyName = target.propertyName
+        else:
+            self.targetPropertyName = targetPropertyName
+            
+        try:
+            self.targetReadOnly = target.isReadOnly()
+        except AttributeError:
+            self.targetReadOnly = False
         
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
-        hsizer.Add(wx.StaticText(self, -1, target.propertyName), 1, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
+        hsizer.Add(wx.StaticText(self, -1, self.targetPropertyName), 1, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
         
         self.cChoice = wx.Choice(self, -1, size = [100,-1])
         self.cChoice.Bind(wx.EVT_CHOICE, self.onChange)
@@ -26,10 +36,11 @@ class EnumControl(wx.Panel):
         self.SetSizerAndFit(hsizer)
         
     def onChange(self, event=None):
-        self.scope.frameWrangler.stop()
-        self.target.setString(self.cChoice.GetStringSelection())
-        self.scope.frameWrangler.start()
-        self.parent.update()
+        if not self.targetReadOnly:
+            self.scope.frameWrangler.stop()
+            self.target.setString(self.cChoice.GetStringSelection())
+            self.scope.frameWrangler.start()
+            self.parent.update()
         
     def update(self):
         choices = self.target.getAvailableValues()
@@ -73,16 +84,20 @@ class ZylaControl(wx.Panel):
         self.cam = cam
         self.scope = scope
         
-        self.ctrls = [EnumControl(self, cam.SimpleGainEnumInstance),
+        self.ctrls = [EnumControl(self, cam.SimplePreAmpGainControl, targetPropertyName='SimpleGainMode'),
                       EnumControl(self, cam.PixelReadoutRate),
                       BoolControl(self, cam.SpuriousNoiseFilter),
                       BoolControl(self, cam.StaticBlemishCorrection),
-                      EnumControl(self, cam.CycleMode),]
-        
+                      EnumControl(self, cam.CycleMode),
+                      EnumControl(self, cam.TemperatureStatus),]
+
+        if len(cam.TemperatureControl.getAvailableValues()) > 0: # need to check that Zyla has at least one mode
+            self.ctrls.append(EnumControl(self, cam.TemperatureControl))
+
         self._init_ctrls()
         
     def update(self):
         for c in self.ctrls:
             c.update()
-        
+
         


### PR DESCRIPTION
Addresses issue #425.

**Is this a bugfix or an enhancement?**

Enhancement of the Zyla backend to allow Sona heads to be connected.

**Proposed changes:**

- Changes to the AndorZyla code to self-detect some capabilities.

- Additional interface changes in ZylaControlPanel so that the cooling mode options of the Sona are autodetected and offered in the control panel as options for selection.





**Checklist:**

- [x] Tested with numpy=1.16
- [x] Tested on python 2.7 only
- [NA ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)? [has been raised]
- [-] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [-] Does this change the required dependencies?
- [-] Are there any other side effects of the change? [don't think so but will discuss]
