### PR TITLE
if image is grayscale don't try to convert to cmy

### DIFF
--- a/PYME/IO/rgb_image.py
+++ b/PYME/IO/rgb_image.py
@@ -26,6 +26,8 @@ def image_to_rgb(image, zoom=1.0, scaling='min-max', scaling_factor=0.99):
 
 def image_to_cmy(image, *args, **kwargs):
     data = image_to_rgb(image, *args, **kwargs)
+    if image.data.shape[3] == 1:
+        return data  # grayscale, can't convert to CMY (rather than CMYK)
     
     output = np.zeros_like(data)
     


### PR DESCRIPTION
Addresses issue #452 

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- check if image is grayscale and skip 'RGB' -> CMY conversion in that case