### PR TITLE
Adjust spacing between fitFluorBrightness text lines

### DIFF
--- a/PYME/Analysis/BleachProfile/kinModels.py
+++ b/PYME/Analysis/BleachProfile/kinModels.py
@@ -392,7 +392,7 @@ def fitFluorBrightness(colourFilter, metadata, channame='', i=0, rng = None, qui
         plt.title('Event Intensity - CAUTION - unreliable if evt. duration $>\\sim$ exposure time')
         #print res[0][2]
     
-        plt.figtext(.4,.8 -.05*i, channame + '\t$N_{det} = %3.0f\\;\\lambda = %3.0f$\n\t$Ph.mean = %3.0f$' % (res[0][1], res[0][3], nPh.mean()), size=18, color=colours[i], verticalalignment='top', horizontalalignment='left')
+        plt.figtext(.4,.8 -.15*i, channame + '\t$N_{det} = %3.0f\\;\\lambda = %3.0f$\n\t$Ph.mean = %3.0f$' % (res[0][1], res[0][3], nPh.mean()), size=18, color=colours[i], verticalalignment='top', horizontalalignment='left')
 
     return [channame, res[0][3], NEvents]
 


### PR DESCRIPTION
For multicolor photophysics plots, the fitFluorBrightness fit result text for 2nd (n-th) color channel overlaps that of the 1st ((n-1)-th).

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Space out the lines in the fitFluorBrightness plots so they don't overlap




**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
