### PR TITLE
Fix pco crashes

### DIFF
--- a/PYME/Acquire/Hardware/pco/pco_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_cam.py
@@ -48,6 +48,7 @@ class PcoCam(Camera):
         self.buffer_size = 0
         self.n_read = 0
         self.initalized = True
+        self.__roi = None
 
     @property
     def noise_properties(self):
@@ -242,12 +243,14 @@ class PcoCam(Camera):
 
         # Recording state is reset, so set to 0
         self.n_read = 0
-
+        self.GetROI()
         self.SetDescription() # Update the description, for safety. TODO: Is this necessary??
 
     def GetROI(self):
-        roi = self.cam.sdk.get_roi()
-        return roi['x0'], roi['y0'], roi['x1'], roi['y1']
+        if self.n_read == 0:
+            # We reset, check the ROI again
+            self.__roi = self.cam.sdk.get_roi()
+        return self.__roi['x0'], self.__roi['y0'], self.__roi['x1'], self.__roi['y1']
     
     def GetElectrTemp(self):
         return self.cam.sdk.get_temperature()['camera temperature']  # FIXME: should this be 'power temperature'?
@@ -290,6 +293,7 @@ class PcoCam(Camera):
     def StopAq(self):
         self.cam.stop()
         self.n_read = 0
+        self.SetDescription() # Update the description, for safety. TODO: Is this necessary??
 
     def GetNumImsBuffered(self):
         try:

--- a/PYME/Acquire/Hardware/pco/pco_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_cam.py
@@ -112,8 +112,6 @@ class PcoCam(Camera):
         # This is going to reset the recorder, so we need to change ring buffer position
         self.n_read = 0
 
-        self.SetDescription() # Update the description, for safety. TODO: Is this necessary??
-
     def GetIntegTime(self):
         d = self.cam.sdk.get_delay_exposure_time()
         return d['exposure']*timebase[d['exposure timebase']] 
@@ -149,8 +147,6 @@ class PcoCam(Camera):
 
         self.n_read = 0
 
-        self.SetDescription() # Update the description, for safety. TODO: Is this necessary??
-
     def GetHorizontalBin(self):
         return self.cam.sdk.get_binning()['binning x']
 
@@ -168,8 +164,6 @@ class PcoCam(Camera):
         self.cam.sdk.set_binning(self.GetHorizontalBin(), value)
 
         self.n_read = 0
-
-        self.SetDescription() # Update the description, for safety. TODO: Is this necessary??
 
     def GetVerticalBin(self):
         return self.cam.sdk.get_binning()['binning y']
@@ -244,7 +238,6 @@ class PcoCam(Camera):
         # Recording state is reset, so set to 0
         self.n_read = 0
         self.GetROI()
-        self.SetDescription() # Update the description, for safety. TODO: Is this necessary??
 
     def GetROI(self):
         if self.n_read == 0:
@@ -293,7 +286,6 @@ class PcoCam(Camera):
     def StopAq(self):
         self.cam.stop()
         self.n_read = 0
-        self.SetDescription() # Update the description, for safety. TODO: Is this necessary??
 
     def GetNumImsBuffered(self):
         try:


### PR DESCRIPTION
I think was asking the `pco` camera for the same information too quickly in rapid succession. There must be some sort of internal timeout between calls. 

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
* Store the ROI in between setting a new ROI so we don't keep asking the camera for its ROI.
* Get rid of extra `SetDescription` calls.


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
