### PR TITLE
fix pipelineify/AddPipelineDerivedVars for splitter-fit data

### DIFF
--- a/PYME/recipes/localisations.py
+++ b/PYME/recipes/localisations.py
@@ -203,8 +203,8 @@ class Pipelineify(ModuleBase):
                 mapped_ds.addColumn('nPhotons', pipeline.getPhotonNums(mapped_ds, mdh))
             
             if 'SplitterFitFNR' in fitModule:
-                mapped_ds.addColumn('nPhotonsg', pipeline.getPhotonNums({'A': mapped_ds['fitResults_Ag'], 'sig': mapped_ds['fitResults_sigma']}, self.mdh))
-                mapped_ds.addColumn('nPhotonsr', pipeline.getPhotonNums({'A': mapped_ds['fitResults_Ar'], 'sig': mapped_ds['fitResults_sigma']}, self.mdh))
+                mapped_ds.addColumn('nPhotonsg', pipeline.getPhotonNums({'A': mapped_ds['fitResults_Ag'], 'sig': mapped_ds['fitResults_sigma']}, mdh))
+                mapped_ds.addColumn('nPhotonsr', pipeline.getPhotonNums({'A': mapped_ds['fitResults_Ar'], 'sig': mapped_ds['fitResults_sigma']}, mdh))
                 mapped_ds.setMapping('nPhotons', 'nPhotonsg+nPhotonsr')
 
         mapped_ds.mdh = mdh


### PR DESCRIPTION
Addresses issue I missed the `self.` when migrating from `pipeline.py` code in #284 

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- don't treat mdh as an attribute of a recipe module
