### PR TITLE
add output_dir setting/passing for remaining recipe clusterUI views

### DIFF
--- a/PYME/cluster/clusterUI/recipes/templates/recipes/form_recipe.html
+++ b/PYME/cluster/clusterUI/recipes/templates/recipes/form_recipe.html
@@ -16,6 +16,17 @@
                 </span>
             </div>
         </div>
+        
+        <div class="form-group">
+            <label class="control-label" for="recipeOutputPath">Output path</label>
+            <div class="input-group">
+                <span class="input-group-addon">pyme-cluster:///</span>
+                <input type="text" class="form-control" id="recipeOutputPath" name="recipeOutputPath">
+                <!-- <span class="input-group-btn">
+                    <button class="btn btn-default" type="button" id="select_output">select</button>
+                </span> -->
+            </div>
+        </div>
 
         <div id="recipe_image"></div>
 

--- a/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_editrun.html
+++ b/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_editrun.html
@@ -35,16 +35,16 @@
 
         <div id="recipe_input_list"></div>
 
-{#        <div class="form-group">#}
-{#            <label class="control-label" for="recipeOutputPath">Output path</label>#}
-{#            <div class="input-group">#}
-{#                <span class="input-group-addon">pyme-cluster:///</span>#}
-{#                <input type="text" class="form-control" id="recipeOutputPath" name="recipeOutputPath">#}
-{#                <span class="input-group-btn">#}
-{#                    <button class="btn btn-default" type="button" id="select_output">select</button>#}
-{#                </span>#}
-{#            </div>#}
-{#        </div>#}
+        <div class="form-group">
+            <label class="control-label" for="recipeOutputPath">Output path</label>
+            <div class="input-group">
+                <span class="input-group-addon">pyme-cluster:///</span>
+                <input type="text" class="form-control" id="recipeOutputPath" name="recipeOutputPath">
+                <!-- <span class="input-group-btn">
+                    <button class="btn btn-default" type="button" id="select_output">select</button>
+                </span> -->
+            </div>
+        </div>
 
         <input name="recipe_text" class="cu-hidden-text" type="hidden" value="">
 

--- a/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_editrun.html
+++ b/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_editrun.html
@@ -39,7 +39,7 @@
 {#            <label class="control-label" for="recipeOutputPath">Output path</label>#}
 {#            <div class="input-group">#}
 {#                <span class="input-group-addon">pyme-cluster:///</span>#}
-{#                <input type="text" class="form-control" id="recipeOutputPAth" name="recipeOutputPath">#}
+{#                <input type="text" class="form-control" id="recipeOutputPath" name="recipeOutputPath">#}
 {#                <span class="input-group-btn">#}
 {#                    <button class="btn btn-default" type="button" id="select_output">select</button>#}
 {#                </span>#}

--- a/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_standalone.html
+++ b/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_standalone.html
@@ -36,16 +36,16 @@
 
         <div id="recipe_input_list"></div>
 
-{#        <div class="form-group">#}
-{#            <label class="control-label" for="recipeOutputPath">Output path</label>#}
-{#            <div class="input-group">#}
-{#                <span class="input-group-addon">pyme-cluster:///</span>#}
-{#                <input type="text" class="form-control" id="recipeOutputPath" name="recipeOutputPath">#}
-{#                <span class="input-group-btn">#}
-{#                    <button class="btn btn-default" type="button" id="select_output">select</button>#}
-{#                </span>#}
-{#            </div>#}
-{#        </div>#}
+        <div class="form-group">
+            <label class="control-label" for="recipeOutputPath">Output path</label>
+            <div class="input-group">
+                <span class="input-group-addon">pyme-cluster:///</span>
+                <input type="text" class="form-control" id="recipeOutputPath" name="recipeOutputPath">
+                <!-- <span class="input-group-btn">
+                    <button class="btn btn-default" type="button" id="select_output">select</button>
+                </span> -->
+            </div>
+        </div>
 
         <div class="form-group pull-right">
             <input type="submit" value="Launch recipe" class="btn btn-primary"/>

--- a/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_standalone.html
+++ b/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_standalone.html
@@ -40,7 +40,7 @@
 {#            <label class="control-label" for="recipeOutputPath">Output path</label>#}
 {#            <div class="input-group">#}
 {#                <span class="input-group-addon">pyme-cluster:///</span>#}
-{#                <input type="text" class="form-control" id="recipeOutputPAth" name="recipeOutputPath">#}
+{#                <input type="text" class="form-control" id="recipeOutputPath" name="recipeOutputPath">#}
 {#                <span class="input-group-btn">#}
 {#                    <button class="btn btn-default" type="button" id="select_output">select</button>#}
 {#                </span>#}

--- a/PYME/cluster/clusterUI/recipes/views.py
+++ b/PYME/cluster/clusterUI/recipes/views.py
@@ -43,13 +43,16 @@ def run(request):
         from PYME.cluster.HTTPTaskPusher import RecipePusher
     
     recipe_url = request.POST.get('recipeURL')
+    output_directory = 'pyme-cluster://%s/%s' % (server_filter, 
+                                                 request.POST.get('recipeOutputPath').lstrip('/'))
+    
     if recipe_url is not None:
         recipeURI = ('pyme-cluster://%s/' % server_filter) + recipe_url.lstrip('/')
 
-        pusher = RecipePusher(recipeURI=recipeURI)
+        pusher = RecipePusher(recipeURI=recipeURI, output_dir=output_directory)
     else:
         recipe_text = request.POST.get('recipe_text')
-        pusher = RecipePusher(recipe=recipe_text)
+        pusher = RecipePusher(recipe=recipe_text, output_dir=output_directory)
 
     fileNames = request.POST.getlist('files', [])
     pusher.fileTasksForInputs(input=fileNames)


### PR DESCRIPTION
Addresses issue only the templated recipe view being able to save outputs at the moment.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- add output path text entry to the forms and pass it in views / run



**Checklist:**

- [ ] Tested with numpy=1.14

1.19
- [ ] Tested on python 2.7 and 3.6

3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]

4.0.4
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]