### PR TITLE
bytes/str fix on ruleID hashing for recipe rules

### DIFF
--- a/PYME/cluster/HTTPRulePusher.py
+++ b/PYME/cluster/HTTPRulePusher.py
@@ -317,9 +317,14 @@ class RecipePusher(object):
         self.taskQueueURI = _getTaskQueueURI()
 
         #generate a queue ID as a hash of the recipe and the current time
-        h = hashlib.md5(self.recipeURI if self.recipeURI else self.recipe_text)
-        h.update('%s' % time.time())
-        self.queueID = h.hexdigest()
+        to_hash = self.recipeURI if self.recipeURI else self.recipe_text
+        try:  # hashlib requires bytes on py3
+            to_hash = to_hash.encode()
+        except TypeError:  # encoding without a string argument, i.e. already bytes
+            pass
+        h = hashlib.md5(to_hash)
+        h.update(str(time.time()).encode())
+        self.queueID = h.hexdigest()  # hexdigest returns str
 
 
     @property


### PR DESCRIPTION
Addresses issue

```
PatchedServiceInfo(type='_pyme-taskdist._tcp.local.', name='PYMERuleServer: greenback._pyme-taskdist._tcp.local.', addresses=[b'\n\x96\x07\x84'], port=15346, weight=0, priority=0, server='PYMERuleServer: greenback._pyme-taskdist._tcp.local.', properties={}) b'\n\x96\x07\x84'
Internal Server Error: /recipes/run/
Traceback (most recent call last):
  File "/home/smeagol/miniconda3/lib/python3.6/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/home/smeagol/miniconda3/lib/python3.6/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/home/smeagol/miniconda3/lib/python3.6/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/smeagol/miniconda3/lib/python3.6/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/smeagol/code/python-microscopy/PYME/cluster/clusterUI/recipes/views.py", line 37, in run
    pusher = RecipePusher(recipeURI=recipeURI)
  File "/home/smeagol/code/python-microscopy/PYME/cluster/HTTPRulePusher.py", line 320, in __init__
    h = hashlib.md5(self.recipeURI if self.recipeURI else self.recipe_text)
TypeError: Unicode-objects must be encoded before hashing
```

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- make sure we hash on bytes. Note that the queueID is still string






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

