### PR TITLE
remove hack around software trigger issue which makes it worse

### DIFF
--- a/PYME/Acquire/frameWrangler.py
+++ b/PYME/Acquire/frameWrangler.py
@@ -237,18 +237,6 @@ class FrameWrangler(object):
             import traceback
             traceback.print_exc()
 
-            # If we are running in software trigger mode and fail to get a
-            # frame we may need a another software trigger to e.g. Tick over
-            # the rest of a protocol. See https://github.com/python-microscopy/python-microscopy/issues/517
-            # This is not an ideal addition to frameWrangler, and will
-            # hopefully be removed in the future.
-            try:  # as of 2020/10 a couple cameras don't use the base class
-                if self.cam.GetAcquisitionMode() == self.cam.MODE_SOFTWARE_TRIGGER:
-                    logger.debug('retrying software trigger')
-                    self.cam.FireSoftwareTrigger()
-            except AttributeError:
-                pass
-
         finally:       
             if not contMode:
                 #flag the need to start a new exposure


### PR DESCRIPTION
Addresses issue #517.

**Is this a bugfix or an enhancement?**
~bugfix
**Proposed changes:**
- remove the software-trigger re-fire on error in frameWrangler

During tiling we sometimes hit this error. We'd thought this would help since previously manually firing one from the shell got us started again, however I found that this did not help (as mentioned in #517).

I tried commenting out the HDFSpoolFrame update freespace (which takes awhile on the moment when spooling to the cluster, see #545 ), which got the GUI running smoothly again but we still locked up when we hit the dcam error. Instead I commented out this re-fire and ran again and things work smoothly! We do still hit this error pretty regularly, but this re-fire certainly isn't out ticket out of it.






**Checklist:**

- [ ] Tested with numpy=1.14

1.19
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]


**additional context**
testing with multiwell tiling using htsms-tile.py, a modified version which I'm about to PR (though i don't think it should really affect this)