### PR TITLE
find selected 'series' _and_ 'files' for recipe form

### DIFF
--- a/PYME/cluster/clusterUI/recipes/templates/recipes/form_recipe.html
+++ b/PYME/cluster/clusterUI/recipes/templates/recipes/form_recipe.html
@@ -43,6 +43,12 @@
                     fileNames.push(sn);
                     f.append('<input name="files" class="cu-hidden-filename" type="hidden" value="' + sn + '">')
                 }
+                // Also check for series, e.g. pcs extensions
+                var sn = item.getAttribute('data-cu-seriesname');
+                if (sn != null) {
+                    fileNames.push(sn);
+                    f.append('<input name="files" class="cu-hidden-filename" type="hidden" value="' + sn + '">')
+                }
             });
             console.log(fileNames);
         };


### PR DESCRIPTION
Addresses issue #539

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- grab anything selected, even if it happens to be a 'series'

Alternatively we change the cluster browser such that 'series' are a subset of 'files' rather than else-ing them in `clusterUI.clusterbrowser.views._get_listing`