### PR TITLE
recipe module and datasource to lazily swap color and time dimensions

### DIFF
--- a/PYME/IO/DataSources/SwapColorAndSliceDataSource.py
+++ b/PYME/IO/DataSources/SwapColorAndSliceDataSource.py
@@ -1,0 +1,52 @@
+from .BaseDataSource import BaseDataSource, DefaultList
+import numpy as np
+
+
+class DataSource(BaseDataSource):
+    moduleName = 'SwapColorAndSliceDataSource'
+    def __init__(self, datasource):
+        if len(datasource.shape) < 4:
+            raise ValueError('no')
+        self._datasource = datasource
+        self.sizeC = self._datasource.shape[3]
+        
+    def _getNumFrames(self):
+        self._datasource.shape[3]
+    
+    @property
+    def shape(self):
+        return DefaultList(self.getSliceShape() + (self.sizeC, int(self.getNumSlices()/self.sizeC)))
+    
+    def getSlice(self, ind):
+        return self[:,:,ind % self.shape[2], ind // self.shape[2]].squeeze()
+    
+    def __getitem__(self, keys):
+        keys = list(keys)
+        if len(keys) == 3:
+            keys.insert(2, slice(None))
+        elif len(keys) == 4:  # swap
+            keys[3], keys[2] = keys[2], keys[3]
+        
+        raw = self._datasource[keys]
+
+        try:
+            return np.swapaxes(raw, 2, 3)
+        except np.AxisError:
+            return raw
+
+    
+    def getSliceShape(self):
+        return self._datasource.getSliceShape()
+        
+    def getNumSlices(self):
+        """supposedly this is the product of c and t, so doesn't change
+
+        Returns
+        -------
+        [type]
+            [description]
+        """
+        return self._datasource.getNumSlices()
+
+    def getEvents(self):
+        return self._datasource.getEvents()

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -1491,3 +1491,19 @@ def _issubclass(cl, c):
         return issubclass(cl, c)
     except TypeError:
         return False
+
+
+@register_module('SwapColorAndSlice')    
+class SwapColorAndSlice(ModuleBase):
+    """swap slice (z/t) with color"""
+    input_name = Input('input')
+    output_name = Output('swapped')
+    
+    def execute(self, namespace):
+        from PYME.IO.DataSources.SwapColorAndSliceDataSource import DataSource
+        from PYME.IO.MetaDataHandler import DictMDHandler
+        im = namespace[self.input_name]
+        mdh = DictMDHandler()
+        mdh.copyEntriesFrom(im.mdh)
+        mdh['SwapColorAndSlice'] = True
+        namespace[self.output_name] = ImageStack(DataSource(im.data), mdh=mdh)


### PR DESCRIPTION
Addresses issue #people loading e.g. lifs converted to tif in Fiji often end up with color loaded as dim 2 rather than 3.

**Is this a bugfix or an enhancement?**
enhacnement
**Proposed changes:**
add a datasource to swap the z/t dim with c dim






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]