### PR TITLE
HTSMLM tweaks

### DIFF
--- a/PYME/Acquire/Hardware/Camera.py
+++ b/PYME/Acquire/Hardware/Camera.py
@@ -1067,3 +1067,19 @@ class MultiviewCameraMixin(object):
                 mdh.setEntry('Multiview.ActiveViews', self.active_views)
                 for ind in range(self.n_views):
                     mdh.setEntry('Multiview.ROI%dOrigin' % ind, self.view_origins[ind])
+
+        def register_state_handlers(self, state_manager):
+            """ Allow key multiview settings to be updated easily through
+            the microscope state handler
+
+            Parameters
+            ----------
+            state_manager : PYME.Acquire.microscope.State
+            """
+            state_manager.registerHandler('Multiview.ActiveViews', 
+                                          lambda : self.active_views, 
+                                          self.enable_multiview, True)
+            state_manager.registerHandler('Multiview.ROISize', 
+                                          lambda : [self.size_x, self.size_y],
+                                          lambda x, y : self.ChangeMultiviewROISize(x, y),
+                                          True)

--- a/PYME/Acquire/Hardware/Camera.py
+++ b/PYME/Acquire/Hardware/Camera.py
@@ -947,6 +947,15 @@ class MultiviewCameraMixin(object):
                 return self._current_pic_height
             else:
                 return self.camera_class.GetPicHeight(self)
+        
+        def set_active_views(self, views):
+            if len(views) == 0:
+                self.disable_multiview()
+            elif sorted(views) == self.active_views:
+                pass
+            else:
+                self.enable_multiview(views)
+            
 
         def enable_multiview(self, views):
             """
@@ -965,7 +974,7 @@ class MultiviewCameraMixin(object):
             again. This is not special to this function, but rather anytime SetROI gets called.
 
             """
-            views = list(views)  # tuple(int) isn't iterable, make sure we avoid it
+            views = sorted(list(views))  # tuple(int) isn't iterable, make sure we avoid it
             # set the camera FOV to be just large enough so we do most of the cropping where it is already optimized
             self.x_origins, self.y_origins = zip(*[self.view_origins[view] for view in views])
             chip_x_min, chip_x_max = min(self.x_origins), max(self.x_origins)
@@ -1078,7 +1087,7 @@ class MultiviewCameraMixin(object):
             """
             state_manager.registerHandler('Multiview.ActiveViews', 
                                           lambda : self.active_views, 
-                                          self.enable_multiview, True)
+                                          self.set_active_views, True)
             state_manager.registerHandler('Multiview.ROISize', 
                                           lambda : [self.size_x, self.size_y],
                                           lambda x, y : self.ChangeMultiviewROISize(x, y),

--- a/PYME/Acquire/Hardware/Camera.py
+++ b/PYME/Acquire/Hardware/Camera.py
@@ -1085,10 +1085,12 @@ class MultiviewCameraMixin(object):
             ----------
             state_manager : PYME.Acquire.microscope.State
             """
+            logger.debug('registering multiview camera state handlers')
+            
             state_manager.registerHandler('Multiview.ActiveViews', 
                                           lambda : self.active_views, 
                                           self.set_active_views, True)
             state_manager.registerHandler('Multiview.ROISize', 
                                           lambda : [self.size_x, self.size_y],
-                                          lambda x, y : self.ChangeMultiviewROISize(x, y),
+                                          lambda p : self.ChangeMultiviewROISize(p[0], p[1]),
                                           True)

--- a/PYME/Acquire/Protocols/htsms-flow.py
+++ b/PYME/Acquire/Protocols/htsms-flow.py
@@ -3,9 +3,16 @@ from PYME.Acquire.protocol import *
 # T(when, what, *args) creates a new task. "when" is the frame number, "what" is a function to
 # be called, and *args are any additional arguments.
 taskList = [
-    T(0, scope.focus_lock.DisableLock),
-    T(0, scope.l642.TurnOn),
-    T(0, scope.l560.TurnOn),
+    T(-1, scope.state.update, {
+        'Lasers.MPB560.On': True,
+        'Lasers.MPB560.Power': 550.0,
+        'Lasers.MPB642.On': True,
+        'Lasers.MPB642.Power': 575.0,
+        'Multiview.ActiveViews': [0, 1, 2, 3],
+        'Multiview.ROISize': [256, 256],
+        'Camera.IntegrationTime': 0.00125,
+    }),
+    T(-1, scope.focus_lock.DisableLock),
     # T(maxint, scope.turnAllLasersOff),
     T(maxint, scope.focus_lock.EnableLock)
 ]

--- a/PYME/Acquire/Protocols/htsms-tile.py
+++ b/PYME/Acquire/Protocols/htsms-tile.py
@@ -43,6 +43,14 @@ class Scanner(CircularPointScanner):
         scope.cam.SetIntegTime(integration_time)
         scope.frameWrangler.Prepare()
         scope.frameWrangler.start()
+    
+    def check_focus_lock_ok(self):
+        if not scope.focus_lock.LockOK():
+            import time
+            logger.debug('lock not OK, pausing for 10 s')
+            time.sleep(10)
+            logger.debug('starting reacquire sequence')
+            scope.focus_lock.ReacquireLock()
 
 
 scanner = Scanner(scan_radius_um=500)
@@ -53,6 +61,7 @@ taskList = [
     T(-1, scope.l405.SetPower, 1),
     T(-1, scanner.set_state, [1], (256, 256), 0.005),
     T(-1, scope.focus_lock.EnableLock),  # should already be enabled, but just in case
+    T(-1, scanner.check_focus_lock_ok),
     T(-1, scope.l405.TurnOn),
     T(-1, scanner.genCoords),
     T(0, scanner.start),

--- a/PYME/Acquire/Protocols/htsms-tile.py
+++ b/PYME/Acquire/Protocols/htsms-tile.py
@@ -12,16 +12,7 @@ class Scanner(CircularPointScanner):
         self.enabled_views = []
         self.scan_radius_um = scan_radius_um
     
-    def set_state(self, views=(1), size=(256, 256), integration_time=0.004):
-        logger.debug('CAMERA SETTINGS - views %s, size %s, integration time %f [s]' % (views, size, integration_time))
-        scope.frameWrangler.stop()
-        scope.cam.disable_multiview()
-        scope.cam.enable_multiview(views)
-        scope.cam.ChangeMultiviewROISize(size[0], size[1])
-        scope.cam.SetIntegTime(integration_time)
-        scope.frameWrangler.Prepare()
-        scope.frameWrangler.start()
-
+    def setup(self):
         fs = np.array((scope.cam.size_x, scope.cam.size_y))
         # calculate tile spacing such that there is ~30% overlap.
         tile_spacing = (1/np.sqrt(2)) * fs * np.array(scope.GetPixelSize())
@@ -33,18 +24,13 @@ class Scanner(CircularPointScanner):
                                             1, 0, False, True, trigger=True, 
                                             stop_on_complete=True, return_to_start=False)
         self.on_stop.connect(scope.spoolController.StopSpooling)
-    
-    def return_state(self, views=(0), size=(256, 256), integration_time=0.004):
-        logger.debug('returning camera state')
-        scope.frameWrangler.stop()
-        scope.cam.disable_multiview()
-        scope.cam.enable_multiview(views)
-        scope.cam.ChangeMultiviewROISize(size[0], size[1])
-        scope.cam.SetIntegTime(integration_time)
-        scope.frameWrangler.Prepare()
-        scope.frameWrangler.start()
+        
+        self.genCoords()
+
+        self.check_focus_lock_ok()
     
     def check_focus_lock_ok(self):
+        scope.focus_lock.EnableLock()  # make sure we have the lock on
         if not scope.focus_lock.LockOK():
             import time
             logger.debug('lock not OK, pausing for 10 s')
@@ -58,15 +44,16 @@ scanner = Scanner(scan_radius_um=500)
 # T(frame, function, *args) creates a new task
 taskList = [
     T(-1, scope.turnAllLasersOff),
-    T(-1, scope.l405.SetPower, 1),
-    T(-1, scanner.set_state, [1], (256, 256), 0.005),
-    T(-1, scope.focus_lock.EnableLock),  # should already be enabled, but just in case
-    T(-1, scanner.check_focus_lock_ok),
+    T(-1, scope.state.update, {
+        'Lasers.OBIS405.Power': 1.0,
+        'Multiview.ActiveViews': [1],
+        'Multiview.ROISize': [256, 256],
+        'Camera.IntegrationTime': 0.005,
+    }),
+    T(-1, scanner.setup),
     T(-1, scope.l405.TurnOn),
-    T(-1, scanner.genCoords),
     T(0, scanner.start),
     T(maxint, scope.turnAllLasersOff),
-    T(maxint, scanner.return_state, [0, 1, 2, 3], (256, 256), 0.00125)
 ]
 
 #optional - metadata entries

--- a/PYME/Acquire/Protocols/htsms-two-color.py
+++ b/PYME/Acquire/Protocols/htsms-two-color.py
@@ -3,8 +3,15 @@ from PYME.Acquire.protocol import *
 # T(when, what, *args) creates a new task. "when" is the frame number, "what" is a function to
 # be called, and *args are any additional arguments.
 taskList = [
-    T(-1, scope.l642.TurnOn),
-    T(-1, scope.l560.TurnOn),
+    T(-1, scope.state.update, {
+        'Lasers.MPB560.On': True,
+        'Lasers.MPB560.Power': 550.0,
+        'Lasers.MPB642.On': True,
+        'Lasers.MPB642.Power': 575.0,
+        'Multiview.ActiveViews': [0, 1, 2, 3],
+        'Multiview.ROISize': [256, 256],
+        'Camera.IntegrationTime': 0.00125,
+    }),
     T(0, scope.focus_lock.DisableLock),
     T(maxint, scope.turnAllLasersOff),
     T(maxint, scope.focus_lock.EnableLock)

--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -106,14 +106,7 @@ def orca_cam(scope):
     # as it's much easier
     # TODO - make flip, rotate etc actually work for tiling in case we have two cameras
     scope.register_camera(cam, 'HamamatsuORCA', rotate=False, flipx=False, flipy=False)
-
-    def set_camera_views(views):
-        if (views is None) or (len(views) == 0):
-            cam.disable_multiview()
-        else:
-            cam.enable_multiview(views)
-
-    scope.state.registerHandler('Camera.Views', lambda: cam.active_views, set_camera_views, True)
+    cam.register_state_handlers(scope.state)
 
 
 @init_gui('sCMOS Camera controls')
@@ -125,8 +118,10 @@ def orca_cam_controls(MainFrame, scope):
     scope.camControls['HamamatsuORCA'] = wx.Panel(MainFrame)
     MainFrame.camPanels.append((scope.camControls['HamamatsuORCA'], 'ORCA Properties'))
 
-    MainFrame.AddMenuItem('Camera', 'Set Multiview', lambda e: scope.state.setItem('Camera.Views', [0, 1, 2, 3]))
-    MainFrame.AddMenuItem('Camera', 'Clear Multiview', lambda e: scope.state.setItem('Camera.Views', []))
+    MainFrame.AddMenuItem('Camera', 'Set Multiview', 
+                          lambda e: scope.state.setItem('Multiview.ActiveViews', [0, 1, 2, 3]))
+    MainFrame.AddMenuItem('Camera', 'Clear Multiview', 
+                          lambda e: scope.state.setItem('Multiview.ActiveViews', []))
 
 @init_gui('Sample Metadata')
 def sample_metadata(main_frame, scope):

--- a/PYME/Acquire/Scripts/init_htsms_focus_lock.py
+++ b/PYME/Acquire/Scripts/init_htsms_focus_lock.py
@@ -72,7 +72,7 @@ def focus_lock(MainFrame, scope):
     scope.focus_lock = RLPIDFocusLockServer(scope, scope.piFoc, p=kp, i=ki, d=0,
                                             sample_time=0.0035, 
                                             min_amp=0.5 * 10**5,
-                                            max_sigma=12.)
+                                            max_sigma=14.5)
     scope.focus_lock.register()
     panel = FocusLockPanel(MainFrame, scope.focus_lock)
     MainFrame.camPanels.append((panel, 'Focus Lock'))

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -352,7 +352,9 @@ class MultiwellProtocolQueuePanel(wx.Panel):
 
         curr_pos = self.scope.GetPos()
 
-        xind_names = np.array([chr(ord('@') + n) for n in range(1, n_x + 1)])   # TODO - make this work for e.g. 384 wp, and configurable from a dialog
+        # TODO - making this more flexible orientation wise, numbering for e.g.
+        # 384wp, etc.. This puts H1 of a 96er at the min x, min y well.
+        xind_names = np.array([chr(ord('@') + n) for n in range(1, n_x + 1)[::-1]])
         yind_names = np.arange(1, n_y + 1).astype(str)
 
         x_w = np.arange(0, n_x * x_spacing, x_spacing)


### PR DESCRIPTION
**Proposed changes:**
- change sigma threshold on the focus lock so we don't clip too much off the upper part of our range
- check that we have our lock, and reacquire if necessary, at the beginning of tiling






**Notes:**
will submit another PR adding some sort of a method to the multiview cameras to check that we have all the settings we want (restart/prepare frameWrangler [an argument of this method] if we need to) and make sure all of the htsms protocols have their cam settings enforced in the protocol that way rather than this hacky change to 'tile mode' then change to 'SMLM mode' afterwards (which is really odd if all you're doing is tiling!)