### PR TITLE
extract multiview channel recipe module

### DIFF
--- a/PYME/recipes/multiview.py
+++ b/PYME/recipes/multiview.py
@@ -381,6 +381,26 @@ class CalibrateShifts(ModuleBase):
 
 
 class ExtractMultiviewChannel(ModuleBase):
+    """Extract a single multiview channel
+
+    Parameters
+    ----------
+    input_name : PYME.IO.image.ImageStack
+        input, with multiview metadata
+    view_number : int
+        which multiview view to extract for the new ImageStack. Number should
+        match the multiview ROI number, not the number within the subset of
+        active views. By default, 0
+    output_name : PYME.IO.image.ImageStack
+        image cropped to contain a single multiview channel
+    
+    Notes
+    -----
+    Multiview metadata of the output image will not be updated other than to
+    note which channel has been extracted. All downstream analyses should be
+    not be multiview specific.
+    
+    """
     input_name = Input('input')
     view_number = Int(0)
     output_name = Output('extracted')
@@ -393,7 +413,7 @@ class ExtractMultiviewChannel(ModuleBase):
         roi_size = source.mdh['Multiview.ROISize']
         ind = np.argwhere(np.asarray(source.mdh['Multiview.ActiveViews']) == self.view_number)[0][0]
         x_i, x_f = int(ind * roi_size[0]), int((ind + 1 ) * roi_size[0])
-        extracted = DataSource(source, (x_i, x_f))
+        extracted = DataSource(source.data, (x_i, x_f))
 
         mdh = DictMDHandler(source.mdh)
         mdh['Multiview.Extracted'] = ind

--- a/PYME/recipes/multiview.py
+++ b/PYME/recipes/multiview.py
@@ -378,3 +378,23 @@ class CalibrateShifts(ModuleBase):
 
         namespace[self.output_name] = tabular.RecArraySource(shift_maps)
         namespace[self.output_name].mdh = mdh
+
+
+class ExtractMultiviewChannel(ModuleBase):
+    input_name = Input('input')
+    view_number = Int(0)
+    output_name = Output('extracted')
+
+    def execute(self, namespace):
+        from PYME.IO.DataSources.CropDataSource import DataSource
+        from PYME.IO.MetaDataHandler import DictMDHandler
+
+        source = namespace[self.input_name]
+        roi_size = source.mdh['Multiview.ROISize']
+        ind = np.argwhere(np.asarray(source.mdh['Multiview.ActiveViews']) == self.view_number)[0][0]
+        x_i, x_f = int(ind * roi_size[0]), int((ind + 1 ) * roi_size[0])
+        extracted = DataSource(source, (x_i, x_f))
+
+        mdh = DictMDHandler(source.mdh)
+        mdh['Multiview.Extracted'] = ind
+        namespace[self.output_name] = extracted

--- a/tests/PYME/Analysis/points/test_multiview.py
+++ b/tests/PYME/Analysis/points/test_multiview.py
@@ -65,5 +65,3 @@ def test_extract_channel():
 
     np.testing.assert_equal(out.getSlice(0).squeeze(), 1)
     np.testing.assert_equal(roi_size, out.shape[:2])
-
-test_extract_channel()

--- a/tests/PYME/Analysis/points/test_multiview.py
+++ b/tests/PYME/Analysis/points/test_multiview.py
@@ -49,6 +49,8 @@ def test_extract_channel():
     from PYME.recipes.multiview import ExtractMultiviewChannel
     from PYME.IO.DataSources.ArrayDataSource import ArrayDataSource
     from PYME.IO.MetaDataHandler import DictMDHandler
+    from PYME.IO.image import ImageStack
+
     roi_size = [123, 456]
     mdh = DictMDHandler()
     mdh['Multiview.ActiveViews'] = [0, 1]
@@ -58,7 +60,7 @@ def test_extract_channel():
                   roi_size[1], 1, 1))
     d[roi_size[0]:, :] = 1
     d = ArrayDataSource(d)
-    d.mdh = mdh
+    d = ImageStack(data=d, mdh=mdh)
     out = ExtractMultiviewChannel(view_number=1).apply_simple(input_name=d)
 
     np.testing.assert_equal(out.getSlice(0).squeeze(), 1)

--- a/tests/PYME/Analysis/points/test_multiview.py
+++ b/tests/PYME/Analysis/points/test_multiview.py
@@ -44,3 +44,24 @@ def test_merge_clumps():
         np.sum(weights[half_n:] * unmerged['y'][half_n:]) / np.sum(weights[half_n:])
     ]
     np.testing.assert_allclose(merged['y'], wm)
+
+def test_extract_channel():
+    from PYME.recipes.multiview import ExtractMultiviewChannel
+    from PYME.IO.DataSources.ArrayDataSource import ArrayDataSource
+    from PYME.IO.MetaDataHandler import DictMDHandler
+    roi_size = [123, 456]
+    mdh = DictMDHandler()
+    mdh['Multiview.ActiveViews'] = [0, 1]
+    mdh['Multiview.ROISize'] = roi_size
+
+    d = np.zeros((roi_size[0] * len(mdh['Multiview.ActiveViews']), 
+                  roi_size[1], 1, 1))
+    d[roi_size[0]:, :] = 1
+    d = ArrayDataSource(d)
+    d.mdh = mdh
+    out = ExtractMultiviewChannel(view_number=1).apply_simple(input_name=d)
+
+    np.testing.assert_equal(out.getSlice(0).squeeze(), 1)
+    np.testing.assert_equal(roi_size, out.shape[:2])
+
+test_extract_channel()


### PR DESCRIPTION
Addresses issue #537 

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- make a recipe module to easily split multiview views into separate imagestacks. goal here is to allow multiview tile series to be split and generate two separate image pyramids, two separate supertile sources, and either do subsequent analysis or recombine as a 'normal' stack.


**Checklist:**

- [ ] Tested with numpy=1.14

1.19
- [ ] Tested on python 2.7 and 3.6

3.7
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
