### PR TITLE
allow dh5view SUPERTILE:PYME-CLUSTER:///tileseries.pcs loading

### DIFF
--- a/PYME/IO/DataSources/SupertileDatasource.py
+++ b/PYME/IO/DataSources/SupertileDatasource.py
@@ -86,6 +86,9 @@ class SupertileDataSource(BaseDataSource):
         overlap = int(qp.get('overlap', [1])[0])
         
         mdh = MetaDataHandler.load_json(os.path.join(tile_base, 'metadata.json'))  # TODO - does this need to be posixpath?
+        if 'Pyramid.TileSize' not in mdh.keys():
+            return SupertileDataSource.from_raw_tile_series(filename)
+        
         # TODO - make the ImagePyramid read it's own metadata
         p = ImagePyramid(tile_base, pyramid_tile_size=mdh['Pyramid.TileSize'], x0=mdh['Pyramid.x0'], y0=mdh['Pyramid.y0'], mdh=mdh)
         


### PR DESCRIPTION
Addresses issue #wanting to grab a high level of supertile from the cluster quickly without writing two new recipe modules

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- if we don't have pyramid metadata when we hit supertile from filename make the pyramid. Note we already have a warning in place for the non-lightweightness of this (though for small series, e.g. 300 frames, it's really not bad)






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

