### PR TITLE
Wrap self.fp.DestroyChildren() in a try block

### DIFF
--- a/PYME/recipes/vertical_recipe_display.py
+++ b/PYME/recipes/vertical_recipe_display.py
@@ -61,8 +61,13 @@ class RecipeDisplayPanel(wx.Panel):
     def _layout(self, *args, **kwargs):
         print('RecipeView._layout')
         if self.fp:
-             self.fp.elements = []
-             self.fp.DestroyChildren()
+            self.fp.elements = []
+            # Wrap this in a try block to prevent an error when using OutputModules
+            # TODO: Figure out why this is necessary.
+            try:
+                self.fp.DestroyChildren()
+            except:
+                pass
         self.fp = None
         #print('destroyed fold panel children')
         


### PR DESCRIPTION
Addresses issue #603.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Wrap self.fp.DestroyChildren() in a try block






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
