### PR TITLE
linting rules.py

### DIFF
--- a/PYME/cluster/rules.py
+++ b/PYME/cluster/rules.py
@@ -642,12 +642,10 @@ class RuleFactory(object):
         
 
 class RecipeRuleFactory(RuleFactory):
-    _type = 'recipe'
     def __init__(self, **kwargs):
         RuleFactory.__init__(self, rule_class=RecipeRule, **kwargs)
         
 class LocalisationRuleFactory(RuleFactory):
-    _type = 'localization'
     def __init__(self, **kwargs):
         RuleFactory.__init__(self, rule_class=LocalisationRule, **kwargs)
         

--- a/PYME/cluster/rules.py
+++ b/PYME/cluster/rules.py
@@ -398,7 +398,7 @@ class RecipeRule(Rule):
                     name, serverfilter = unifiedIO.split_cluster_URI(v)
                     return clusterIO.cglob(name, serverfilter)
                     
-            inputs = {k: _to_input_list(inputs[k] for k in input_names)}
+            inputs = {k: _to_input_list(inputs[k]) for k in input_names}
     
             self._num_recipe_tasks = len(list(inputs.values())[0])
     

--- a/PYME/cluster/rules.py
+++ b/PYME/cluster/rules.py
@@ -395,7 +395,7 @@ class RecipeRule(Rule):
                     return v
                 else:
                     # value is a string glob
-                    name, serverfilter = unifiedIO.split_cluster_URI(v)
+                    name, serverfilter = unifiedIO.split_cluster_url(v)
                     return clusterIO.cglob(name, serverfilter)
                     
             inputs = {k: _to_input_list(inputs[k]) for k in input_names}

--- a/PYME/cluster/rules.py
+++ b/PYME/cluster/rules.py
@@ -398,7 +398,7 @@ class RecipeRule(Rule):
                     name, serverfilter = unifiedIO.split_cluster_URI(v)
                     return clusterIO.cglob(name, serverfilter)
                     
-            inputs = {k: _to_input_list(inputs[k] for k in input_names}
+            inputs = {k: _to_input_list(inputs[k] for k in input_names)}
     
             self._num_recipe_tasks = len(list(inputs.values())[0])
     
@@ -642,10 +642,12 @@ class RuleFactory(object):
         
 
 class RecipeRuleFactory(RuleFactory):
+    _type = 'recipe'
     def __init__(self, **kwargs):
         RuleFactory.__init__(self, rule_class=RecipeRule, **kwargs)
         
 class LocalisationRuleFactory(RuleFactory):
+    _type = 'localization'
     def __init__(self, **kwargs):
         RuleFactory.__init__(self, rule_class=LocalisationRule, **kwargs)
         


### PR DESCRIPTION
Addresses issue #invalid syntax.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**

Would be nice if we can lint syntax and imports as well as trailing whitespace
https://twitter.com/sigsegmeme/status/1328821021349179392?s=20
