### PR TITLE
bytes/str collision in clusterUI recipe view 

### DIFF
--- a/PYME/cluster/clusterUI/recipes/views.py
+++ b/PYME/cluster/clusterUI/recipes/views.py
@@ -58,7 +58,7 @@ def run_template(request):
     output_directory = 'pyme-cluster://%s/%s' % (server_filter, request.POST.get('recipeOutputPath').lstrip('/'))
 
 
-    recipe_text = unifiedIO.read(recipeURI).decode()
+    recipe_text = unifiedIO.read(recipeURI).decode('utf-8')
     recipe = ModuleCollection.fromYAML(recipe_text)
     
     for file_input in recipe.file_inputs:
@@ -95,6 +95,5 @@ def extra_inputs(request):
     recipe = ModuleCollection.fromYAML(unifiedIO.read(recipeURI))
     
     return render(request, 'recipes/extra_inputs.html', {'file_inputs': recipe.file_inputs, 'serverfilter' : server_filter})
-
 
 

--- a/PYME/cluster/clusterUI/recipes/views.py
+++ b/PYME/cluster/clusterUI/recipes/views.py
@@ -58,7 +58,7 @@ def run_template(request):
     output_directory = 'pyme-cluster://%s/%s' % (server_filter, request.POST.get('recipeOutputPath').lstrip('/'))
 
 
-    recipe_text = unifiedIO.read(recipeURI)
+    recipe_text = unifiedIO.read(recipeURI).decode()
     recipe = ModuleCollection.fromYAML(recipe_text)
     
     for file_input in recipe.file_inputs:


### PR DESCRIPTION
Addresses issue
```
Traceback:
File "/home/smeagol/miniconda3/lib/python3.6/site-packages/django/core/handlers/exception.py" in inner
  41.             response = get_response(request)
File "/home/smeagol/miniconda3/lib/python3.6/site-packages/django/core/handlers/base.py" in _legacy_get_response
  249.             response = self._get_response(request)
File "/home/smeagol/miniconda3/lib/python3.6/site-packages/django/core/handlers/base.py" in _get_response
  187.                 response = self.process_exception_by_middleware(e, request)
File "/home/smeagol/miniconda3/lib/python3.6/site-packages/django/core/handlers/base.py" in _get_response
  185.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/home/smeagol/code/python-microscopy/PYME/cluster/clusterUI/recipes/views.py" in run_template
  66.         recipe_text = recipe_text.replace('{'+file_input +'}', input_url)
Exception Type: TypeError at /recipes/run_template/
Exception Value: a bytes-like object is required, not 'str'
```

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
decode the recipe text so it's str


