### PR TITLE
add subdirectory kwarg to `SpoolController.StartSpooling`

### DIFF
--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -201,7 +201,28 @@ class SpoolController(object):
         
     @property
     def dirname(self):
+        return self.get_dirname()
+    
+    def get_dirname(self, subdirectory=None):
+        """ Get the current directory name, including any subdirectories from
+        chunking or additional spec.
+
+        Parameters
+        ----------
+        subdirectory : str, optional
+            Directory within current set directory to spool this series. The
+            directory will be created if it doesn't already exist.
+
+        Returns
+        -------
+        str
+            spool directory name
+        """
         dir = self._dirname if self.spoolType != 'Cluster' else self._cluster_dirname
+
+        if subdirectory != None:
+            dir = dir + self._sep + subdirectory
+        
         if config.get('acquire-spool_subdirectories', False):
             # limit single directory size for (cluster) IO performance
             subdir = '%03d' % int(self.seriesCounter/100)
@@ -290,19 +311,37 @@ class SpoolController(object):
             
         self.onSpoolProgress.send(self)
         
-    def _get_queue_name(self, fn, pcs=False):
+    def _get_queue_name(self, fn, pcs=False, subdirectory=None):
+        """ Get fully resolved uri to spool to
+
+        Parameters
+        ----------
+        fn : str
+            file stub of the series
+        pcs : bool, optional
+            sets extension to PYME Cluster Series (pcs) if spooling series as
+            plurality of pcs files, by default False (spooling to h5 file)
+        subdirectory : str, optional
+            Directory within current set directory to spool this series. The
+            directory will be created if it doesn't already exist.
+
+        Returns
+        -------
+        str
+            fully resolved uri to spool to
+        """
         if pcs:
             ext = '.pcs'
         else:
             ext = '.h5'
         
-        return self._sep.join([self.dirname, fn + ext])
+        return self._sep.join([self.get_dirname(subdirectory), fn + ext])
 
 
     def StartSpooling(self, fn=None, stack=None, compLevel=None, 
                       zDwellTime=None, doPreflightCheck=True, 
                       maxFrames=sys.maxsize, pzf_compression_settings=None, 
-                      cluster_h5=None, protocol=None):
+                      cluster_h5=None, protocol=None, subdirectory=None):
         """
 
         Parameters
@@ -338,6 +377,9 @@ class SpoolController(object):
         protocol : str, optional
             path to acquisition protocol. By default None which differs to 
             current `SpoolController` state.
+        subdirectory : str, optional
+            Directory within current set directory to spool this series. The
+            directory will be created if it doesn't already exist.
         """
         # these settings were managed by the GUI, but are now managed by the 
         # controller, still allow them to be passed in, but default to internals
@@ -354,8 +396,8 @@ class SpoolController(object):
             protocol, protocol_z = pmod.PROTOCOL, pmod.PROTOCOL_STACK
 
         # make directories as needed, makedirs(dir, exist_ok=True) once py2 support is dropped
-        if (self.spoolType != 'Cluster') and (not os.path.exists(self.dirname)):
-                os.makedirs(self.dirname)
+        if (self.spoolType != 'Cluster') and (not os.path.exists(self.get_dirname(subdirectory))):
+                os.makedirs(self.get_dirname(subdirectory))
 
         if self._checkOutputExists(fn): #check to see if data with the same name exists
             self.seriesCounter +=1
@@ -384,14 +426,15 @@ class SpoolController(object):
         
         if self.spoolType == 'Queue':
             from PYME.Acquire import QueueSpooler
-            self.queueName = getRelFilename(self._get_queue_name(fn))
+            self.queueName = getRelFilename(self._get_queue_name(fn, subdirectory=subdirectory))
             self.spooler = QueueSpooler.Spooler(self.queueName, self.scope.frameWrangler.onFrame, 
                                                 frameShape = frameShape, protocol=protocol, 
                                                 guiUpdateCallback=self._ProgressUpate, complevel=compLevel, 
                                                 fakeCamCycleTime=fakeCycleTime, maxFrames=maxFrames)
         elif self.spoolType == 'Cluster':
             from PYME.Acquire import HTTPSpooler
-            self.queueName = self._get_queue_name(fn, pcs=(not cluster_h5))
+            self.queueName = self._get_queue_name(fn, pcs=(not cluster_h5), 
+                                                  subdirectory=subdirectory)
             self.spooler = HTTPSpooler.Spooler(self.queueName, self.scope.frameWrangler.onFrame,
                                                frameShape = frameShape, protocol=protocol,
                                                guiUpdateCallback=self._ProgressUpate,
@@ -400,7 +443,8 @@ class SpoolController(object):
            
         else:
             from PYME.Acquire import HDFSpooler
-            self.spooler = HDFSpooler.Spooler(self._get_queue_name(fn), self.scope.frameWrangler.onFrame,
+            self.spooler = HDFSpooler.Spooler(self._get_queue_name(fn, subdirectory=subdirectory),
+                                              self.scope.frameWrangler.onFrame,
                                               frameShape = frameShape, protocol=protocol, 
                                               guiUpdateCallback=self._ProgressUpate, complevel=compLevel, 
                                               fakeCamCycleTime=fakeCycleTime, maxFrames=maxFrames)
@@ -579,7 +623,7 @@ class SpoolControllerWrapper(object):
     def start_spooling(self, filename=None, stack=None, hdf_comp_level=None, 
                       z_dwell=None, preflight_check=True, 
                       max_frames=sys.maxsize, pzf_compression_settings=None, 
-                      cluster_h5=None, protocol=None):
+                      cluster_h5=None, protocol=None, subdirectory=None):
         """
 
         Parameters
@@ -615,10 +659,13 @@ class SpoolControllerWrapper(object):
         protocol : str, optional
             path to acquisition protocol. By default None which differs to 
             current `SpoolController` state.
+        subdirectory : str, optional
+            Directory within current set directory to spool this series. The
+            directory will be created if it doesn't already exist.
         """
         self.spool_controller.StartSpooling(filename, stack, hdf_comp_level, 
                                             z_dwell, preflight_check,
                                             max_frames, 
                                             pzf_compression_settings, 
-                                            cluster_h5, protocol)
+                                            cluster_h5, protocol, subdirectory)
         return 'OK'

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -221,7 +221,7 @@ class SpoolController(object):
         dir = self._dirname if self.spoolType != 'Cluster' else self._cluster_dirname
 
         if subdirectory != None:
-            dir = dir + self._sep + subdirectory
+            dir = dir + self._sep + subdirectory.replace(os.sep, self._sep)
         
         if config.get('acquire-spool_subdirectories', False):
             # limit single directory size for (cluster) IO performance

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -43,6 +43,10 @@ class QueueAcquisitions(OutputModule):
                 see PYME.Acquire.HTTPSpooler
             protocol_name : str
                 filename of the acquisition protocol to follow while spooling
+            subdirectory : str
+                firectory within current SpoolController set directory to spool
+                a given series. The directory will be created if it doesn't 
+                already exist.
     lifo: Bool
         last-in first-out behavior (True) starts at the last position in 
         `input_positions`, False starts with the 0th. Useful in instances where


### PR DESCRIPTION
Addresses issue #528 

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- add an optional subdirectory kwarg to StartSpooling. This does not call the full 'SetDirectory', and will only add a directory below the current directory. We do a quick replace(os.sep, SpoolController._sep) just in case someone wants multiple subdirectories _and_ was bold enough to `\\` it






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [x] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
