### PR TITLE
fix/tweak to multiviewMapping PYMEVis calls

### DIFF
--- a/PYME/LMVis/Extras/multiviewMapping.py
+++ b/PYME/LMVis/Extras/multiviewMapping.py
@@ -200,7 +200,7 @@ class MultiviewMapper:
 
 
         calibration_module = CalibrateShifts()
-        if not calibration_module.configure_traits(view=calibration_module.pipeline_view_min, kind='modal'):
+        if not calibration_module.configure_traits(kind='modal'):
             return
         
         sm = calibration_module.apply_simple(self.pipeline.selectedDataSource)
@@ -387,7 +387,7 @@ class MultiviewMapper:
         mapping_module = MapAstigZ(recipe, input_name=self.pipeline.selectedDataSourceKey,
                                    astigmatism_calibration_location=pathToMap, output_name='z_mapped')
 
-        if mapping_module.configure_traits(view=mapping_module.pipeline_view_min, kind='modal'):
+        if mapping_module.configure_traits(kind='modal'):
             recipe.add_modules_and_execute([mapping_module,])
             
             self.pipeline.selectDataSource('z_mapped')

--- a/PYME/LMVis/Extras/multiviewMapping.py
+++ b/PYME/LMVis/Extras/multiviewMapping.py
@@ -120,11 +120,10 @@ class MultiviewMapper:
         from PYME.recipes.tablefilters import FilterTable
 
         recipe = self.pipeline.recipe
-        #TODO - move me to building the pipeline
-        recipe.add_modules_and_execute([FilterTable(recipe, inputName=self.pipeline.selectedDataSourceKey,
-                                                    outputName='filtered_input', filters={'error_x':[0, 30.], 'error_y':[0,30.]}),
-                                        Fold(recipe, input_name='filtered_input', output_name='folded')
-                                        ])
+        
+        recipe.add_modules_and_execute([Fold(recipe,
+                                             input_name=self.pipeline.selectedDataSourceKey, 
+                                             output_name='folded')])
         
         self.pipeline.selectDataSource('folded')
 


### PR DESCRIPTION
Addresses issue see comments of #531

**Is this a bugfix or an enhancement?**
one bugfix, one enhancement
**Proposed changes:**
- don't use pipeline view when configuring an individual module as this results in no 'OK' button (see #531)
- drop the filter (I think following a TODO) we had added originally to make sure we didn't merge awful localizations, but we now take care of by default with an upstream `FilterTable`






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
