### PR TITLE
make FlatfieldAndDarkCorrect work for multiview data/without flatmap

### DIFF
--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -136,6 +136,8 @@ class CameraInfoManager(object):
         """
         Extract ROI coordinates from metadata
 
+        TODO - refactor out of here as it is being used in non-fitting code
+
         Parameters
         ----------
         md: dict-like

--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -131,7 +131,8 @@ class CameraInfoManager(object):
     def __init__(self):
         self._cache = {}
 
-    def _parseROI(self, md):
+    @staticmethod
+    def _parseROI(md):
         """
         Extract ROI coordinates from metadata
 

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -1540,7 +1540,10 @@ class FlatfiledAndDarkCorrect(ModuleBase):
         from PYME.IO.image import ImageStack
         image = namespace[self.inputImage]
         
-        flat = ImageStack(filename=self.flatfieldFilename).data[:,:,0].squeeze()
+        if self.flatfieldFilename != '':
+            flat = ImageStack(filename=self.flatfieldFilename).data[:,:,0].squeeze()
+        else:
+            flat = None
         
         if not self.darkFilename == '':
             dark = ImageStack(filename=self.darkFilename).data[:,:,0].squeeze()


### PR DESCRIPTION
Addresses issue camera origin + camera roi size often won't get you the right darkmap slice for multiview data.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- use camera info manager to get slices
- make flatfield map optional



**Checklist:**

- [ ] Tested with numpy=1.14
1.16
- [ ] Tested on python 2.7 and 3.6
3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
