### PR TITLE
Add label to point size using character for space

### DIFF
--- a/PYME/LMVis/layers/pointcloud.py
+++ b/PYME/LMVis/layers/pointcloud.py
@@ -281,7 +281,7 @@ class PointCloudRenderLayer(EngineLayer):
                      Group([Item('clim', editor=HistLimitsEditor(data=self._get_cdata, update_signal=self.on_update), show_label=False), ], visible_when='cmap not in ["R", "G", "B", "C", "M","Y", "K"]'),
                      Group(Item('cmap', label='LUT'),
                            Item('alpha', visible_when="method in ['pointsprites', 'transparent_points']", editor=TextEditor(auto_set=False, enter_set=True, evaluate=float)),
-                           Item('point_size', editor=TextEditor(auto_set=False, enter_set=True, evaluate=float)))])
+                           Item('point_size', label='Point\u00A0size', editor=TextEditor(auto_set=False, enter_set=True, evaluate=float)))])
         #buttons=['OK', 'Cancel'])
 
     def default_traits_view(self):


### PR DESCRIPTION
"Point size" in points layers is currently displaying as "Points " on py3. Same issue as in https://github.com/python-microscopy/python-microscopy/pull/388. Feels like there should be a more general fix for this, but who knows? Might just fix itself in wx 4.1.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
-Force character for space in "Point size"





**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
