### PR TITLE
Update number of localizations displayed after recipe execution

### DIFF
--- a/PYME/recipes/vertical_recipe_display.py
+++ b/PYME/recipes/vertical_recipe_display.py
@@ -47,7 +47,7 @@ class RecipeDisplayPanel(wx.Panel):
         self.recipe = recipe
         self.recipe.recipe_changed.connect(self._layout)
         self._layout()
-        self.recipe.recipe_executed.connect(self._update_st)
+        self.recipe.recipe_executed.connect(self._update_n_events)
 
     def _refr(self, **kwargs):
         #print 'p_'
@@ -58,17 +58,20 @@ class RecipeDisplayPanel(wx.Panel):
         self.GetParent().Layout()
         self.GetParent().GetParent().Layout()
         self.Refresh()
-    
-    def _update_st(self, *args, **kwargs):
-        for node, t in self.data_panes.items():
-            node_col = tuple([int(v) for v in (255 * self._col(node)[:3])])
 
-            evts = ''
-            data = self.recipe.namespace.get(node, None)
-            if isinstance(data, tabular.TabularBase):
-                evts = ' [%d evts]' % len(data)
-                    
-            t[1].SetLabelMarkup("<span foreground='#%02x%02x%02x'>%s%s</span>" % (node_col + (node,evts)))
+    def _set_n_events(self, node, st):
+        node_col = tuple([int(v) for v in (255 * self._col(node)[:3])])
+
+        evts = ''
+        data = self.recipe.namespace.get(node, None)
+        if isinstance(data, tabular.TabularBase):
+            evts = ' [%d evts]' % len(data)
+                
+        st.SetLabelMarkup("<span foreground='#%02x%02x%02x'>%s%s</span>" % (node_col + (node,evts)))
+
+    def _update_n_events(self, *args, **kwargs):
+        for node, t in self.data_panes.items():
+            self._set_n_events(node, t[1])
 
     def _layout(self, *args, **kwargs):
         print('RecipeView._layout')
@@ -174,14 +177,7 @@ class RecipeDisplayPanel(wx.Panel):
                         item = afp.foldingPane(self.fp, -1, caption=None, pinned=True, folded=False, padding=0, style=0)
                         st = wx.StaticText(item, -1, node)
                         
-                        node_col = tuple([int(v) for v in (255 * self._col(node)[:3])])
-
-                        evts = ''
-                        data = self.recipe.namespace.get(node, None)
-                        if isinstance(data, tabular.TabularBase):
-                            evts = ' [%d evts]' % len(data)
-                                
-                        st.SetLabelMarkup("<span foreground='#%02x%02x%02x'>%s%s</span>" % (node_col + (node,evts)))
+                        self._set_n_events(node, st)
                             
                         item.AddNewElement(st, foldable=False)
                         self.fp.AddPane(item)

--- a/PYME/recipes/vertical_recipe_display.py
+++ b/PYME/recipes/vertical_recipe_display.py
@@ -47,6 +47,7 @@ class RecipeDisplayPanel(wx.Panel):
         self.recipe = recipe
         self.recipe.recipe_changed.connect(self._layout)
         self._layout()
+        self.recipe.recipe_executed.connect(self._update_st)
 
     def _refr(self, **kwargs):
         #print 'p_'
@@ -57,7 +58,18 @@ class RecipeDisplayPanel(wx.Panel):
         self.GetParent().Layout()
         self.GetParent().GetParent().Layout()
         self.Refresh()
-        
+    
+    def _update_st(self, *args, **kwargs):
+        for node, t in self.data_panes.items():
+            node_col = tuple([int(v) for v in (255 * self._col(node)[:3])])
+
+            evts = ''
+            data = self.recipe.namespace.get(node, None)
+            if isinstance(data, tabular.TabularBase):
+                evts = ' [%d evts]' % len(data)
+                    
+            t[1].SetLabelMarkup("<span foreground='#%02x%02x%02x'>%s%s</span>" % (node_col + (node,evts)))
+
     def _layout(self, *args, **kwargs):
         print('RecipeView._layout')
         if self.fp:


### PR DESCRIPTION
Addresses issue #571.

**Is this a bugfix or an enhancement?**
Yes

**Proposed changes:**
- Option 2 proposed by @David-Baddeley in #571: only update the event counts when the pipeline updates. Conveniently, we were already keeping track of stack text elements in `RecipeDisplayPanel.data_panes`.

![image](https://user-images.githubusercontent.com/1263313/98324268-d3ef0580-1fb9-11eb-8e72-a6054472c22b.png)


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
