### PR TITLE
change get to getordefault for detection filter size in AstigGaussGPUFitFR

### DIFF
--- a/PYME/localization/FitFactories/AstigGaussGPUFitFR.py
+++ b/PYME/localization/FitFactories/AstigGaussGPUFitFR.py
@@ -162,7 +162,8 @@ class GaussianFitFactory:
             pass
 
         # Account for any changes we need to make to the detector instance
-        small_filter_size = self.metadata.getEntry('Analysis.DetectionFilterSize')
+        small_filter_size = self.metadata.getOrDefault('Analysis.DetectionFilterSize', 
+                                                       4)
         guess_psf_sigma_pix = self.metadata.getOrDefault('Analysis.GuessPSFSigmaPix',
                                                          600 / 2.8 / (self.metadata.voxelsize_nm.x))
 


### PR DESCRIPTION
Addresses issue #currently fitfactory specific metadata, 'analysis details', do not get pulled into analysismdh for e.g. measurement.FitPoints

**Is this a bugfix or an enhancement?**
bugfix, smaller than the full issue but would get me back in action without taxing our limited bandwidth as much as reviewing my making FitFactory instances default their metadata from PARAMETERS
