### PR TITLE
fix indexing error in fitpoints

### DIFF
--- a/PYME/recipes/measurement.py
+++ b/PYME/recipes/measurement.py
@@ -219,7 +219,7 @@ class FitPoints(ModuleBase):
         ps = img.pixelSize
         print('pixel size: %s' % ps)
 
-        for x, y, t, i in zip(inp['x'], inp['y'], inp['t'], range(len(inp['x']))):
+        for x, y, t, i in zip(inp['x'], inp['y'], inp['t'].astype(int), range(len(inp['x']))):
             if not t == ff_t:
                 md['tIndex'] = t
                 ff = fitMod.FitFactory(img.data[:, :, t, self.channel], md)


### PR DESCRIPTION
Addresses issue 

```
pixel size: 115.0
ERROR:PYME.recipes.base:Error in recipe module: <PYME.recipes.measurement.FitPoints object at 0x7fd667477a98>
Traceback (most recent call last):
  File "/home/smeagol/code/python-microscopy/PYME/recipes/base.py", line 641, in execute
    m.execute(self.namespace)
  File "/home/smeagol/code/python-microscopy/PYME/recipes/measurement.py", line 225, in execute
    ff = fitMod.FitFactory(img.data[:, :, t, self.channel], md)
  File "/home/smeagol/code/python-microscopy/PYME/IO/DataSources/BaseDataSource.py", line 124, in __getitem__
    r = np.concatenate([np.atleast_2d(self.getSlice(i)[keys[0], keys[1]])[:,:,None] for i in range(*keys[2].indices(self.getNumSlices()))], 2)
TypeError: slice indices must be integers or None or have an __index__ method

```

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
type t as int before we slice

Note we could also fix this downstream in basedatasource as this has come up a couple times (#450 most recently), though it wouldn't hurt to fix here and basedatasource reworking is already on the roadmap.



**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
