### PR TITLE
simple sample metadata panel

### DIFF
--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -128,6 +128,12 @@ def orca_cam_controls(MainFrame, scope):
     MainFrame.AddMenuItem('Camera', 'Set Multiview', lambda e: scope.state.setItem('Camera.Views', [0, 1, 2, 3]))
     MainFrame.AddMenuItem('Camera', 'Clear Multiview', lambda e: scope.state.setItem('Camera.Views', []))
 
+@init_gui('Sample Metadata')
+def sample_metadata(main_frame, scope):
+    from PYME.Acquire.sampleInformation import SimpleSampleInfoPanel
+    sampanel = SimpleSampleInfoPanel(main_frame)
+    main_frame.camPanels.append((sampanel, 'Sample Metadata'))
+
 @init_hardware('Lasers & Shutters')
 def lasers(scope):
     from PYME.Acquire.Hardware.Coherent import OBIS

--- a/PYME/Acquire/sampleInformation.py
+++ b/PYME/Acquire/sampleInformation.py
@@ -582,3 +582,4 @@ class SimpleSampleInfoPanel(wx.Panel):
             mdh['Sample.SlideRef'] = self.slide.GetValue()
             mdh['Sample.Creator'] = self.creator.GetValue()
             mdh['Sample.Notes'] = self.notes.GetValue()
+            mdh['AcquiringUser'] = self.imager.GetValue()

--- a/PYME/Acquire/sampleInformation.py
+++ b/PYME/Acquire/sampleInformation.py
@@ -528,6 +528,12 @@ class SimpleSampleInfoPanel(wx.Panel):
         """Simple sample info panel to tide over until the SampleInfoDialog is
         refactored to work independently of a sampleDB database.
 
+TODOS/LIMITATIONS: potentially better addressed by the full refactor rather than by modifying this class, but included here for information / to reinforce that this should ideally be replaced at some point in the future.
+
+ - auto-populate and/or hide acquiring user using logon name on multi-user systems (preference would be to have a config option which can be set on a single user system, but which defaults to false)
+ - include info on what is labelled (i.e. Sample.Labelling entries). This is super,super useful to have in the metadata
+ - because there is no sanity checking / database backend etc ... you will likely get subtly differing values for acquiring user and creator which will make it hard to search on these if the data ever gets ingested into a database in the future.
+ 
         Parameters
         ----------
         parent : wx parent

--- a/PYME/Acquire/sampleInformation.py
+++ b/PYME/Acquire/sampleInformation.py
@@ -521,3 +521,64 @@ def createImage(mdh, slide, comments=''):
     pass
 
 #MetaDataHandler.provideStartMetadata.append(lambda mdh: getSampleDataFailsafe)
+
+
+class SimpleSampleInfoPanel(wx.Panel):
+    def __init__(self, parent):
+        """Simple sample info panel to tide over until the SampleInfoDialog is
+        refactored to work independently of a sampleDB database.
+
+        Parameters
+        ----------
+        parent : wx parent
+        """
+        wx.Panel.__init__(self, parent)
+        from PYME.IO import MetaDataHandler
+
+        MetaDataHandler.provideStartMetadata.append(self.GenStartMetadata)
+
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, 'Slide:'), 0, wx.ALL, 2)
+        self.slide = wx.TextCtrl(self, -1, value='')
+        hsizer.Add(self.slide, 1, wx.EXPAND)
+        vsizer.Add(hsizer, 1, wx.EXPAND)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, 'Creator:'), 0, wx.ALL, 2)
+        self.creator = wx.TextCtrl(self, -1, value='')
+        hsizer.Add(self.creator, 1, wx.EXPAND)
+        vsizer.Add(hsizer, 1, wx.EXPAND)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, 'Imager:'), 0, wx.ALL, 2)
+        self.imager = wx.TextCtrl(self, -1, value='')
+        hsizer.Add(self.imager, 1, wx.EXPAND)
+        vsizer.Add(hsizer, 1, wx.EXPAND)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, 'Notes:'), 0, wx.ALL, 2)
+        self.notes = wx.TextCtrl(self, -1, value='')
+        hsizer.Add(self.notes, 1, wx.EXPAND)
+        vsizer.Add(hsizer, 1, wx.EXPAND)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.save = wx.CheckBox(self, -1, 'Save to metadata')
+        hsizer.Add(self.save, 1, wx.EXPAND)
+        vsizer.Add(hsizer, 1, wx.EXPAND)
+
+        self.SetSizerAndFit(vsizer)
+
+    def GenStartMetadata(self, mdh):
+        """Collects the metadata we want to record at the start of a sequence
+        
+        Parameters
+        ----------
+        mdh : PYME.IO.MetaDataHandler.MDHandlerBase
+            The metadata handler to which we should write our metadata         
+        """
+        if self.save.GetValue():
+            mdh['Sample.SlideRef'] = self.slide.GetValue()
+            mdh['Sample.Creator'] = self.creator.GetValue()
+            mdh['Sample.Notes'] = self.notes.GetValue()


### PR DESCRIPTION
Addresses issue #536.



**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- add a sample sample metadata entry panel - pragmatic solution to have _something_ easily while we refactor the full sampleinfodialog
- use it in init_htsms

<img width="242" alt="Screen Shot 2020-11-02 at 10 46 00 PM" src="https://user-images.githubusercontent.com/31105780/97948348-45327c80-1d5e-11eb-818c-0951f30bf528.png">




**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
