### PR TITLE
Polishing multiview.merge_clumps / coalesce_dict_sorted

### DIFF
--- a/PYME/Analysis/points/DeClump/deClump.c
+++ b/PYME/Analysis/points/DeClump/deClump.c
@@ -565,6 +565,10 @@ static PyObject * aggregateWeightedMean(PyObject *self, PyObject *args, PyObject
         return NULL;
     }
 
+    //initialise memory in output arrays
+    PyArray_FILLWBYTE(outVarA, 0);
+    PyArray_FILLWBYTE(outSigA, 0);
+
     outVar = (float*)PyArray_DATA(outVarA);
     outSig = (float*)PyArray_DATA(outSigA);
 
@@ -719,6 +723,10 @@ static PyObject * aggregateMean(PyObject *self, PyObject *args, PyObject *keywds
 
     outVar = (float*)PyArray_DATA(outVarA);
 
+    //initialise memory in output arrays
+    PyArray_FILLWBYTE(outVarA, 0);
+    //PyArray_FILLWBYTE(outSigA, 0);
+
     /*
     for (i=0; i < nPts; i++)
     {
@@ -853,6 +861,10 @@ static PyObject * aggregateMin(PyObject *self, PyObject *args, PyObject *keywds)
 
     outVar = (float*)PyArray_DATA(outVarA);
 
+        //initialise memory in output arrays
+    PyArray_FILLWBYTE(outVarA, 0);
+    //PyArray_FILLWBYTE(outSigA, 0);
+
     /*
     for (i=0; i < nPts; i++)
     {
@@ -976,6 +988,10 @@ static PyObject * aggregateSum(PyObject *self, PyObject *args, PyObject *keywds)
         PyErr_Format(PyExc_RuntimeError, "Error allocating array for clumped output");
         return NULL;
     }
+
+        //initialise memory in output arrays
+    PyArray_FILLWBYTE(outVarA, 0);
+    //PyArray_FILLWBYTE(outSigA, 0);
 
     outVar = (float*)PyArray_DATA(outVarA);
 

--- a/PYME/Analysis/points/multiview.py
+++ b/PYME/Analysis/points/multiview.py
@@ -38,23 +38,38 @@ def load_shiftmap(uri):
 def coalesce_dict_sorted(inD, assigned, keys, weights_by_key, discard_trivial=False):  # , notKosher=None):
     """
     Agregates clumps to a single event
-    Note that this will evaluate the lazy pipeline events and add them into the dict as an array, not a code
-    object.
-    Also note that copying a large dictionary can be rather slow, and a structured ndarray approach may be preferable.
-    DB - we should never have a 'large' dictionary (ie there will only ever be a handful of keys)
 
-    Args:
-        inD: input dictionary containing fit results
-        assigned: clump assignments to be coalesced
-        keys: list whose elements are strings corresponding to keys to be copied from the input to output dictionaries
-        weights_by_key: dictionary of weights.
-        discard_trivial : Bool
-            by default, the output of aggregation/coalescing is indexable by the original clump ID and contains entries
-            for the unassigned (0) clump and any other clumps which might have been lost to filtering. Setting discard_trial
-            to true returns only those clumps for which idx >=1 and which contain at least 1 point.
-
-    Returns:
-        fres: output dictionary containing the coalesced results
+    Parameters
+    ----------
+    inD : dict
+        input dictionary containing fit results
+    assigned : ndarray
+        clump assignments to be coalesced. Cluster assignment index can start at
+        0 or 1 (the latter following PYME cluster labeling convention), however
+        any index present will be coalesced (including the 0 cluster, if 
+        present).
+    keys : list 
+        elements are strings corresponding to keys to be copied from the input 
+        to output dictionaries
+    weights_by_key : dict
+        maps weighting keys to coalescing weights or coalescing style (mean, 
+        min, sum).
+    discard_trivial : bool
+        by default, the output of aggregation/coalescing is indexable by the 
+        original clump ID and contains entries for the unassigned (0) clump 
+        and any other clumps which might have been lost to filtering. Setting 
+        discard_trial to true returns only those clumps for which  idx >=1 and 
+        which contain at least 1 point.
+    
+    Returns
+    -------
+    fres: dict
+        coalesced results
+    
+    Notes
+    -----
+    This will evaluate the lazy pipeline events and add them into the dict as 
+    an array, not a code object.
 
     """
     from PYME.Analysis.points.DeClump import deClump

--- a/PYME/Analysis/points/multiview.py
+++ b/PYME/Analysis/points/multiview.py
@@ -35,7 +35,9 @@ def load_shiftmap(uri):
 
     return shift_map
 
-def coalesce_dict_sorted(inD, assigned, keys, weights_by_key, discard_trivial=False):
+
+def coalesce_dict_sorted(inD, assigned, keys, weights_by_key, 
+                         discard_trivial=False):
     """
     Agregates clumps to a single event
 
@@ -46,29 +48,29 @@ def coalesce_dict_sorted(inD, assigned, keys, weights_by_key, discard_trivial=Fa
     assigned : ndarray
         clump assignments to be coalesced. Cluster assignment index can start at
         0 or 1 (the latter following PYME cluster labeling convention), however
-        any index present will be coalesced (including the 0 cluster, if 
+        any index present will be coalesced (including the 0 cluster, if
         present).
-    keys : list 
-        elements are strings corresponding to keys to be copied from the input 
+    keys : list
+        elements are strings corresponding to keys to be copied from the input
         to output dictionaries
     weights_by_key : dict
-        maps weighting keys to coalescing weights or coalescing style (mean, 
+        maps weighting keys to coalescing weights or coalescing style (mean,
         min, sum).
     discard_trivial : bool
-        by default, the output of aggregation/coalescing is indexable by the 
-        original clump ID and contains entries for the unassigned (0) clump 
-        and any other clumps which might have been lost to filtering. Setting 
-        discard_trial to true returns only those clumps for which  idx >=1 and 
+        by default, the output of aggregation/coalescing is indexable by the
+        original clump ID and contains entries for the unassigned (0) clump
+        and any other clumps which might have been lost to filtering. Setting
+        discard_trial to true returns only those clumps for which  idx >=1 and
         which contain at least 1 point.
-    
+
     Returns
     -------
     fres: dict
         coalesced results
-    
+
     Notes
     -----
-    This will evaluate the lazy pipeline events and add them into the dict as 
+    This will evaluate the lazy pipeline events and add them into the dict as
     an array, not a code object.
 
     """

--- a/PYME/Analysis/points/multiview.py
+++ b/PYME/Analysis/points/multiview.py
@@ -35,7 +35,7 @@ def load_shiftmap(uri):
 
     return shift_map
 
-def coalesce_dict_sorted(inD, assigned, keys, weights_by_key, discard_trivial=False):  # , notKosher=None):
+def coalesce_dict_sorted(inD, assigned, keys, weights_by_key, discard_trivial=False):
     """
     Agregates clumps to a single event
 
@@ -74,7 +74,7 @@ def coalesce_dict_sorted(inD, assigned, keys, weights_by_key, discard_trivial=Fa
     """
     from PYME.Analysis.points.DeClump import deClump
 
-    NClumps = int(np.max(assigned) + 1)  # len(np.unique(assigned))  #
+    NClumps = int(np.max(assigned) + 1)  # yes this is weird, but look at the C code
 
     clumped = {}
     
@@ -422,7 +422,7 @@ def find_clumps_within_channel(datasource, gap_tolerance, radius_scale, radius_o
     return datasource
 
 def merge_clumps(datasource, numChan, labelKey='clumpIndex'):
-    from PYME.IO.tabular import CachingResultsFilter, MappingFilter
+    from PYME.IO.tabular import DictSource
 
     keys_to_aggregate = ['x', 'y', 'z', 't', 'A', 'probe', 'tIndex', 'multiviewChannel', labelKey, 'focus', 'LLH']
     keys_to_aggregate += ['sigmax%d' % chan for chan in range(numChan)]
@@ -443,7 +443,7 @@ def merge_clumps(datasource, numChan, labelKey='clumpIndex'):
     sorted_src = {k: datasource[k][I] for k in all_keys}
 
     grouped = coalesce_dict_sorted(sorted_src, sorted_src[labelKey], keys_to_aggregate, aggregation_weights, discard_trivial=True)
-    return MappingFilter(grouped)
+    return DictSource(grouped)
 
 
 

--- a/PYME/Analysis/points/multiview.py
+++ b/PYME/Analysis/points/multiview.py
@@ -81,7 +81,7 @@ def coalesce_dict_sorted(inD, assigned, keys, weights_by_key, discard_trivial=Fa
         else:
             # if weights is an array, take weighted average
             var, errVec = deClump.aggregateWeightedMean(NClumps, assigned.astype('i'), inD[rkey].astype('f'), inD[weights].astype('f'))
-            clumped[weights] = errVec
+            clumped[weights] = errVec[non_trivial] if discard_trivial else errVec
 
         if discard_trivial:
             clumped[rkey] = var[non_trivial]

--- a/PYME/Analysis/points/multiview.py
+++ b/PYME/Analysis/points/multiview.py
@@ -36,7 +36,7 @@ def load_shiftmap(uri):
     return shift_map
 
 
-def coalesce_dict_sorted(inD, assigned, keys, weights_by_key, 
+def coalesce_dict_sorted(inD, assigned, keys, weights_by_key,
                          discard_trivial=False):
     """
     Agregates clumps to a single event
@@ -46,10 +46,10 @@ def coalesce_dict_sorted(inD, assigned, keys, weights_by_key,
     inD : dict
         input dictionary containing fit results
     assigned : ndarray
-        clump assignments to be coalesced. Cluster assignment index can start at
-        0 or 1 (the latter following PYME cluster labeling convention), however
-        any index present will be coalesced (including the 0 cluster, if
-        present).
+        clump assignments to be coalesced. Cluster assignment index can start
+        at 0 or 1 (the latter following PYME cluster labeling convention),
+        however any index present will be coalesced (including the 0 cluster,
+        if present).
     keys : list
         elements are strings corresponding to keys to be copied from the input
         to output dictionaries

--- a/tests/PYME/Analysis/points/test_multiview.py
+++ b/tests/PYME/Analysis/points/test_multiview.py
@@ -14,8 +14,10 @@ def test_merge_clumps():
         'A': np.arange(float(n)),
         # error_y of 0 works, but do we want divide by zero warnings in test?
         'error_y': np.arange(1, float(n + 1)),
-        'cluster_id': np.concatenate([np.zeros(half_n, int), 
-                                      np.ones(half_n, int)])
+        # PYME cluster convention: 0 is unclustered, and we dodge it in 
+        # multiview
+        'cluster_id': np.concatenate([np.ones(half_n, int), 
+                                      2 * np.ones(half_n, int)])
     })
 
     merged = multiview.merge_clumps(unmerged, 0, 'cluster_id')

--- a/tests/PYME/Analysis/points/test_multiview.py
+++ b/tests/PYME/Analysis/points/test_multiview.py
@@ -1,0 +1,44 @@
+
+from PYME.IO.tabular import DictSource
+import numpy as np
+from PYME.Analysis.points import multiview
+
+def test_merge_clumps():
+    # partially but not completely degenerate with points/test_clumps.py
+    n = 10
+    half_n = int(n/2)
+    unmerged = DictSource({
+        'x': np.arange(float(n)),
+        'y': np.arange(float(n)),
+        't': np.arange(n),
+        'A': np.arange(float(n)),
+        # error_y of 0 works, but do we want divide by zero warnings in test?
+        'error_y': np.arange(1, float(n + 1)),
+        'cluster_id': np.concatenate([np.zeros(half_n, int), 
+                                      np.ones(half_n, int)])
+    })
+
+    merged = multiview.merge_clumps(unmerged, 0, 'cluster_id')
+
+    # test len
+    assert len(merged['cluster_id']) == len(np.unique(unmerged['cluster_id']))
+
+    # test sum
+    np.testing.assert_allclose(merged['A'], 
+                               [np.sum(unmerged['A'][:half_n]),
+                                np.sum(unmerged['A'][half_n:])])
+
+    # test mean
+    np.testing.assert_allclose(merged['x'], 
+                               [np.average(unmerged['x'][:half_n]),
+                                np.average(unmerged['x'][half_n:])])
+
+    # test weighted NOTE - this not simply weighted avg, we assume gasussian dist
+    # could consider renaming if we start using aggregateWeightedMean in more
+    # parts of the code.
+    weights = 1 / (unmerged['error_y'] ** 2)
+    wm = [
+        np.sum(weights[:half_n] * unmerged['y'][:half_n]) / np.sum(weights[:half_n]),
+        np.sum(weights[half_n:] * unmerged['y'][half_n:]) / np.sum(weights[half_n:])
+    ]
+    np.testing.assert_allclose(merged['y'], wm)


### PR DESCRIPTION
Addresses issue small remaining part of #493 .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- crop valid out of weights too if non_trivial flag is set
- numpy docstrings
- dodge deprecation warning by using DictSource instead of initializing MappingFilter with a dict
- add test_multiview from #501 as its not completely degenerate with test_clumps, will fill more in later, and displays a current issue with the head(remaining even after this PR)
```
        merged = multiview.merge_clumps(unmerged, 0, 'cluster_id')
    
        # test len
>       assert len(merged['cluster_id']) == len(np.unique(unmerged['cluster_id']))
E       assert 1 == 2
E        +  where 1 = len(array([1.], dtype=float32))
E        +  and   2 = len(array([0, 1]))
E        +    where array([0, 1]) = <function unique at 0x7fa52a501158>(array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]))
E        +      where <function unique at 0x7fa52a501158> = np.unique

tests/PYME/Analysis/points/test_multiview.py:24: AssertionError
```






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6

