### PR TITLE
Fix py3 list/dict conflict in twoColour.py

### DIFF
--- a/PYME/Analysis/points/twoColour.py
+++ b/PYME/Analysis/points/twoColour.py
@@ -108,14 +108,14 @@ class ShiftModel(object):
         import json
         import importlib
         
-        cn, dict = json.loads(mdentry).items()[0]
+        cn, d = list(json.loads(mdentry).items())[0]
         
         parts = cn.split('.')
         mod, cln = '.'.join(parts[:-1]), parts[-1]
         
         cl = getattr(importlib.import_module(mod), cln)
         
-        return cl(dict=dict)
+        return cl(dict=d)
 
     
 class linModel(ShiftModel):


### PR DESCRIPTION
Addresses issue #437.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Explicitly cast `dict.items()` to `list` for py3 compatibility
- Rename `dict` variable to `d` so as not to use a python type keyword (not strictly necessary, but recommended) 


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
