### PR TITLE
stop modifying input metadata in recipe modules

### DIFF
--- a/PYME/recipes/measurement.py
+++ b/PYME/recipes/measurement.py
@@ -32,12 +32,13 @@ class MultifitBlobs(ModuleBase):
         
         img = namespace[self.inputImage]
         
-        img.mdh['Analysis.PSFSigma'] = self.blobSigma
+        mdh = MetaDataHandler.NestedClassMDHandler(img.mdh)
+        mdh['Analysis.PSFSigma'] = self.blobSigma
         
         res = []
         
         for i in range(img.data.shape[2]):
-            md = MetaDataHandler.NestedClassMDHandler(img.mdh)
+            md = MetaDataHandler.NestedClassMDHandler(mdh)
             md['tIndex'] = i
             ff = GaussMultifitSR.FitFactory(self.scale*img.data[:,:,i], img.mdh, noiseSigma=np.ones_like(img.data[:,:,i].squeeze()))
         
@@ -45,7 +46,7 @@ class MultifitBlobs(ModuleBase):
             
         #FIXME - this shouldn't be a DataFrame
         res = pd.DataFrame(np.vstack(res))
-        res.mdh = img.mdh
+        res.mdh = mdh
         
         namespace[self.outputName] = res
 

--- a/PYME/recipes/multiview.py
+++ b/PYME/recipes/multiview.py
@@ -2,6 +2,7 @@ from .base import register_module, ModuleBase, Filter
 from .traits import Input, Output, Float, CStr, Bool, Int, FileOrURI
 import numpy as np
 from PYME.IO import tabular
+from PYME.IO import MetaDataHandler
 from PYME.Analysis.points import multiview
 
 
@@ -88,7 +89,7 @@ class ShiftCorrect(ModuleBase):
 
         multiview.apply_shifts_to_points(mapped, shift_map)
         # propagate metadata
-        mapped.mdh = inp.mdh
+        mapped.mdh = MetaDataHandler.NestedClassMDHandler(inp.mdh) #copy as we are going to modify
         mapped.mdh['Multiview.shift_map.location'] = loc
 
         namespace[self.output_name] = mapped
@@ -250,7 +251,7 @@ class MapAstigZ(ModuleBase):
         mapped.addColumn('astigmatic_z_lookup_error', zerr)
         mapped.setMapping('z', 'astigmatic_z + z')
 
-        mapped.mdh = inp.mdh
+        mapped.mdh = MetaDataHandler.NestedClassMDHandler(inp.mdh)
         mapped.mdh['Analysis.astigmatism_calibration_used'] = calibration_location
 
         namespace[self.output_name] = mapped

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -18,6 +18,7 @@ import numpy as np
 from scipy import ndimage
 from PYME.IO.image import ImageStack
 from PYME.IO import tabular
+from PYME.IO import MetaDataHandler
 
 import logging
 logger=logging.getLogger(__name__)
@@ -1779,7 +1780,7 @@ class AverageFramesByZStep(ModuleBase):
             new_stack.append(data_avg / count[None, None, :])
 
         fudged_events = np.array(fudged_events, dtype=[('EventName', 'S32'), ('Time', '<f8'), ('EventDescr', 'S256')])
-        averaged = ImageStack(new_stack, mdh=image_stack.mdh, events=fudged_events)
+        averaged = ImageStack(new_stack, mdh=MetaDataHandler.NestedClassMDHandler(image_stack.mdh), events=fudged_events)
 
         # fudge metadata, leaving breadcrumbs
         averaged.mdh['Camera.CycleTime'] = cycle_time
@@ -1841,7 +1842,7 @@ class ResampleZ(ModuleBase):
             interp = RegularGridInterpolator((x, y, sorted_z_vals), stack.data[:, :, :, ci][:,:,I], method='linear')
             regular.append(interp((xx, yy, zz)))
 
-        regular_stack = ImageStack(regular, mdh=stack.mdh)
+        regular_stack = ImageStack(regular, mdh=MetaDataHandler.NestedClassMDHandler(stack.mdh))
 
         regular_stack.mdh['RegularizedStack'] = True
         regular_stack.mdh['StackSettings.StepSize'] = self.z_sampling
@@ -1887,7 +1888,7 @@ class BackgroundSubtractionMovingAverage(ModuleBase):
         bgs = BGSDataSource.DataSource(series.data, bgRange=self.window)
         bgs.setBackgroundBufferPCT(self.percentile)
 
-        background = ImageStack(data=bgs, mdh=series.mdh)
+        background = ImageStack(data=bgs, mdh=MetaDataHandler.NestedClassMDHandler(series.mdh))
 
         background.mdh['Parent'] = series.filename
         background.mdh['Processing.SlidingWindowBackground.Percentile'] = self.percentile


### PR DESCRIPTION
Addresses issue #492  

**Is this a bugfix or an enhancement?**

#492 unearthed a couple of recipe modules who were modifying their input (which violates the "no side effects" principle of recipe modules which is important if we want recipes to be reproducible and avoid odd behaviour). Fixed by creating a new metadatahandler each time before modifying.
