### PR TITLE
Two small but important fixes

### DIFF
--- a/PYME/DSView/modules/filtering.py
+++ b/PYME/DSView/modules/filtering.py
@@ -46,7 +46,11 @@ class Filterer(Plugin):
         from PYME.IO.image import ImageStack
         from PYME.DSView import ViewIm3D
 
-        dlg = wx.TextEntryDialog(self.dsviewer, 'Blur size [pixels]:', 'Gaussian Blur', '[1,1,1]')
+        filter_size = '[1,1,1]'
+        if self.image.data.shape[2] == 1:
+            filter_size = '[1,1]'
+
+        dlg = wx.TextEntryDialog(self.dsviewer, 'Blur size [pixels]:', 'Gaussian Blur', filter_size)
 
         if dlg.ShowModal() == wx.ID_OK:
             sigmas = eval(dlg.GetValue())

--- a/PYME/LMVis/Extras/objectMeasurements.py
+++ b/PYME/LMVis/Extras/objectMeasurements.py
@@ -60,7 +60,7 @@ class ObjectMeasurer:
 
         dlg = wx.SingleChoiceDialog(
                 None, 'choose the image which contains labels', 'Use Segmentation',
-                image.openImages.keys(),
+                list(image.openImages.keys()),
                 wx.CHOICEDLG_STYLE
                 )
 


### PR DESCRIPTION
- py3 fix for get objectid from labels
- Automatically set default gaussian filter size to match image dimension