### PR TITLE
make dh5view recipe somehow accessible from shell for debugging

### DIFF
--- a/PYME/DSView/modules/recipes.py
+++ b/PYME/DSView/modules/recipes.py
@@ -41,7 +41,9 @@ from ._base import Plugin
 class RecipePlugin(recipeGui.RecipeManager, Plugin):
     def __init__(self, dsviewer):
         Plugin.__init__(self, dsviewer)
-        
+        recipeGui.RecipeManager.__init__(self)
+        dsviewer.active_recipe = lambda : getattr(self, 'activeRecipe')
+
         self.cannedIDs = {}
         
 


### PR DESCRIPTION
Addresses issue #no handle to module collection if one wants to play with a namespace item in the shell, etc.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- add a method to get the recipe plugin modulecollection from the shell






**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
