### PR TITLE
Add smoothed curvature as an option for mesh display

### DIFF
--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -259,6 +259,7 @@ cdef class TriangleMesh(TrianglesBase):
 
     cdef object _H
     cdef object _K
+    cdef public object smooth_curvature
     
 
     def __init__(self, vertices=None, faces=None, mesh=None, **kwargs):
@@ -351,6 +352,7 @@ cdef class TriangleMesh(TrianglesBase):
         # Curvatures
         self._H = None
         self._K = None
+        self.smooth_curvature = False
 
         # Set fix_boundary, etc.
         for key, value in kwargs.items():
@@ -877,9 +879,10 @@ cdef class TriangleMesh(TrianglesBase):
             k_2 = 3.*l2 - l1 #e[1] - e[0]
             self._H[iv] = 0.5*(k_1 + k_2)
             self._K[iv] = k_1*k_2
-            
-        #self._H = self.smooth_per_vertex_data(self._H)
-        #self._K = self.smooth_per_vertex_data(self._K)
+
+        if self.smooth_curvature:    
+            self._H = self.smooth_per_vertex_data(self._H)
+            self._K = self.smooth_per_vertex_data(self._K)
         
     def smooth_per_vertex_data(self, data):
         # replace a vertex value with the average of that value and it's neighbours. TODO - add some form of weighting

--- a/PYME/recipes/surface_fitting.py
+++ b/PYME/recipes/surface_fitting.py
@@ -134,6 +134,7 @@ class DualMarchingCubes(ModuleBase):
     threshold_density = Float(2e-5)
     n_points_min = Int(50) # lets us truncate on SNR
     
+    smooth_curvature = Bool(True)  # TODO: This is actually a mesh property, so it can be toggled outside of the recipe.
     repair = Bool(False)
     remesh = Bool(False)
     
@@ -148,7 +149,7 @@ class DualMarchingCubes(ModuleBase):
         tris = dmc.march(dual_march=False)
 
         print('Generating TriangularMesh object')
-        surf = triangle_mesh.TriangleMesh.from_np_stl(tris)
+        surf = triangle_mesh.TriangleMesh.from_np_stl(tris, smooth_curvature=self.smooth_curvature)
         
         print('Generated TriangularMesh object')
         


### PR DESCRIPTION
**Is this a bugfix or an enhancement?**
Enhancement

**Proposed changes:**
- Allow the user to smooth the mesh curvature calculations. Currently only used for display, but potentially helpful for numerical stability later on.

**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
