### PR TITLE
Correct name to _inject_tables_from_hdf5

### DIFF
--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -677,7 +677,7 @@ class Pipeline:
             self.filesToClose.append(h5f)
             
             #defer our IO to the recipe IO method - TODO - do this for other file types as well
-            self.recipe._inject_tables_from_h5('', h5f, filename, '.hdf')
+            self.recipe._inject_tables_from_hdf5('', h5f, filename, '.hdf')
 
             for dsname, ds_ in self.dataSources.items():
                 #loop through tables until we get one which defines x. If no table defines x, take the last table to be added


### PR DESCRIPTION
Addresses issue #475.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Change function call `_inject_tables_from_h5` to `_inject_tables_from_hdf5`






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
