### PR TITLE
add refresh_settings for percentile buffers called during buffer refresh

### DIFF
--- a/PYME/IO/buffers.py
+++ b/PYME/IO/buffers.py
@@ -235,6 +235,19 @@ class backgroundBufferM:
 
         return self.curBG
     
+    def refresh_settings(self, percentile, buffer_length):
+        """Change percentile.
+
+        Parameters
+        ----------
+        percentile : float
+            fractional index to grab at each pixel (i.e. 0.5 corresponds to the
+            median)
+        buffer_length : int
+            ignored, as this buffer grows itself as needed.
+        """
+        self.pctile = percentile
+    
 class backgroundBufferMC(backgroundBufferM):
     def __init__(self, *args, **kwargs):
         backgroundBufferM.__init__(self, *args, **kwargs)

--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -115,8 +115,9 @@ class BufferManager(object):
                     # use our default CPU implementation
                     self.bBuffer = buffers.backgroundBufferM(self.dBuffer, md['Analysis.PCTBackground'])
             else:
-                # we already have a percentile buffer - just change the settings. TODO - Does this need to change to reflect introduction of GPU based buffering?
-                self.bBuffer.pctile = md['Analysis.PCTBackground']
+                # we already have a percentile buffer - just change the settings
+                self.bBuffer.refresh_settings(md['Analysis.PCTBackground'],
+                                              bufferLen)
         else:
             if not isinstance(self.bBuffer, buffers.backgroundBuffer):
                 self.bBuffer = buffers.backgroundBuffer(self.dBuffer)


### PR DESCRIPTION
Addresses issue TODO in `PYME.localization.remFitBuf`, and https://github.com/python-microscopy/pyme-warp-drive/issues/4.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- add `refresh_settings` method to all percentile buffers




**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
