### PR TITLE
HTSMLM protocols / init script tweaks

### DIFF
--- a/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
+++ b/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
@@ -26,7 +26,7 @@ class OffsetPiezo(PiezoBase):
         self.basePiezo = basePiezo
         self.offset = 0
         # webframework.APIHTTPServer handles requests in separate threads
-        self._offset_lock = threading.Lock()
+        self._move_lock = threading.Lock()
         
     @property
     def units_um(self):
@@ -37,11 +37,17 @@ class OffsetPiezo(PiezoBase):
         
     @webframework.register_endpoint('/MoveTo', output_is_json=False)
     def MoveTo(self, iChannel, fPos, bTimeOut=True):
-        return self.basePiezo.MoveTo(int(iChannel), float(fPos) + self.offset, bool(bTimeOut))
+        with self._move_lock:
+            p = self.basePiezo.MoveTo(int(iChannel), float(fPos) + self.offset, 
+                                      bool(bTimeOut))
+        return p
 
     @webframework.register_endpoint('/MoveRel', output_is_json=False)
     def MoveRel(self, iChannel, incr, bTimeOut=True):
-        return self.basePiezo.MoveRel(int(iChannel), float(incr), bool(bTimeOut))
+        with self._move_lock:
+            p = self.basePiezo.MoveRel(int(iChannel), float(incr), 
+                                       bool(bTimeOut))
+        return p
 
     @webframework.register_endpoint('/GetPos', output_is_json=False)
     def GetPos(self, iChannel=0):
@@ -69,24 +75,24 @@ class OffsetPiezo(PiezoBase):
     @webframework.register_endpoint('/SetOffset', output_is_json=False)
     def SetOffset(self, offset):
         # both gettarget and moveto account for offset, so make sure we only apply the change once
-        with self._offset_lock:
+        with self._move_lock:
             pos = self.GetTargetPos(0)
             self.offset = float(offset)
-            self.MoveTo(0, pos)
+            # self.MoveTo(0, pos)
+            self.basePiezo.MoveTo(0, pos + self.offset, True)
 
     @webframework.register_endpoint('/CorrectOffset', output_is_json=False)
     def CorrectOffset(self, correction):
         # both gettarget and moveto account for offset, so make sure we only apply the change once
-        with self._offset_lock:
+        correction = float(correction)
+        with self._move_lock:
             target = self.GetTargetPos(0)
-            self.offset += float(correction)  # correct the offset; positive means push base pos higher than offsetpiezo pos
-            # make sure we don't go out of bounds for our base piezo
-            # the actual base position is the largest possible offset without dipping below 0. Base target is target + offset
-            # self.offset = min(self.offset, target + self.offset)
-            # should the offset be negative, the most we can hit is max travel - target position
-            # self.offset = max(self.offset, target + self.offset - self.basePiezo.max_travel)
-            self.offset = max(min(self.offset, target + self.offset), target + self.offset - self.basePiezo.max_travel)
-            self.MoveTo(0, target)  # move the base piezo to correct position
+            # correct the offset; positive means push base pos higher than offsetpiezo pos
+            correction = max(min(self.basePiezo.max_travel - (target + self.offset), 
+                                 correction), -(target + self.offset))
+            self.offset += correction
+            # self.MoveTo(0, target)  # move the base piezo to correct position
+            self.basePiezo.MoveTo(0, target + self.offset, True)
 
     @webframework.register_endpoint('/LogShifts', output_is_json=False)
     def LogShifts(self, dx, dy, dz, active=True):
@@ -224,15 +230,23 @@ class TargetOwningOffsetPiezo(OffsetPiezo):
 
     @webframework.register_endpoint('/MoveTo', output_is_json=False)
     def MoveTo(self, iChannel, fPos, bTimeOut=True):
-        self._target_position = float(fPos)
-        return self.basePiezo.MoveTo(int(iChannel), self._target_position + self.offset, bool(bTimeOut))
+        with self._move_lock:
+            self._target_position = float(fPos)
+            p = self.basePiezo.MoveTo(int(iChannel), 
+                                      self._target_position + self.offset, 
+                                      bool(bTimeOut))
+            return p
 
     @webframework.register_endpoint('/MoveRel', output_is_json=False)
     def MoveRel(self, iChannel, incr, bTimeOut=True):
-        self._target_position += float(incr)
-        print('here - moving to %f' % self._target_position)
-        return self.basePiezo.MoveTo(int(iChannel), self._target_position + self.offset, bool(bTimeOut))
-
+        with self._move_lock:
+            self._target_position += float(incr)
+            print('here - moving to %f' % self._target_position)
+            p = self.basePiezo.MoveTo(int(iChannel), 
+                                      self._target_position + self.offset, 
+                                      bool(bTimeOut))
+            return p
+    
     @webframework.register_endpoint('/GetPos', output_is_json=False)
     def GetPos(self, iChannel=0):
         return self.basePiezo.GetPos(int(iChannel)) - self.offset

--- a/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
+++ b/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
@@ -16,6 +16,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from PYME.Acquire.Hardware.Piezos.base_piezo import PiezoBase
+import threading
 
 class OffsetPiezo(PiezoBase):
     """
@@ -24,6 +25,8 @@ class OffsetPiezo(PiezoBase):
     def __init__(self, basePiezo):
         self.basePiezo = basePiezo
         self.offset = 0
+        # webframework.APIHTTPServer handles requests in separate threads
+        self._offset_lock = threading.Lock()
         
     @property
     def units_um(self):
@@ -66,9 +69,9 @@ class OffsetPiezo(PiezoBase):
     @webframework.register_endpoint('/SetOffset', output_is_json=False)
     def SetOffset(self, offset):
         # both gettarget and moveto account for offset, so make sure we only apply the change once
-        pos = self.GetPos()
+        pos = self.GetTargetPos()
         self.offset = float(offset)
-        self.MoveTo(pos)
+        self.MoveTo(0, pos)
 
     @webframework.register_endpoint('/CorrectOffset', output_is_json=False)
     def CorrectOffset(self, correction):

--- a/PYME/Acquire/Protocols/htsms-flow.py
+++ b/PYME/Acquire/Protocols/htsms-flow.py
@@ -3,9 +3,9 @@ from PYME.Acquire.protocol import *
 # T(when, what, *args) creates a new task. "when" is the frame number, "what" is a function to
 # be called, and *args are any additional arguments.
 taskList = [
-    # T(-1, scope.l642.TurnOn),
     T(0, scope.focus_lock.DisableLock),
-    # T(8000, scope.l560.TurnOn),
+    T(0, scope.l642.TurnOn),
+    T(0, scope.l560.TurnOn),
     # T(maxint, scope.turnAllLasersOff),
     T(maxint, scope.focus_lock.EnableLock)
 ]

--- a/PYME/Acquire/Protocols/htsms-tile.py
+++ b/PYME/Acquire/Protocols/htsms-tile.py
@@ -2,6 +2,10 @@
 from PYME.Acquire.protocol import *
 from PYME.Acquire.Utils.pointScanner import CircularPointScanner
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class Scanner(CircularPointScanner):
     def __init__(self, scan_radius_um=100):
@@ -9,11 +13,14 @@ class Scanner(CircularPointScanner):
         self.scan_radius_um = scan_radius_um
     
     def set_state(self, views=(0), size=(256, 256), integration_time=0.004):
-        self.enabled_views = scope.cam.active_views
-        self.roi_size = (scope.cam.size_x, scope.cam.size_y)
-        self.integration_time = scope.cam.GetIntegTime()
+        # for now, force views, otherwise if we don't queue before second htsms-tile we'll be stuck on view 1
+        self.enabled_views = [0, 1, 2, 3]  # scope.cam.active_views  
+        self.roi_size = (256, 256)  # (scope.cam.size_x, scope.cam.size_y)
+        self.integration_time = 0.0125  # scope.cam.GetIntegTime()
 
+        logger.debug('CAMERA SETTINGS - views %s, size %s, integration time %f [s]' % (views, size, integration_time))
         scope.frameWrangler.stop()
+        scope.cam.disable_multiview()
         scope.cam.enable_multiview(views)
         scope.cam.ChangeMultiviewROISize(size[0], size[1])
         scope.cam.SetIntegTime(integration_time)
@@ -33,9 +40,13 @@ class Scanner(CircularPointScanner):
         self.on_stop.connect(scope.spoolController.StopSpooling)
     
     def return_state(self):
+        logger.debug('returning camera state')
         scope.frameWrangler.stop()
+        scope.cam.disable_multiview()
         scope.cam.enable_multiview(self.enabled_views)
         scope.cam.ChangeMultiviewROISize(self.roi_size[0], self.roi_size[1])
+        scope.cam.SetIntegTime(self.integration_time)
+        # this is gross, but often setting 1.25 ms just hits 80 FPS first time
         scope.cam.SetIntegTime(self.integration_time)
         scope.frameWrangler.Prepare()
         scope.frameWrangler.start()
@@ -46,12 +57,14 @@ scanner = Scanner(scan_radius_um=500)
 
 # T(frame, function, *args) creates a new task
 taskList = [
+    T(-1, scope.turnAllLasersOff),
     T(-1, scope.l405.SetPower, 1),
-    T(-1, scanner.set_state, [1], (304, 304), 0.004),
+    T(-1, scanner.set_state, [1], (256, 256), 0.005),
     T(-1, scope.focus_lock.EnableLock),  # should already be enabled, but just in case
     T(-1, scope.l405.TurnOn),
     T(-1, scanner.genCoords),
     T(0, scanner.start),
+    # T(maxint, scope.l642.SetPower, 600),
     T(maxint, scope.turnAllLasersOff),
     T(maxint, scanner.return_state)
 ]

--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -53,6 +53,7 @@ def pz(scope):
     from PYME.Acquire import stage_leveling, PYMEAcquire
     import sys
     import subprocess
+    import requests
 
     # try and update the pifoc position roughly as often as the PID / camera, but a little faster if we can
     scope._piFoc = piezo_e816_dll.piezo_e816T(maxtravel=100, target_tol=0.035, update_rate=0.002)
@@ -63,9 +64,13 @@ def pz(scope):
 
     scope.focus_lock = RLPIDFocusLockClient()
     
-    subprocess.Popen('%s "%s" -i init_htsms_focus_lock.py -t "Focus Lock"' % (sys.executable,
-                                                                              PYMEAcquire.__file__),
-                     creationflags=subprocess.CREATE_NEW_CONSOLE)
+    try:  # check if we've got a focus lock PYMEAcquire instance up already
+        requests.get('http://127.0.0.1:9798/LockEnabled')
+    except requests.exceptions.ConnectionError:
+        fl_command = "%s" % PYMEAcquire.__file__
+        fl_command += ' -i init_htsms_focus_lock.py -t "Focus Lock"'
+        subprocess.Popen('%s %s' % (sys.executable, fl_command),
+                        creationflags=subprocess.CREATE_NEW_CONSOLE)
     
     scope._stage_leveler = stage_leveling.StageLeveler(scope, scope.piFoc)
 

--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -72,7 +72,8 @@ def pz(scope):
         subprocess.Popen('%s %s' % (sys.executable, fl_command),
                         creationflags=subprocess.CREATE_NEW_CONSOLE)
     
-    scope._stage_leveler = stage_leveling.StageLeveler(scope, scope.piFoc)
+    scope._stage_leveler = stage_leveling.StageLeveler(scope, scope.piFoc,
+                                                       focus_lock=scope.focus_lock)
 
 
 @init_hardware('HamamatsuORCA')

--- a/PYME/Acquire/stage_leveling.py
+++ b/PYME/Acquire/stage_leveling.py
@@ -24,6 +24,7 @@ class StageLeveler(object):
         offset_piezo: PYME.Acquire.Hardware.offsetPiezoREST.OffsetPiezo
         pause_on_relocate: float
             [optional] time to pause during measure loop after moving to a new location and before measuring offset.
+        focus_lock : PYME.Acquire.Hardware.focus_locks
 
         Notes
         -----
@@ -41,6 +42,11 @@ class StageLeveler(object):
         self._scope = scope
         self._offset_piezo = offset_piezo
         self._focus_lock = focus_lock
+        if self._focus_lock == None:
+            try:
+                self._focus_lock = scope.focus_lock
+            except AttributeError:
+                pass
         self._positions = []
         self._scans = []
         self._pause_on_relocate = pause_on_relocate
@@ -141,9 +147,12 @@ class StageLeveler(object):
             offset[ind] = self._offset_piezo.GetOffset()
             try:
                 lock_ok[ind] = self._focus_lock.LockOK()
+                logger.debug('lock OK %s, x %.1f, y %.1f, offset %.1f' % (lock_ok[ind],
+                                                                            x[ind], y[ind],
+                                                                            offset[ind]))
             except AttributeError:
-                pass
-
+                logger.debug('x %.1f, y %.1f, offset %.1f' % (x[ind], y[ind], 
+                                                              offset[ind]))
 
         self._scans.append({
             'x': x[lock_ok], 'y': y[lock_ok], 'offset': offset[lock_ok]

--- a/PYME/Acquire/stage_leveling.py
+++ b/PYME/Acquire/stage_leveling.py
@@ -1,9 +1,13 @@
 
 import numpy as np
 import time
+import logging
+
+logger = logging.getLogger(__name__)
 
 class StageLeveler(object):
-    def __init__(self, scope, offset_piezo, pause_on_relocate=0.25):
+    def __init__(self, scope, offset_piezo, pause_on_relocate=0.25, 
+                 focus_lock=None):
         """
         Allows semi-automated mapping of coverslip positions are various lateral positions using a focus lock/offset
         piezo to determine the offset.
@@ -36,6 +40,7 @@ class StageLeveler(object):
         """
         self._scope = scope
         self._offset_piezo = offset_piezo
+        self._focus_lock = focus_lock
         self._positions = []
         self._scans = []
         self._pause_on_relocate = pause_on_relocate
@@ -85,6 +90,23 @@ class StageLeveler(object):
         x_grid, y_grid = np.meshgrid(x, y, indexing='ij')
 
         self._positions.extend([{'x': xi, 'y': yi} for xi, yi in zip(x_grid.ravel(), y_grid.ravel())])
+    
+    def add_96wp_positions(self, short='x'):
+        """Shortcut for queueing center positions on a 96-well plate from 
+        minimum x, y well. x (8 well) should be short axis, y (12 well) long
+
+        Parameters
+        ----------
+        short: str
+            stage dimension of the short axis (8 wells) of the plate. Defaults
+            to x.
+        """
+        if short=='x':
+            self.add_grid(9000 * 8, 9000 * 12, 9000, 9000, center=False)
+        elif short=='y':
+            self.add_grid(9000 * 12, 9000 * 8, 9000, 9000, center=False)
+        else:
+            logger.error('short axes must be "x" or "y"')
 
     def measure_offsets(self, optimize_path=True):
         """
@@ -100,6 +122,7 @@ class StageLeveler(object):
         from PYME.Analysis.points.traveling_salesperson import sort
         n_positions = len(self._positions)
         offset = np.zeros(len(self._positions), dtype=float)
+        lock_ok = np.ones(len(self._positions), dtype=bool)
         x, y = np.zeros_like(offset), np.zeros_like(offset)
         positions = np.zeros((n_positions, 2), dtype=float)
         for ind in range(n_positions):
@@ -111,13 +134,19 @@ class StageLeveler(object):
 
         for ind in range(n_positions):
             self._scope.SetPos(x=positions[ind, 0], y=positions[ind, 1])
+            
             time.sleep(self._pause_on_relocate)
             actual = self._scope.GetPos()
             x[ind], y[ind] = actual['x'], actual['y']
             offset[ind] = self._offset_piezo.GetOffset()
+            try:
+                lock_ok[ind] = self._focus_lock.LockOK()
+            except AttributeError:
+                pass
+
 
         self._scans.append({
-            'x': x, 'y': y, 'offset': offset
+            'x': x[lock_ok], 'y': y[lock_ok], 'offset': offset[lock_ok]
         })
 
     @staticmethod
@@ -152,9 +181,11 @@ class StageLeveler(object):
                                                                               x_min - 0.5 * x_spacing, x_max + 0.5 * x_spacing))
         cbar = plt.colorbar()
         cbar.ax.set_ylabel('Offset [um]')
+        plt.plot(scan['y'], scan['x'], 'k--')
         plt.scatter(scan['y'], scan['x'], marker='x', label='measured')
         plt.xlabel('y [um]')
         plt.ylabel('x [um]')
+        plt.title('basePiezo position - offset = OffsetPiezo position')
         plt.legend()
         plt.axes().set_aspect('equal', 'box')
         plt.tight_layout()


### PR DESCRIPTION
Addresses issue 
- tiling protocol needs to have return state hardcoded. will clean out the 'return' stuff at some point. 
- Focus lock process doesn't need to be started if it's already running.
- helpful to only look at legitimate offset measures when leveling the stage
- offsetPiezoREST offset correction clipping was faulty, which let us jump to offsets out of range of the base piezo

**Is this a bugfix or an enhancement?**
yes
**Proposed changes:**
