### PR TITLE
fix clusterUI mkdir

### DIFF
--- a/PYME/cluster/clusterUI/clusterbrowser/views.py
+++ b/PYME/cluster/clusterUI/clusterbrowser/views.py
@@ -138,6 +138,6 @@ def mkdir(request, basedir):
     if clusterIO.exists(newDirectory) or clusterIO.exists(newDirectory[:-1]):
         return HttpResponseForbidden('Directory already exists')
 
-    clusterIO.put_file(newDirectory, '')
+    clusterIO.put_file(newDirectory, bytes('', 'utf-8'))
 
     return HttpResponse(newDirectory)


### PR DESCRIPTION
Addresses issue mkdir issue from #487 .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- type `''` as bytes since `clusterIO.put_file` takes data input as bytes






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]