### PR TITLE
Re-animate Voronoi based reconstruction.

### DIFF
--- a/PYME/LMVis/renderers.py
+++ b/PYME/LMVis/renderers.py
@@ -523,7 +523,18 @@ class QuadTreeRenderer(ColourRenderer):
         return im[int(max(imb.x0 - quads.x0, 0)/pixelSize):int((imb.x1 - quads.x0)/pixelSize),int(max(imb.y0 - quads.y0, 0)/pixelSize):int((imb.y1 - quads.y0)/pixelSize)]
 
 
-RENDERER_GROUPS = ((HistogramRenderer, GaussianRenderer, TriangleRenderer, TriangleRendererW,LHoodRenderer, QuadTreeRenderer, DensityFitRenderer),
+class VoronoiRenderer(ColourRenderer):
+    """2D histogram rendering"""
+
+    name = 'Voronoi'
+    mode = 'voronoi'
+
+    def genIm(self, settings, imb, mdh):
+        return visHelpers.rendVoronoi(self.colourFilter['x'],self.colourFilter['y'], imb, settings['pixelSize'])
+
+
+
+RENDERER_GROUPS = ((HistogramRenderer, GaussianRenderer, TriangleRenderer, TriangleRendererW,LHoodRenderer, QuadTreeRenderer, DensityFitRenderer, VoronoiRenderer),
                    (Histogram3DRenderer, Gaussian3DRenderer, Triangle3DRenderer))
 
 RENDERERS = {i.name : i for s in RENDERER_GROUPS for i in s}

--- a/PYME/LMVis/visHelpers.py
+++ b/PYME/LMVis/visHelpers.py
@@ -790,3 +790,88 @@ def rendGauss3D(x,y, z, sx, sz, imageBounds, pixelSize, zb, sliceSize=100):
     im = im[roiSize:-roiSize, roiSize:-roiSize, :]
 
     return im
+
+
+def rendVoronoi(x, y, imageBounds, pixelSize):
+    from matplotlib import tri
+    from PYME.Analysis.points.SoftRend import drawTriang, drawTriangles
+    from PYME.recipes.pointcloud import Tesselation
+    sizeX = int((imageBounds.x1 - imageBounds.x0) / pixelSize)
+    sizeY = int((imageBounds.y1 - imageBounds.y0) / pixelSize)
+    
+    im = np.zeros((sizeX, sizeY))
+    
+    #T = tri.Triangulation(x, y)
+    Ts = Tesselation({'x': x, 'y': y, 'z': 0 * x}, three_d=False)
+    cc = Ts.circumcentres()
+    T = Ts.T
+
+    tdb = []
+    for i in range(len(x)):
+        tdb.append([])
+
+    for i in range(len(T.simplices)):
+        nds = T.simplices[i]
+        for n in nds:
+            tdb[n].append(i)
+
+    xs_ = None
+    ys_ = None
+    c_ = None
+
+    area_colouring = True
+    for i in range(len(x)):
+        #get triangles around point
+        impingentTriangs = tdb[i] #numpy.where(T.triangle_nodes == i)[0]
+        if len(impingentTriangs) >= 3:
+        
+            circumcenters = cc[impingentTriangs] #get their circumcenters
+        
+            #add current point - to deal with edge cases
+            newPts = np.array(list(circumcenters) + [[x[i], y[i]]])
+        
+            #re-triangulate (we could try and sort the triangles somehow, but this is easier)
+            T2 = tri.Triangulation(newPts[:, 0], newPts[:, 1])
+        
+            #now do the same as for the standard triangulation
+            xs = T2.x[T2.triangles]
+            ys = T2.y[T2.triangles]
+        
+            a = np.vstack((xs[:, 0] - xs[:, 1], ys[:, 0] - ys[:, 1])).T
+            b = np.vstack((xs[:, 0] - xs[:, 2], ys[:, 0] - ys[:, 2])).T
+        
+            #area of triangle
+            c = 0.5 * np.sqrt((b * b).sum(1) - ((a * b).sum(1) ** 2) / (a * a).sum(1)) * np.sqrt((a * a).sum(1))
+        
+            #c = numpy.maximum(((b*b).sum(1)),((a*a).sum(1)))
+        
+            #c_neighbours = c[T.triangle_neighbors].sum(1)
+            #c = 1.0/(c + c_neighbours + 1)
+            c = c.sum() * np.ones(c.shape)
+            c = 1.0 / (c + 1)
+        
+        
+            #print xs.shape
+            #print c.shape
+        
+            if xs_ is None:
+                xs_ = xs
+                ys_ = ys
+                c_ = c
+            else:
+                xs_ = np.vstack((xs_, xs))
+                ys_ = np.vstack((ys_, ys))
+                c_ = np.hstack((c_, c))
+
+    
+
+    # convert vertices [nm] to pixel position in output image (still floating point)
+    xs = (xs_ - imageBounds.x0) / pixelSize
+    ys = (ys_ - imageBounds.y0) / pixelSize
+
+    # NOTE 1: drawTriangles truncates co-ordinates to the nearest pixel on the left.
+    # NOTE 2: this truncation means that nothing is drawn for triangles < 1 pixel
+    # NOTE 3: triangles which would intersect with the edge of the image are discarded
+    drawTriangles(im, xs, ys, c_)
+    
+    return im

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -11,16 +11,16 @@ import six
 
 from PYME.recipes.traits import HasTraits, Float, List, Bool, Int, CStr, Enum, File, on_trait_change, Input, Output
     
-    #for some reason traitsui raises SystemExit when called from sphinx on OSX
-    #This is due to the framework build problem of anaconda on OSX, and also
-    #creates a problem whenever there is no GUI available.
-    #as we want to be able to use recipes without a GUI (presumably the reason for this problem)
-    #it's prudent to catch this and spoof the View and Item functions which are not going to be used anyway
-    #try:
-    #from traitsui.api import View, Item, Group# EnumEditor, InstanceEditor, Group
-    #except SystemExit:
-    #   print('Got stupid OSX SystemExit exception - using dummy traitsui')
-    #   from PYME.misc.mock_traitsui import *
+#for some reason traitsui raises SystemExit when called from sphinx on OSX
+#This is due to the framework build problem of anaconda on OSX, and also
+#creates a problem whenever there is no GUI available.
+#as we want to be able to use recipes without a GUI (presumably the reason for this problem)
+#it's prudent to catch this and spoof the View and Item functions which are not going to be used anyway
+#try:
+#from traitsui.api import View, Item, Group# EnumEditor, InstanceEditor, Group
+#except SystemExit:
+#   print('Got stupid OSX SystemExit exception - using dummy traitsui')
+#   from PYME.misc.mock_traitsui import *
 
 from PYME.IO.image import ImageStack
 import numpy as np


### PR DESCRIPTION
Voronoi output disappeared from PYMEVis when we made the shader transition, re-animate and make recipe compatible.

NOTE: implementation is super slow, but as this is only here for completeness (results are not as good as Jittered triangulation) that probably doesn't matter.