### PR TITLE
Sort the children on class name for py3

### DIFF
--- a/PYME/recipes/recipeLayout.py
+++ b/PYME/recipes/recipeLayout.py
@@ -194,7 +194,7 @@ def layout_vertical(dg, rdg):
             for child in sorted(children):
                 _descend(child, dg, rdg)
         else:
-            for child in sorted(children, key=lambda x: x if isinstance(x,str) else x.__class__.__name__) :
+            for child in sorted(children, key=lambda x: str(x)) :
                 if (not child in ordered) and (np.all([d in ordered for d in dg[child]])):
                     # are all the childs dependencies already in our list of nodes?
                     ordered.append(child)

--- a/PYME/recipes/recipeLayout.py
+++ b/PYME/recipes/recipeLayout.py
@@ -194,7 +194,7 @@ def layout_vertical(dg, rdg):
             for child in sorted(children):
                 _descend(child, dg, rdg)
         else:
-            for child in sorted(children):
+            for child in sorted(children, key=lambda x: x if isinstance(x,str) else x.__class__.__name__) :
                 if (not child in ordered) and (np.all([d in ordered for d in dg[child]])):
                     # are all the childs dependencies already in our list of nodes?
                     ordered.append(child)


### PR DESCRIPTION
Addresses issue #469.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Add a key to sort on for py3.






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
