### PR TITLE
Remove cutoff at object size of 100 nm^2

### DIFF
--- a/PYME/LMVis/Extras/objectMeasurements.py
+++ b/PYME/LMVis/Extras/objectMeasurements.py
@@ -105,7 +105,7 @@ class ObjectMeasurer:
         pipeline.objectMeasures = {}
 
         if len(chans) == 0:
-            pipeline.objectMeasures['Everything'] = objectMeasure.measureObjectsByID(pipeline.colourFilter, 10,ids,key)
+            pipeline.objectMeasures['Everything'] = objectMeasure.measureObjectsByID(pipeline.colourFilter, np.inf,ids,key)
 
             from PYME.ui import recArrayView
             f = recArrayView.ArrayFrame(pipeline.objectMeasures['Everything'], parent=self.visFr, title='Object Measurements')
@@ -126,7 +126,7 @@ class ObjectMeasurer:
             for ch, i in zip(chans, range(len(chans))):
                 pipeline.colourFilter.setColour(ch)
                 #fitDecayChan(colourFilter, metadata, chanNames[i], i)
-                pipeline.objectMeasures[chanNames[i]] = objectMeasure.measureObjectsByID(pipeline.colourFilter, 10,ids,key)
+                pipeline.objectMeasures[chanNames[i]] = objectMeasure.measureObjectsByID(pipeline.colourFilter, np.inf,ids,key)
             
             pipeline.colourFilter.setColour(curChan)
 


### PR DESCRIPTION
We had an arbitrary cutoff of 100 nm^2 in Analysis > Measure Objects. Switched to a cutoff of infinity.