### PR TITLE
py3 fixes for html recipe editor

### DIFF
--- a/PYME/cluster/clusterUI/clusterui_tornado.py
+++ b/PYME/cluster/clusterUI/clusterui_tornado.py
@@ -57,14 +57,14 @@ class JignaWebApp(web.Application):
 
     def __init__(self, handlers=None, default_host="", transforms=None,
                  context=None, template=None, trait_change_dispatch="same",
-                 async=False, **kw):
+                 asynchronous=False, **kw):
 
         if template is not None:
-            template.async = async
+            template._async = asynchronous
         self.context = context
         self.template = template
         self.trait_change_dispatch = trait_change_dispatch
-        self.async = async
+        self._async = asynchronous
 
         if handlers is None:
             handlers = []
@@ -81,7 +81,7 @@ class JignaWebApp(web.Application):
         """
 
         # Set up the WebServer to serve the domain models in context
-        klass = jignaws.AsyncWebServer if self.async else jignaws.WebServer
+        klass = jignaws.AsyncWebServer if self._async else jignaws.WebServer
         server = klass(
             base_url              = os.path.join(os.getcwd(), self.template.base_url),
             html                  = self.template.html,

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -1122,10 +1122,19 @@ class ModuleCollection(HasTraits):
         TODO - potential issues on Py3 with how jigna treats namedtuple?
         """
         from . import recipeLayout
-        from collections import namedtuple
-        layout_info = namedtuple('layout', ['node_positions', 'connecting_lines'])
-        node = namedtuple('node', ['key', 'pos'])
-        
+        #from collections import namedtuple
+        #layout_info = namedtuple('layout', ['node_positions', 'connecting_lines'])
+        #node = namedtuple('node', ['key', 'pos'])
+        class layout_info(object):
+            def __init__(self, node_positions, connecting_lines):
+                self.node_positions = node_positions
+                self.connecting_lines = connecting_lines
+
+        class node(object):
+            def __init__(self, key, pos):
+                self.key = key
+                self.pos = pos
+
         node_positions, connecting_lines = recipeLayout.layout(self.dependancyGraph())
         ret =   layout_info([node(k, v) for k, v in node_positions.items()], [(a.tolist(), b.tolist(), c) for a,b,c in connecting_lines])
         #print (ret)


### PR DESCRIPTION
- replace `namedtuple` with custom class so structure gets parsed correctly by jigna on py3
- replace all `async` variable names in `clusterui_tornado.py` (python >=3.7 compat) - note needs patched version of jigna as well.

@barentine - should now be working on py3 & chrome (firefox has an issue with Float typed params, but I suspect this isn't python version related).
