### PR TITLE
add dispatch as contrib subpackage

### DIFF
--- a/PYME/contrib/setup.py
+++ b/PYME/contrib/setup.py
@@ -27,7 +27,7 @@ def configuration(parent_package='',top_path=None):
     config = Configuration('contrib',parent_package,top_path)
     config.add_subpackage('pad')
     config.add_subpackage('gohlke')
-    #config.add_subpackage('cpmath')
+    config.add_subpackage('dispatch')
     config.add_subpackage('aniso')
     
     return config

--- a/PYME/contrib/setup.py
+++ b/PYME/contrib/setup.py
@@ -27,6 +27,7 @@ def configuration(parent_package='',top_path=None):
     config = Configuration('contrib',parent_package,top_path)
     config.add_subpackage('pad')
     config.add_subpackage('gohlke')
+    #config.add_subpackage('cpmath') #TODO - why is this commented out?
     config.add_subpackage('dispatch')
     config.add_subpackage('aniso')
     


### PR DESCRIPTION
Addresses issue cannot `from PYME.contrib import dispatch` on a conda install, only setuptools

conda install / traceback:
<details> <summary> conda install / runtime traceback </summary> 

```
$ conda create -n frantest python-microscopy
Collecting package metadata (current_repodata.json): done
Solving environment: failed with repodata from current_repodata.json, will retry with next repodata source.
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /opt/miniconda3/envs/frantest

  added / updated specs:
    - python-microscopy


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    alabaster-0.7.12           |           py37_0          18 KB
    backports.lzma-0.0.14      |   py37hd621484_0          50 KB
    blosc-1.20.0               |       hab81aa3_0          56 KB
    brotlipy-0.7.0             |py37haf1e3a3_1000         329 KB
    cffi-1.14.2                |   py37hed5b41f_0         219 KB
    cheroot-8.3.0              |           py37_0         135 KB
    cherrypy-18.6.0            |           py37_0         528 KB
    cloudpickle-1.6.0          |             py_0          30 KB
    cryptography-3.1           |   py37hddc9c9b_0         549 KB
    cycler-0.10.0              |           py37_0          14 KB
    cytoolz-0.10.1             |   py37h1de35cc_0         307 KB
    dask-core-2.26.0           |             py_0         602 KB
    dispatch-1.0               |           py37_0          18 KB  david_baddeley
    docutils-0.16              |           py37_1         667 KB
    future-0.18.2              |           py37_1         630 KB
    jaraco.text-3.2.0          |           py37_0          15 KB
    kiwisolver-1.2.0           |   py37h04f5b5a_0          55 KB
    markupsafe-1.1.1           |   py37h1de35cc_0          27 KB
    matplotlib-3.3.1           |                0          24 KB
    matplotlib-base-3.3.1      |   py37h181983e_0         5.1 MB
    more-itertools-8.5.0       |             py_0          43 KB
    mpld3-v0.3                 |           py37_0         128 KB  david_baddeley
    networkx-2.5               |             py_0         1.1 MB
    numexpr-2.7.1              |   py37hce01a72_0         121 KB
    numpy-1.19.1               |   py37h3b9f5b6_0          21 KB
    numpy-base-1.19.1          |   py37hcfb5961_0         4.0 MB
    olefile-0.46               |           py37_0          49 KB
    pandas-1.1.1               |   py37hb1e8313_0         7.8 MB
    pillow-7.2.0               |   py37ha54b6ba_0         581 KB
    portend-2.6                |             py_0           8 KB
    psutil-5.7.2               |   py37haf1e3a3_0         337 KB
    pycairo-1.19.1             |   py37h126230b_0          64 KB
    pyface-7.0.1               |           py37_1         1.0 MB
    pyfftw-v0.11.1             |   py37h39e3cac_0         152 KB  david_baddeley
    pygments-2.7.0             |             py_0         674 KB
    pyme-depends-1.09          |           py37_0           5 KB  david_baddeley
    pymecompress-0.2.0         |           py37_0         124 KB  david_baddeley
    pyopengl-3.1.1a1           |           py37_0         1.0 MB
    pyqt-5.9.2                 |   py37h655552a_2         3.6 MB
    pytables-3.6.1             |   py37h5bccee9_0         1.1 MB
    python-3.7.9               |       h26836e1_0        19.7 MB
    python-microscopy-20.09.01 |           py37_0         3.9 MB  david_baddeley
    pywavelets-1.1.1           |   py37h1de35cc_0         3.4 MB
    pyyaml-5.3.1               |   py37haf1e3a3_1         165 KB
    repoze.lru-0.7             |           py37_0          23 KB
    scikit-image-0.16.2        |   py37h6c726b0_0        22.5 MB
    scikit-learn-0.23.2        |   py37h959d312_0         4.7 MB
    scipy-1.3.0                |   py37h1410ff5_0        12.4 MB
    simplejson-3.17.2          |   py37haf1e3a3_0          99 KB
    sip-4.19.8                 |   py37h0a44026_0         237 KB
    sphinx-3.2.1               |             py_0         1.1 MB
    tempora-4.0.0              |             py_0          19 KB
    toposort-1.5               |           py37_3          10 KB  david_baddeley
    tornado-6.0.4              |   py37h1de35cc_1         597 KB
    traits-6.1.1               |   py37haf1e3a3_0         586 KB
    ujson-3.1.0                |   py37hb1e8313_0          48 KB
    wxpython-4.0.4             |   py37hebc47a7_0        12.3 MB
    zeroconf-0.28.0            |           py37_3          76 KB  david_baddeley
    ------------------------------------------------------------
                                           Total:       113.1 MB

The following NEW packages will be INSTALLED:

  alabaster          pkgs/main/osx-64::alabaster-0.7.12-py37_0
  babel              pkgs/main/noarch::babel-2.8.0-py_0
  backports          pkgs/main/noarch::backports-1.0-py_2
  backports.lzma     pkgs/main/osx-64::backports.lzma-0.0.14-py37hd621484_0
  blas               pkgs/main/osx-64::blas-1.0-mkl
  blosc              pkgs/main/osx-64::blosc-1.20.0-hab81aa3_0
  brotlipy           pkgs/main/osx-64::brotlipy-0.7.0-py37haf1e3a3_1000
  bzip2              pkgs/main/osx-64::bzip2-1.0.8-h1de35cc_0
  ca-certificates    pkgs/main/osx-64::ca-certificates-2020.7.22-0
  cairo              pkgs/main/osx-64::cairo-1.14.12-hc4e6be7_4
  certifi            pkgs/main/osx-64::certifi-2020.6.20-py37_0
  cffi               pkgs/main/osx-64::cffi-1.14.2-py37hed5b41f_0
  chardet            pkgs/main/osx-64::chardet-3.0.4-py37_1003
  cheroot            pkgs/main/osx-64::cheroot-8.3.0-py37_0
  cherrypy           pkgs/main/osx-64::cherrypy-18.6.0-py37_0
  cloudpickle        pkgs/main/noarch::cloudpickle-1.6.0-py_0
  cryptography       pkgs/main/osx-64::cryptography-3.1-py37hddc9c9b_0
  cycler             pkgs/main/osx-64::cycler-0.10.0-py37_0
  cython             pkgs/main/osx-64::cython-0.29.21-py37hb1e8313_0
  cytoolz            pkgs/main/osx-64::cytoolz-0.10.1-py37h1de35cc_0
  dask-core          pkgs/main/noarch::dask-core-2.26.0-py_0
  dbus               pkgs/main/osx-64::dbus-1.13.16-h18a8e69_0
  decorator          pkgs/main/noarch::decorator-4.4.2-py_0
  dispatch           david_baddeley/osx-64::dispatch-1.0-py37_0
  docutils           pkgs/main/osx-64::docutils-0.16-py37_1
  expat              pkgs/main/osx-64::expat-2.2.9-hb1e8313_2
  fftw               david_baddeley/osx-64::fftw-3.3.4-0
  fontconfig         pkgs/main/osx-64::fontconfig-2.13.0-h5d5b041_1
  freetype           pkgs/main/osx-64::freetype-2.10.2-ha233b18_0
  future             pkgs/main/osx-64::future-0.18.2-py37_1
  gettext            pkgs/main/osx-64::gettext-0.19.8.1-hb0f4f8b_2
  glib               pkgs/main/osx-64::glib-2.65.0-hc5f4afa_0
  hdf5               pkgs/main/osx-64::hdf5-1.10.4-hfa1e0ec_0
  icu                pkgs/main/osx-64::icu-58.2-h0a44026_3
  idna               pkgs/main/noarch::idna-2.10-py_0
  ifaddr             david_baddeley/noarch::ifaddr-0.1.6-py_0
  imageio            pkgs/main/noarch::imageio-2.9.0-py_0
  imagesize          pkgs/main/noarch::imagesize-1.2.0-py_0
  intel-openmp       pkgs/main/osx-64::intel-openmp-2019.4-233
  jaraco.classes     pkgs/main/noarch::jaraco.classes-3.1.0-py_0
  jaraco.collections pkgs/main/noarch::jaraco.collections-3.0.0-py_0
  jaraco.functools   pkgs/main/noarch::jaraco.functools-3.0.1-py_0
  jaraco.text        pkgs/main/osx-64::jaraco.text-3.2.0-py37_0
  jinja2             pkgs/main/noarch::jinja2-2.11.2-py_0
  joblib             pkgs/main/noarch::joblib-0.16.0-py_0
  jpeg               pkgs/main/osx-64::jpeg-9b-he5867d9_2
  kiwisolver         pkgs/main/osx-64::kiwisolver-1.2.0-py37h04f5b5a_0
  lcms2              pkgs/main/osx-64::lcms2-2.11-h92f6f08_0
  libcxx             pkgs/main/osx-64::libcxx-10.0.0-1
  libedit            pkgs/main/osx-64::libedit-3.1.20191231-h1de35cc_1
  libffi             pkgs/main/osx-64::libffi-3.3-hb1e8313_2
  libgfortran        pkgs/main/osx-64::libgfortran-3.0.1-h93005f0_2
  libiconv           pkgs/main/osx-64::libiconv-1.16-h1de35cc_0
  libpng             pkgs/main/osx-64::libpng-1.6.37-ha441bb4_0
  libtiff            pkgs/main/osx-64::libtiff-4.1.0-hcb84e12_1
  libxml2            pkgs/main/osx-64::libxml2-2.9.10-h3b9e6c8_1
  llvm-openmp        pkgs/main/osx-64::llvm-openmp-10.0.0-h28b9765_0
  lz4-c              pkgs/main/osx-64::lz4-c-1.9.2-hb1e8313_1
  lzo                pkgs/main/osx-64::lzo-2.10-h1de35cc_2
  markupsafe         pkgs/main/osx-64::markupsafe-1.1.1-py37h1de35cc_0
  matplotlib         pkgs/main/osx-64::matplotlib-3.3.1-0
  matplotlib-base    pkgs/main/osx-64::matplotlib-base-3.3.1-py37h181983e_0
  mkl                pkgs/main/osx-64::mkl-2019.4-233
  mkl-service        pkgs/main/osx-64::mkl-service-2.3.0-py37hfbe908c_0
  mkl_fft            pkgs/main/osx-64::mkl_fft-1.1.0-py37hc64f4ea_0
  mkl_random         pkgs/main/osx-64::mkl_random-1.1.1-py37h959d312_0
  mock               pkgs/main/noarch::mock-4.0.2-py_0
  more-itertools     pkgs/main/noarch::more-itertools-8.5.0-py_0
  mpld3              david_baddeley/osx-64::mpld3-v0.3-py37_0
  ncurses            pkgs/main/osx-64::ncurses-6.2-h0a44026_1
  networkx           pkgs/main/noarch::networkx-2.5-py_0
  numexpr            pkgs/main/osx-64::numexpr-2.7.1-py37hce01a72_0
  numpy              pkgs/main/osx-64::numpy-1.19.1-py37h3b9f5b6_0
  numpy-base         pkgs/main/osx-64::numpy-base-1.19.1-py37hcfb5961_0
  olefile            pkgs/main/osx-64::olefile-0.46-py37_0
  openssl            pkgs/main/osx-64::openssl-1.1.1g-h1de35cc_0
  packaging          pkgs/main/noarch::packaging-20.4-py_0
  pandas             pkgs/main/osx-64::pandas-1.1.1-py37hb1e8313_0
  pcre               pkgs/main/osx-64::pcre-8.44-hb1e8313_0
  pillow             pkgs/main/osx-64::pillow-7.2.0-py37ha54b6ba_0
  pip                pkgs/main/osx-64::pip-20.2.2-py37_0
  pixman             pkgs/main/osx-64::pixman-0.40.0-haf1e3a3_0
  portend            pkgs/main/noarch::portend-2.6-py_0
  psutil             pkgs/main/osx-64::psutil-5.7.2-py37haf1e3a3_0
  pycairo            pkgs/main/osx-64::pycairo-1.19.1-py37h126230b_0
  pycparser          pkgs/main/noarch::pycparser-2.20-py_2
  pyface             pkgs/main/osx-64::pyface-7.0.1-py37_1
  pyfftw             david_baddeley/osx-64::pyfftw-v0.11.1-py37h39e3cac_0
  pygments           pkgs/main/noarch::pygments-2.7.0-py_0
  pyme-depends       david_baddeley/osx-64::pyme-depends-1.09-py37_0
  pymecompress       david_baddeley/osx-64::pymecompress-0.2.0-py37_0
  pyopengl           pkgs/main/osx-64::pyopengl-3.1.1a1-py37_0
  pyopenssl          pkgs/main/noarch::pyopenssl-19.1.0-py_1
  pyparsing          pkgs/main/noarch::pyparsing-2.4.7-py_0
  pyqt               pkgs/main/osx-64::pyqt-5.9.2-py37h655552a_2
  pysocks            pkgs/main/osx-64::pysocks-1.7.1-py37_0
  pytables           pkgs/main/osx-64::pytables-3.6.1-py37h5bccee9_0
  python             pkgs/main/osx-64::python-3.7.9-h26836e1_0
  python-dateutil    pkgs/main/noarch::python-dateutil-2.8.1-py_0
  python-microscopy  david_baddeley/osx-64::python-microscopy-20.09.01-py37_0
  python.app         pkgs/main/osx-64::python.app-2-py37_10
  pytz               pkgs/main/noarch::pytz-2020.1-py_0
  pywavelets         pkgs/main/osx-64::pywavelets-1.1.1-py37h1de35cc_0
  pyyaml             pkgs/main/osx-64::pyyaml-5.3.1-py37haf1e3a3_1
  qt                 pkgs/main/osx-64::qt-5.9.7-h468cd18_1
  readline           pkgs/main/osx-64::readline-8.0-h1de35cc_0
  repoze.lru         pkgs/main/osx-64::repoze.lru-0.7-py37_0
  requests           pkgs/main/noarch::requests-2.24.0-py_0
  routes             pkgs/main/noarch::routes-2.4.1-py_1
  scikit-image       pkgs/main/osx-64::scikit-image-0.16.2-py37h6c726b0_0
  scikit-learn       pkgs/main/osx-64::scikit-learn-0.23.2-py37h959d312_0
  scipy              pkgs/main/osx-64::scipy-1.3.0-py37h1410ff5_0
  setuptools         pkgs/main/osx-64::setuptools-49.6.0-py37_0
  simplejson         pkgs/main/osx-64::simplejson-3.17.2-py37haf1e3a3_0
  sip                pkgs/main/osx-64::sip-4.19.8-py37h0a44026_0
  six                pkgs/main/noarch::six-1.15.0-py_0
  snappy             pkgs/main/osx-64::snappy-1.1.8-hb1e8313_0
  snowballstemmer    pkgs/main/noarch::snowballstemmer-2.0.0-py_0
  sphinx             pkgs/main/noarch::sphinx-3.2.1-py_0
  sphinxcontrib-app~ pkgs/main/noarch::sphinxcontrib-applehelp-1.0.2-py_0
  sphinxcontrib-dev~ pkgs/main/noarch::sphinxcontrib-devhelp-1.0.2-py_0
  sphinxcontrib-htm~ pkgs/main/noarch::sphinxcontrib-htmlhelp-1.0.3-py_0
  sphinxcontrib-jsm~ pkgs/main/noarch::sphinxcontrib-jsmath-1.0.1-py_0
  sphinxcontrib-qth~ pkgs/main/noarch::sphinxcontrib-qthelp-1.0.3-py_0
  sphinxcontrib-ser~ pkgs/main/noarch::sphinxcontrib-serializinghtml-1.1.4-py_0
  sqlite             pkgs/main/osx-64::sqlite-3.33.0-hffcf06c_0
  tempora            pkgs/main/noarch::tempora-4.0.0-py_0
  threadpoolctl      pkgs/main/noarch::threadpoolctl-2.1.0-pyh5ca1d4c_0
  tk                 pkgs/main/osx-64::tk-8.6.10-hb0a8c7a_0
  toolz              pkgs/main/noarch::toolz-0.10.0-py_0
  toposort           david_baddeley/osx-64::toposort-1.5-py37_3
  tornado            pkgs/main/osx-64::tornado-6.0.4-py37h1de35cc_1
  traits             pkgs/main/osx-64::traits-6.1.1-py37haf1e3a3_0
  traitsui           pkgs/main/noarch::traitsui-7.0.1-py_0
  ujson              pkgs/main/osx-64::ujson-3.1.0-py37hb1e8313_0
  urllib3            pkgs/main/noarch::urllib3-1.25.10-py_0
  wheel              pkgs/main/noarch::wheel-0.35.1-py_0
  wxpython           pkgs/main/osx-64::wxpython-4.0.4-py37hebc47a7_0
  xz                 pkgs/main/osx-64::xz-5.2.5-h1de35cc_0
  yaml               pkgs/main/osx-64::yaml-0.2.5-haf1e3a3_0
  zc.lockfile        pkgs/main/noarch::zc.lockfile-2.0-py_0
  zeroconf           david_baddeley/osx-64::zeroconf-0.28.0-py37_3
  zlib               pkgs/main/osx-64::zlib-1.2.11-h1de35cc_3
  zstd               pkgs/main/osx-64::zstd-1.4.5-h41d2c2f_0


Proceed ([y]/n)? y


Downloading and Extracting Packages
alabaster-0.7.12     | 18 KB     | ########################## | 100% 
cffi-1.14.2          | 219 KB    | ########################## | 100% 
scipy-1.3.0          | 12.4 MB   | ########################## | 100% 
networkx-2.5         | 1.1 MB    | ########################## | 100% 
cherrypy-18.6.0      | 528 KB    | ########################## | 100% 
cryptography-3.1     | 549 KB    | ########################## | 100% 
scikit-learn-0.23.2  | 4.7 MB    | ########################## | 100% 
kiwisolver-1.2.0     | 55 KB     | ########################## | 100% 
pygments-2.7.0       | 674 KB    | ########################## | 100% 
more-itertools-8.5.0 | 43 KB     | ########################## | 100% 
dask-core-2.26.0     | 602 KB    | ########################## | 100% 
tempora-4.0.0        | 19 KB     | ########################## | 100% 
numpy-base-1.19.1    | 4.0 MB    | ########################## | 100% 
toposort-1.5         | 10 KB     | ########################## | 100% 
markupsafe-1.1.1     | 27 KB     | ########################## | 100% 
pyfftw-v0.11.1       | 152 KB    | ########################## | 100% 
brotlipy-0.7.0       | 329 KB    | ########################## | 100% 
pycairo-1.19.1       | 64 KB     | ########################## | 100% 
pandas-1.1.1         | 7.8 MB    | ########################## | 100% 
pyface-7.0.1         | 1.0 MB    | ########################## | 100% 
dispatch-1.0         | 18 KB     | ########################## | 100% 
traits-6.1.1         | 586 KB    | ########################## | 100% 
pytables-3.6.1       | 1.1 MB    | ########################## | 100% 
pyme-depends-1.09    | 5 KB      | ########################## | 100% 
python-microscopy-20 | 3.9 MB    | ########################## | 100% 
psutil-5.7.2         | 337 KB    | ########################## | 100% 
sphinx-3.2.1         | 1.1 MB    | ########################## | 100% 
docutils-0.16        | 667 KB    | ########################## | 100% 
repoze.lru-0.7       | 23 KB     | ########################## | 100% 
simplejson-3.17.2    | 99 KB     | ########################## | 100% 
python-3.7.9         | 19.7 MB   | ########################## | 100% 
scikit-image-0.16.2  | 22.5 MB   | ########################## | 100% 
mpld3-v0.3           | 128 KB    | ########################## | 100% 
matplotlib-base-3.3. | 5.1 MB    | ########################## | 100% 
pyyaml-5.3.1         | 165 KB    | ########################## | 100% 
tornado-6.0.4        | 597 KB    | ########################## | 100% 
wxpython-4.0.4       | 12.3 MB   | ########################## | 100% 
pymecompress-0.2.0   | 124 KB    | ########################## | 100% 
zeroconf-0.28.0      | 76 KB     | ########################## | 100% 
blosc-1.20.0         | 56 KB     | ########################## | 100% 
numexpr-2.7.1        | 121 KB    | ########################## | 100% 
future-0.18.2        | 630 KB    | ########################## | 100% 
cycler-0.10.0        | 14 KB     | ########################## | 100% 
sip-4.19.8           | 237 KB    | ########################## | 100% 
pyqt-5.9.2           | 3.6 MB    | ########################## | 100% 
numpy-1.19.1         | 21 KB     | ########################## | 100% 
olefile-0.46         | 49 KB     | ########################## | 100% 
pywavelets-1.1.1     | 3.4 MB    | ########################## | 100% 
portend-2.6          | 8 KB      | ########################## | 100% 
cheroot-8.3.0        | 135 KB    | ########################## | 100% 
backports.lzma-0.0.1 | 50 KB     | ########################## | 100% 
jaraco.text-3.2.0    | 15 KB     | ########################## | 100% 
pyopengl-3.1.1a1     | 1.0 MB    | ########################## | 100% 
cytoolz-0.10.1       | 307 KB    | ########################## | 100% 
ujson-3.1.0          | 48 KB     | ########################## | 100% 
matplotlib-3.3.1     | 24 KB     | ########################## | 100% 
pillow-7.2.0         | 581 KB    | ########################## | 100% 
cloudpickle-1.6.0    | 30 KB     | ########################## | 100% 
Preparing transaction: done
Verifying transaction: done
Executing transaction: done
#
# To activate this environment, use
#
#     $ conda activate frantest
#
# To deactivate an active environment, use
#
#     $ conda deactivate

(base) Andrews-MacBook-Pro-5:~ Andrew$ conda activate frantest
(frantest) Andrews-MacBook-Pro-5:~ Andrew$ dh5view -t -m lite
Traceback (most recent call last):
  File "/opt/miniconda3/envs/frantest/bin/dh5view", line 7, in <module>
    from PYME.DSView.dsviewer import main
  File "/opt/miniconda3/envs/frantest/lib/python3.7/site-packages/PYME/DSView/__init__.py", line 31, in <module>
    from .dsviewer import View3D, ViewIm3D
  File "/opt/miniconda3/envs/frantest/lib/python3.7/site-packages/PYME/DSView/dsviewer.py", line 51, in <module>
    from PYME.DSView.displayOptions import DisplayOpts
  File "/opt/miniconda3/envs/frantest/lib/python3.7/site-packages/PYME/DSView/displayOptions.py", line 28, in <module>
    from PYME.contrib import dispatch
ImportError: cannot import name 'dispatch' from 'PYME.contrib' (/opt/miniconda3/envs/frantest/lib/python3.7/site-packages/PYME/contrib/__init__.py)

```

</details>

**Is this a bugfix or an enhancement?**
bugfix, follow-on from compatibility push in d6e65b9
**Proposed changes:**


**NOTE**
I have not tested repackaging with this change - I'm sort of trying to pull a foot out the door for a short vacation but didn't want the ball to drop on this.