### PR TITLE
allow pickled shiftmaps to load on numpy > 1.14

### DIFF
--- a/PYME/localization/MetaDataEdit.py
+++ b/PYME/localization/MetaDataEdit.py
@@ -396,7 +396,7 @@ class ShiftFieldParam(FilenameParam):
         FilenameParam.retrieveValue(self, mdh, *args, **kwargs)
         
         if not self.filename == oldfn and not self.filename in ['<none>', '']:
-            dx, dy = np.load(self.filename)
+            dx, dy = np.load(self.filename, allow_pickle=True)
             mdh.setEntry('chroma.dx', dx)
             mdh.setEntry('chroma.dy', dy)
         


### PR DESCRIPTION
Addresses issue #numpy load was made more secure after 1.14.6 (I think in 1.15, but definitely in 1.16) in response to [this](https://nvd.nist.gov/vuln/detail/CVE-2019-6446), which is cool, but means that we hit

```
Traceback (most recent call last):
  File "c:\users\bergamot\code\python-microscopy\PYME\localization\MetaDataEdit.py", line 316, in <lambda>
    bSetFile.Bind(wx.EVT_BUTTON, lambda e : self._setFile(mdh))
  File "c:\users\bergamot\code\python-microscopy\PYME\localization\MetaDataEdit.py", line 342, in _setFile
    self.retrieveValue(mdh, False)
  File "c:\users\bergamot\code\python-microscopy\PYME\localization\MetaDataEdit.py", line 399, in retrieveValue
    dx, dy = np.load(self.filename)
  File "C:\Users\Bergamot\Anaconda2\envs\pyme\lib\site-packages\numpy\lib\npyio.py", line 451, in load
    raise ValueError("Cannot load file containing pickled data "
ValueError: Cannot load file containing pickled data when allow_pickle=False
```
when loading shiftmaps on later numpy versions

**Is this a bugfix or an enhancement?**
i guess bugfix
**Proposed changes:**

- allow `numpy.load` to unpickle shiftmaps





**Checklist:**

- [ ] Tested with numpy=1.14
did not test, but the argument has been there forever it just defaulted to `True` on numpy 1.14
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.1
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
