### PR TITLE
make --clusterUI flag sufficient to open clusterUI on PYMEClusterOfOne launch

### DIFF
--- a/PYME/cluster/cluster_of_one.py
+++ b/PYME/cluster/cluster_of_one.py
@@ -127,7 +127,8 @@ def main():
                   help="Root directory of virtual filesystem (default %s, see also 'dataserver-root' config entry)" % default_root,
                   default=default_root)
     op.add_option('--ui', dest='ui', help='launch web based ui', default=True)
-    op.add_option('--clusterUI', dest='clusterui', help='launch the full django-based cluster UI', default=False)
+    op.add_option('--clusterUI', dest='clusterui', help='launch the full django-based cluster UI', 
+                  action='store_true', default=False)
 
     options, args = op.parse_args()
     

--- a/PYME/cluster/cluster_of_one.py
+++ b/PYME/cluster/cluster_of_one.py
@@ -127,8 +127,7 @@ def main():
                   help="Root directory of virtual filesystem (default %s, see also 'dataserver-root' config entry)" % default_root,
                   default=default_root)
     op.add_option('--ui', dest='ui', help='launch web based ui', default=True)
-    op.add_option('--clusterUI', dest='clusterui', help='launch the full django-based cluster UI', 
-                  action="store_true", default=False)
+    op.add_option('--clusterUI', dest='clusterui', help='launch the full django-based cluster UI', default=False)
 
     options, args = op.parse_args()
     

--- a/PYME/cluster/cluster_of_one.py
+++ b/PYME/cluster/cluster_of_one.py
@@ -127,7 +127,8 @@ def main():
                   help="Root directory of virtual filesystem (default %s, see also 'dataserver-root' config entry)" % default_root,
                   default=default_root)
     op.add_option('--ui', dest='ui', help='launch web based ui', default=True)
-    op.add_option('--clusterUI', dest='clusterui', help='launch the full django-based cluster UI', default=False)
+    op.add_option('--clusterUI', dest='clusterui', help='launch the full django-based cluster UI', 
+                  action="store_true", default=False)
 
     options, args = op.parse_args()
     


### PR DESCRIPTION
Addresses issue `PYMEClusterOfOne --clusterUI` will throw expecting an argument, e.g. `PYMEClusterOfOne --clusterUI True`, which is a little verbose.

**Is this a bugfix or an enhancement?**
small enhancement
**Proposed changes:**
make use of the flag store true so `PYMEClusterOfOne --clusterUI` launches the cluster and clusterUI.






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

