### PR TITLE
swap order so we generate start metadata after protocol setup tasks

### DIFF
--- a/PYME/Acquire/Spooler.py
+++ b/PYME/Acquire/Spooler.py
@@ -123,14 +123,17 @@ class Spooler:
        
 
     def StartSpool(self):
+        """ Perform protocol 'frame -1' tasks, log start metadata, then connect
+        to the frame source.
+        """
         self.watchingFrames = True
         eventLog.WantEventNotification.append(self.evtLogger)
 
         self.imNum = 0
-   
-        self.doStartLog()
 
         self.protocol.Init(self)
+
+        self.doStartLog()
    
         self.frameSource.connect(self.OnFrame, dispatch_uid=self._spooler_uuid)
         self.spoolOn = True


### PR DESCRIPTION
Addresses issue discussed in #582, where changing something, e.g. active camera views, in a protocol initialization doesn't carry through to start metadata because it was already generated.

**Is this a bugfix or an enhancement?**
~eh
**Proposed changes:**







**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?

I don't know if anyone's trying to do weird back metadata hacks, or using final metadata to get around this or not

- [x] Does this maintain backwards compatibility with old data?
- [x] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
