### PR TITLE
coalesce_dict_sorted / deClump aggregate 0/1 indexing fixes

### DIFF
--- a/PYME/Analysis/points/DeClump/deClump.c
+++ b/PYME/Analysis/points/DeClump/deClump.c
@@ -489,7 +489,8 @@ static PyObject * aggregateWeightedMean(PyObject *self, PyObject *args, PyObject
 
     int nPts = 0;
     int nClumps = 0;
-    int currentClump = -1;
+    int currentClump = 0;
+    int clump_0 = 0;
 
     int i=0;
     //int j=0;
@@ -575,22 +576,24 @@ static PyObject * aggregateWeightedMean(PyObject *self, PyObject *args, PyObject
         outSig[i] = -1e4;
     }
     */
-
-
+    clump_0 = clumpIDs[0];
+    currentClump = clump_0;
+    weight_sum = 0;
+    var_sum = 0;
     //j = 0;
     for (i=0; i < nPts; i++)
     {
         if (currentClump != clumpIDs[i]){
             //We have moved on to the next clump
-            if (currentClump >= 0)
+            if (currentClump - clump_0 >= 0)  // FIXME - do we allow negative clumpIDs to get here?
             {
                 if (weight_sum == 0){
-                    outVar[currentClump] = 0;
-                    outSig[currentClump] = -1e4;
+                    outVar[currentClump - clump_0] = 0;
+                    outSig[currentClump - clump_0] = -1e4;
                 } else {
                     iws = 1.0/weight_sum;
-                    outVar[currentClump] = var_sum*iws;
-                    outSig[currentClump] = sqrtf(iws);
+                    outVar[currentClump - clump_0] = var_sum*iws;
+                    outSig[currentClump - clump_0] = sqrtf(iws);
                 }
             }
 
@@ -605,15 +608,15 @@ static PyObject * aggregateWeightedMean(PyObject *self, PyObject *args, PyObject
         var_sum += w*vars[i];
     }
 
-    if (currentClump >= 0)
+    if (currentClump - clump_0 >= 0)
     {
         if (weight_sum == 0){
-            outVar[currentClump] = 0;
-            outSig[currentClump] = -1e4;
+            outVar[currentClump - clump_0] = 0;
+            outSig[currentClump - clump_0] = -1e4;
         } else {
             iws = 1.0/weight_sum;
-            outVar[currentClump] = var_sum*iws;
-            outSig[currentClump] = sqrtf(iws);
+            outVar[currentClump - clump_0] = var_sum*iws;
+            outSig[currentClump - clump_0] = sqrtf(iws);
         }
     }
 
@@ -734,9 +737,9 @@ static PyObject * aggregateMean(PyObject *self, PyObject *args, PyObject *keywds
     //j = 0;
     for (i=0; i < nPts; i++)
     {
-        if (currentClump != clumpIDs[i]){  // FIXME - do we allow negative clumpIDs to get here?
+        if (currentClump != clumpIDs[i]){
             //We have moved on to the next clump
-            if (currentClump - clump_0 >= 0)
+            if (currentClump - clump_0 >= 0)  // FIXME - do we allow negative clumpIDs to get here?
             {
                 iws = 1.0/weight_sum;
                 outVar[currentClump - clump_0] = var_sum*iws;
@@ -800,7 +803,8 @@ static PyObject * aggregateMin(PyObject *self, PyObject *args, PyObject *keywds)
 
     int nPts = 0;
     int nClumps = 0;
-    int currentClump = -1;
+    int currentClump = 0;
+    int clump_0 = 0;
 
     int i=0;
     //int j=0;
@@ -863,16 +867,17 @@ static PyObject * aggregateMin(PyObject *self, PyObject *args, PyObject *keywds)
         outSig[i] = -1e4;
     }
     */
-
-
+    clump_0 = clumpIDs[0];
+    currentClump = clump_0;
+    var_min = 1e9;
     //j = 0;
     for (i=0; i < nPts; i++)
     {
         if (currentClump != clumpIDs[i]){
             //We have moved on to the next clump
-            if (currentClump >= 0)
+            if (currentClump - clump_0 >= 0) // FIXME - do we allow negative clumpIDs to get here?
             {
-                outVar[currentClump] = var_min;
+                outVar[currentClump - clump_0] = var_min;
             }
 
             var_min = 1e9;
@@ -883,9 +888,9 @@ static PyObject * aggregateMin(PyObject *self, PyObject *args, PyObject *keywds)
         var_min = MIN(var_min, vars[i]);
     }
 
-    if (currentClump >= 0)
+    if (currentClump - clump_0 >= 0)
     {
-        outVar[currentClump] = var_min;
+        outVar[currentClump - clump_0] = var_min;
     }
 
 
@@ -926,7 +931,8 @@ static PyObject * aggregateSum(PyObject *self, PyObject *args, PyObject *keywds)
 
     int nPts = 0;
     int nClumps = 0;
-    int currentClump = -1;
+    int currentClump = 0;
+    int clump_0 = 0;
 
     int i=0;
     //int j=0;
@@ -989,16 +995,17 @@ static PyObject * aggregateSum(PyObject *self, PyObject *args, PyObject *keywds)
         outSig[i] = -1e4;
     }
     */
-
-
+    clump_0 = clumpIDs[0];
+    currentClump = clump_0;
+    var_sum = 0;
     //j = 0;
     for (i=0; i < nPts; i++)
     {
         if (currentClump != clumpIDs[i]){
             //We have moved on to the next clump
-            if (currentClump >= 0)
+            if (currentClump - clump_0 >= 0) // FIXME - do we allow negative clumpIDs to get here?
             {
-                outVar[currentClump] = var_sum;
+                outVar[currentClump - clump_0] = var_sum;
             }
 
             var_sum = 0;
@@ -1009,9 +1016,9 @@ static PyObject * aggregateSum(PyObject *self, PyObject *args, PyObject *keywds)
         var_sum +=  vars[i];
     }
 
-    if (currentClump >= 0)
+    if (currentClump - clump_0 >= 0)
     {
-        outVar[currentClump] = var_sum;
+        outVar[currentClump - clump_0] = var_sum;
     }
 
 

--- a/PYME/Analysis/points/DeClump/deClump.c
+++ b/PYME/Analysis/points/DeClump/deClump.c
@@ -663,7 +663,8 @@ static PyObject * aggregateMean(PyObject *self, PyObject *args, PyObject *keywds
 
     int nPts = 0;
     int nClumps = 0;
-    int currentClump = -1;
+    int currentClump = 0;
+    int clump_0 = 0;
 
     int i=0;
     //int j=0;
@@ -726,17 +727,19 @@ static PyObject * aggregateMean(PyObject *self, PyObject *args, PyObject *keywds
         outSig[i] = -1e4;
     }
     */
-
-
+    clump_0 = clumpIDs[0];
+    currentClump = clump_0;
+    weight_sum = 0;
+    var_sum = 0;
     //j = 0;
     for (i=0; i < nPts; i++)
     {
-        if (currentClump != clumpIDs[i]){
+        if (currentClump != clumpIDs[i]){  // FIXME - do we allow negative clumpIDs to get here?
             //We have moved on to the next clump
-            if (currentClump >= 0)
+            if (currentClump - clump_0 >= 0)
             {
                 iws = 1.0/weight_sum;
-                outVar[currentClump] = var_sum*iws;
+                outVar[currentClump - clump_0] = var_sum*iws;
             }
 
             weight_sum = 0;
@@ -750,10 +753,10 @@ static PyObject * aggregateMean(PyObject *self, PyObject *args, PyObject *keywds
         var_sum += w*vars[i];
     }
 
-    if (currentClump >= 0)
+    if (currentClump - clump_0 >= 0)  // FIXME - do we allow negative clumpIDs to get here?
     {
         iws = 1.0/weight_sum;
-        outVar[currentClump] = var_sum*iws;
+        outVar[currentClump - clump_0] = var_sum*iws;
     }
 
 

--- a/PYME/Analysis/points/multiview.py
+++ b/PYME/Analysis/points/multiview.py
@@ -43,15 +43,25 @@ def coalesce_dict_sorted(inD, assigned, keys, weights_by_key):  # , notKosher=No
     Also note that copying a large dictionary can be rather slow, and a structured ndarray approach may be preferable.
     DB - we should never have a 'large' dictionary (ie there will only ever be a handful of keys)
 
-    Args:
-        inD: input dictionary containing fit results
-        assigned: clump assignments to be coalesced
-        keys: list whose elements are strings corresponding to keys to be copied from the input to output dictionaries
-        weights_by_key: dictionary of weights.
-
-    Returns:
-        fres: output dictionary containing the coalesced results
-
+    Parameters
+    ----------
+    inD : dict
+        input dictionary containing fit results
+    assigned : ndarray
+        clump assignments to be coalesced. Cluster assignment index can start at
+        0 or 1 (the latter following PYME cluster labeling convention), however
+        any index present will be coalesced (including the 0 cluster, if 
+        present).
+    keys : list 
+        elements are strings corresponding to keys to be copied from the input to output dictionaries
+    weights_by_key : dict
+        maps weighting keys to coalescing weights or coalescing style (mean, 
+        min, sum).
+    
+    Returns
+    -------
+    fres: dict
+        coalesced results
     """
     from PYME.Analysis.points.DeClump import deClump
 

--- a/PYME/Analysis/points/multiview.py
+++ b/PYME/Analysis/points/multiview.py
@@ -55,7 +55,7 @@ def coalesce_dict_sorted(inD, assigned, keys, weights_by_key):  # , notKosher=No
     """
     from PYME.Analysis.points.DeClump import deClump
 
-    NClumps = int(np.max(assigned) + 1)  # len(np.unique(assigned))  #
+    NClumps = len(np.unique(assigned))
 
     clumped = {}
 

--- a/PYME/Analysis/points/multiview.py
+++ b/PYME/Analysis/points/multiview.py
@@ -406,7 +406,7 @@ def find_clumps_within_channel(datasource, gap_tolerance, radius_scale, radius_o
     return datasource
 
 def merge_clumps(datasource, numChan, labelKey='clumpIndex'):
-    from PYME.IO.tabular import CachingResultsFilter, MappingFilter
+    from PYME.IO.tabular import DictSource
 
     keys_to_aggregate = ['x', 'y', 'z', 't', 'A', 'probe', 'tIndex', 'multiviewChannel', labelKey, 'focus', 'LLH']
     keys_to_aggregate += ['sigmax%d' % chan for chan in range(numChan)]
@@ -427,7 +427,7 @@ def merge_clumps(datasource, numChan, labelKey='clumpIndex'):
     sorted_src = {k: datasource[k][I] for k in all_keys}
 
     grouped = coalesce_dict_sorted(sorted_src, sorted_src[labelKey], keys_to_aggregate, aggregation_weights)
-    return MappingFilter(grouped)
+    return DictSource(grouped)
 
 
 

--- a/tests/PYME/Analysis/points/test_multiview.py
+++ b/tests/PYME/Analysis/points/test_multiview.py
@@ -1,0 +1,43 @@
+
+from PYME.IO.tabular import DictSource
+import numpy as np
+from PYME.Analysis.points import multiview
+
+def test_merge_clumps():
+    n = 10
+    half_n = int(n/2)
+    unmerged = DictSource({
+        'x': np.arange(float(n)),
+        'y': np.arange(float(n)),
+        't': np.arange(n),
+        'A': np.arange(float(n)),
+        # error_y of 0 works, but do we want divide by zero warnings in test?
+        'error_y': np.arange(1, float(n + 1)),
+        'cluster_id': np.concatenate([np.zeros(half_n, int), 
+                                      np.ones(half_n, int)])
+    })
+
+    merged = multiview.merge_clumps(unmerged, 0, 'cluster_id')
+
+    # test len
+    assert len(merged['cluster_id']) == len(np.unique(unmerged['cluster_id']))
+
+    # test sum
+    np.testing.assert_allclose(merged['A'], 
+                               [np.sum(unmerged['A'][:half_n]),
+                                np.sum(unmerged['A'][half_n:])])
+    
+    # test mean
+    np.testing.assert_allclose(merged['x'], 
+                               [np.average(unmerged['x'][:half_n]),
+                                np.average(unmerged['x'][half_n:])])
+    
+    # test weighted NOTE - this not simply weighted avg, we assume gasussian dist
+    # could consider renaming if we start using aggregateWeightedMean in more
+    # parts of the code.
+    weights = 1 / (unmerged['error_y'] ** 2)
+    wm = [
+        np.sum(weights[:half_n] * unmerged['y'][:half_n]) / np.sum(weights[:half_n]),
+        np.sum(weights[half_n:] * unmerged['y'][half_n:]) / np.sum(weights[half_n:])
+    ]
+    np.testing.assert_allclose(merged['y'], wm)


### PR DESCRIPTION
Addresses issue #493 .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- fix output of deClump to be the correct length (currently the 0th value in each out array is left to the whims of RAM)

DRAFT for now - need to fix the other aggregate versions / update docstrings

**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]