### PR TITLE
Check hybridns config before choosing nameserver for local HTTPDataServer

### DIFF
--- a/PYME/cluster/HTTPDataServer.py
+++ b/PYME/cluster/HTTPDataServer.py
@@ -898,11 +898,12 @@ def main(protocol="HTTP/1.0"):
 
     if options.advertisements == 'local':
         # preference is to avoid zeroconf on clusterofone due to poor
-        # performance on windows on crowded networks (for oldish versions at least)
+        # performance on crowded networks
         if config.get('clusterIO-hybridns', True):
             ns = sqlite_ns.getNS('_pyme-http')
         else:
             # if we aren't using the hybridns, we are using zeroconf in clusterIO
+            # TODO - warn that we might run into performance issues???
             ns = pzc.getNS('_pyme-http')
         server_address = ('127.0.0.1', int(options.port))
         ip_addr = '127.0.0.1'

--- a/PYME/cluster/HTTPDataServer.py
+++ b/PYME/cluster/HTTPDataServer.py
@@ -897,7 +897,13 @@ def main(protocol="HTTP/1.0"):
     os.chdir(options.root)
 
     if options.advertisements == 'local':
-        ns = sqlite_ns.getNS('_pyme-http')
+        # preference is to avoid zeroconf on clusterofone due to poor
+        # performance on windows on crowded networks (for oldish versions at least)
+        if config.get('clusterIO-hybridns', True):
+            ns = sqlite_ns.getNS('_pyme-http')
+        else:
+            # if we aren't using the hybridns, we are using zeroconf in clusterIO
+            ns = pzc.getNS('_pyme-http')
         server_address = ('127.0.0.1', int(options.port))
         ip_addr = '127.0.0.1'
     else:


### PR DESCRIPTION
Addresses issue #618 .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- if we are not using hybrid nameserver in clusterIO, make sure PYMEDataServer registers with zeroconf even if we are just running local






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
