### PR TITLE
Stop-gap fixes for object measurements

### DIFF
--- a/PYME/Analysis/points/objectMeasure.py
+++ b/PYME/Analysis/points/objectMeasure.py
@@ -22,7 +22,8 @@
 ##################
 
 import numpy as np
-from matplotlib import tri
+# from matplotlib import tri
+from scipy.spatial import Delaunay
 from PYME.Analysis.points import gen3DTriangs
 from PYME.Analysis.points import moments
 from PYME.IO.MetaDataHandler import get_camera_roi_origin
@@ -80,7 +81,8 @@ def measure(object, sizeCutoff, measurements = np.zeros(1, dtype=measureDType)):
     measurements['yPos'] = object[:,1].mean()
 
     if object.shape[0] > 3:
-        T = tri.Triangulation(object.ravel(),2)
+        # T = tri.Triangulation(object.ravel(),2)
+        T = Delaunay(object)
         P, A, triI = gen3DTriangs.gen2DTriangsTF(T, sizeCutoff)
 
         if not len(P) == 0:
@@ -115,10 +117,11 @@ def measureObjects(objects, sizeCutoff):
 
     return measurements
 
-def measureObjectsByID(filter, sizeCutoff, ids):
+def measureObjectsByID(filter, sizeCutoff, ids, key='objectID'):
     x = filter['x'] #+ 0.1*random.randn(filter['x'].size)
     y = filter['y'] #+ 0.1*random.randn(x.size)
-    id = filter['objectID'].astype('i')
+    # id = filter['objectID'].astype('i')
+    id = filter[key].astype('i')
 
     #ids = set(ids)
 

--- a/PYME/LMVis/Extras/objectMeasurements.py
+++ b/PYME/LMVis/Extras/objectMeasurements.py
@@ -86,6 +86,10 @@ class ObjectMeasurer:
         chans = pipeline.colourFilter.getColourChans()
 
         # If we're not using objectIDs from an image, look for other clustering labels
+        # TODO - rather than trying a few pre-set objectID alternatives, make this a dialog instead
+        # - look for objectID and carry on if present
+        # - if not present, display a dialog "No objectID found - did you segment objects? Either cancel, 
+        # segment, and come back, or choose an alternative column to use as an ID.
         keys = ['objectID', 'dbscanClumpID', 'clumpIndex']
         key = 'objectID'
 

--- a/PYME/LMVis/Extras/objectMeasurements.py
+++ b/PYME/LMVis/Extras/objectMeasurements.py
@@ -85,11 +85,23 @@ class ObjectMeasurer:
 
         chans = pipeline.colourFilter.getColourChans()
 
-        ids = set(pipeline.mapping['objectID'].astype('i'))
+        # If we're not using objectIDs from an image, look for other clustering labels
+        keys = ['objectID', 'dbscanClumpID', 'clumpIndex']
+        key = 'objectID'
+
+        for k in keys:
+            try:
+                ids = set(pipeline.mapping[k].astype('i'))
+                key = k
+                break
+            except(KeyError):
+                continue
+        # ids = set(pipeline.mapping['objectID'].astype('i'))
+
         pipeline.objectMeasures = {}
 
         if len(chans) == 0:
-            pipeline.objectMeasures['Everything'] = objectMeasure.measureObjectsByID(pipeline.colourFilter, 10,ids)
+            pipeline.objectMeasures['Everything'] = objectMeasure.measureObjectsByID(pipeline.colourFilter, 10,ids,key)
         else:
             curChan = pipeline.colourFilter.currentColour
 
@@ -105,7 +117,7 @@ class ObjectMeasurer:
             for ch, i in zip(chans, range(len(chans))):
                 pipeline.colourFilter.setColour(ch)
                 #fitDecayChan(colourFilter, metadata, chanNames[i], i)
-                pipeline.objectMeasures[chanNames[i]] = objectMeasure.measureObjectsByID(pipeline.colourFilter, 10,ids)
+                pipeline.objectMeasures[chanNames[i]] = objectMeasure.measureObjectsByID(pipeline.colourFilter, 10,ids,key)
             
             pipeline.colourFilter.setColour(curChan)
             


### PR DESCRIPTION
Addresses issue #613.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Iterate over multiple `objectID` keys to still run measurements if we're clustering in non-standard ways
- Fix the `Delaunay` triangulation. I'm not 100% sure what was going on before, so I'm not sure this is right, but it appears to work and it makes sense.

**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
