### PR TITLE
add save recipe outputs to PYMEVis gui + backend for dict editing

### DIFF
--- a/PYME/recipes/recipeGui.py
+++ b/PYME/recipes/recipeGui.py
@@ -327,7 +327,24 @@ class RecipeView(wx.Panel):
         self.bSaveRecipe.Bind(wx.EVT_BUTTON, self.recipes.OnSaveRecipe)
         
         vsizer.Add(hsizer, 0, wx.EXPAND, 0)
-        
+
+        if hasattr(self.recipes, 'OnSaveOutputs'):
+            hsizer = wx.BoxSizer(wx.HORIZONTAL)
+
+            self.b_toggle_exec_live = wx.CheckBox(self, -1, 'Live-Update')
+            self.b_toggle_exec_live.SetValue(self.recipes.pipeline.recipe.execute_on_invalidation)
+            self.b_toggle_exec_live.Bind(wx.EVT_CHECKBOX, self.recipes.OnToggleLiveRun)
+            hsizer.Add(self.b_toggle_exec_live)
+
+            self.b_run = wx.Button(self, -1, 'Run Recipe')
+            self.b_run.Bind(wx.EVT_BUTTON, self.recipes.OnRun)
+            hsizer.Add(self.b_run)
+
+            self.b_save_outputs = wx.Button(self, -1, 'Save Outputs')
+            hsizer.Add(self.b_save_outputs)
+            self.b_save_outputs.Bind(wx.EVT_BUTTON, self.recipes.OnSaveOutputs)
+
+            vsizer.Add(hsizer, 0, wx.EXPAND, 0)
         
         hsizer1.Add(vsizer, 1, wx.EXPAND|wx.ALL, 2)
         
@@ -615,6 +632,36 @@ class PipelineRecipeManager(RecipeManager):
         
     def load_recipe_from_mdh(self, mdh):
         self.LoadRecipeText(mdh['Pipeline.Recipe'])
+    
+    def OnSaveOutputs(self, wx_event=None):
+        from PYME.ui import editList
+        import os
+
+        # get output context
+        context = {
+            'file_stub' : os.path.splitext(os.path.basename(self.pipeline.filename))[0]
+        }
+        
+        dlg = editList.DictCtrlDialog(base_dict=context, size=(300, 250),
+                                      title='Set OutputModule Context')
+
+        if dlg.ShowModal() == wx.ID_OK:
+            context = dlg.base_dict
+        
+        dlg.Destroy()
+
+        # make sure we've executed
+        if not self.pipeline.recipe.execute_on_invalidation:
+            self.pipeline.recipe.execute()
+        
+        self.pipeline.recipe.save(context)
+    
+    def OnRun(self, wx_event=None):
+        self.pipeline.recipe.execute()
+    
+    def OnToggleLiveRun(self, wx_event=None):
+        current = self.pipeline.recipe.execute_on_invalidation
+        self.pipeline.recipe.execute_on_invalidation = not current
 
 class dt(wx.FileDropTarget):
     def __init__(self, window):

--- a/PYME/ui/editList.py
+++ b/PYME/ui/editList.py
@@ -28,12 +28,162 @@ class EditListCtrl(wx.ListCtrl,
                    listmix.TextEditMixin):
 
     def __init__(self, parent, ID, pos=wx.DefaultPosition,
-                 size=wx.DefaultSize, style=0):
+                 size=wx.DefaultSize, style=wx.LC_REPORT|wx.LC_SINGLE_SEL|wx.SUNKEN_BORDER):
         wx.ListCtrl.__init__(self, parent, ID, pos, size, style)
 
         listmix.ListCtrlAutoWidthMixin.__init__(self)
         listmix.TextEditMixin.__init__(self)
 
+
+class DictCtrlDialog(wx.Dialog):
+    def __init__(self, parent=None, base_dict=dict(), title='', 
+                 size=wx.DefaultSize, column_names=('keys', 'values')):
+        import sys
+        wx.Dialog.__init__(self, parent, title=title)
+        
+        self.edit_list = EditListCtrl(self, -1, size=size)
+
+        self.edit_list.InsertColumn(0, column_names[0])
+        self.edit_list.InsertColumn(1, column_names[1])
+        self.edit_list.makeColumnEditable(0)
+        self.edit_list.makeColumnEditable(1)
+
+        self.base_dict = base_dict
+
+        for key, value in self.base_dict.items():
+            ind = self.edit_list.InsertStringItem(sys.maxsize, key)
+            self.edit_list.SetStringItem(ind, 1, value)
+
+        v_sizer = wx.BoxSizer(wx.VERTICAL)
+        h_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        h_sizer.Add(self.edit_list, 0, wx.ALL, 5)
+        v_sizer.Add(h_sizer, 0, wx.ALL, 5)
+
+        h_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        btn = wx.Button(self, wx.ID_OK)
+        btn.SetDefault()
+        h_sizer.Add(btn, 0, wx.ALL, 5)
+
+        self.b_add = wx.Button(self, -1, 'Add')
+        self.b_add.Bind(wx.EVT_BUTTON, self.OnItemAdd)
+        h_sizer.Add(self.b_add, 0, wx.ALL, 5)
+
+        v_sizer.Add(h_sizer, 0, wx.ALL, 5)
+
+        # for wxMSW
+        self.edit_list.Bind(wx.EVT_COMMAND_RIGHT_CLICK, self.OnRightClick)
+        self.edit_list.Bind(wx.EVT_COMMAND_LEFT_CLICK, self.OnRightClick)
+        # for wxGTK
+        self.edit_list.Bind(wx.EVT_RIGHT_UP, self.OnRightClick)
+        self.edit_list.Bind(wx.EVT_LEFT_UP, self.OnRightClick)
+
+        self.SetSizerAndFit(v_sizer)
+
+        self.ID_FILT_ADD = wx.NewId()
+        self.ID_FILT_DELETE = wx.NewId()
+        self.ID_FILT_EDIT = wx.NewId()
+
+        self.Bind(wx.EVT_MENU, self.OnItemAdd, id=self.ID_FILT_ADD)
+        self.Bind(wx.EVT_MENU, self.OnItemDelete, id=self.ID_FILT_DELETE)
+        self.Bind(wx.EVT_MENU, self.OnItemEdit, id=self.ID_FILT_EDIT)
     
+    def OnRightClick(self, event):
+        x = event.GetX()
+        y = event.GetY()
 
+        item, flags = self.edit_list.HitTest((x, y))
 
+        menu = wx.Menu()
+        menu.Append(self.ID_FILT_ADD, "Add")
+
+        if item != wx.NOT_FOUND and flags & wx.LIST_HITTEST_ONITEM:
+            self.current_list_item = item
+            self.edit_list.Select(item)
+
+            menu.Append(self.ID_FILT_DELETE, "Delete")
+            menu.Append(self.ID_FILT_EDIT, "Edit")
+
+        # Popup the menu.  If an item is selected then its handler
+        # will be called before PopupMenu returns.
+        self.PopupMenu(menu)
+        menu.Destroy()
+
+    def OnItemSelected(self, event):
+        self.current_list_item = event.GetIndex()
+        event.Skip()
+
+    def OnItemDeselected(self, event):
+        self.current_list_item = None
+        event.Skip()
+
+    def OnItemAdd(self, event):
+        import sys
+
+        dlg = DictItemEditDialog(self)
+
+        ret = dlg.ShowModal()
+
+        if ret == wx.ID_OK:
+            val = str(dlg.tVal.GetValue())
+            key = str(dlg.tKey.GetValue())
+
+            self.base_dict[key] = val
+
+            ind = self.edit_list.InsertStringItem(sys.maxsize, key)
+            self.edit_list.SetStringItem(ind, 1, val)
+
+        dlg.Destroy()
+
+    def OnItemDelete(self, event):
+        it = self.edit_list.GetItem(self.current_list_item)
+        self.edit_list.DeleteItem(self.current_list_item)
+        self.base_dict.pop(it.GetText())
+
+    def OnItemEdit(self, event):
+        key = str(self.edit_list.GetItem(self.current_list_item).GetText())
+        
+        val = self.base_dict[key]
+        
+        dlg = DictItemEditDialog(self, key=key, val=val)
+
+        ret = dlg.ShowModal()
+
+        if ret == wx.ID_OK:
+            val = str(dlg.tVal.GetValue())
+            self.base_dict[key] = val
+            self.edit_list.SetStringItem(self.current_list_item, 1, val)
+
+        dlg.Destroy()
+
+class DictItemEditDialog(wx.Dialog):
+    def __init__(self, parent, key='', val=''):
+        wx.Dialog.__init__(self, parent, title='Edit ...')
+
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        
+        hsizer.Add(wx.StaticText(self, -1, 'Key:'), 0, 
+                   wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        self.tKey = wx.TextCtrl(self, -1, key, size=(140, -1))
+        hsizer.Add(self.tKey, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        vsizer.Add(hsizer, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, 'Value:'), 0, 
+                   wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        self.tVal = wx.TextCtrl(self, -1, val, size=(140, -1))
+        hsizer.Add(self.tVal, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        vsizer.Add(hsizer, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+
+        btSizer = wx.StdDialogButtonSizer()
+        btn = wx.Button(self, wx.ID_OK)
+        btn.SetDefault()
+        btSizer.AddButton(btn)
+        btn = wx.Button(self, wx.ID_CANCEL)
+        btSizer.AddButton(btn)
+        btSizer.Realize()
+
+        vsizer.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+
+        self.SetSizer(vsizer)
+        vsizer.Fit(self)


### PR DESCRIPTION
Addresses issue currently PYMEVis only uses output modules through menu items, e.g. one at a time, but does not support using them in a recipe. This is not necessarily an issue for most people - the solution could be to add a menu item for each output module, only things are we would have to actually do that, PYMEVis would not serve as a 100% complete recipe tester, and any output-ing people do through PYMEVis would require manual setting entry each time. @David-Baddeley what's the move here? dh5view has `run recipe` and `rune recipe and save outputs` menu items, which makes sense to me, so I added button-versions to PYMEVis (so a collaborator could run an output plugin module (pyme-omero).

I'm not 100% sure I understood what you would like to see differently long term for the choice-box dict editor we added for the `HDFOutput` view, but I wanted a dict editor for setting the output context (since the only thing I felt like we could reliably auto-fill was `file_stub`), so I used the `EditListCtrl` that you mentioned last time. If this is a bit closer to what you have in mind for `HDFOutput` module it would be easy use `DictCtrlDialog` (or panel version) for both, and add/edits would either open `DictItemEditDialog` or the choice box version. I didn't worry super much about refactoring the other into this, where it lives, etc. until I know whether it's remotely something we're interested in


**Is this a bugfix or an enhancement?**
Enhancement
**Proposed changes:**
- set a default style parameter in `EditListCtrl` init since `style=0` throws an error and is therefore not super helpful
- add a checkbox to toggle `pipeline.execute_on_invalidation`, a button to call `pipeline.recipe.execute()`, and a button to make sure the recipe has already run, gui-configure the output module context, and then call `pipeline.recipe.save()`.
![Screen Shot 2020-09-04 at 2 18 10 PM](https://user-images.githubusercontent.com/31105780/92273644-be763600-eeb9-11ea-9764-d76e4288b14b.png)
(maybe wasn't the move to put them on a different horizontal boxsizer, don't know)
- add a dict editor using the `EditListCtrl` to set the `context` dict for `ModuleCollection.save`. `file_stub` key auto-populates
![Screen Shot 2020-09-04 at 2 18 23 PM](https://user-images.githubusercontent.com/31105780/92273788-0301d180-eeba-11ea-86e7-77eb0337f9cb.png)
The rest of the screenshots are pretty superfluous and could have easily been left out, but I already took them so I'm including them
  - left or right clicking inside the listctrl gives you the menu
![Screen Shot 2020-09-04 at 2 18 32 PM](https://user-images.githubusercontent.com/31105780/92273847-20cf3680-eeba-11ea-930d-5c244e804491.png)
  - add / edit dialog is str / str, rather than choice-box / str (for HDFOutput view) or str/float (for the other custom dict editor factory) ![Screen Shot 2020-09-04 at 2 18 39 PM](https://user-images.githubusercontent.com/31105780/92273900-3e040500-eeba-11ea-891f-2ca07041338f.png)
  - ![Screen Shot 2020-09-04 at 2 18 51 PM](https://user-images.githubusercontent.com/31105780/92273991-6d1a7680-eeba-11ea-8a62-4879b7a9bdf3.png)








**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
