### PR TITLE
clip Analysis.StartAt to current frame in test frame

### DIFF
--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -923,7 +923,9 @@ class LMAnalyser2(Plugin):
         if mn == 'BufferedDataSource':
             mn = self.image.dataSource.dataSource.moduleName
 
-        ft = remFitBuf.fitTask(dataSourceID=self.image.seriesName, frameIndex=zp, metadata=MetaDataHandler.NestedClassMDHandler(analysisMDH), dataSourceModule=mn)
+        mdh = MetaDataHandler.NestedClassMDHandler(analysisMDH)
+        mdh['Analysis.StartAt'] = min(mdh['Analysis.StartAt'], zp)
+        ft = remFitBuf.fitTask(dataSourceID=self.image.seriesName, frameIndex=zp, metadata=mdh, dataSourceModule=mn)
         res = ft(gui=gui,taskQueue=self.tq)
         
         if gui:
@@ -979,8 +981,6 @@ class LMAnalyser2(Plugin):
                     # 
                     # TODO - document GPU background interface via creating a base class in PYME.IO.buffers
                     d = (ft.data - ft.bg.get_background().reshape(ft.data.shape)).squeeze().T
-                else:
-                    raise RuntimeError('Background format not understood')
                     
                 plt.imshow(d, cmap=plt.cm.jet, interpolation='nearest', clim = [0, d.max()])
                 plt.xlim(0, d.shape[1])

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -981,6 +981,8 @@ class LMAnalyser2(Plugin):
                     # 
                     # TODO - document GPU background interface via creating a base class in PYME.IO.buffers
                     d = (ft.data - ft.bg.get_background().reshape(ft.data.shape)).squeeze().T
+                else:
+                    raise RuntimeError('Background format not understood')
                     
                 plt.imshow(d, cmap=plt.cm.jet, interpolation='nearest', clim = [0, d.max()])
                 plt.xlim(0, d.shape[1])


### PR DESCRIPTION
Addresses issue #558 .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- for frame testing, clip StartAt so we include the current frame. Note issue 558 is a bit more than defining fittask.bg, as data also has to be defined, etc.. 


**Note**
- I think this is the right move, but also looking at remFitBuf shortcircuiting running test frame on a frame of zeros would also hit same error as #558 which is not solved by this PR






**Checklist:**

- [ ] Tested with numpy=1.14

1.19
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
