### PR TITLE
Address #478 via casting of faces, vertices

### DIFF
--- a/PYME/experimental/triangle_mesh_utils.c
+++ b/PYME/experimental/triangle_mesh_utils.c
@@ -313,8 +313,10 @@ static void update_face_normal(int f_idx, halfedge_t *halfedges, void *vertices_
     }
 }
 
-static void _update_face_normals(int32_t *f_idxs, halfedge_t *halfedges, vertex_t *vertices, face_t *faces, signed int n_idxs)
+static void _update_face_normals(int32_t *f_idxs, halfedge_t *halfedges, void *vertices_, void *faces_, signed int n_idxs)
 {
+    vertex_t *vertices = (vertex_t*) vertices_;
+    face_t *faces = (face_t*) faces_;
     int f_idx;
     for (int j = 0; j < n_idxs; ++j)
     {


### PR DESCRIPTION
Addresses issue #478.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Apply same face/vertex casting as in other c functions to deal with `face_t` vs. `face_d` structs, etc.



**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
