### PR TITLE
add option to close underlying h5rFile in to_hdf

### DIFF
--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -118,7 +118,26 @@ class TabularBase(object):
         return records.fromarrays(cols, names=keys_, dtype=dt)
 
     def to_hdf(self, filename, tablename='Data', keys=None, metadata=None,
-               close_after=False):
+               force_close=True):
+        """
+        Writes data to a table in an HDF5 file
+        
+        Parameters
+        ----------
+        
+        filename: string
+            the name of the file to save to
+        tablename: string [optional]
+            the name of the table within the file to save to. Defaults to "Data"
+        keys: list [optional]
+            a list of column names to save (if keys == None, all columns are saved)
+        metadata: a MetaDataHandler instance [optional]
+            associated metadata to write to the file
+        force_close: Bool
+            force the file to close after writing. If false, the file is closed with a 20s timeout after no further writes. Setting force_close=False
+            results in better performance when making multiple writes to the same file.
+            
+        """
         from PYME.IO import h5rFile
 
         with h5rFile.openH5R(filename, 'a') as f:
@@ -130,7 +149,7 @@ class TabularBase(object):
             #wait until data is written
             f.flush()
             
-        if close_after:
+        if force_close:
             f.wait_close()
                 
     def keys(self):

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -117,7 +117,8 @@ class TabularBase(object):
         #print(dt)
         return records.fromarrays(cols, names=keys_, dtype=dt)
 
-    def to_hdf(self, filename, tablename='Data', keys=None, metadata=None):
+    def to_hdf(self, filename, tablename='Data', keys=None, metadata=None,
+               close_after=False):
         from PYME.IO import h5rFile
 
         with h5rFile.openH5R(filename, 'a') as f:
@@ -128,6 +129,9 @@ class TabularBase(object):
                 
             #wait until data is written
             f.flush()
+            
+        if close_after:
+            f.wait_close()
                 
     def keys(self):
         raise NotImplementedError('Should be over-ridden in derived class')


### PR DESCRIPTION
Addresses issue wanting to save an hdf file without a 20 second keep alive before deleting it. Use case I'm running up against this with is saving an hdf file in a temporary directory to upload to OMERO

```
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "c:\users\laf62\code\python-microscopy\PYME\recipes\base.py", line 857, in save
    mod.save(self.namespace, context)
  File "c:\users\laf62\code\pyme-omero\pyme_omero\recipe_modules\omero_upload.py", line 85, in save
    self.omero_project, loc_filenames)
  File "C:\Users\laf62\.conda\envs\pyme\lib\tempfile.py", line 809, in __exit__
    self.cleanup()
  File "C:\Users\laf62\.conda\envs\pyme\lib\tempfile.py", line 813, in cleanup
    _shutil.rmtree(self.name)
  File "C:\Users\laf62\.conda\envs\pyme\lib\shutil.py", line 500, in rmtree
    return _rmtree_unsafe(path, onerror)
  File "C:\Users\laf62\.conda\envs\pyme\lib\shutil.py", line 395, in _rmtree_unsafe
    onerror(os.unlink, fullname, sys.exc_info())
  File "C:\Users\laf62\.conda\envs\pyme\lib\shutil.py", line 393, in _rmtree_unsafe
    os.unlink(fullname)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\laf62\\AppData\\Local\\Temp\\tmp9g1ovsxy\\Localizations'
```

Note that I would also be happy with just having `to_hdf` return a handle to the H5rFile instance so I can close it on my own.

**Is this a bugfix or an enhancement?**
enhancement

**Proposed changes:**
- add optional kwarg to call H5rFile.wait_close() after saving






**Checklist:**

- [ ] Tested with numpy=1.14

1.19
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.1
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
