### PR TITLE
Change default retry behavior on rules -> no retries unless specified

### DIFF
--- a/PYME/cluster/ruleserver.py
+++ b/PYME/cluster/ruleserver.py
@@ -166,10 +166,10 @@ class IntegerIDRule(Rule):
         self._template = task_template
         self._task_info = np.zeros(max_task_ID, self.TASK_INFO_DTYPE)
         
-        # number of times to re-queue a task if it times out is set by the 'ruleserver-retries' config option
-        # NOTE: the new default of 0 effectively disables re-trying and makes analysis less robust. TODO - revisit whether this is a good idea
-        # Note that a timeout is different to a failure - failing tasks will be marked as having failed and will not be re-tried. Timeouts will occur in one of 4 
-        # scenarios:
+        # Number of times to re-queue a task if it times out is set by the 'ruleserver-retries' config option
+        # Setting a value of 0 effectively disables re-trying and makes analysis less robust.
+        # Note that a timeout is different to a failure - failing tasks will be marked as having failed and will not be re-tried. Timeouts will
+        # occur in one of 4 scenarios:
         # - a worker falls over completely or is disconnected from the network
         # - an unhandled exception - e.g. due to an IO error connecting to the ruleserver in `taskWorkerHTTP.taskWorker._return_task_results()`
         # - analysis is getting massively bogged down and nothing is keeping up
@@ -178,7 +178,7 @@ class IntegerIDRule(Rule):
         # In scenarios 1 & 2 it's reasonable to expect that retrying will result in success. In scenarios 3 & 4 it's a bit muddier, but seeing as a) these kind of
         # failures tend to be a bit stochastic and b) the retries get punted to the back of the queue, when the load might have let up a bit, the odds are
         # reasonably good.
-        self._n_retries = config.get('ruleserver-retries', 0)
+        self._n_retries = config.get('ruleserver-retries', 1)
         self._timeout = task_timeout
         
         self._rule_timeout = rule_timeout

--- a/PYME/cluster/ruleserver.py
+++ b/PYME/cluster/ruleserver.py
@@ -166,7 +166,7 @@ class IntegerIDRule(Rule):
         self._template = task_template
         self._task_info = np.zeros(max_task_ID, self.TASK_INFO_DTYPE)
         
-        self._n_retries =  config.get('ruleserver-retries', 0)
+        self._n_retries = config.get('ruleserver-retries', 0)
         self._timeout = task_timeout
         
         self._rule_timeout = rule_timeout

--- a/PYME/cluster/ruleserver.py
+++ b/PYME/cluster/ruleserver.py
@@ -166,7 +166,7 @@ class IntegerIDRule(Rule):
         self._template = task_template
         self._task_info = np.zeros(max_task_ID, self.TASK_INFO_DTYPE)
         
-        self._n_retries =  config.get('ruleserver-retries', 3)
+        self._n_retries =  config.get('ruleserver-retries', 0)
         self._timeout = task_timeout
         
         self._rule_timeout = rule_timeout

--- a/PYME/cluster/ruleserver.py
+++ b/PYME/cluster/ruleserver.py
@@ -166,6 +166,18 @@ class IntegerIDRule(Rule):
         self._template = task_template
         self._task_info = np.zeros(max_task_ID, self.TASK_INFO_DTYPE)
         
+        # number of times to re-queue a task if it times out is set by the 'ruleserver-retries' config option
+        # NOTE: the new default of 0 effectively disables re-trying and makes analysis less robust. TODO - revisit whether this is a good idea
+        # Note that a timeout is different to a failure - failing tasks will be marked as having failed and will not be re-tried. Timeouts will occur in one of 4 
+        # scenarios:
+        # - a worker falls over completely or is disconnected from the network
+        # - an unhandled exception - e.g. due to an IO error connecting to the ruleserver in `taskWorkerHTTP.taskWorker._return_task_results()`
+        # - analysis is getting massively bogged down and nothing is keeping up
+        # - the task timeout is unrealistically short for a given processing task
+        # 
+        # In scenarios 1 & 2 it's reasonable to expect that retrying will result in success. In scenarios 3 & 4 it's a bit muddier, but seeing as a) these kind of
+        # failures tend to be a bit stochastic and b) the retries get punted to the back of the queue, when the load might have let up a bit, the odds are
+        # reasonably good.
         self._n_retries = config.get('ruleserver-retries', 0)
         self._timeout = task_timeout
         


### PR DESCRIPTION
Addresses issue rarely is this helpful on a dedicated cluster, or clusterofone setup, and can be configured when needed on ad-hocs. Probably eases #490.

**Is this a bugfix or an enhancement?**
?
**Proposed changes:**
- change default number of retries to 0, i.e. try once and if a task times out mark it as failed.






**Checklist:**

- [ ] Tested 

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
