### PR TITLE
pymajor version in install docs

### DIFF
--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -5,12 +5,10 @@ Installation
 
 The best to install PYME will depend on your background and whether you are already using python on your computer.
 
-Executable installers (Windows-only)
-=====================================
+Executable installers (Windows and OSX)
+=======================================
 
 Recommended if you don't already have python on your computer and/or are unfamiliar with python. Download the latest installer from https://python-microscopy.org/downloads/. Double-click the installer and follow instructions. 
-
-**Caveats:** The executable installers lag the conda packages so you're getting an older version. The installers give you a bunch of error messages which you can safely ignore.
 
 
 Installing using conda
@@ -27,7 +25,7 @@ Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. note::
 
-    **Which Python version?** We are currently in the process of switching the default install from Python 2.7 to Python 3.7. As of 2020/09/25, we support both. Some parts of the Python 2 version are better tested, but the core functionality runs on Python 3. We aim to drop Python 2 support in January of 2021.
+    **Which Python version?** We are in the process of switching the default install from Python 2.7 to Python 3.6. As of 2020/09/25, we support python 2.7, 3.6 & 3.7. The Python 2 version is currently better tested, but the most of the core functionality runs on Python 3. Due to ongoing changes in the anaconda repositories, installation on Python 3 tends to be easier. We aim to drop Python 2 support in January of 2021.
 
 
 Updating

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -16,7 +16,7 @@ Recommended if you don't already have python on your computer and/or are unfamil
 Installing using conda
 ======================
 
-Download and install the python **2.7** version of `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
+Download and install the python 3.7 version of `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
 Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. code-block:: bash
@@ -27,7 +27,7 @@ Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. note::
 
-    **Which python version?** We are currently in the process of switching the default install from python 2.7 to python 3. As of 2020/8/6 the python 3 packages are not in the above conda channel, but that should change shortly. The python2.7 version is better tested, but most of the core functionality now runs on python 3 as well.
+    **Which Python version?** We are currently in the process of switching the default install from Python 2 to Python 3. As of 2020/09/25, we support both. Some parts of the Python 2 version are better tested, but the core functionality runs on Python 3. We aim to drop Python 2 support in January of 2021.
 
 
 Updating

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -16,7 +16,7 @@ Recommended if you don't already have python on your computer and/or are unfamil
 Installing using conda
 ======================
 
-Download and install the python 3.7 version of `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
+Download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
 Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. code-block:: bash
@@ -27,7 +27,7 @@ Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. note::
 
-    **Which Python version?** We are currently in the process of switching the default install from Python 2 to Python 3. As of 2020/09/25, we support both. Some parts of the Python 2 version are better tested, but the core functionality runs on Python 3. We aim to drop Python 2 support in January of 2021.
+    **Which Python version?** We are currently in the process of switching the default install from Python 2.7 to Python 3.7. As of 2020/09/25, we support both. Some parts of the Python 2 version are better tested, but the core functionality runs on Python 3. We aim to drop Python 2 support in January of 2021.
 
 
 Updating

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -25,7 +25,7 @@ Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. note::
 
-    **Which Python version?** We are in the process of switching the default install from Python 2.7 to Python 3.6. As of 2020/09/25, we support python 2.7, 3.6 & 3.7. The Python 2 version is currently better tested, but the most of the core functionality runs on Python 3. Due to ongoing changes in the anaconda repositories, installation on Python 3 tends to be easier. We aim to drop Python 2 support in January of 2021.
+    **Which Python version?** We are in the process of switching the default install from Python 2.7 to Python 3.6. As of 2020/09/25, we support python 2.7, 3.6 & 3.7. The Python 2 version is currently better tested, but most of the core functionality runs on Python 3. Due to ongoing changes in the anaconda repositories, installation on Python 3 tends to be easier. We aim to drop Python 2 support in January of 2021.
 
 
 Updating


### PR DESCRIPTION
Addresses issue people emailing me unable to install PYME with the miniconda 2.7 install.

**Proposed changes:**
- just tell people to install miniconda; in the note we already say our piece about versions/status