### PR TITLE
set filenames for multiwell tile acqs and subdirectories for follow-on series

### DIFF
--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -91,7 +91,17 @@ class QueueAcquisitions(OutputModule):
             resolved directory name in which the input file resides) and 
             'filestub' (which is the filename without any extension) should be 
             resolved.
+        
+        Notes
+        -----
+        str spool_settings values can context-substitute templated parameters,
+        e.g. spool_settings = {'subdirectory': '{filestub}'}
         """
+        # substitute spool settings
+        spool_settings = self.spool_settings.copy()
+        for k in spool_settings.keys():
+            if isinstance(spool_settings[k], str):
+                spool_settings[k].format(**context)
         
         try:  # get positions in units of micrometers
             positions = np.stack((namespace[self.input_positions]['x_um'], 
@@ -122,7 +132,7 @@ class QueueAcquisitions(OutputModule):
             time.sleep(self.between_post_throttle)
 
             args = {'function_name': 'spoolController.StartSpooling',
-                    'args': self.spool_settings,
+                    'args': spool_settings,
                     'timeout': self.timeout, 'nice': self.nice,
                     'max_duration': self.max_duration}
             session.post(dest, data=json.dumps(args), 

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -101,7 +101,7 @@ class QueueAcquisitions(OutputModule):
         spool_settings = self.spool_settings.copy()
         for k in spool_settings.keys():
             if isinstance(spool_settings[k], str):
-                spool_settings[k].format(**context)
+                spool_settings[k] = spool_settings[k].format(**context)
         
         try:  # get positions in units of micrometers
             positions = np.stack((namespace[self.input_positions]['x_um'], 


### PR DESCRIPTION
Addresses issue organizing multiwell acquisitions, particularly with chained detection/acquisition queuing.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- assume we start at A1 and name tile acquisition series queued from multiwell tile panel
![image](https://user-images.githubusercontent.com/31105780/97635963-a7ae1480-1a0e-11eb-8844-350cf164d287.png)

-  allow recipe output context (e.g. input filestub, basedir) to be substitute values in `recipes.acquisition.QueueAcquisitions.spool_settings`

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?

** note **
- multiwell tile panel could eventually be moved to a nice gui menu item which let you preview (based on tile_triggered preflight), select circular/square, support for 384 wp, not starting at A1, etc.. Eventually
