### PR TITLE
Fix 678 wxpython 4.1

### DIFF
--- a/PYME/Acquire/Hardware/AndorIXon/AndorControlFrame.py
+++ b/PYME/Acquire/Hardware/AndorIXon/AndorControlFrame.py
@@ -73,15 +73,15 @@ class AndorPanel(afp.foldingPane):
         self.rbSingleShot.SetValue(False)
         #self.rbSingleShot.SetToolTipString('Allows multiple channels with different integration times and good shutter synchronisation')
         self.rbSingleShot.Bind(wx.EVT_RADIOBUTTON,self.OnRbSingleShotRadiobutton)
-        sbAqMode.Add(self.rbSingleShot, 1, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL, 0)
+        sbAqMode.Add(self.rbSingleShot, 1, wx.EXPAND, 0)
 
         self.rbContin = wx.RadioButton(cp, -1, 'Continuous')
         self.rbContin.SetValue(True)
         #self.rbContin.SetToolTipString('Allows fastest speeds, albeit without good syncronisation (fixable) or integration time flexibility')
         self.rbContin.Bind(wx.EVT_RADIOBUTTON, self.OnRbContinRadiobutton)
-        sbAqMode.Add(self.rbContin, 1, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL, 0)
+        sbAqMode.Add(self.rbContin, 1, wx.EXPAND, 0)
 
-        vsizer.Add(sbAqMode, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL|wx.TOP, 5)
+        vsizer.Add(sbAqMode, 0, wx.EXPAND|wx.TOP, 5)
 
         #self.bUpdateInt = wx.Button(id=wxID_ANDORFRAMEBUPDATEINT,
         #      label='Update Integration Time', name='bUpdateInt',
@@ -127,7 +127,7 @@ class AndorPanel(afp.foldingPane):
         hsizer.Add(self.cbBaselineClamp, 0, wx.ALIGN_CENTER_VERTICAL, 0)
 
         sbReadout.Add(hsizer, 0, wx.TOP, 2)
-        vsizer.Add(sbReadout, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL|wx.TOP, 5)
+        vsizer.Add(sbReadout, 0, wx.EXPAND|wx.TOP, 5)
 
         cp.SetSizer(vsizer)
 
@@ -148,7 +148,7 @@ class AndorPanel(afp.foldingPane):
 
         self.tCCDTemp = wx.TextCtrl(pan, -1, '0', size=(30, -1))
         hsizer2.Add(self.tCCDTemp, 1, wx.RIGHT|wx.ALIGN_CENTER_VERTICAL, 5)
-        sbCooling.Add(hsizer2, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        sbCooling.Add(hsizer2, 0, wx.EXPAND, 0)
 
         self.bSetTemp = wx.Button(pan, -1, 'Set', style=wx.BU_EXACTFIT)
         self.bSetTemp.Bind(wx.EVT_BUTTON, self.OnBSetTempButton)
@@ -164,20 +164,20 @@ class AndorPanel(afp.foldingPane):
         self.tEMGain.Bind(wx.EVT_TEXT, self.OnEMGainTextChange)
         self.tEMGain.Bind(wx.EVT_TEXT_ENTER, self.OnBSetGainButton)
         self.tEMGain.Bind(wx.EVT_COMBOBOX, self.OnBSetGainButton)
-        hsizer2.Add(self.tEMGain, 1, wx.EXPAND|wx.RIGHT|wx.ALIGN_CENTER_VERTICAL, 5)
+        hsizer2.Add(self.tEMGain, 1, wx.EXPAND|wx.RIGHT, 5)
 
         self.bSetGain = wx.Button(pan, -1, 'Set', style=wx.BU_EXACTFIT)
         self.bSetGain.Bind(wx.EVT_BUTTON, self.OnBSetGainButton)
-        hsizer2.Add(self.bSetGain, 0, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL, 0)
+        hsizer2.Add(self.bSetGain, 0, wx.EXPAND, 0)
 
-        sbEMGain.Add(hsizer2, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        sbEMGain.Add(hsizer2, 0, wx.EXPAND, 0)
 
         self.stTrueEMGain = wx.StaticText(pan, -1, '????')
         self.stTrueEMGain.SetForegroundColour(wx.RED)
-        sbEMGain.Add(self.stTrueEMGain, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        sbEMGain.Add(self.stTrueEMGain, 0, wx.EXPAND, 0)
 
-        hsizer.Add(sbEMGain, 1, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL, 0)
-        vsizer.Add(hsizer, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        hsizer.Add(sbEMGain, 1, wx.EXPAND, 0)
+        vsizer.Add(hsizer, 0, wx.EXPAND, 0)
 
         self.cbShutter = wx.CheckBox(pan, -1, u'Camera Shutter Open')
         self.cbShutter.SetValue(True)

--- a/PYME/Acquire/Hardware/AndorIXon/AndorControlFrame.py
+++ b/PYME/Acquire/Hardware/AndorIXon/AndorControlFrame.py
@@ -182,7 +182,7 @@ class AndorPanel(afp.foldingPane):
         self.cbShutter = wx.CheckBox(pan, -1, u'Camera Shutter Open')
         self.cbShutter.SetValue(True)
         self.cbShutter.Bind(wx.EVT_CHECKBOX, self.OnCbShutterCheckbox)
-        vsizer.Add(self.cbShutter, 0, wx.ALIGN_CENTER_VERTICAL|wx.TOP, 5)
+        vsizer.Add(self.cbShutter, 0, wx.TOP, 5)
 
         #self.cp = self._createCollapsingPane(self)
 

--- a/PYME/Acquire/Hardware/Simulator/simui_wx.py
+++ b/PYME/Acquire/Hardware/Simulator/simui_wx.py
@@ -212,13 +212,13 @@ class dSimControl(afp.foldPanel):
         
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
         
-        hsizer.Add(wx.StaticText(pFirstPrinciples, -1, 'Generate matrix for:'), 0, wx.ALL | wx.ALIGN_CENTRE_HORIZONTAL,
+        hsizer.Add(wx.StaticText(pFirstPrinciples, -1, 'Generate matrix for:'), 0, wx.ALL,
                    2)
         
         self.cModelPresets = wx.Choice(pFirstPrinciples, -1, choices=['STORM', 'PALM', 'PAINT'])
         self.cModelPresets.Bind(wx.EVT_CHOICE, self.OnModelPresets)
         
-        hsizer.Add(self.cModelPresets, 0, wx.ALL | wx.ALIGN_CENTRE_HORIZONTAL, 2)
+        hsizer.Add(self.cModelPresets, 0, wx.ALL, 2)
         
         sbsizer2.Add(hsizer, 0, wx.ALL, 2)
         
@@ -284,7 +284,7 @@ class dSimControl(afp.foldPanel):
         self.bLoadEmpiricalHist = wx.Button(pEmpiricalModel, -1, 'Load')
         self.bLoadEmpiricalHist.Bind(wx.EVT_BUTTON, self.OnBLoadEmpiricalHistButton)
         sbsizer2.Add(self.bLoadEmpiricalHist, 0,
-                     wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT, 2)
+                     wx.ALIGN_CENTER_VERTICAL, 2)
         
         pEmpiricalModelSizer.Add(sbsizer2, 0, wx.ALL | wx.EXPAND, 2)
         
@@ -293,7 +293,7 @@ class dSimControl(afp.foldPanel):
         self.bGenEmpiricalHistFluors = wx.Button(pEmpiricalModel, -1, 'Go')
         self.bGenEmpiricalHistFluors.Bind(wx.EVT_BUTTON, self.OnBGenEmpiricalHistFluorsButton)
         hsizer.Add(self.bGenEmpiricalHistFluors, 1,
-                   wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT, 2)
+                   wx.ALIGN_CENTER_VERTICAL, 2)
         
         pEmpiricalModelSizer.Add(hsizer, 0, wx.ALL | wx.ALIGN_RIGHT, 2)
         

--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -67,7 +67,7 @@ class PanSpool(afp.foldingPane):
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
     
         self.stAqProtocol = wx.StaticText(pan, -1, '<None>', size=wx.Size(136, -1))
-        hsizer.Add(self.stAqProtocol, 5, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, 2)
+        hsizer.Add(self.stAqProtocol, 5, wx.ALL | wx.EXPAND, 2)
     
         self.bSetAP = wx.Button(pan, -1, 'Set', style=wx.BU_EXACTFIT)
         self.bSetAP.Bind(wx.EVT_BUTTON, self.OnBSetAqProtocolButton)
@@ -79,7 +79,7 @@ class PanSpool(afp.foldingPane):
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
         self.rbNoSteps = wx.RadioButton(pan, -1, 'Standard', style=wx.RB_GROUP)
         self.rbNoSteps.Bind(wx.EVT_RADIOBUTTON, self.OnToggleZStepping)
-        hsizer.Add(self.rbNoSteps, 1, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, 2)
+        hsizer.Add(self.rbNoSteps, 1, wx.ALL | wx.EXPAND, 2)
         self.rbZStepped = wx.RadioButton(pan, -1, 'Z stepped')
         self.rbZStepped.Bind(wx.EVT_RADIOBUTTON, self.OnToggleZStepping)
         hsizer.Add(self.rbZStepped, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 2)
@@ -109,7 +109,7 @@ class PanSpool(afp.foldingPane):
     
         self.rbSpoolFile = wx.RadioButton(pan, -1, 'File', style=wx.RB_GROUP)
         self.rbSpoolFile.Bind(wx.EVT_RADIOBUTTON, self.OnSpoolMethodChanged)
-        hsizer.Add(self.rbSpoolFile, 1, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, 2)
+        hsizer.Add(self.rbSpoolFile, 1, wx.ALL | wx.EXPAND, 2)
         self.rbSpoolCluster = wx.RadioButton(pan, -1, 'Cluster')
         self.rbSpoolCluster.Bind(wx.EVT_RADIOBUTTON, self.OnSpoolMethodChanged)
         hsizer.Add(self.rbSpoolCluster, 1, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 2)
@@ -132,7 +132,7 @@ class PanSpool(afp.foldingPane):
     
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
         self.stSpoolDirName = wx.StaticText(pan, -1, 'Save images in: Blah Blah', size=wx.Size(136, -1))
-        hsizer.Add(self.stSpoolDirName, 5, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, 5)
+        hsizer.Add(self.stSpoolDirName, 5, wx.ALL | wx.EXPAND, 5)
     
         self.bSetSpoolDir = wx.Button(pan, -1, 'Set', style=wx.BU_EXACTFIT)
         self.bSetSpoolDir.Bind(wx.EVT_BUTTON, self.OnBSetSpoolDirButton)
@@ -218,7 +218,7 @@ class PanSpool(afp.foldingPane):
         self.tcSpoolFile = wx.TextCtrl(pan, -1, 'dd_mm_series_a', size=wx.Size(100, -1))
         self.tcSpoolFile.Bind(wx.EVT_TEXT, self.OnTcSpoolFileText)
     
-        hsizer.Add(self.tcSpoolFile, 5, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, 5)
+        hsizer.Add(self.tcSpoolFile, 5, wx.ALL | wx.EXPAND, 5)
     
         self.bStartSpool = wx.Button(pan, -1, 'Start', style=wx.BU_EXACTFIT)
         self.bStartSpool.Bind(wx.EVT_BUTTON, self.OnBStartSpoolButton)

--- a/PYME/Acquire/ui/intsliders.py
+++ b/PYME/Acquire/ui/intsliders.py
@@ -157,7 +157,7 @@ class IntegrationSliders(wx.Panel):
         else:
             sz = wx.BoxSizer(wx.HORIZONTAL)
 
-        sz.Add(sl, 1, wx.ALL|wx.EXPAND|wx.ALIGN_CENTER_VERTICAL, 2)
+        sz.Add(sl, 1, wx.ALL|wx.EXPAND, 2)
         sz.Add(sl_val, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
         sz.Add(wx.StaticText(self, -1, 'ms'), 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
         sizer_2.Add(sz,1,wx.EXPAND,0)

--- a/PYME/Acquire/ui/lasersliders.py
+++ b/PYME/Acquire/ui/lasersliders.py
@@ -85,7 +85,7 @@ class LaserSliders(wx.Panel):
                 #FIXME for wx >= 4
                 sl.SetTickFreq(10,1)
             
-            sz.Add(sl, 1, wx.ALL|wx.ALIGN_CENTER_VERTICAL|wx.EXPAND, 2)
+            sz.Add(sl, 1, wx.ALL|wx.EXPAND, 2)
             self.sliders.append(sl)
 
             l = wx.StaticText(self, -1, '100.0')

--- a/PYME/Acquire/ui/positionUI.py
+++ b/PYME/Acquire/ui/positionUI.py
@@ -190,14 +190,14 @@ class PositionPanel(wx.Panel):
             self.tY = wx.TextCtrl(self, -1, "0")
             gsizer.Add(self.tY, 1, wx.ALIGN_CENTRE_VERTICAL | wx.ALL | wx.EXPAND, 0)
             
-            hsizer.Add(gsizer, 1, wx.EXPAND|wx.ALL|wx.ALIGN_CENTRE_VERTICAL, 0)
+            hsizer.Add(gsizer, 1, wx.EXPAND|wx.ALL, 0)
             
             self.bGo = wx.Button(self, -1, "G\nO", size=(30, -1))
             #self.bGo.SetSize((25, 200))
             self.bGo.Bind(wx.EVT_BUTTON, self.on_moveto)
             vsizer = wx.BoxSizer(wx.VERTICAL)
             vsizer.Add(self.bGo, 1, wx.EXPAND, 0)
-            hsizer.Add(vsizer, 0, wx.EXPAND|wx.ALIGN_CENTRE_VERTICAL,0)
+            hsizer.Add(vsizer, 0, wx.EXPAND,0)
             
             gsizer = wx.GridBagSizer(2, 2)
             self.bLeft = wx.Button(self, -1, '<', style=wx.BU_EXACTFIT)

--- a/PYME/Acquire/ui/seqdialog.py
+++ b/PYME/Acquire/ui/seqdialog.py
@@ -121,7 +121,7 @@ class seqPanel(wx.Panel):
         
         self.bStartHere = wx.Button(self, -1,'Start', size=(30,-1), style=wx.BU_EXACTFIT)
         self.bStartHere.Bind(wx.EVT_BUTTON, self.OnBStartHereButton)
-        hsizer.Add(self.bStartHere, 1, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND|wx.RIGHT, 2)
+        hsizer.Add(self.bStartHere, 1, wx.EXPAND|wx.RIGHT, 2)
 
         #sStart = wx.StaticBoxSizer(wx.StaticBox(self, -1, u'Start Pos [\u03BCm]'), wx.HORIZONTAL)
 
@@ -140,7 +140,7 @@ class seqPanel(wx.Panel):
         
         self.bEndHere = wx.Button(self, -1,'End', size=(30,-1), style=wx.BU_EXACTFIT)
         self.bEndHere.Bind(wx.EVT_BUTTON, self.OnBEndHereButton)
-        hsizer.Add(self.bEndHere, 1, wx.ALIGN_CENTER_VERTICAL|wx.EXPAND|wx.LEFT, 5)
+        hsizer.Add(self.bEndHere, 1, wx.EXPAND|wx.LEFT, 5)
 
         self.tEndPos = wx.TextCtrl(self, -1, value='40', size=(10,-1))
         self.tEndPos.Bind(wx.EVT_KILL_FOCUS, self.OnTEndPosKillFocus)

--- a/PYME/DSView/displaySettingsPanel.py
+++ b/PYME/DSView/displaySettingsPanel.py
@@ -172,7 +172,7 @@ class dispSettingsPanel2(wx.Panel):
         self.hlDispMapping = histLimits.HistLimitPanel(self, -1, self.dsa, self.do.Offs[0], self.do.Offs[0] + 255./self.do.Gains[0], True, size=(100, 80))
         self.hlDispMapping.Bind(histLimits.EVT_LIMIT_CHANGE, self.OnMappingChange)
 
-        hsizer.Add(self.hlDispMapping, 1, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        hsizer.Add(self.hlDispMapping, 1, wx.EXPAND|wx.ALL, 5)
 
         vsizer2 = wx.BoxSizer(wx.VERTICAL)
         self.bOptimise = wx.Button(self, -1, 'Optimise', style=wx.BU_EXACTFIT)
@@ -198,9 +198,9 @@ class dispSettingsPanel2(wx.Panel):
 
         #scaleSizer.Add(self.cbScale, 0, wx.ALL, 5)
         #hsizer.Add(wx.StaticText(self, -1, 'Scale: '), 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
-        vsizer2.Add(self.cbScale, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.EXPAND, 5)
+        vsizer2.Add(self.cbScale, 0, wx.EXPAND, 5)
 
-        hsizer.Add(vsizer2, 0, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        hsizer.Add(vsizer2, 0, wx.EXPAND|wx.ALL, 5)
 
         #vsizer.Add(hsizer, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.ALL, 5)
 


### PR DESCRIPTION
Addresses issue #678 .

**Proposed changes:**

This fix was discussed on issue #678. I believe this will no break on wxPython 3 but I did not actually test that. This chang removes some alignment flags that are ignored in wxWidgets but that since wxPython 4.1 raise assertion errors. I did test this on wxPython 4.0.7, 4.1.0, and 4.1.1.

I found two types of alignment flags being ignored. 1) alignment flags that are meaningless in the specific sizer, e.g., vertical alignment flags makes no sense on vertical sizers; 2) alignment flags used together with the expand flag (the expand and align flag act on the window, so if the window is expanded there is no alignment to be made.

I did not remove all instances of those ignored flags, only the instances that were raising errors to me because I'm afraid to break the other parts of the code that I'm not using. However, grepping the code for this, suggests this happens in many places:

    $ grep -r wx.EXPAND PYME/ | grep wx.ALIGN | wc -l
    68


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]