### PR TITLE
slice with int in psfQuality.noise

### DIFF
--- a/PYME/Analysis/PSFEst/psfQuality.py
+++ b/PYME/Analysis/PSFEst/psfQuality.py
@@ -146,7 +146,7 @@ def noise(image, psft):
     """This test looks at a region to the side of the in-focus plane to assess
     noise levels. Noise can be improved by using a longer integration time when
     acquiring the bead images or by averaging more beads."""
-    n = image.data[:,:,image.data.shape[2]/2][:5,:5].std()
+    n = image.data[:,:, int(image.data.shape[2] / 2)][:5,:5].std()
     merit = n/.0005    
     return n, merit
     


### PR DESCRIPTION
Addresses issue bug found by @khu6

```
Traceback (most recent call last):
  File "C:\ProgramData\Anaconda3\envs\pyme\lib\site-packages\wx\core.py", line 3259, in <lambda>
    lambda event: event.callable(*event.args, **event.kw) )
  File "c:\users\kh725\python-microscopy\PYME\DSView\dsviewer.py", line 455, in LoadData
    vframe = DSViewFrame(im, None, im.filename, mode = mode)
  File "c:\users\kh725\python-microscopy\PYME\DSView\dsviewer.py", line 167, in __init__
    modules.loadMode(self.mode, self)
  File "c:\users\kh725\python-microscopy\PYME\DSView\modules\__init__.py", line 148, in loadMode
    loadModule(m, dsviewer)
  File "c:\users\kh725\python-microscopy\PYME\DSView\modules\__init__.py", line 118, in loadModule
    ret = mod.Plug(dsviewer)
  File "c:\users\kh725\python-microscopy\PYME\DSView\modules\psfTools.py", line 562, in Plug
    dsviewer.psfqp = PSFQualityPanel(dsviewer)
  File "c:\users\kh725\python-microscopy\PYME\DSView\modules\psfTools.py", line 67, in __init__
    self.FillGrid()
  File "c:\users\kh725\python-microscopy\PYME\DSView\modules\psfTools.py", line 109, in FillGrid
    loc_res, dec_res = psfQuality.runTests(self.image, self.dsviewer.crbv)
  File "c:\users\kh725\python-microscopy\PYME\Analysis\PSFEst\psfQuality.py", line 210, in runTests
    loc_res[k] = v(image, psft)
  File "c:\users\kh725\python-microscopy\PYME\Analysis\PSFEst\psfQuality.py", line 149, in noise
    n = image.data[:,:,image.data.shape[2]/2][:5,:5].std()
  File "c:\users\kh725\python-microscopy\PYME\IO\DataSources\BaseDataSource.py", line 124, in __getitem__
    r = np.concatenate([np.atleast_2d(self.getSlice(i)[keys[0], keys[1]])[:,:,None] for i in range(*keys[2].indices(self.getNumSlices()))], 2)
TypeError: slice indices must be integers or None or have an __index__ method
```

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
type as int
