### PR TITLE
add physical units flag to processing.Gradient recipe modules

### DIFF
--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -719,15 +719,16 @@ class Gradient2D(ModuleBase):
     ----------
     inputName : PYME.IO.image.ImageStack
         input image
-    physical_units : Bool
-        Flag to return gradient in units of input data intensity per micrometer
-        [True] or leave in units of input data intensity per pixel [False,
-        default].
+    units : Enum
+        specify whether to return gradient in units of intensity/pixel or
+        intensity/um. Note that intensity/um will account for anisotropic 
+        voxels, while the per pixel in intensity/pixel can be direction 
+        dependent.
     """
     inputName = Input('input')
     outputNameX = Output('grad_x')
     outputNameY = Output('grad_y')
-    physical_units = Bool(False)
+    units = Enum(['intensity/pixel', 'intensity/um'])
     
     def calc_grad(self, data, chanNum):
         grad_x = []
@@ -747,7 +748,7 @@ class Gradient2D(ModuleBase):
         grad_y = []
         for chanNum in range(image.data.shape[3]):
             fx, fy = self.calc_grad(image.data, chanNum)
-            if self.physical_units:
+            if self.units == 'intensity/um':
                 fx /= (image.voxelsize_nm.x / 1e3)  # [data/pix] -> [data/um]
                 fy /= (image.voxelsize_nm.y / 1e3)
             grad_x.append(fx)
@@ -777,16 +778,17 @@ class Gradient3D(ModuleBase):
     ----------
     inputName : PYME.IO.image.ImageStack
         input image
-    physical_units : Bool
-        Flag to return gradient in units of input data intensity per micrometer
-        [True] or leave in units of input data intensity per pixel [False,
-        default].
+    units : Enum
+        specify whether to return gradient in units of intensity/pixel or
+        intensity/um. Note that intensity/um will account for anisotropic 
+        voxels, while the per pixel in intensity/pixel can be direction 
+        dependent.
     """
     inputName = Input('input')
     outputNameX = Output('grad_x')
     outputNameY = Output('grad_y')
     outputNameZ = Output('grad_z')
-    physical_units = Bool(False)
+    units = Enum(['intensity/pixel', 'intensity/um'])
 
     def calc_grad(self, data, chanNum):
         dx, dy, dz = np.gradient(np.atleast_3d(data[:,:,:,chanNum].squeeze()))
@@ -801,7 +803,7 @@ class Gradient3D(ModuleBase):
 
         for chanNum in range(image.data.shape[3]):
             fx, fy, fz = self.calc_grad(image.data, chanNum)
-            if self.physical_units:
+            if self.units == 'intensity/um':
                 fx /= (image.voxelsize_nm.x / 1e3)  # [data/pix] -> [data/um]
                 fy /= (image.voxelsize_nm.y / 1e3)
                 fz /= (image.voxelsize_nm.z / 1e3)

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -711,10 +711,23 @@ class FindCaWaves(ModuleBase):
         
         
 @register_module('Gradient')         
-class Gradient2D(ModuleBase):   
+class Gradient2D(ModuleBase):
+    """
+    Calculate the gradient along x and y for each channel of an ImageStack
+
+    Parameters
+    ----------
+    inputName : PYME.IO.image.ImageStack
+        input image
+    physical_units : Bool
+        Flag to return gradient in units of input data intensity per micrometer
+        [True] or leave in units of input data intensity per pixel [False,
+        default].
+    """
     inputName = Input('input')
     outputNameX = Output('grad_x')
     outputNameY = Output('grad_y')
+    physical_units = Bool(False)
     
     def calc_grad(self, data, chanNum):
         grad_x = []
@@ -734,6 +747,9 @@ class Gradient2D(ModuleBase):
         grad_y = []
         for chanNum in range(image.data.shape[3]):
             fx, fy = self.calc_grad(image.data, chanNum)
+            if self.physical_units:
+                fx /= (image.voxelsize_nm.x / 1e3)  # [data/pix] -> [data/um]
+                fy /= (image.voxelsize_nm.y / 1e3)
             grad_x.append(fx)
             grad_y.append(fy)
         

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -754,10 +754,23 @@ class Gradient2D(ModuleBase):
 
 @register_module('Gradient3D')
 class Gradient3D(ModuleBase):
+    """
+    Calculate the gradient along x, y, and z for each channel of an ImageStack
+
+    Parameters
+    ----------
+    inputName : PYME.IO.image.ImageStack
+        input image
+    physical_units : Bool
+        Flag to return gradient in units of input data intensity per micrometer
+        [True] or leave in units of input data intensity per pixel [False,
+        default].
+    """
     inputName = Input('input')
     outputNameX = Output('grad_x')
     outputNameY = Output('grad_y')
     outputNameZ = Output('grad_z')
+    physical_units = Bool(False)
 
     def calc_grad(self, data, chanNum):
         dx, dy, dz = np.gradient(np.atleast_3d(data[:,:,:,chanNum].squeeze()))
@@ -772,6 +785,10 @@ class Gradient3D(ModuleBase):
 
         for chanNum in range(image.data.shape[3]):
             fx, fy, fz = self.calc_grad(image.data, chanNum)
+            if self.physical_units:
+                fx /= (image.voxelsize_nm.x / 1e3)  # [data/pix] -> [data/um]
+                fy /= (image.voxelsize_nm.y / 1e3)
+                fz /= (image.voxelsize_nm.z / 1e3)
             grad_x.append(fx)
             grad_y.append(fy)
             grad_z.append(fz)


### PR DESCRIPTION
Addresses issue #calculating the gradient in units of data intensity / um instead of data intensity / voxel.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- use image.voxelsize_nm to put gradient denominator in physical units if flagged to do so





- ran Gradient3D, did not run Gradient2D
