### PR TITLE
consolidate verify results filename in nameUtils

### DIFF
--- a/PYME/IO/FileUtils/nameUtils.py
+++ b/PYME/IO/FileUtils/nameUtils.py
@@ -273,3 +273,34 @@ def getRelFilename(filename, datadir=datadir):
         return filename[len(dataDir):]
 
     return filename
+
+def verify_cluster_results_filename(resultsFilename):
+    """
+    Checks whether a results file already exists on the cluster, and returns an
+    available version of the results filename. Should be called before writing
+    a new results file.
+
+    Parameters
+    ----------
+    resultsFilename : str
+        cluster path, e.g. pyme-cluster:///example_folder/name.h5r
+    Returns
+    -------
+    resultsFilename : str
+        cluster path which may have _# appended to it if the input 
+        resultsFileName is already in use, e.g. 
+        pyme-cluster:///example_folder/name_1.h5r
+
+    """
+    from PYME.IO import clusterIO
+    import os
+    if clusterIO.exists(resultsFilename):
+        di, fn = os.path.split(resultsFilename)
+        i = 1
+        stub = os.path.splitext(fn)[0]
+        while clusterIO.exists(os.path.join(di, stub + '_%d.h5r' % i)):
+            i += 1
+
+        resultsFilename = os.path.join(di, stub + '_%d.h5r' % i)
+
+    return resultsFilename

--- a/PYME/cluster/HTTPRulePusher.py
+++ b/PYME/cluster/HTTPRulePusher.py
@@ -56,36 +56,6 @@ def _getTaskQueueURI(n_retries=2):
         logger.info('no local rule server, choosing one at random')
         return random.choice(list(queueURLs.values()))
 
-def verify_cluster_results_filename(resultsFilename):
-    """
-    Checks whether a results file already exists on the cluster, and returns an available version of the results
-    filename. Should be called before writing a new results file.
-
-    Parameters
-    ----------
-    resultsFilename : str
-        cluster path, e.g. pyme-cluster:///example_folder/name.h5r
-    Returns
-    -------
-    resultsFilename : str
-        cluster path which may have _# appended to it if the input resultsFileName is already in use, e.g.
-        pyme-cluster:///example_folder/name_1.h5r
-
-    """
-    from PYME.IO import clusterIO
-    import os
-    if clusterIO.exists(resultsFilename):
-        di, fn = os.path.split(resultsFilename)
-        i = 1
-        stub = os.path.splitext(fn)[0]
-        while clusterIO.exists(os.path.join(di, stub + '_%d.h5r' % i)):
-            i += 1
-
-        resultsFilename = os.path.join(di, stub + '_%d.h5r' % i)
-
-    return resultsFilename
-
-
 def launch_localize(analysisMDH, seriesName):
     """
     Pushes an analysis task for a given series to the distributor
@@ -105,7 +75,7 @@ def launch_localize(analysisMDH, seriesName):
     #from PYME.ParallelTasks import HTTPTaskPusher
     from PYME.IO import MetaDataHandler
     from PYME.Analysis import MetaData
-    from PYME.IO.FileUtils.nameUtils import genClusterResultFileName
+    from PYME.IO.FileUtils.nameUtils import genClusterResultFileName, verify_cluster_results_filename
     from PYME.IO import unifiedIO
 
     unifiedIO.assert_uri_ok(seriesName)

--- a/PYME/cluster/HTTPTaskPusher.py
+++ b/PYME/cluster/HTTPTaskPusher.py
@@ -52,36 +52,6 @@ def _getTaskQueueURI(n_retries=2):
         logger.info('no local distributor, choosing one at random')
         return random.choice(queueURLs.values())
 
-def verify_cluster_results_filename(resultsFilename):
-    """
-    Checks whether a results file already exists on the cluster, and returns an available version of the results
-    filename. Should be called before writing a new results file.
-
-    Parameters
-    ----------
-    resultsFilename : str
-        cluster path, e.g. pyme-cluster:///example_folder/name.h5r
-    Returns
-    -------
-    resultsFilename : str
-        cluster path which may have _# appended to it if the input resultsFileName is already in use, e.g.
-        pyme-cluster:///example_folder/name_1.h5r
-
-    """
-    from PYME.IO import clusterIO
-    import os
-    if clusterIO.exists(resultsFilename):
-        di, fn = os.path.split(resultsFilename)
-        i = 1
-        stub = os.path.splitext(fn)[0]
-        while clusterIO.exists(os.path.join(di, stub + '_%d.h5r' % i)):
-            i += 1
-
-        resultsFilename = os.path.join(di, stub + '_%d.h5r' % i)
-
-    return resultsFilename
-
-
 def launch_localize(analysisMDH, seriesName):
     """
     Pushes an analysis task for a given series to the distributor
@@ -100,7 +70,7 @@ def launch_localize(analysisMDH, seriesName):
     import json
     from PYME.IO import MetaDataHandler
     from PYME.Analysis import MetaData
-    from PYME.IO.FileUtils.nameUtils import genClusterResultFileName
+    from PYME.IO.FileUtils.nameUtils import genClusterResultFileName, verify_cluster_results_filename
     from PYME.IO import unifiedIO
 
     resultsFilename = verify_cluster_results_filename(genClusterResultFileName(seriesName))

--- a/PYME/cluster/_rules.py
+++ b/PYME/cluster/_rules.py
@@ -176,8 +176,8 @@ class LocalizationRule(Rule):
         import json
         from PYME.IO import MetaDataHandler
         from PYME.Analysis import MetaData
-        from PYME.IO.FileUtils.nameUtils import genClusterResultFileName
-        from PYME.cluster.HTTPRulePusher import verify_cluster_results_filename  # TODO - David if you like maybe we move this function to clusterResults?
+        from PYME.IO.FileUtils.nameUtils import genClusterResultFileName, verify_cluster_results_filename
+        
         unifiedIO.assert_uri_ok(series_uri)
         self.results_filename = verify_cluster_results_filename(genClusterResultFileName(series_uri))
         if '~' in series_uri or '~' in self.results_filename:

--- a/PYME/cluster/rules.py
+++ b/PYME/cluster/rules.py
@@ -46,36 +46,6 @@ class NoNewTasks(Exception):
     pass
 
 
-def verify_cluster_results_filename(resultsFilename):
-    """
-    Checks whether a results file already exists on the cluster, and returns an available version of the results
-    filename. Should be called before writing a new results file.
-
-    Parameters
-    ----------
-    resultsFilename : str
-        cluster path, e.g. pyme-cluster:///example_folder/name.h5r
-    Returns
-    -------
-    resultsFilename : str
-        cluster path which may have _# appended to it if the input resultsFileName is already in use, e.g.
-        pyme-cluster:///example_folder/name_1.h5r
-
-    """
-    from PYME.IO import clusterIO
-    import os
-    if clusterIO.exists(resultsFilename):
-        di, fn = os.path.split(resultsFilename)
-        i = 1
-        stub = os.path.splitext(fn)[0]
-        while clusterIO.exists(os.path.join(di, stub + '_%d.h5r' % i)):
-            i += 1
-
-        resultsFilename = os.path.join(di, stub + '_%d.h5r' % i)
-
-    return resultsFilename
-
-
 class Rule(object):
     def __init__(self, on_completion=None, **kwargs):
         """
@@ -451,7 +421,7 @@ class LocalisationRule(Rule):
     def __init__(self, seriesName, analysisMetadata, resultsFilename=None, startAt=10, dataSourceModule=None, serverfilter=clusterIO.local_serverfilter, **kwargs):
         from PYME.IO import MetaDataHandler
         from PYME.Analysis import MetaData
-        from PYME.IO.FileUtils.nameUtils import genClusterResultFileName
+        from PYME.IO.FileUtils.nameUtils import genClusterResultFileName, verify_cluster_results_filename
         from PYME.IO import unifiedIO
     
         unifiedIO.assert_uri_ok(seriesName)


### PR DESCRIPTION
Addresses issue same function in a couple files. No functional changes

**Is this a bugfix or an enhancement?**

**Proposed changes:**
- move verify_cluster_results_filename to nameUtils instead of each of our task-post approaches




**Checklist:**

- [x] This PR is just tidying, but did not go wild re: camelCase, etc.
