### PR TITLE
double quote sys.executable to handle spaces in paths

### DIFF
--- a/PYME/cluster/cluster_of_one.py
+++ b/PYME/cluster/cluster_of_one.py
@@ -39,14 +39,14 @@ class ClusterOfOne(object):
             self._kill_procs([self._data_server,])
             
         logger.info('Launching data server: root=%s' % self._root_dir)
-        self._data_server = subprocess.Popen('%s -m PYME.cluster.HTTPDataServer -a local -p 0 -r %s' % (sys.executable, self._root_dir), shell=True)
+        self._data_server = subprocess.Popen('"%s" -m PYME.cluster.HTTPDataServer -a local -p 0 -r "%s"' % (sys.executable, self._root_dir), shell=True)
         
     def _launch_rule_server(self):
         if not self._rule_server is None:
             self._kill_procs([self._rule_server, ])
 
         logger.info('Launching rule server')
-        self._rule_server = subprocess.Popen('%s -m PYME.cluster.PYMERuleServer -a local -p 0'
+        self._rule_server = subprocess.Popen('"%s" -m PYME.cluster.PYMERuleServer -a local -p 0'
                                              '' % sys.executable, shell=True)
         
     def _launch_node_server(self):
@@ -54,7 +54,7 @@ class ClusterOfOne(object):
             self._kill_procs([self._node_server, ])
 
         logger.info('Launching node server')
-        self._node_server = subprocess.Popen('%s -m PYME.cluster.PYMERuleNodeServer -a local -p 0' % sys.executable, shell=True)
+        self._node_server = subprocess.Popen('"%s" -m PYME.cluster.PYMERuleNodeServer -a local -p 0' % sys.executable, shell=True)
         
     def _launch_cluster_ui(self, gui=False):
         if not self._cluster_ui is None:
@@ -62,7 +62,7 @@ class ClusterOfOne(object):
 
         logger.info('Launching clusterUI')
         self._cluster_ui_stderr = open('clusterui.log', 'w')
-        self._cluster_ui = subprocess.Popen('%s %s runserver 9999' % (sys.executable, os.path.join(os.path.split(__file__)[0], 'clusterUI', 'manage.py')), stderr=self._cluster_ui_stderr, shell=True)
+        self._cluster_ui = subprocess.Popen('"%s" %s runserver 9999' % (sys.executable, os.path.join(os.path.split(__file__)[0], 'clusterUI', 'manage.py')), stderr=self._cluster_ui_stderr, shell=True)
         
         if gui:
             #launch a web-browser to view clusterUI


### PR DESCRIPTION
Addresses issue #617 .

**Is this a bugfix or an enhancement?**
bit of both - allow people with spaces in their python path to run PYMEClusterOfOne
**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]