### PR TITLE
Apply HistLimitPanel colour bounds hack to pointcloud layer

### DIFF
--- a/PYME/LMVis/layers/pointcloud.py
+++ b/PYME/LMVis/layers/pointcloud.py
@@ -159,7 +159,7 @@ class PointCloudRenderLayer(EngineLayer):
 
     def _update(self, *args, **kwargs):
         cdata = self._get_cdata()
-        self.clim = [float(np.nanmin(cdata)), float(np.nanmax(cdata))]
+        self.clim = [float(np.nanmin(cdata)), float(np.nanmax(cdata))+1e-9]
         #self.update(*args, **kwargs)
 
     def update(self, *args, **kwargs):


### PR DESCRIPTION
Addresses issue #460  .

If `t` and `z` are both all zeros, adjust the upper limit so we don't get a zero in initial color map guess.

This is the same thing done in `PYME.ui.histLimits.HistLimitPanel.GenHist`.