### PR TITLE
Move focus lock reacquisition from stage leveling to focuslock code

### DIFF
--- a/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
+++ b/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
@@ -175,6 +175,14 @@ class OffsetPiezoClient(PiezoBase):
 
     def LogFocusCorrection(self, offset):
         self._session.get(self.urlbase + '/LogFocusCorrection?offset=%3.3f' % (offset,))
+    
+    def GetMaxOffset(self):
+        res = self._session.get(self.urlbase + '/GetMaxOffset')
+        return float(res.json())
+    
+    def GetMinOffset(self):
+        res = self._session.get(self.urlbase + '/GetMinOffset')
+        return float(res.json())
 
 def generate_offset_piezo_server(offset_piezo_base_class):
     """

--- a/PYME/Acquire/stage_leveling.py
+++ b/PYME/Acquire/stage_leveling.py
@@ -144,7 +144,10 @@ class StageLeveler(object):
             time.sleep(self._pause_on_relocate)
             if hasattr(self, '_focus_lock') and not self._focus_lock.LockOK():
                 logger.debug('focus lock not OK, scanning offset')
-                self.scan_offset_until_ok()
+                # self.scan_offset_until_ok()
+                self._focus_lock.ReacquireLock()
+                time.sleep(1.)
+
                 if self._focus_lock.LockOK():
                     time.sleep(1.)
             actual = self._scope.GetPos()
@@ -162,27 +165,6 @@ class StageLeveler(object):
         self._scans.append({
             'x': x[lock_ok], 'y': y[lock_ok], 'offset': offset[lock_ok]
         })
-    
-    def scan_offset_until_ok(self, step_size=5.):
-        done=False
-        min_offset = self._offset_piezo.GetMinOffset() + 1e-6
-        max_offset = self._offset_piezo.GetMaxOffset() - 1e-6
-        scan_positions = np.arange(min_offset, max_offset + step_size, 
-                                   step_size)
-        for pos in scan_positions:
-            logger.debug('looking for focus, offset: %.1f' % pos)
-            # self._focus_lock.DisableLock()
-            self._offset_piezo.SetOffset(pos)
-            # self._focus_lock.EnableLock()
-            time.sleep(0.5)
-            done = self._focus_lock.LockOK()
-            if done:
-                logger.debug('found focus, offset %.1f' % pos)
-                break
-        
-        if not done:
-            logger.debug('failed to find focus, lowering objective')
-            self._offset_piezo.SetOffset(min_offset)
 
     @staticmethod
     def plot_scan(scan, interpolation_factor=50):


### PR DESCRIPTION
Addresses issue #550, first two sub-proposals. Makes things easier for stage leveling - piezo is calmer when lock is off during step-through.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- move ReacquireLock (focus finding routine) from stage_leveling into `reflection_focus_lock.py`






**Checklist:**

- [ ] Tested with numpy=1.14

1.19
- [ ] Tested on python 2.7 and 3.6

3.6
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?


