### PR TITLE
actually use config'd cluster name during spool

### DIFF
--- a/PYME/Acquire/HTTPSpooler.py
+++ b/PYME/Acquire/HTTPSpooler.py
@@ -76,8 +76,6 @@ class EventLogger:
         return json.dumps(self._events)
           
 
-CLUSTERID=''  
-
 def genSequenceID(filename=''):
     return  int(time.time()) & random.randint(0, 2**31) << 31 
     
@@ -123,7 +121,8 @@ class Spooler(sp.Spooler):
         #print filename, self.seriesName
         self._aggregate_h5 = kwargs.get('aggregate_h5', False)
         
-        self.clusterFilter = kwargs.get('serverfilter', CLUSTERID)
+        self.clusterFilter = kwargs.get('serverfilter', 
+                                        config.get('dataserver-filter', ''))
         self._buffer = []
         
         self.buflen = config.get('httpspooler-chunksize', 50)


### PR DESCRIPTION
Addresses issue just making sure we get cache keys right everywhere, even though I don't think `clusterIO._locateCache` is going to be super important on the instrument computer.

**Is this a bugfix or an enhancement?**
maybe slight bugfix
**Proposed changes:**
- user config'd serverfilter rather than `''` in `HTTPSpooler`






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
