### PR TITLE
make sure ruleserver doesn't fail if log directory isn't yet created

### DIFF
--- a/PYME/cluster/PYMERuleServer.py
+++ b/PYME/cluster/PYMERuleServer.py
@@ -52,6 +52,12 @@ def main():
     data_root = config.get('dataserver-root')
     if data_root:
         distr_log_dir = '%s/LOGS' % data_root
+        try:  # make sure the directory exists
+            os.makedirs(distr_log_dir)  # exist_ok flag not present on py2
+        except OSError as e:
+            import errno
+            if e.errno != errno.EEXIST:
+                raise e
 
         dist_log_err_file = os.path.join(distr_log_dir, 'distributor.log')
         if os.path.exists(dist_log_err_file):


### PR DESCRIPTION
Addresses issue #391 .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- make the distributor log directory if it doesn't already exist






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

could have imported makedirs_safe from HTTPDataServer but that felt a little weird and this has a descriptive comment which makes it clear we can remove it and use the exist_ok flag eventually

