### PR TITLE
despeckle filter float -> int fix

### DIFF
--- a/PYME/recipes/filters.py
+++ b/PYME/recipes/filters.py
@@ -149,7 +149,7 @@ class DespeckleFilter(Filter):
     nPix = Int(3)
     
     def _filt(self, data):
-        v = data[data.size/2]
+        v = data[int(data.size / 2)]
         
         dv = np.abs(data - v)
         


### PR DESCRIPTION
```
Error whilst running Recipes>Run Current Recipe F5
==============================================
python-microscopy=20.11.25
python=3.6.10, platform=darwin
numpy=1.16.6, wx=4.0.4 osx-cocoa (phoenix) wxWidgets 3.0.5
Traceback
=========
Traceback (most recent call last):
  File "/Users/Andrew/code/python-microscopy/PYME/ui/progress.py", line 107, in func
    return fcn(*args, **kwargs)
  File "/Users/Andrew/code/python-microscopy/PYME/DSView/modules/recipes.py", line 99, in RunCurrentRecipe
    self.outp = self.activeRecipe.execute(input=self.image)
  File "/Users/Andrew/code/python-microscopy/PYME/recipes/base.py", line 665, in execute
    m.execute(self.namespace)
  File "/Users/Andrew/code/python-microscopy/PYME/recipes/base.py", line 1219, in execute
    namespace[self.outputName] = self.filter(namespace[self.inputName])
  File "/Users/Andrew/code/python-microscopy/PYME/recipes/base.py", line 1206, in filter
    filt_ims.append(np.concatenate([np.atleast_3d(self.applyFilter(image.data[:,:,i,chanNum].squeeze().astype('f'), chanNum, i, image)) for i in range(image.data.shape[2])], 2))
  File "/Users/Andrew/code/python-microscopy/PYME/recipes/base.py", line 1206, in <listcomp>
    filt_ims.append(np.concatenate([np.atleast_3d(self.applyFilter(image.data[:,:,i,chanNum].squeeze().astype('f'), chanNum, i, image)) for i in range(image.data.shape[2])], 2))
  File "/Users/Andrew/code/python-microscopy/PYME/recipes/filters.py", line 166, in applyFilter
    return ndimage.generic_filter(data, self._filt, self.sigmas[:len(data.shape)])
  File "/opt/miniconda3/lib/python3.6/site-packages/scipy/ndimage/filters.py", line 1447, in generic_filter
    cval, origins, extra_arguments, extra_keywords)
  File "/Users/Andrew/code/python-microscopy/PYME/recipes/filters.py", line 152, in _filt
    v = data[data.size/2]
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```