### PR TITLE
make sure pipeline datasources have writable metadatahandlers

### DIFF
--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -728,7 +728,8 @@ class Pipeline:
             else:
                 ds = tabular.TextfileSource(filename, kwargs['FieldNames'])
         
-        ds.mdh = mdh
+        # make sure mdh is writable (file-based might not be)
+        ds.mdh = MetaDataHandler.NestedClassMDHandler(mdToCopy=mdh)
         if events is not None:
             # only set the .events attribute if we actually have events.
             ds.events = events


### PR DESCRIPTION
Addresses issue #492 .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- make sure datasources coming out of `pipeline._ds_from_file` have a `mdh` attribute pointing to a metadatahandler which is writable, as file-based handlers may not be depending on the mode (and regardless we don't want to edit that metadata, but rather allow any add-ons to be saved/carried forward)






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
