### PR TITLE
make the recarray viewer also handle tabular data (and add save)

### DIFF
--- a/PYME/DSView/modules/blobFinding.py
+++ b/PYME/DSView/modules/blobFinding.py
@@ -175,7 +175,7 @@ class BlobFinder(Plugin):
         self.objPosRA = numpy.rec.fromrecords(self.dsviewer.view.points, names='x,y,z')
 
         if self.vObjPos is None:
-            self.vObjPos = recArrayView.recArrayPanel(self.dsviewer, self.objPosRA)
+            self.vObjPos = recArrayView.ArrayPanel(self.dsviewer, self.objPosRA)
             self.dsviewer.AddPage(self.vObjPos, caption='Object Positions')
         else:
             self.vObjPos.grid.SetData(self.objPosRA)
@@ -244,7 +244,7 @@ class BlobFinder(Plugin):
             #if self.nObjFit == None:
                 
                 
-            vObjFit = recArrayView.recArrayPanel(self.dsviewer, self.objFitRes[chnum]['fitResults'])
+            vObjFit = recArrayView.ArrayPanel(self.dsviewer, self.objFitRes[chnum]['fitResults'])
             self.dsviewer.AddPage(vObjFit, caption = 'Fitted Positions %d - %d' % (chnum, self.nObjFit))
         self.nObjFit += 1
         #else:

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -151,6 +151,26 @@ class TabularBase(object):
                 
             #wait until data is written
             f.flush()
+
+    def to_csv(self, outFile, keys=None):
+        if outFile.endswith('.csv'):
+            delim = ', '
+        else:
+            delim = '\t'
+    
+        if keys is None:
+            keys = self.keys()
+    
+        #nRecords = len(ds[keys[0]])
+    
+        of = open(outFile, 'w')
+    
+        of.write('#' + delim.join(['%s' % k for k in keys]) + '\n')
+    
+        for row in zip(*[self[k] for k in keys]):
+            of.write(delim.join(['%e' % c for c in row]) + '\n')
+    
+        of.close()
             
                 
     def keys(self):

--- a/PYME/LMVis/triBlobs.py
+++ b/PYME/LMVis/triBlobs.py
@@ -133,7 +133,7 @@ class BlobSettingsPanel(wx.Panel):
         om = self.pipeline.measureObjects()
         
         if self.visgui.rav is None:
-            self.visgui.rav = recArrayView.recArrayPanel(self.visgui, om)
+            self.visgui.rav = recArrayView.ArrayPanel(self.visgui, om)
             self.visgui.AddPage(self.visgui.rav, 'Measurements')
         else:
             self.visgui.rav.grid.SetData(om)

--- a/PYME/recipes/recipeGui.py
+++ b/PYME/recipes/recipeGui.py
@@ -548,7 +548,7 @@ class RecipeView(wx.Panel):
                     
             elif isinstance(outp, tabular.TabularBase):
                 from PYME.ui import recArrayView
-                f = recArrayView.ArrayFrame(outp, parent=self)
+                f = recArrayView.ArrayFrame(outp, parent=self, title='Data table - %s' % k)
                 f.Show()
     
     

--- a/PYME/recipes/recipeGui.py
+++ b/PYME/recipes/recipeGui.py
@@ -342,7 +342,7 @@ class RecipeView(wx.Panel):
         vsizer.Add(self.tRecipeText, 1, wx.ALL, 2)
         
         self.bApply = wx.Button(self, -1, 'Apply Text Changes')
-        vsizer.Add(self.bApply, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
+        vsizer.Add(self.bApply, 0, wx.ALL, 2)
         self.bApply.Bind(wx.EVT_BUTTON, self.OnApplyText)
                                        
         hsizer1.Add(vsizer, 0, wx.EXPAND|wx.ALL, 2)
@@ -529,6 +529,7 @@ class RecipeView(wx.Panel):
         
         
     def OnPick(self, event):
+        from PYME.IO import tabular
         k = event.artist._data
         if not (isinstance(k, six.string_types)):
             self.configureModule(k)
@@ -544,6 +545,11 @@ class RecipeView(wx.Panel):
                         mode = 'lite'
                                    
                     dv = ViewIm3D(outp, mode=mode, glCanvas=self.recipes.dsviewer.glCanvas)
+                    
+            elif isinstance(outp, tabular.TabularBase):
+                from PYME.ui import recArrayView
+                f = recArrayView.ArrayFrame(outp, parent=self)
+                f.Show()
     
     
     def configureModule(self, k):

--- a/PYME/ui/recArrayView.py
+++ b/PYME/ui/recArrayView.py
@@ -22,7 +22,9 @@
 ##################
 
 import wx
-import  wx.grid as  gridlib
+import wx.grid as  gridlib
+import numpy as np
+from PYME.IO import tabular
 
 class RecArrayTable(gridlib.PyGridTableBase):
 
@@ -67,21 +69,59 @@ class RecArrayTable(gridlib.PyGridTableBase):
         return self.recarray.dtype.names[col]
 
 
+class TabularTable(gridlib.PyGridTableBase):
+
+    def __init__(self, tabular):
+        gridlib.PyGridTableBase.__init__(self)
+        self._tabular = tabular
+
+#        self.odd=gridlib.GridCellAttr()
+#        self.odd.SetBackgroundColour("sky blue")
+#        self.even=gridlib.GridCellAttr()
+#        self.even.SetBackgroundColour("sea green")
+#
+#    def GetAttr(self, row, col, kind):
+#        attr = [self.even, self.odd][row % 2]
+#        attr.IncRef()
+#        return attr
 
 
-class RecarrayTableGrid(gridlib.Grid):
-    def __init__(self, parent, recarray):
+
+    # This is all it takes to make a custom data table to plug into a
+    # wxGrid.  There are many more methods that can be overridden, but
+    # the ones shown below are the required ones.  This table simply
+    # provides strings containing the row and column values.
+
+    def GetNumberRows(self):
+        return len(self._tabular)
+
+    def GetNumberCols(self):
+        return len(self._tabular.keys())
+
+    def IsEmptyCell(self, row, col):
+        return False
+
+    def GetValue(self, row, col):
+        return str( self._tabular[self._tabular.keys()[col]][row])
+
+    def SetValue(self, row, col, value):
+        pass
+        #self.log.write('SetValue(%d, %d, "%s") ignored.\n' % (row, col, value))
+
+    def GetColLabelValue(self, col):
+        return self._tabular.keys()[col]
+
+class ArrayTableGrid(gridlib.Grid):
+    def __init__(self, parent, data):
         gridlib.Grid.__init__(self, parent, -1, size = (-1,-1))
+        
+        self.SetData(data)
 
-        table = RecArrayTable(recarray)
-
-        # The second parameter means that the grid is to take ownership of the
-        # table and will destroy it when done.  Otherwise you would need to keep
-        # a reference to it and call it's Destroy method later.
-        self.SetTable(table, True)
-
-    def SetData(self, recarray):
-        table = RecArrayTable(recarray)
+    def SetData(self, data):
+        if isinstance(data, tabular.TabularBase):
+            table = TabularTable(data)
+        else:
+            table = RecArrayTable(data)
 
         # The second parameter means that the grid is to take ownership of the
         # table and will destroy it when done.  Otherwise you would need to keep
@@ -89,21 +129,28 @@ class RecarrayTableGrid(gridlib.Grid):
         self.SetTable(table, True)
     
 
-class recArrayPanel(wx.Panel):
+
+
+class ArrayPanel(wx.Panel):
     def __init__(self, parent, recarray):
         wx.Panel.__init__(self, parent)
 
-        self.recarray = recarray
+        self.data = recarray
 
-        #sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        
+        tool_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        bSave = wx.BitmapButton(self, -1, wx.ArtProvider.GetBitmap(wx.ART_FILE_SAVE), style=wx.NO_BORDER | wx.BU_AUTODRAW, name='Save')
+        bSave.Bind(wx.EVT_BUTTON, self.OnSave)
+        tool_sizer.Add(bSave)
+        
+        sizer.Add(tool_sizer)
 
-        self.grid = RecarrayTableGrid(self, recarray)
-
+        self.grid = ArrayTableGrid(self, recarray)
         self.grid.SetSize((10,10))
 
-        #sizer.Add(self.grid, 1, wx.EXPAND, 0)
-
-        #self.SetSizerAndFit(sizer)
+        sizer.Add(self.grid, 1, wx.EXPAND, 0)
+        self.SetSizerAndFit(sizer)
         #self.SetAutoLayout(True)
 
         wx.EVT_SIZE(self, self.OnSize)
@@ -112,3 +159,25 @@ class recArrayPanel(wx.Panel):
         self.grid.SetSize(self.GetClientSize())
         #self.Refresh()
         event.Skip()
+        
+    def OnSave(self, event):
+        filename = wx.SaveFileSelector("Save data as ...", 'HDF (*.hdf)|*.hdf|Comma separated text (*.csv)|*.csv')
+        if not filename == '':
+            if isinstance(self.data, tabular.TabularBase):
+                data = self.data
+            else:
+                data = tabular.RecArraySource(self.data)
+                
+            if filename.endswith('.hdf'):
+                data.to_hdf(filename)
+            else:
+                data.to_csv(filename)
+                
+class ArrayFrame(wx.Frame):
+    def __init__(self, data, title='Data table', parent=-1):
+        wx.Frame.__init__(self, parent, title=title, size=(600,600))
+        
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        self._array_pan = ArrayPanel(self, data)
+        sizer.Add(self._array_pan, 1, wx.EXPAND, 0)
+        self.SetSizerAndFit(sizer)

--- a/PYME/ui/recArrayView.py
+++ b/PYME/ui/recArrayView.py
@@ -175,9 +175,9 @@ class ArrayPanel(wx.Panel):
                 
 class ArrayFrame(wx.Frame):
     def __init__(self, data, title='Data table', parent=-1):
-        wx.Frame.__init__(self, parent, title=title, size=(600,600))
+        wx.Frame.__init__(self, parent, title=title, size=(800,600))
         
         sizer = wx.BoxSizer(wx.VERTICAL)
         self._array_pan = ArrayPanel(self, data)
         sizer.Add(self._array_pan, 1, wx.EXPAND, 0)
-        self.SetSizerAndFit(sizer)
+        self.SetSizer(sizer)

--- a/PYME/ui/recArrayView.py
+++ b/PYME/ui/recArrayView.py
@@ -82,7 +82,7 @@ class ArrayTableGrid(gridlib.Grid):
 
     def SetData(self, data):
         if isinstance(data, tabular.TabularBase):
-            table = TabularTable(data)
+            table = TabularTable(tabular.CachingResultsFilter(data))
         else:
             table = RecArrayTable(data)
 

--- a/PYME/ui/recArrayView.py
+++ b/PYME/ui/recArrayView.py
@@ -22,32 +22,14 @@
 ##################
 
 import wx
-import wx.grid as  gridlib
+import wx.grid as gridlib
 import numpy as np
 from PYME.IO import tabular
 
 class RecArrayTable(gridlib.PyGridTableBase):
-
     def __init__(self, recarray):
         gridlib.PyGridTableBase.__init__(self)
         self.recarray = recarray
-
-#        self.odd=gridlib.GridCellAttr()
-#        self.odd.SetBackgroundColour("sky blue")
-#        self.even=gridlib.GridCellAttr()
-#        self.even.SetBackgroundColour("sea green")
-#
-#    def GetAttr(self, row, col, kind):
-#        attr = [self.even, self.odd][row % 2]
-#        attr.IncRef()
-#        return attr
-
-
-
-    # This is all it takes to make a custom data table to plug into a
-    # wxGrid.  There are many more methods that can be overridden, but
-    # the ones shown below are the required ones.  This table simply
-    # provides strings containing the row and column values.
 
     def GetNumberRows(self):
         return len(self.recarray)
@@ -59,38 +41,19 @@ class RecArrayTable(gridlib.PyGridTableBase):
         return False
 
     def GetValue(self, row, col):
-        return str( self.recarray[row][col] )
+        return str(self.recarray[row][col] )
 
     def SetValue(self, row, col, value):
         pass
-        #self.log.write('SetValue(%d, %d, "%s") ignored.\n' % (row, col, value))
 
     def GetColLabelValue(self, col):
         return self.recarray.dtype.names[col]
 
 
 class TabularTable(gridlib.PyGridTableBase):
-
     def __init__(self, tabular):
         gridlib.PyGridTableBase.__init__(self)
         self._tabular = tabular
-
-#        self.odd=gridlib.GridCellAttr()
-#        self.odd.SetBackgroundColour("sky blue")
-#        self.even=gridlib.GridCellAttr()
-#        self.even.SetBackgroundColour("sea green")
-#
-#    def GetAttr(self, row, col, kind):
-#        attr = [self.even, self.odd][row % 2]
-#        attr.IncRef()
-#        return attr
-
-
-
-    # This is all it takes to make a custom data table to plug into a
-    # wxGrid.  There are many more methods that can be overridden, but
-    # the ones shown below are the required ones.  This table simply
-    # provides strings containing the row and column values.
 
     def GetNumberRows(self):
         return len(self._tabular)
@@ -102,14 +65,14 @@ class TabularTable(gridlib.PyGridTableBase):
         return False
 
     def GetValue(self, row, col):
-        return str( self._tabular[self._tabular.keys()[col]][row])
+        return str(self._tabular[self._tabular.keys()[col]][row])
 
     def SetValue(self, row, col, value):
         pass
-        #self.log.write('SetValue(%d, %d, "%s") ignored.\n' % (row, col, value))
 
     def GetColLabelValue(self, col):
         return self._tabular.keys()[col]
+
 
 class ArrayTableGrid(gridlib.Grid):
     def __init__(self, parent, data):
@@ -127,8 +90,6 @@ class ArrayTableGrid(gridlib.Grid):
         # table and will destroy it when done.  Otherwise you would need to keep
         # a reference to it and call it's Destroy method later.
         self.SetTable(table, True)
-    
-
 
 
 class ArrayPanel(wx.Panel):
@@ -172,6 +133,7 @@ class ArrayPanel(wx.Panel):
                 data.to_hdf(filename)
             else:
                 data.to_csv(filename)
+
                 
 class ArrayFrame(wx.Frame):
     def __init__(self, data, title='Data table', parent=-1):


### PR DESCRIPTION
Addresses issue #584.

**Proposed changes:**

Makes the existing recarray view handle tabular data as well and adds a save button.
- currently implemented as a drop in replacement for the couple of recarray views
- launchable by clicking on a tabular item in the pipeline

TODOs:

- launch / add tab automatically for certain analyses
- integrate plotting and potentially sorting from #594
- a bit laggy for full localisation data.





