### PR TITLE
initial work on an xyztc data source

### DIFF
--- a/PYME/IO/DataSources/BGSDataSource.py
+++ b/PYME/IO/DataSources/BGSDataSource.py
@@ -229,6 +229,14 @@ class DataSource(BaseDataSource):
         self.bgRange = bgRange
         self.dataStart = 0
         
+    @property
+    def additionalDims(self):
+        return self.datasource.additionalDims
+    
+    @property
+    def sizeC(self):
+        return self.datasource.sizeC
+        
     def setBackgroundBufferPCT(self, pctile=0):
         if not pctile == 0:
             self.bBufferP.pctile = pctile

--- a/PYME/IO/dataExporter.py
+++ b/PYME/IO/dataExporter.py
@@ -86,6 +86,7 @@ class H5Exporter(Exporter):
         filters=tables.Filters(self.complevel,self.complib,shuffle=True)
 
         nframes = (zslice.stop - zslice.start)/zslice.step
+        nChans = data.shape[3]
 
         xSize, ySize = data[xslice, yslice, 0].shape[:2]
         
@@ -101,26 +102,32 @@ class H5Exporter(Exporter):
         ims = h5out.create_earray(h5out.root,'ImageData',atm,(0,xSize,ySize), filters=filters, expectedrows=nframes, chunkshape=(1,xSize,ySize))
 
         curFrame = 0
-        for frameN in range(zslice.start,zslice.stop, zslice.step):
-            curFrame += 1
-            im = data[xslice, yslice, frameN].squeeze()
-            
-            for fN in range(frameN+1, frameN+zslice.step):
-                im += data[xslice, yslice, fN].squeeze()
+        for ch_num in range(nChans):
+            for frameN in range(zslice.start,zslice.stop, zslice.step):
+                curFrame += 1
+                im = data[xslice, yslice, frameN, ch_num].squeeze()
                 
-            if im.ndim == 1:
-                im = im.reshape((-1, 1))[None, :,:]
-            else:
-                im = im[None, :,:]
-            
-            #print im.shape    
-            ims.append(im)
-            if ((curFrame % 10) == 0)  and progressCallback:
-                try:
-                    progressCallback(curFrame, nframes)
-                except:
-                    pass
+                for fN in range(frameN+1, frameN+zslice.step):
+                    im += data[xslice, yslice, fN, ch_num].squeeze()
+                    
+                if im.ndim == 1:
+                    im = im.reshape((-1, 1))[None, :,:]
+                else:
+                    im = im[None, :,:]
+                
+                #print im.shape
+                ims.append(im)
+                if ((curFrame % 10) == 0)  and progressCallback:
+                    try:
+                        progressCallback(curFrame, nframes)
+                    except:
+                        pass
             #ims.flush()
+        
+        ims.attrs.DimOrder = 'XYZTC'
+        ims.attrs.SizeC = nChans
+        ims.attrs.SizeZ = nframes  #FIXME for proper XYZTC data model
+        ims.attrs.SizeT = 1        #FIXME for proper XYZTC data model
             
         ims.flush()
 


### PR DESCRIPTION
Initial steps in a longstanding item on the roadmap, namely the transition to an xyztc data model from an xy(z/t)c model. Also relevant to #64.

Plan is to create an xyztc data source for every input data source and initially have this live beside `image.data` so that recipe modules, display, etc ... can use it if they prefer, before finally moving everything over. 
