### PR TITLE
use the right metadatahandler in GaussMultifitSR construction

### DIFF
--- a/PYME/recipes/measurement.py
+++ b/PYME/recipes/measurement.py
@@ -40,7 +40,7 @@ class MultifitBlobs(ModuleBase):
         for i in range(img.data.shape[2]):
             md = MetaDataHandler.NestedClassMDHandler(mdh)
             md['tIndex'] = i
-            ff = GaussMultifitSR.FitFactory(self.scale*img.data[:,:,i], img.mdh, noiseSigma=np.ones_like(img.data[:,:,i].squeeze()))
+            ff = GaussMultifitSR.FitFactory(self.scale*img.data[:,:,i], md, noiseSigma=np.ones_like(img.data[:,:,i].squeeze()))
         
             res.append(tabular.FitResultsSource(ff.FindAndFit(self.threshold)))
             


### PR DESCRIPTION
Addresses issue arising from #500, which itself is fix for #492.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- use the metadatahandler which has `tIndex` and `Analysis.PSFSigma` defined when constructing the fitfactory, otherwise it never gets the settings and just uses the defaults
