### PR TITLE
tweaks to HTSMS init/protocols (and one UOA_n!)

### DIFF
--- a/PYME/Acquire/Protocols/htsms-flow.py
+++ b/PYME/Acquire/Protocols/htsms-flow.py
@@ -7,8 +7,7 @@ taskList = [
     T(0, scope.focus_lock.DisableLock),
     # T(8000, scope.l560.TurnOn),
     # T(maxint, scope.turnAllLasersOff),
-    T(maxint, scope.focus_lock.EnableLock),
-    T(maxint, scope.spoolController.LaunchAnalysis)  # todo - add this back in
+    T(maxint, scope.focus_lock.EnableLock)
 ]
 
 metaData = [

--- a/PYME/Acquire/Protocols/htsms-staggered.py
+++ b/PYME/Acquire/Protocols/htsms-staggered.py
@@ -8,7 +8,7 @@ taskList = [
     T(8000, scope.l560.TurnOn),
     T(maxint, scope.turnAllLasersOff),
     T(maxint, scope.focus_lock.EnableLock),
-    T(maxint, scope.spoolController.LaunchAnalysis)
+    # T(maxint, scope.spoolController.LaunchAnalysis)
 ]
 
 metaData = [

--- a/PYME/Acquire/Protocols/htsms-two-color.py
+++ b/PYME/Acquire/Protocols/htsms-two-color.py
@@ -7,8 +7,7 @@ taskList = [
     T(-1, scope.l560.TurnOn),
     T(0, scope.focus_lock.DisableLock),
     T(maxint, scope.turnAllLasersOff),
-    T(maxint, scope.focus_lock.EnableLock),
-    T(maxint, scope.spoolController.LaunchAnalysis)
+    T(maxint, scope.focus_lock.EnableLock)
 ]
 
 metaData = [

--- a/PYME/Acquire/Scripts/init_UOA_n.py
+++ b/PYME/Acquire/Scripts/init_UOA_n.py
@@ -235,7 +235,7 @@ def drift_tracking(MainFrame, scope):
 
     def _drift_init():
         #scope.p_drift = subprocess.Popen('%s "%s" -i init_drift_tracking.py -t "Drift Tracking" -m "compact"' % (sys.executable, PYMEAcquire.__file__), shell=True)
-        scope.p_drift = subprocess.Popen('%s "%s" -i init_drift_tracking.py -t "Drift Tracking"' % (sys.executable, PYMEAcquire.__file__), shell=True)
+        scope.p_drift = subprocess.Popen('%s "%s" -i init_drift_tracking.py -t "Drift Tracking"' % (sys.executable, PYMEAcquire.__file__), creationflags=subprocess.CREATE_NEW_CONSOLE)
 
     time.sleep(15)
     _drift_init()

--- a/PYME/Acquire/Scripts/init_UOA_n.py
+++ b/PYME/Acquire/Scripts/init_UOA_n.py
@@ -235,7 +235,7 @@ def drift_tracking(MainFrame, scope):
 
     def _drift_init():
         #scope.p_drift = subprocess.Popen('%s "%s" -i init_drift_tracking.py -t "Drift Tracking" -m "compact"' % (sys.executable, PYMEAcquire.__file__), shell=True)
-        scope.p_drift = subprocess.Popen('%s "%s" -i init_drift_tracking.py -t "Drift Tracking"' % (sys.executable, PYMEAcquire.__file__), creationflags=subprocess.CREATE_NEW_CONSOLE)
+        scope.p_drift = subprocess.Popen('%s "%s" -i init_drift_tracking.py -t "Drift Tracking"' % (sys.executable, PYMEAcquire.__file__), shell=True)
 
     time.sleep(15)
     _drift_init()
@@ -253,5 +253,4 @@ joinBGInit() #wait for anyhting which was being done in a separate thread
 
 #time.sleep(.5)
 scope.initDone = True
-
 

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -1,5 +1,7 @@
 import wx
 from PYME.Acquire.Utils import tiler
+import logging
+logger = logging.getLogger(__name__)
 
 class TilePanel(wx.Panel):
     def __init__(self, parent, scope):
@@ -93,7 +95,7 @@ class TilePanel(wx.Panel):
         self.scope.tiler.on_stop.disconnect(self._on_stop)
         self.scope.tiler.progress.disconnect(self._update)
         
-        wx.CallAfter(wx.CallLater,1e3, self._launch_viewer)
+        wx.CallAfter(wx.CallLater,1e4, self._launch_viewer)
         
         
     def _launch_viewer(self):
@@ -111,7 +113,7 @@ class TilePanel(wx.Panel):
         try:
             requests.get('http://127.0.0.1:8979/set_tile_source?tile_dir=%s' % self.scope.tiler._tiledir)
         except requests.ConnectionError:
-            self._gui_proc = subprocess.Popen('%s -m PYME.tileviewer.tileviewer %s' % (sys.executable, self.scope.tiler._tiledir), shell=True)
+            self._gui_proc = subprocess.Popen('%s -m PYME.tileviewer.tileviewer %s' % (sys.executable, self.scope.tiler._tiledir), creationflags=subprocess.CREATE_NEW_CONSOLE)
             time.sleep(3)
             
         webbrowser.open('http://127.0.0.1:8979/')

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -1,7 +1,5 @@
 import wx
 from PYME.Acquire.Utils import tiler
-import logging
-logger = logging.getLogger(__name__)
 
 class TilePanel(wx.Panel):
     def __init__(self, parent, scope):

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -114,7 +114,9 @@ class TilePanel(wx.Panel):
         # abs path the tile dir
         tiledir = self.scope.tiler._tiledir
         if not os.path.isabs(tiledir):
-            tiledir = os.path.join(os.getcwd(), tiledir)
+            # TODO - should we be doing the `.isabs()` check on the parent directory instead?
+            from PYME.IO.FileUtils import nameUtils
+            tiledir = nameUtils.getFullFilename(tiledir)
         
         try:  # if we already have a tileviewer serving, change the directory
             requests.get('http://127.0.0.1:8979/set_tile_source?tile_dir=%s' % tiledir)

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -93,6 +93,8 @@ class TilePanel(wx.Panel):
         self.scope.tiler.on_stop.disconnect(self._on_stop)
         self.scope.tiler.progress.disconnect(self._update)
         
+        # FIXME - previous delay was 1e3, which seems more reasonable. Do we need a config option (or heuristic) here ?
+        # assume this change was due to the time it takes to build a pyramid after tiling ends. Might ultimately be fixed when we revisit live tiling. 
         wx.CallAfter(wx.CallLater,1e4, self._launch_viewer)
         
         

--- a/PYME/IO/rgb_image.py
+++ b/PYME/IO/rgb_image.py
@@ -26,6 +26,8 @@ def image_to_rgb(image, zoom=1.0, scaling='min-max', scaling_factor=0.99):
 
 def image_to_cmy(image, *args, **kwargs):
     data = image_to_rgb(image, *args, **kwargs)
+    if image.data.shape[3] == 1:
+        return data  # grayscale, can't convert to CMY (rather than CMYK)
     
     output = np.zeros_like(data)
     

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PYME (the PYthon Microscopy Environment) is an open-source application suite for
 ![plat](https://img.shields.io/conda/pn/david_baddeley/python-microscopy.svg)-->
 
 - **Website:** https://www.python-microscopy.org
-- **Installation:** https://www.python-microscopy.org/doc/Installation/InstallationWithAnaconda.html
+- **Installation:** https://python-microscopy.org/doc/Installation/Installation.html
 - **Documentation:** https://python-microscopy.org/doc/
 - **Source code:** https://github.com/python-microscopy/python-microscopy/
 - **Contributing:** https://python-microscopy.org/doc/Contributing.html
@@ -20,4 +20,4 @@ PYME (the PYthon Microscopy Environment) is an open-source application suite for
 The documentation is also available in the *docs* subdirectory of the repository.
 
 **Have a question?** Get in touch! \
-You can email us on support@python-microscopy.org, or raise a [support issue](https://github.com/python-microscopy/python-microscopy/issues/new?assignees=&labels=support&template=support.md&title=%5BSUPPORT%5D). We are also active on the [image.sc forum](https://forum.image.sc/) - tag your post with `pyme` and we'll be happy to support you.
+You can email us at support@python-microscopy.org, or raise a [support issue](https://github.com/python-microscopy/python-microscopy/issues/new?assignees=&labels=support&template=support.md&title=%5BSUPPORT%5D). We are also active on the [image.sc forum](https://forum.image.sc/) - tag your post with `pyme` and we'll be happy to support you.

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -5,12 +5,10 @@ Installation
 
 The best to install PYME will depend on your background and whether you are already using python on your computer.
 
-Executable installers (Windows-only)
-=====================================
+Executable installers (Windows and OSX)
+=======================================
 
 Recommended if you don't already have python on your computer and/or are unfamiliar with python. Download the latest installer from https://python-microscopy.org/downloads/. Double-click the installer and follow instructions. 
-
-**Caveats:** The executable installers lag the conda packages so you're getting an older version. The installers give you a bunch of error messages which you can safely ignore.
 
 
 Installing using conda
@@ -27,7 +25,7 @@ Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. note::
 
-    **Which Python version?** We are currently in the process of switching the default install from Python 2.7 to Python 3.7. As of 2020/09/25, we support both. Some parts of the Python 2 version are better tested, but the core functionality runs on Python 3. We aim to drop Python 2 support in January of 2021.
+    **Which Python version?** We are in the process of switching the default install from Python 2.7 to Python 3.6. As of 2020/09/25, we support python 2.7, 3.6 & 3.7. The Python 2 version is currently better tested, but the most of the core functionality runs on Python 3. Due to ongoing changes in the anaconda repositories, installation on Python 3 tends to be easier. We aim to drop Python 2 support in January of 2021.
 
 
 Updating

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -16,7 +16,7 @@ Recommended if you don't already have python on your computer and/or are unfamil
 Installing using conda
 ======================
 
-Download and install the python **2.7** version of `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
+Download and install the python 3.7 version of `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
 Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. code-block:: bash
@@ -27,7 +27,7 @@ Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. note::
 
-    **Which python version?** We are currently in the process of switching the default install from python 2.7 to python 3. As of 2020/8/6 the python 3 packages are not in the above conda channel, but that should change shortly. The python2.7 version is better tested, but most of the core functionality now runs on python 3 as well.
+    **Which Python version?** We are currently in the process of switching the default install from Python 2 to Python 3. As of 2020/09/25, we support both. Some parts of the Python 2 version are better tested, but the core functionality runs on Python 3. We aim to drop Python 2 support in January of 2021.
 
 
 Updating

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -16,7 +16,7 @@ Recommended if you don't already have python on your computer and/or are unfamil
 Installing using conda
 ======================
 
-Download and install the python 3.7 version of `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
+Download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
 Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. code-block:: bash
@@ -27,7 +27,7 @@ Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. note::
 
-    **Which Python version?** We are currently in the process of switching the default install from Python 2 to Python 3. As of 2020/09/25, we support both. Some parts of the Python 2 version are better tested, but the core functionality runs on Python 3. We aim to drop Python 2 support in January of 2021.
+    **Which Python version?** We are currently in the process of switching the default install from Python 2.7 to Python 3.7. As of 2020/09/25, we support both. Some parts of the Python 2 version are better tested, but the core functionality runs on Python 3. We aim to drop Python 2 support in January of 2021.
 
 
 Updating

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -25,7 +25,7 @@ Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 
 .. note::
 
-    **Which Python version?** We are in the process of switching the default install from Python 2.7 to Python 3.6. As of 2020/09/25, we support python 2.7, 3.6 & 3.7. The Python 2 version is currently better tested, but the most of the core functionality runs on Python 3. Due to ongoing changes in the anaconda repositories, installation on Python 3 tends to be easier. We aim to drop Python 2 support in January of 2021.
+    **Which Python version?** We are in the process of switching the default install from Python 2.7 to Python 3.6. As of 2020/09/25, we support python 2.7, 3.6 & 3.7. The Python 2 version is currently better tested, but most of the core functionality runs on Python 3. Due to ongoing changes in the anaconda repositories, installation on Python 3 tends to be easier. We aim to drop Python 2 support in January of 2021.
 
 
 Updating


### PR DESCRIPTION
**Proposed changes:**
- open focus lock in same script but different console
- pass popen flag to UOA_n init to get a second console as well (obviously take this out if you don't want it @David-Baddeley )
- open tileviewer with separate console so it can be killed/restarted e.g. if it hangs on a recipe, etc.
- remove LaunchAnalysis calls from htsms protocols 
- remove serial fiber shaker as we switched to a wall-plug always-on unit
- extend delay in callafter from 1 to 10 s for tile_panel update_pyramid call. See #386. This isn't an elegant fix, but at least on small tiles does the trick. Didn't intend to commit this change with the rest, but it is helpful for the small tiles I've been doing on test samples lately so I'd be OK leaving it in for now.






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
