### PR TITLE
focus correction event mapping fixes

### DIFF
--- a/PYME/Analysis/piecewiseMapping.py
+++ b/PYME/Analysis/piecewiseMapping.py
@@ -77,7 +77,7 @@ def times_to_frames(t, events, mdh):
     #fr = np.zeros_like(t)
     
     
-    fr = sfr[si-1] + ((t - startEvents['Time'][si-1]) / cycTime)
+    fr = sfr[si-1] + ((t - startEvents['Time'][si-1]) / cycTime).astype(int)
     
     if np.isscalar(fr):
         if si < len(sfr):

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -1762,7 +1762,7 @@ class AverageFramesByZStep(ModuleBase):
         logger.debug('Averaged stack size: %d' % n_steps)
 
         new_stack = []
-        t = time.time()
+        t = image_stack.mdh.getOrDefault('StartTime', time.time())
         fudged_events = []
         cycle_time = image_stack.mdh.getOrDefault('Camera.CycleTime', 1.0)
         for ci in range(image_stack.data.shape[3]):

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -1762,7 +1762,8 @@ class AverageFramesByZStep(ModuleBase):
         logger.debug('Averaged stack size: %d' % n_steps)
 
         new_stack = []
-        t = image_stack.mdh.getOrDefault('StartTime', time.time())
+       # TODO - should we default to zero or abort?
+        t = image_stack.mdh.getOrDefault('StartTime', 0)
         fudged_events = []
         cycle_time = image_stack.mdh.getOrDefault('Camera.CycleTime', 1.0)
         for ci in range(image_stack.data.shape[3]):

--- a/tests/PYME/Analysis/test_piezo_movement_correction.py
+++ b/tests/PYME/Analysis/test_piezo_movement_correction.py
@@ -2,6 +2,10 @@
 import numpy as np
 from PYME.IO.MetaDataHandler import NestedClassMDHandler
 
+# basePiezo position - offset = OffsetPiezo position
+# Note that the ProtocolFocus events know about the offset (ie are logged by
+# the OffsetPiezo), while the PiezoOnTarget events are logged by the BasePiezo.
+
 TEST_EVENTS = np.array([('PiezoOnTarget', 0, '48.262'),
        ('ProtocolFocus', 0, '0, 49.988'),
        ('PiezoOnTarget', 1 * 0.00125, '48.307'),
@@ -17,7 +21,25 @@ TEST_EVENTS = np.array([('PiezoOnTarget', 0, '48.262'),
                        # fixme - but the S32 and S256 back to unicode once we fix event typing elsewhere
       dtype=[('EventName', 'S32'), ('Time', '<f8'), ('EventDescr', 'S256')])
 
+CHANGES = np.array([(0, 0, 48.262, 48.262),
+       (1 * 0.00125, 1, 48.307, 48.307),
+       (801 * 0.00125, 801, 51.188, 51.188),
+       (850 * 0.00125, 850, 49.489 + 1.6720, 49.489),
+       (1601 * 0.00125, 1601, 52.388, 52.388),
+       (1650 * 0.00125, 1650, 50.705 + 1.6720, 50.705),
+       (2401 * 0.00125, 2401, 53.588, 53.588)],
+       dtype= [('t', '<f8'), ('frame', '<i4'), ('z', '<f8'), 
+               ('z_ignoring_offset', '<f8')])
+
 TEST_DATA_SOURCE = np.arange(2500).astype([('t', '<i4')])
+GROUND_TRUTH_Z = np.empty(len(TEST_DATA_SOURCE), dtype=float)
+GROUND_TRUTH_Z_IGNORING_OFFSET = np.empty_like(GROUND_TRUTH_Z)
+I = np.argsort(CHANGES['t'])
+CHANGES = CHANGES[I]
+for frame, z, z_no_off in zip(CHANGES['frame'], CHANGES['z'], CHANGES['z_ignoring_offset']):
+    GROUND_TRUTH_Z[frame:] = z
+    GROUND_TRUTH_Z_IGNORING_OFFSET[frame:] = z_no_off
+
 
 TEST_MDH = NestedClassMDHandler()
 TEST_MDH['Camera.CycleTime'] = 0.00125
@@ -33,4 +55,4 @@ def test_flag_piezo_movement():
 def test_focus_correction():
     from PYME.Analysis.piezo_movement_correction import correct_target_positions
     corrected_focus = correct_target_positions(TEST_DATA_SOURCE['t'], TEST_EVENTS, TEST_MDH)
-    # fixme - write an actual test
+    np.testing.assert_array_almost_equal(GROUND_TRUTH_Z, corrected_focus)


### PR DESCRIPTION
Addresses issue #575 and not actually testing piezo ontarget / offsetpiezo stuff.

**Is this a bugfix or an enhancement?**
both
**Proposed changes:**
- type integers in `piecewiseMapping.times_to_frames` as int so we don't get sporadic rounding errors when deciding which side of a piecewise point something falls on
- beef up the piezo movement focus correction test
- use start time from metadata in `processing.AverageFramesByZStep` so our fudged events match our metadata



**OLD, but leaving it here Note**
This brings up a potential issue with piecewiseMapping and rounding. The test fails on one of the ProtocolFocus events active like it's 1-indexed (or the focus takes place on the next frame) while the rest do not. Having StartTime at zero, and setting all frame numbers as cycletime * frame number, I wonder if we are rounding somewhere in a str->back converstion.