### PR TITLE
Windows related path fixes for PYMEClusterOfOne

### DIFF
--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -20,7 +20,7 @@
 #
 ##################
 import os
-
+import posixpath
 import PYME.localization.FitFactories
 #import PYME.ui.autoFoldPanel as afp
 import PYME.ui.manualFoldPanel as afp
@@ -93,17 +93,17 @@ def _verifyClusterResultsFilename(resultsFilename):
     resultsFilename = unifiedIO.verbose_fix_name(resultsFilename) # fix any spaces in the input filename
     
     if clusterIO.exists(resultsFilename):
-        di, fn = os.path.split(resultsFilename)
+        di, fn = posixpath.split(resultsFilename)
         i = 1
-        stub = os.path.splitext(fn)[0]
-        while clusterIO.exists(os.path.join(di, stub + '_%d.h5r' % i)):
+        stub = posixpath.splitext(fn)[0]
+        while clusterIO.exists(posixpath.join(di, stub + '_%d.h5r' % i)):
             i += 1
 
         fdialog = wx.TextEntryDialog(None, 'Analysis file already exists, please select a new filename')#,
         fdialog.SetValue(stub + '_%d.h5r' % i)
         succ = fdialog.ShowModal()
         if (succ == wx.ID_OK):
-            resultsFilename = os.path.join(di, str(fdialog.GetValue()))
+            resultsFilename = posixpath.join(di, str(fdialog.GetValue()))
         else:
             raise RuntimeError('Invalid results file - not running')
 

--- a/PYME/IO/FileUtils/nameUtils.py
+++ b/PYME/IO/FileUtils/nameUtils.py
@@ -133,11 +133,8 @@ def genClusterResultFileName(dataFileName, create=True):
         rel_name = fn.split('://%s/' % clusterfilter)[1]
     else:
         # special case for cluster of one uses where we didn't open file using a cluster URI
-        if not fn.startswith('/'):
-            # filename is relative to PYMEDATATDIR
-            # TODO - this looks really unsafe under windows!!! Filenames won't ever start with / even if fully resolved, which means that the PYMEDATADIR path will be prepended
-            # to the filename (and we might end up with something like C:\Users\foo\PYMEData\D:\Data\bar\seriesx.tif).
-            # is it possible that we get away with it because os.path.splitdrive (in posix_path() just truncates at the last : in the string?
+        if not os.path.isabs(fn):
+            # add the PYMEData dir path on if we weren't given an absolute path
             fn = getFullFilename(fn)
         
         try:
@@ -149,7 +146,7 @@ def genClusterResultFileName(dataFileName, create=True):
             # recreate the tree under PYMEData, dropping the drive letter or UNC
             rel_name = fn
             
-        rel_name = posix_path(rel_name)
+        rel_name = rel_path_as_posix(rel_name)
 
     dir_name = posixpath.dirname(rel_name)
     file_name = posixpath.basename(rel_name)
@@ -219,12 +216,11 @@ def translateSeparators(filename):
 
     return fn
 
-def posix_path(path):
+def rel_path_as_posix(path):
     """
     Translate any separators to '/' and drop drive letters
     
     #FIXME - do something sensible with drive letters?
-    #FIXME - rename? [as this is a relative path / not resolvable]
     """
     import posixpath
     # FIXME - just use pathlib.path().to_posix() when we drop py2

--- a/PYME/cluster/HTTPDataServer.py
+++ b/PYME/cluster/HTTPDataServer.py
@@ -690,10 +690,12 @@ class PYMEHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         Parameters
         ----------
         path: str
-            path to an hdf or h5r file on the dataserver computer. Append the part of the file to read after the file
-            extension, e.g. .h5r/Events. Return format (for arrays) can additionally be specified, as can slices
-            using the following syntax: test.h5r/FitResults.json?from=0&to=100. Supported array formats include json and
-            npy.
+            OS-translated path to an hdf or h5r file on the dataserver computer. 
+            Append the part of the file to read after the file extension, e.g. 
+            .h5r/Events. Return format (for arrays) can additionally be 
+            specified, as can slices
+            using the following syntax: test.h5r/FitResults.json?from=0&to=100. 
+            Supported array formats include json and npy.
 
         Returns
         -------
@@ -705,7 +707,7 @@ class PYMEHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         # parse path
         ext = '.h5r' if '.h5r' in path else '.hdf'
-        filename, details = path.split(ext + '/')
+        filename, details = path.split(ext + os.sep)
         filename = filename + ext  # path to file on dataserver disk
         query = urlparse.urlparse(details).query
         details = details.strip('?' + query)

--- a/PYME/cluster/HTTPDataServer.py
+++ b/PYME/cluster/HTTPDataServer.py
@@ -707,6 +707,7 @@ class PYMEHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         # parse path
         ext = '.h5r' if '.h5r' in path else '.hdf'
+        # TODO - should we just use the the untranslated path?
         filename, details = path.split(ext + os.sep)
         filename = filename + ext  # path to file on dataserver disk
         query = urlparse.urlparse(details).query


### PR DESCRIPTION
Addresses issues:
- connecterrors in dh5view from on go because dataserver-side `get_tabular_part` split on '/' rather than os.sep and it gets pass an os-translated path rather than the dataserver.path attribute
```
DEBUG:root:C:\Users\Bergamot\PYMEData\Bergamot\analysis\Cell1_test_13.h5r\FitResults.npy?from=0
DEBUG:root:.h5r/
----------------------------------------
Exception happened during processing of request from ('127.0.0.1', 60595)
Traceback (most recent call last):
  File "C:\Users\Bergamot\Anaconda2\envs\pyme\lib\socketserver.py", line 654, in process_request_thread
    self.finish_request(request, client_address)
  File "C:\Users\Bergamot\Anaconda2\envs\pyme\lib\socketserver.py", line 364, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "C:\Users\Bergamot\Anaconda2\envs\pyme\lib\socketserver.py", line 724, in __init__
    self.handle()
  File "C:\Users\Bergamot\Anaconda2\envs\pyme\lib\http\server.py", line 418, in handle
    self.handle_one_request()
  File "C:\Users\Bergamot\Anaconda2\envs\pyme\lib\http\server.py", line 406, in handle_one_request
    method()
  File "c:\users\bergamot\code\python-microscopy\PYME\cluster\HTTPDataServer.py", line 483, in do_GET
    f = self.send_head()
  File "c:\users\bergamot\code\python-microscopy\PYME\cluster\HTTPDataServer.py", line 573, in send_head
    return self.get_tabular_part(path + '?' + urlparse.urlparse(self.path).query)
  File "c:\users\bergamot\code\python-microscopy\PYME\cluster\HTTPDataServer.py", line 710, in get_tabular_part
    filename, details = path.split(ext + '/')
ValueError: not enough values to unpack (expected 2, got 1)
```
- rename the posix relpath function as suggested
- use os.path.isabs instead of checking filename.startswith('/') - David is right this was pretty flaky
```
In [3]: abpath = r"C:\Users\Bergamot\PYMEData\Bergamot\Cell1_test.h5"

In [4]: abpath
Out[4]: 'C:\\Users\\Bergamot\\PYMEData\\Bergamot\\Cell1_test.h5'

In [5]: import posixpath

In [6]: posixpath.split(abpath)
Out[6]: ('', 'C:\\Users\\Bergamot\\PYMEData\\Bergamot\\Cell1_test.h5')

In [7]: posixpath.splitext(abpath)
Out[7]: ('C:\\Users\\Bergamot\\PYMEData\\Bergamot\\Cell1_test', '.h5')

In [8]: posixpath.splitdrive(abpath)
Out[8]: ('', 'C:\\Users\\Bergamot\\PYMEData\\Bergamot\\Cell1_test.h5')

In [9]: import os

In [10]: os.path.abspath(r'PYMEData\\Bergamot')
Out[10]: 'C:\\Users\\Bergamot\\PYMEData\\Bergamot'

In [11]: os.path.abspath(r'boo\\Bergamot')
Out[11]: 'C:\\Users\\Bergamot\\boo\\Bergamot'

In [12]: os.path.isabs(r'boo\\Bergamot')
Out[12]: False
```
- use posixpath instead of os.path when generating a cluster results filename in the clause we hit if the file already exists
```
>>> image.filename
'C:\\Users\\Bergamot\\PYMEData\\Bergamot\\Cell1_test.h5'
>>> from PYME.IO.FileUtils.nameUtils import genClusterResultFileName as gn
>>> gn(image.filename)
'Bergamot/analysis/Cell1_test.h5r'
>>> import posixpath
>>> from PYME.DSView.modules.LMAnalysis import _verifyClusterResultsFilename
>>> _verifyClusterResultsFilename(gn(image.filename))
'Bergamot/analysis\\Cell1_test_1.h5r'
```

**Is this a bugfix or an enhancement?**
bugfixes
**Proposed changes:**

Note this gets our live view stuff running on windows py36 up to the wx gui stuff, 
![image](https://user-images.githubusercontent.com/31105780/93266474-1cd3cc00-f778-11ea-8646-3af898d939cf.png)

but I'm running wx 4.1 and can't terribly complain. In any event I will use #347 or similar on my windows setup


**Checklist:**

- [ ] Tested with numpy=1.14

1.19
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.1
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
