### PR TITLE
Meshing tweaks

### DIFF
--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -1236,6 +1236,7 @@ cdef class TriangleMesh(TrianglesBase):
         cdef int idx
         
         try:
+            # TODO: This was originally set to pop(0). What was the reasoning?
             idx = el_vacancies.pop(-1)
         except IndexError:
             # no vacant slot, resize
@@ -1254,6 +1255,7 @@ cdef class TriangleMesh(TrianglesBase):
                 # el_vacancies = [int(x) for x in np.flatnonzero(el_arr[key] == -1)]
                 el_vacancies = np.flatnonzero(el_arr[key] == -1).tolist()
 
+            # TODO: This was originally set to pop(0). What was the reasoning?
             idx = el_vacancies.pop(-1)
 
         if idx == -1:

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -1236,7 +1236,7 @@ cdef class TriangleMesh(TrianglesBase):
         cdef int idx
         
         try:
-            # TODO: This was originally set to pop(0). What was the reasoning?
+            # This was originally set to pop(0) to try to fill in early gaps in the array before later ones.
             idx = el_vacancies.pop(-1)
         except IndexError:
             # no vacant slot, resize
@@ -1255,7 +1255,7 @@ cdef class TriangleMesh(TrianglesBase):
                 # el_vacancies = [int(x) for x in np.flatnonzero(el_arr[key] == -1)]
                 el_vacancies = np.flatnonzero(el_arr[key] == -1).tolist()
 
-            # TODO: This was originally set to pop(0). What was the reasoning?
+            # This was originally set to pop(0) to try to fill in early gaps in the array before later ones.
             idx = el_vacancies.pop(-1)
 
         if idx == -1:
@@ -1355,7 +1355,7 @@ cdef class TriangleMesh(TrianglesBase):
         
         cdef int idx
         
-        idx = self._insert_new_edge(vertex, compact, **kwargs)
+        idx = self._insert_new_edge(vertex, **kwargs)
         
         ed = self._halfedges[idx]
         return ed, idx

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -2075,7 +2075,7 @@ cdef class TriangleMesh(TrianglesBase):
             # TODO - move this to a helper function
             self._vertices['locally_manifold'] = 1
             self._vertices['locally_manifold'][self._halfedges['vertex'][self._halfedges['twin'] == -1]] = 0
-            self._vertices['locally_manifold'][-1] = (self._halfedges['vertex'] != -1) and (self._halfedges['twin'][-1] == -1)
+            self._vertices['locally_manifold'][-1] = (self._halfedges['vertex'][-1] != -1) and (self._halfedges['twin'][-1] == -1)
             
             for i in range(n_halfedges):
                 if (self._chalfedges[i].vertex != -1) and (self._chalfedges[i].length < collapse_threshold):
@@ -2089,7 +2089,7 @@ cdef class TriangleMesh(TrianglesBase):
             # TODO - move this to a helper function / make collapse update this so we don't need to recompute
             self._vertices['locally_manifold'] = 1
             self._vertices['locally_manifold'][self._halfedges['vertex'][self._halfedges['twin'] == -1]] = 0
-            self._vertices['locally_manifold'][-1] = (self._halfedges['vertex'] != -1) and (self._halfedges['twin'][-1] == -1)
+            self._vertices['locally_manifold'][-1] = (self._halfedges['vertex'][-1] != -1) and (self._halfedges['twin'][-1] == -1)
             
             self.regularize()
 

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -2075,6 +2075,7 @@ cdef class TriangleMesh(TrianglesBase):
             # TODO - move this to a helper function
             self._vertices['locally_manifold'] = 1
             self._vertices['locally_manifold'][self._halfedges['vertex'][self._halfedges['twin'] == -1]] = 0
+            self._vertices['locally_manifold'][-1] = (self._halfedges['vertex'] != -1) and (self._halfedges['twin'][-1] == -1)
             
             for i in range(n_halfedges):
                 if (self._chalfedges[i].vertex != -1) and (self._chalfedges[i].length < collapse_threshold):
@@ -2088,6 +2089,7 @@ cdef class TriangleMesh(TrianglesBase):
             # TODO - move this to a helper function / make collapse update this so we don't need to recompute
             self._vertices['locally_manifold'] = 1
             self._vertices['locally_manifold'][self._halfedges['vertex'][self._halfedges['twin'] == -1]] = 0
+            self._vertices['locally_manifold'][-1] = (self._halfedges['vertex'] != -1) and (self._halfedges['twin'][-1] == -1)
             
             self.regularize()
 

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -2550,11 +2550,11 @@ cdef class TriangleMesh(TrianglesBase):
             
             update_face_normal(self._chalfedges[_h0_twin].face, self._chalfedges, self._cvertices, self._cfaces)
             update_face_normal(self._chalfedges[h0].face, self._chalfedges, self._cvertices, self._cfaces)
-            update_face_normal(self._halfedges[h1].face, self._chalfedges, self._cvertices, self._cfaces)
+            update_face_normal(self._chalfedges[h1].face, self._chalfedges, self._cvertices, self._cfaces)
             
-            update_single_vertex_neighbours(self._halfedges['vertex'][_h0_twin], self._chalfedges, self._cvertices, self._cfaces)
-            update_single_vertex_neighbours(self._halfedges['vertex'][h0], self._chalfedges, self._cvertices, self._cfaces)
-            update_single_vertex_neighbours(self._halfedges['vertex'][h1], self._chalfedges, self._cvertices, self._cfaces)
+            update_single_vertex_neighbours(self._chalfedges[_h0_twin].vertex, self._chalfedges, self._cvertices, self._cfaces)
+            update_single_vertex_neighbours(self._chalfedges[h0].vertex, self._chalfedges, self._cvertices, self._cfaces)
+            update_single_vertex_neighbours(self._chalfedges[h1].vertex, self._chalfedges, self._cvertices, self._cfaces)
 
     def _zig_zag_triangulation(self, polygon):
         """

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -36,12 +36,12 @@ cdef extern from 'triangle_mesh_utils.h':
         np.int32_t component
         
     cdef struct vertex_t:
-        float position[VECTORSIZE];
-        float normal[VECTORSIZE];
-        np.int32_t halfedge;
-        np.int32_t valence;
-        np.int32_t neighbors[NEIGHBORSIZE];
-        np.int32_t component;
+        float position[VECTORSIZE]
+        float normal[VECTORSIZE]
+        np.int32_t halfedge
+        np.int32_t valence
+        np.int32_t neighbors[NEIGHBORSIZE]
+        np.int32_t component
         np.int32_t locally_manifold
         
     cdef struct vertex_d:

--- a/PYME/experimental/triangle_mesh_utils.c
+++ b/PYME/experimental/triangle_mesh_utils.c
@@ -72,6 +72,8 @@ static void update_single_vertex_neighbours(int v_idx, halfedge_t *halfedges, vo
     vertex_t *vertices = (vertex_t*) vertices_;
     face_t *faces = (face_t*) faces_;
 
+    if (v_idx == -1) return;
+
     curr_vertex = &(vertices[v_idx]);
 
     curr_idx = curr_vertex->halfedge;
@@ -274,6 +276,8 @@ static void update_face_normal(int f_idx, halfedge_t *halfedges, void *vertices_
     halfedge_t *curr_edge, *prev_edge, *next_edge;
     face_t *curr_face;
     vertex_t *curr_vertex, *prev_vertex, *next_vertex;
+
+    if (f_idxs == -1) return;
 
     curr_face = &(faces[f_idx]);
 

--- a/PYME/experimental/triangle_mesh_utils.c
+++ b/PYME/experimental/triangle_mesh_utils.c
@@ -277,7 +277,7 @@ static void update_face_normal(int f_idx, halfedge_t *halfedges, void *vertices_
     face_t *curr_face;
     vertex_t *curr_vertex, *prev_vertex, *next_vertex;
 
-    if (f_idxs == -1) return;
+    if (f_idx == -1) return;
 
     curr_face = &(faces[f_idx]);
 


### PR DESCRIPTION
A few cleanups. Nothing major.

**Is this a bugfix or an enhancement?**
Bugfix, barely

**Proposed changes:**
- Remove extraneous argument from `_insert_new_edge`
- Extra safety checks for -1 halfedges in the single vertex/face update functions
- Make sure the last entry in `locally_manifold` isn't automatically marked as non-manifold
- Consistent use of `chalfedges` vs. `halfedges`


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
