### PR TITLE
Establish user-configurable zoom factor

### DIFF
--- a/PYME/LMVis/gl_render3D_shaders.py
+++ b/PYME/LMVis/gl_render3D_shaders.py
@@ -60,12 +60,13 @@ logger = logging.getLogger(__name__)
 
 import sys
 
-if sys.platform == 'darwin':
-    # osx gives us LOTS of scroll events
-    # ajust the mag in smaller increments
-    ZOOM_FACTOR = 1.1
-else:
-    ZOOM_FACTOR = 2.0
+# if sys.platform == 'darwin':
+#     # osx gives us LOTS of scroll events
+#     # ajust the mag in smaller increments
+#     ZOOM_FACTOR = 1.1
+# else:
+#     ZOOM_FACTOR = 2.0
+ZOOM_FACTOR = config.get('zoom_factor', 1.1)
 
 # import statusLog
 


### PR DESCRIPTION
Addresses issue #570. We had originally discussed a slider. I can't help but feel that a `File>Preferences` with only a slider for zoom factor will look silly. Since a change from 2.0x to 1.1x will make the zoom speed much friendlier, and since this change will allow users to change their zoom speed in `config.yaml` file, this may be sufficient for the moment. I suggest we introduce a `File>Preferences` with zoom speed and a few other features in the near future.

**Is this a bugfix or an enhancement?**
Enhancement

**Proposed changes:**
- Make zoom speed 1.1x by defaults
- Make zoom speed a user-configurable value in .PYME/config.yaml



**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
