### PR TITLE
more strictly format the recipe task templates

### DIFF
--- a/PYME/cluster/HTTPRulePusher.py
+++ b/PYME/cluster/HTTPRulePusher.py
@@ -329,26 +329,21 @@ class RecipePusher(object):
 
     @property
     def _taskTemplate(self):
-        task = '''{"id": "{{ruleID}}~{{taskID}}",
-              "type": "recipe",
-              "inputs" : {{taskInputs}},
-              %s,
-              %s
-              }'''
+        task = {
+            'id': '{{ruleID}}~{{taskID}}',
+            'type':'recipe',
+            'inputs': '{{taskInputs}}',
+        }
 
-        if self.output_dir is None:
-            output_dir_n = ''
-        else:
-            output_dir_n = '"output_dir": "%s",' % self.output_dir
-        
+        if self.output_dir != None:
+            task['output_dir'] = self.output_dir
+
         if self.recipeURI:
-            task = task % ('"taskdefRef" : "%s"' % self.recipeURI, output_dir_n)
+            task['taskdefRef'] = self.recipeURI
         else:
-            task = task % ('"taskdef" : {"recipe": "%s"}' % self.recipe_text, output_dir_n)
-            
-
-        return task
-
+            task['taskdef'] = '"taskdef" : {"recipe": "%s"}' % self.recipe_text
+        
+        return json.dumps(task)
 
 
     def fileTasksForInputs(self, **kwargs):
@@ -365,7 +360,7 @@ class RecipePusher(object):
         inputs_by_task = {frameNum: {k : inputs[k][frameNum] for k in inputs.keys()} for frameNum in range(numTotalFrames)}
 
         rule = {'template': self._taskTemplate, 'inputsByTask' : inputs_by_task}
-
+        print('intputs by task %s' % inputs_by_task)
         s = clusterIO._getSession(self.taskQueueURI)
         r = s.post('%s/add_integer_id_rule?max_tasks=%d&release_start=%d&release_end=%d' % (self.taskQueueURI,numTotalFrames, 0, numTotalFrames), data=json.dumps(rule),
                         headers = {'Content-Type': 'application/json'})

--- a/PYME/cluster/HTTPRulePusher.py
+++ b/PYME/cluster/HTTPRulePusher.py
@@ -360,7 +360,7 @@ class RecipePusher(object):
         inputs_by_task = {frameNum: {k : inputs[k][frameNum] for k in inputs.keys()} for frameNum in range(numTotalFrames)}
 
         rule = {'template': self._taskTemplate, 'inputsByTask' : inputs_by_task}
-        print('intputs by task %s' % inputs_by_task)
+        
         s = clusterIO._getSession(self.taskQueueURI)
         r = s.post('%s/add_integer_id_rule?max_tasks=%d&release_start=%d&release_end=%d' % (self.taskQueueURI,numTotalFrames, 0, numTotalFrames), data=json.dumps(rule),
                         headers = {'Content-Type': 'application/json'})

--- a/PYME/cluster/HTTPRulePusher.py
+++ b/PYME/cluster/HTTPRulePusher.py
@@ -335,7 +335,7 @@ class RecipePusher(object):
             'inputs': '{{taskInputs}}',
         }
 
-        if self.output_dir != None:
+        if self.output_dir is not None:
             task['output_dir'] = self.output_dir
 
         if self.recipeURI:
@@ -373,6 +373,5 @@ class RecipePusher(object):
             logging.error('Failed creating rule with status code: %d' % r.status_code)
 
         
-
 
 

--- a/PYME/cluster/HTTPRulePusher.py
+++ b/PYME/cluster/HTTPRulePusher.py
@@ -341,7 +341,7 @@ class RecipePusher(object):
         if self.recipeURI:
             task['taskdefRef'] = self.recipeURI
         else:
-            task['taskdef'] = '"taskdef" : {"recipe": "%s"}' % self.recipe_text
+            task['taskdef'] = {'recipe':  self.recipe_text}
         
         return json.dumps(task)
 

--- a/PYME/cluster/rules.py
+++ b/PYME/cluster/rules.py
@@ -404,7 +404,7 @@ class RecipeRule(Rule):
             'inputs': '{{taskInputs}}',
         }
 
-        if self.output_dir != None:
+        if self.output_dir is not None:
             task['output_dir'] = self.output_dir
 
         if self.recipeURI:

--- a/PYME/cluster/rules.py
+++ b/PYME/cluster/rules.py
@@ -395,6 +395,9 @@ class RecipeRule(Rule):
         return dict(max_tasks=self._num_recipe_tasks, release_start=0, release_end=self._num_recipe_tasks)
     
     def _task_template(self, context):
+        # FIXME - task templates should ideally be a .json formatted string. Generating them from dictionarie
+        # as done here is not ideal as it limits templating to within string entries (and is potentially less
+        # less readable / incurs extra overhead in dumps.
         task = {
             'id': '{{ruleID}}~{{taskID}}',
             'type':'recipe',
@@ -407,7 +410,7 @@ class RecipeRule(Rule):
         if self.recipeURI:
             task['taskdefRef'] = self.recipeURI
         else:
-            task['taskdef'] = '"taskdef" : {"recipe": "%s"}' % self.recipe_text
+            task['taskdef'] = {'recipe': self.recipe_text}
         
         task = json.dumps(task)
             

--- a/PYME/cluster/rules.py
+++ b/PYME/cluster/rules.py
@@ -395,22 +395,21 @@ class RecipeRule(Rule):
         return dict(max_tasks=self._num_recipe_tasks, release_start=0, release_end=self._num_recipe_tasks)
     
     def _task_template(self, context):
-        task = '''{"id": "{{ruleID}}~{{taskID}}",
-                      "type": "recipe",
-                      "inputs" : {{taskInputs}},
-                      %s,
-                      %s
-                      }'''
-        
-        if self.output_dir is None:
-            output_dir_n = ''
-        else:
-            output_dir_n = '"output_dir": "%s",' % self.output_dir
-        
+        task = {
+            'id': '{{ruleID}}~{{taskID}}',
+            'type':'recipe',
+            'inputs': '{{taskInputs}}',
+        }
+
+        if self.output_dir != None:
+            task['output_dir'] = self.output_dir
+
         if self.recipeURI:
-            task = task % ('"taskdefRef" : "%s"' % self.recipeURI, output_dir_n)
+            task['taskdefRef'] = self.recipeURI
         else:
-            task = task % ('"taskdef" : {"recipe": "%s"}' % self.recipe_text, output_dir_n)
+            task['taskdef'] = '"taskdef" : {"recipe": "%s"}' % self.recipe_text
+        
+        task = json.dumps(task)
             
         #if we are a chained rule, hard-code inputs
         rule_outputs = context.get('rule_outputs', None)


### PR DESCRIPTION
Addresses issue #560 .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- more strictly format recipe templates

printed on the rulenodeserver at the end of `template_fill`
```
{"id": "{{ruleID}}~0", "type": "recipe", "inputs": "{"input":"pyme-cluster:\/\/\/Bergamot\/2020_10_28\/CalibrationStacks_real\/000\/analysis\/28_10_series_L_reg.h5r"}", "output_dir": "pyme-cluster:///Bergamot/2020_10_28/CalibrationStacks_real/000/analysis/analysis", "taskdefRef": "pyme-cluster://villains/RECIPES/calibrate-multiview-shifts.yaml"}
```
Note the issue with the inputs / inputsByTask substitution which still needs to be addressed, e.g. by #485 
