### PR TITLE
use x for x pix size on simulated camera

### DIFF
--- a/PYME/Acquire/microscope.py
+++ b/PYME/Acquire/microscope.py
@@ -459,7 +459,7 @@ class microscope(object):
                 logger.info('Reading voxel size directly from simulated camera')
                 vx_um = (self.cam.XVals[1] - self.cam.XVals[0]) / 1.0e3
                 vy_um = (self.cam.YVals[1] - self.cam.YVals[0]) / 1.0e3
-                return vy_um * self.cam.GetHorizontalBin(), vy_um * self.cam.GetVerticalBin()
+                return vx_um * self.cam.GetHorizontalBin(), vy_um * self.cam.GetVerticalBin()
                     
 
     def GenStartMetadata(self, mdh):


### PR DESCRIPTION
Addresses issue #linting microscope.py
