### PR TITLE
fix to allow cluster localization of paths outside PYMEData on windows

### DIFF
--- a/PYME/IO/FileUtils/nameUtils.py
+++ b/PYME/IO/FileUtils/nameUtils.py
@@ -136,6 +136,7 @@ def genClusterResultFileName(dataFileName, create=True):
         if not fn.startswith('/'):
             # filename is relative to PYMEDATATDIR
             fn = getFullFilename(fn)
+        
         try:
             # relpath will raise ValueError on windows if we aren't on the same drive
             rel_name = os.path.relpath(fn, config.get('dataserver-root'))
@@ -144,6 +145,7 @@ def genClusterResultFileName(dataFileName, create=True):
         except ValueError:
             # recreate the tree under PYMEData, dropping the drive letter or UNC
             rel_name = fn
+            
         rel_name = posix_path(rel_name)
 
     dir_name = posixpath.dirname(rel_name)
@@ -217,6 +219,9 @@ def translateSeparators(filename):
 def posix_path(path):
     """
     Translate any separators to '/' and drop drive letters
+    
+    #FIXME - do something sensible with drive letters?
+    #FIXME - rename? [as this is a relative path / not resolvable]
     """
     import posixpath
     # FIXME - just use pathlib.path().to_posix() when we drop py2

--- a/PYME/IO/FileUtils/nameUtils.py
+++ b/PYME/IO/FileUtils/nameUtils.py
@@ -135,6 +135,9 @@ def genClusterResultFileName(dataFileName, create=True):
         # special case for cluster of one uses where we didn't open file using a cluster URI
         if not fn.startswith('/'):
             # filename is relative to PYMEDATATDIR
+            # TODO - this looks really unsafe under windows!!! Filenames won't ever start with / even if fully resolved, which means that the PYMEDATADIR path will be prepended
+            # to the filename (and we might end up with something like C:\Users\foo\PYMEData\D:\Data\bar\seriesx.tif).
+            # is it possible that we get away with it because os.path.splitdrive (in posix_path() just truncates at the last : in the string?
             fn = getFullFilename(fn)
         
         try:


### PR DESCRIPTION
Addresses issue #419. Issue was we replaced all separators with os separators, then joined dirname to analysis/basename with posix separator.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
escape drive letter and substitute posix separators rather than os separators


Tested this on windows localizing a file on another drive than PYMEData dir, worked fine. Should work for files inside and outside PYMEData, and on python 2/3:
```
In [52]: p
Out[52]: 'F:\\2020_7_23\\testing\\okwegetit'
In [53]: nameUtils.genClusterResultFileName(p)
Out[53]: '/2020_7_23/testing/analysis/okwegetit.h5r'
In [54]: pd
Out[54]: 'C:\\Users\\Bergamot\\PYMEData\\Bergamot\\2020_7_14'
In [55]: nameUtils.genClusterResultFileName(pd)
Out[55]: 'Bergamot/analysis/2020_7_14.h5r'
```

I opted not to touch `getRelFileName` since that it used elsewhere e.g. in `image.py` and I don't know if we can e.g. safely drop the drive letter there or not.


**Checklist:**

- [ ] Tested with numpy=1.14

1.19
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.1
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

