### PR TITLE
make sure we slice/index with ints in UnsplitDataSource

### DIFF
--- a/PYME/DSView/modules/splitter.py
+++ b/PYME/DSView/modules/splitter.py
@@ -150,7 +150,7 @@ class Unmixer(Plugin):
             
         fns = os.path.split(self.image.filename)[1]
 
-        zm = usds[0].shape[2]/2
+        zm = int(usds[0].shape[2]/2)
 
         maxs = [u[:,:,zm].max() for u in usds]
         im = ImageStack(usds[np.argmax(maxs)], titleStub = '%s - unsplit' % fns)

--- a/PYME/IO/DataSources/UnsplitDataSource.py
+++ b/PYME/IO/DataSources/UnsplitDataSource.py
@@ -34,7 +34,7 @@ class DataSource(BaseDataSource):
         
         self._raw_w, self._raw_h = self.dataSource.shape[:2]
         
-        self.sliceShape[1]/=2
+        self.sliceShape[1] = int(self.sliceShape[1] / 2)
         
         if not chanROIs is None:
             x, y, w, h = chanROIs[0]
@@ -119,9 +119,9 @@ class DataSource(BaseDataSource):
             w, h = self.sliceShape
         else:
             if self.chan == 0:
-                x, y, w, h = 0,0, dsa.shape[0], dsa.shape[1]/2
+                x, y, w, h = 0,0, dsa.shape[0], int(dsa.shape[1] / 2)
             else:
-                x, y, w, h = 0, dsa.shape[1] / 2, dsa.shape[0], dsa.shape[1] / 2
+                x, y, w, h = 0, int(dsa.shape[1] / 2), dsa.shape[0], int(dsa.shape[1] / 2)
                 #print x, y
                 return dsa[x:(x+w), y:(y+h)]
         


### PR DESCRIPTION
Addresses issue py3 div -> float, resulting in float indexing arrays which either doesn't work or later numpy's won't try to convert.

**Is this a bugfix or an enhancement?**
probable bugfixes
**Proposed changes:**







**Checklist:**
note: untested, but noticed when looking at #537 