### PR TITLE
Mesh fixes

### DIFF
--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -188,8 +188,8 @@ VERTEX_DTYPE2 = np.dtype([('position0', 'f4'),
 cdef extern from "triangle_mesh_utils.c":
     void _update_face_normals(np.int32_t *f_idxs, halfedge_t *halfedges, vertex_d *vertices, face_d *faces, signed int n_idxs)
     
-    void update_face_normal(int f_idx, halfedge_t *halfedges, vertex_d *vertices, face_d *faces)
-    void update_single_vertex_neighbours(int v_idx, halfedge_t *halfedges, vertex_d *vertices, face_d *faces)
+    void update_face_normal(np.int32_t f_idx, halfedge_t *halfedges, vertex_d *vertices, face_d *faces)
+    void update_single_vertex_neighbours(np.int32_t v_idx, halfedge_t *halfedges, vertex_d *vertices, face_d *faces)
 
 LOOP_ALPHA_FACTOR = (np.log(13)-np.log(3))/12
 
@@ -2075,8 +2075,7 @@ cdef class TriangleMesh(TrianglesBase):
             # TODO - move this to a helper function
             self._vertices['locally_manifold'] = 1
             self._vertices['locally_manifold'][self._halfedges['vertex'][self._halfedges['twin'] == -1]] = 0
-            self._vertices['locally_manifold'][-1] = (self._halfedges['vertex'][-1] != -1) and (self._halfedges['twin'][-1] != -1)
-
+            
             for i in range(n_halfedges):
                 if (self._chalfedges[i].vertex != -1) and (self._chalfedges[i].length < collapse_threshold):
                     self.edge_collapse(i)
@@ -2089,7 +2088,6 @@ cdef class TriangleMesh(TrianglesBase):
             # TODO - move this to a helper function / make collapse update this so we don't need to recompute
             self._vertices['locally_manifold'] = 1
             self._vertices['locally_manifold'][self._halfedges['vertex'][self._halfedges['twin'] == -1]] = 0
-            self._vertices['locally_manifold'][-1] = (self._halfedges['vertex'][-1] != -1) and (self._halfedges['twin'][-1] != -1)
             
             self.regularize()
 
@@ -2550,11 +2548,11 @@ cdef class TriangleMesh(TrianglesBase):
             
             update_face_normal(self._chalfedges[_h0_twin].face, self._chalfedges, self._cvertices, self._cfaces)
             update_face_normal(self._chalfedges[h0].face, self._chalfedges, self._cvertices, self._cfaces)
-            update_face_normal(self._halfedges[h1].face, self._chalfedges, self._cvertices, self._cfaces)
+            update_face_normal(self._chalfedges[h1].face, self._chalfedges, self._cvertices, self._cfaces)
             
-            update_single_vertex_neighbours(self._halfedges['vertex'][_h0_twin], self._chalfedges, self._cvertices, self._cfaces)
-            update_single_vertex_neighbours(self._halfedges['vertex'][h0], self._chalfedges, self._cvertices, self._cfaces)
-            update_single_vertex_neighbours(self._halfedges['vertex'][h1], self._chalfedges, self._cvertices, self._cfaces)
+            update_single_vertex_neighbours(self._chalfedges[_h0_twin].vertex, self._chalfedges, self._cvertices, self._cfaces)
+            update_single_vertex_neighbours(self._chalfedges[h0].vertex, self._chalfedges, self._cvertices, self._cfaces)
+            update_single_vertex_neighbours(self._chalfedges[h1].vertex, self._chalfedges, self._cvertices, self._cfaces)
 
     def _zig_zag_triangulation(self, polygon):
         """

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -23,8 +23,8 @@ cdef extern from 'triangle_mesh_utils.h':
         
     cdef struct face_t:
         np.int32_t halfedge
-        float normal[VECTORSIZE]
-        float area
+        np.float32_t normal[VECTORSIZE]
+        np.float32_t area
         np.int32_t component
         
     cdef struct face_d:
@@ -36,12 +36,12 @@ cdef extern from 'triangle_mesh_utils.h':
         np.int32_t component
         
     cdef struct vertex_t:
-        float position[VECTORSIZE];
-        float normal[VECTORSIZE];
-        np.int32_t halfedge;
-        np.int32_t valence;
-        np.int32_t neighbors[NEIGHBORSIZE];
-        np.int32_t component;
+        np.float32_t position[VECTORSIZE]
+        np.float32_t normal[VECTORSIZE]
+        np.int32_t halfedge
+        np.int32_t valence
+        np.int32_t neighbors[NEIGHBORSIZE]
+        np.int32_t component
         np.int32_t locally_manifold
         
     cdef struct vertex_d:

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -2074,8 +2074,9 @@ cdef class TriangleMesh(TrianglesBase):
             #find which vertices are locally manifold
             # TODO - move this to a helper function
             self._vertices['locally_manifold'] = 1
-            self._vertices['locally_manifold'][self._halfedges['vertex'][(self._halfedges['twin'] == -1) | (self._halfedges['vertex'] == -1)]] = 0
-            
+            self._vertices['locally_manifold'][self._halfedges['vertex'][self._halfedges['twin'] == -1]] = 0
+            self._vertices['locally_manifold'][-1] = (self._halfedges['vertex'][-1] != -1) and (self._halfedges['twin'][-1] != -1)
+
             for i in range(n_halfedges):
                 if (self._chalfedges[i].vertex != -1) and (self._chalfedges[i].length < collapse_threshold):
                     self.edge_collapse(i)
@@ -2087,7 +2088,8 @@ cdef class TriangleMesh(TrianglesBase):
             # find which vertices are locally manifold
             # TODO - move this to a helper function / make collapse update this so we don't need to recompute
             self._vertices['locally_manifold'] = 1
-            self._vertices['locally_manifold'][self._halfedges['vertex'][(self._halfedges['twin'] == -1) | (self._halfedges['vertex'] == -1)]] = 0
+            self._vertices['locally_manifold'][self._halfedges['vertex'][self._halfedges['twin'] == -1]] = 0
+            self._vertices['locally_manifold'][-1] = (self._halfedges['vertex'][-1] != -1) and (self._halfedges['twin'][-1] != -1)
             
             self.regularize()
 

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -2087,7 +2087,7 @@ cdef class TriangleMesh(TrianglesBase):
             # find which vertices are locally manifold
             # TODO - move this to a helper function / make collapse update this so we don't need to recompute
             self._vertices['locally_manifold'] = 1
-            self._vertices['locally_manifold'][self._halfedges['vertex'][self._halfedges['twin'] == -1]] = 0
+            self._vertices['locally_manifold'][self._halfedges['vertex'][(self._halfedges['twin'] == -1) & (self._halfedges['vertex'] != -1)]] = 0
             
             self.regularize()
 

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -2074,7 +2074,7 @@ cdef class TriangleMesh(TrianglesBase):
             #find which vertices are locally manifold
             # TODO - move this to a helper function
             self._vertices['locally_manifold'] = 1
-            self._vertices['locally_manifold'][self._halfedges['vertex'][self._halfedges['twin'] == -1]] = 0
+            self._vertices['locally_manifold'][self._halfedges['vertex'][(self._halfedges['twin'] == -1) | (self._halfedges['vertex'] == -1)]] = 0
             
             for i in range(n_halfedges):
                 if (self._chalfedges[i].vertex != -1) and (self._chalfedges[i].length < collapse_threshold):
@@ -2087,7 +2087,7 @@ cdef class TriangleMesh(TrianglesBase):
             # find which vertices are locally manifold
             # TODO - move this to a helper function / make collapse update this so we don't need to recompute
             self._vertices['locally_manifold'] = 1
-            self._vertices['locally_manifold'][self._halfedges['vertex'][(self._halfedges['twin'] == -1) & (self._halfedges['vertex'] != -1)]] = 0
+            self._vertices['locally_manifold'][self._halfedges['vertex'][(self._halfedges['twin'] == -1) | (self._halfedges['vertex'] == -1)]] = 0
             
             self.regularize()
 

--- a/PYME/experimental/triangle_mesh_utils.c
+++ b/PYME/experimental/triangle_mesh_utils.c
@@ -72,6 +72,8 @@ static void update_single_vertex_neighbours(int v_idx, halfedge_t *halfedges, vo
     vertex_t *vertices = (vertex_t*) vertices_;
     face_t *faces = (face_t*) faces_;
 
+    if (v_idx == -1) return;
+
     curr_vertex = &(vertices[v_idx]);
 
     curr_idx = curr_vertex->halfedge;
@@ -274,6 +276,8 @@ static void update_face_normal(int f_idx, halfedge_t *halfedges, void *vertices_
     halfedge_t *curr_edge, *prev_edge, *next_edge;
     face_t *curr_face;
     vertex_t *curr_vertex, *prev_vertex, *next_vertex;
+
+    if (f_idx == -1) return;
 
     curr_face = &(faces[f_idx]);
 

--- a/PYME/experimental/triangle_mesh_utils.c
+++ b/PYME/experimental/triangle_mesh_utils.c
@@ -58,7 +58,7 @@ DB: Performance suggestions:
 
 */
 
-static void update_single_vertex_neighbours(int v_idx, halfedge_t *halfedges, void *vertices_, void *faces_)
+static void update_single_vertex_neighbours(int32_t v_idx, halfedge_t *halfedges, void *vertices_, void *faces_)
 {
     int32_t i, k, orig_idx, curr_idx, twin_idx, tmp;
     halfedge_t *curr_edge, *twin_edge;
@@ -264,9 +264,9 @@ static PyObject *update_vertex_neighbors(PyObject *self, PyObject *args)
 }
 
 
-static void update_face_normal(int f_idx, halfedge_t *halfedges, void *vertices_, void *faces_)
+static void update_face_normal(int32_t f_idx, halfedge_t *halfedges, void *vertices_, void *faces_)
 {
-    int k, curr_idx, prev_idx, next_idx;
+    int32_t k, curr_idx, prev_idx, next_idx;
 
     float v1[VECTORSIZE], u[VECTORSIZE], v[VECTORSIZE], n[VECTORSIZE], nn;
 
@@ -319,7 +319,7 @@ static void update_face_normal(int f_idx, halfedge_t *halfedges, void *vertices_
 
 static void _update_face_normals(int32_t *f_idxs, halfedge_t *halfedges, vertex_t *vertices, face_t *faces, signed int n_idxs)
 {
-    int f_idx;
+    int32_t f_idx;
     for (int j = 0; j < n_idxs; ++j)
     {
         f_idx = f_idxs[j];


### PR DESCRIPTION
The recent mesh speedups cause the resulting mesh to look slightly different from how it used to look.

**Is this a bugfix or an enhancement?**
Bugfix, I think, unless the speedup also included some bugfixes.

**Proposed changes:**
- Update local manifold definition (not the fix, but useful)
- Consistency in use of int32_t and `halfedge` vs. `chalfedge` (not the fix, but useful)
- ...




**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
