### PR TITLE
Bug fix so that scrolling in the recipe module dialog is possible

### DIFF
--- a/PYME/recipes/recipeGui.py
+++ b/PYME/recipes/recipeGui.py
@@ -234,7 +234,7 @@ class ModuleSelectionDialog(wx.Dialog):
 
         hsizer.Add(self.tree_list, 1, wx.EXPAND|wx.ALL, 2)
 
-        self.stModuleHelp = wx.html.HtmlWindow(self, -1, size=(400, -1))#wx.StaticText(self, -1, '', size=(400, -1))
+        self.stModuleHelp = wx.html.HtmlWindow(self.pan, -1, size=(400, -1))#wx.StaticText(self, -1, '', size=(400, -1))
         hsizer.Add(self.stModuleHelp, 0, wx.EXPAND|wx.ALL, 5)
 
         vsizer.Add(hsizer, 1, wx.EXPAND|wx.ALL, 0)


### PR DESCRIPTION
Addresses issue #162  .

**Is this a bugfix or an enhancement?**
bugfix

**Proposed changes:**
Change the parent in the `HtmlWindow` constructor from the wx.Dialog to the wx.Panel
Tested on Windows 10






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
2.7 and 3.7
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing much simpler if this is kept separate from functional changes]

