### PR TITLE
int cast for shape in RGB image array allocation

### DIFF
--- a/PYME/IO/rgb_image.py
+++ b/PYME/IO/rgb_image.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import ndimage
 
 def image_to_rgb(image, zoom=1.0, scaling='min-max', scaling_factor=0.99):
-    data = np.zeros([image.data.shape[0] / zoom, image.data.shape[1] / zoom, 3], dtype='uint8')
+    data = np.zeros([int(image.data.shape[0] / zoom), int(image.data.shape[1] / zoom), 3], dtype='uint8')
     
     for i in range(min(3, image.data.shape[3])):
         chan_i = ndimage.zoom(image.data[:, :, :, i].mean(2).squeeze(), 1. / zoom)


### PR DESCRIPTION
Addresses issue running on py3.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
cast to int, avoid
```
    def image_to_rgb(image, zoom=1.0, scaling='min-max', scaling_factor=0.99):
>       data = np.zeros([image.data.shape[0] / zoom, image.data.shape[1] / zoom, 3], dtype='uint8')
E       TypeError: 'float' object cannot be interpreted as an integer
../python-microscopy/PYME/IO/rgb_image.py:5: TypeError
```






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
