### PR TITLE
Adjust E816 target position to take maxtravel into account

### DIFF
--- a/PYME/Acquire/Hardware/Piezos/piezo_e816.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_e816.py
@@ -216,7 +216,8 @@ class piezo_e816T(PiezoBase):
         self.position = np.array([0.])
         # self.velocity = np.array([self.maxvelocity, self.maxvelocity])
 
-        self.targetPosition = np.array([200.])
+        # self.targetPosition = np.array([200.])
+        self.targetPosition = np.array([(maxtravel / 2.0) + self.osen])
         # self.targetVelocity = self.velocity.copy()
 
         self.lastTargetPosition = self.position.copy()

--- a/PYME/Acquire/Hardware/Piezos/piezo_e816.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_e816.py
@@ -217,7 +217,7 @@ class piezo_e816T(PiezoBase):
         # self.velocity = np.array([self.maxvelocity, self.maxvelocity])
 
         # self.targetPosition = np.array([200.])
-        self.targetPosition = np.array([(maxtravel / 2.0) + self.osen])
+        self.targetPosition = np.array([(maxtravel / 2.0)])
         # self.targetVelocity = self.velocity.copy()
 
         self.lastTargetPosition = self.position.copy()


### PR DESCRIPTION
My piezo has `maxtravel` of 100 and setting the `targetPosition` to `200` by default results in a long string of attempts to reach an unreachable position.

```
DEBUG:root:Moving piezo to target: 100.000000

DEBUG:root:Moving piezo to target: 100.000000

DEBUG:root:Moving piezo to target: 100.000000

DEBUG:root:Moving piezo to target: 100.000000

DEBUG:root:Moving piezo to target: 100.000000

DEBUG:root:Moving piezo to target: 100.000000

DEBUG:root:Moving piezo to target: 100.000000

DEBUG:root:Moving piezo to target: 100.000000

DEBUG:root:Moving piezo to target: 100.000000

DEBUG:root:Moving piezo to target: 100.000000

DEBUG:root:Moving piezo to target: 100.000000

DEBUG:root:Moving piezo to target: 100.000000
```

etc.

**Is this a bugfix or an enhancement?**
Yes

**Proposed changes:**
- Set the initial target position based on maxtravel






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
