### PR TITLE
get the right multiviewChannel if we don't have all of them present

### DIFF
--- a/PYME/Analysis/points/multiview.py
+++ b/PYME/Analysis/points/multiview.py
@@ -109,7 +109,7 @@ def foldX(datasource, mdh, inject=False, chroma_mappings=False):
     if not inject:
         datasource = tabular.MappingFilter(datasource)
 
-    roiSizeNM = (mdh['Multiview.ROISize'][1]*mdh.voxelsize_nm.x)  # voxelsize is in um
+    roiSizeNM = (mdh['Multiview.ROISize'][1]*mdh.voxelsize_nm.x)
 
     numChans = mdh.getOrDefault('Multiview.NumROIs', 1)
     color_chans = np.array(mdh.getOrDefault('Multiview.ChannelColor', np.zeros(numChans, 'i'))).astype('i')
@@ -117,8 +117,13 @@ def foldX(datasource, mdh, inject=False, chroma_mappings=False):
     datasource.addVariable('roiSizeNM', roiSizeNM)
     datasource.addVariable('numChannels', numChans)
 
-    #FIXME - cast to int should probably happen when we use multiViewChannel, not here (because we might have saved and reloaded in between)
-    datasource.setMapping('multiviewChannel', 'clip(floor(x/roiSizeNM), 0, numChannels - 1).astype(int)')
+    active_rois = np.asarray(mdh.getOrDefault('Multiview.ActiveViews', 
+                                              list(range(numChans))))
+    multiview_channel = np.clip(np.floor(datasource['x'] / roiSizeNM), 
+                                0, numChans - 1)
+    multiview_channel = active_rois[multiview_channel.astype(int)]
+    datasource.addColumn('multiviewChannel', multiview_channel)
+    
     if chroma_mappings:
         datasource.addColumn('chromadx', 0 * datasource['x'])
         datasource.addColumn('chromady', 0 * datasource['y'])

--- a/PYME/Analysis/points/multiview.py
+++ b/PYME/Analysis/points/multiview.py
@@ -117,6 +117,7 @@ def foldX(datasource, mdh, inject=False, chroma_mappings=False):
     datasource.addVariable('roiSizeNM', roiSizeNM)
     datasource.addVariable('numChannels', numChans)
 
+    # NB - this assumes that 'Multiview.ActiveViews' is sorted the same way that the views are concatenated (probably a safe assumption)
     active_rois = np.asarray(mdh.getOrDefault('Multiview.ActiveViews', 
                                               list(range(numChans))))
     multiview_channel = np.clip(np.floor(datasource['x'] / roiSizeNM), 
@@ -434,7 +435,6 @@ def merge_clumps(datasource, numChan, labelKey='clumpIndex'):
 
     grouped = coalesce_dict_sorted(sorted_src, sorted_src[labelKey], keys_to_aggregate, aggregation_weights, discard_trivial=True)
     return MappingFilter(grouped)
-
 
 
 


### PR DESCRIPTION
Addresses issue #if you only have one color active, on biplane, say channels 0 and 3, but use the current fold, you get multiviewChannels of 0 and 1, which will mess you up of course if you use a full [0, 1, 2, 3] shiftmap registration, will also mess up probe, etc.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- check if we have `Multiview.ActiveViews` in our metadata, and use it to pull correct channel information.

**notes**
multiviewChannel was a mapping, which is not actually super cheap since we evaluate it later in the same function when we index to get probe. Shouldn't be a performance loss.




**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6

- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

