### PR TITLE
Don't create the overlay panel by default when adding the recipe tab

### DIFF
--- a/PYME/DSView/modules/recipes.py
+++ b/PYME/DSView/modules/recipes.py
@@ -244,7 +244,7 @@ class RecipePlugin(recipeGui.RecipeManager, Plugin):
 
 
 def Plug(dsviewer):
-    dsviewer.create_overlay_panel()
+    # dsviewer.create_overlay_panel()
     return RecipePlugin(dsviewer)
     
 


### PR DESCRIPTION
Addresses issue #621. Medium-term fix proposed by @David-Baddeley.

**Is this a bugfix or an enhancement?**
bugfix

**Proposed changes:**
- don't create the overlay panel

**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
