### PR TITLE
set max_duration for tasks queued through recipes.acquisition.QueueAcquisitions

### DIFF
--- a/PYME/Acquire/ActionManager.py
+++ b/PYME/Acquire/ActionManager.py
@@ -200,6 +200,10 @@ class ActionManagerWebWrapper(object):
                     A timeout in seconds from the current time at which the 
                     action becomes irrelevant and should be ignored. By default
                     1e6.
+                max_duration : float
+                    A generous estimate, in seconds, of how long the task might
+                    take, after which the lasers will be automatically turned 
+                    off and the action queue paused.
         """
         import json
         params = json.loads(body)
@@ -207,7 +211,10 @@ class ActionManagerWebWrapper(object):
         args = params.get('args', {})
         nice = params.get('nice', 10.)
         timeout = params.get('timeout', 1e6)
-        self.action_manager.QueueAction(function_name, args, nice, timeout)
+        max_duration = params.get('max_duration', np.finfo(float).max)
+
+        self.action_manager.QueueAction(function_name, args, nice, timeout,
+                                        max_duration)
 
 
 class ActionManagerServer(webframework.APIHTTPServer, ActionManagerWebWrapper):

--- a/PYME/Acquire/ActionManager.py
+++ b/PYME/Acquire/ActionManager.py
@@ -137,7 +137,11 @@ class ActionManager(object):
             if expiry > time.time():
                 print('%s, %s' % (self.currentTask, functionName))
                 fcn = eval('.'.join(['self.scope()', functionName]))
-                self.isLastTaskDone = fcn(**args)            
+                self.isLastTaskDone = fcn(**args)
+            else:
+                past_expire = time.time() - expiry
+                logger.debug('task expired %f s ago, ignoring %s' % (past_expire,
+                                                                     self.currentTask))
     
     def _monitor_defunct(self):
         """

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -57,6 +57,10 @@ class QueueAcquisitions(OutputModule):
         positions will be ignored/unqueued from the action manager.
     nice: Int
         priority at which acquisition tasks should execute (default=10)
+    max_duration : float
+        A generous estimate, in seconds, of how long the task might take, after
+        which the lasers will be automatically turned off and the action queue
+        paused.
     between_post_throttle : Float
         Time in seconds to sleep between posts to avoid bombarding the 
         microscope-side server. Can be set to zero for ~no throttling.
@@ -67,6 +71,7 @@ class QueueAcquisitions(OutputModule):
     lifo = Bool(True)
     optimize_path = Bool(True)
     timeout = Float(np.finfo(float).max)
+    max_duration = Float(np.finfo(float).max)
     nice = Int(10)
     between_post_throttle = Float(0.01)
 
@@ -105,7 +110,8 @@ class QueueAcquisitions(OutputModule):
         for ri in range(positions.shape[0]):
             args = {'function_name': 'centre_roi_on', 
             'args': {'x': positions[ri, 0], 'y': positions[ri, 1]}, 
-                    'timeout': self.timeout, 'nice': self.nice}
+                    'timeout': self.timeout, 'nice': self.nice,
+                    'max_duration': self.max_duration}
             session.post(dest, data=json.dumps(args), 
                           headers={'Content-Type': 'application/json'})
             
@@ -113,7 +119,8 @@ class QueueAcquisitions(OutputModule):
 
             args = {'function_name': 'spoolController.StartSpooling',
                     'args': self.spool_settings,
-                    'timeout': self.timeout, 'nice': self.nice}
+                    'timeout': self.timeout, 'nice': self.nice,
+                    'max_duration': self.max_duration}
             session.post(dest, data=json.dumps(args), 
                           headers={'Content-Type': 'application/json'})
             

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -125,3 +125,9 @@ class QueueAcquisitions(OutputModule):
                           headers={'Content-Type': 'application/json'})
             
             time.sleep(self.between_post_throttle)
+        
+        # queue a high-nice call to shut off all lasers when we're done
+        args = {'function_name': 'turnAllLasersOff',
+                    'timeout': self.timeout, 'nice': np.iinfo(int).max}
+        session.post(dest, data=json.dumps(args), 
+                          headers={'Content-Type': 'application/json'})


### PR DESCRIPTION
Addresses issue accidentally thinking `timeout` was `max_duration` and setting it to something super low and expiring all but 3 series. 

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- make `max_duration` set-able from the `QueueAcquisitions` recipe module
- debug log when `ActionManager` pops up an action which has already expired






**Checklist:**

- [ ] tested on scope
