### PR TITLE
recipe context docs: correct filestub to file_stub

### DIFF
--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -89,13 +89,13 @@ class QueueAcquisitions(OutputModule):
             Information about the source file to allow pattern substitution to 
             generate the output name. At least 'basedir' (which is the fully 
             resolved directory name in which the input file resides) and 
-            'filestub' (which is the filename without any extension) should be 
+            'file_stub' (which is the filename without any extension) should be 
             resolved.
         
         Notes
         -----
         str spool_settings values can context-substitute templated parameters,
-        e.g. spool_settings = {'subdirectory': '{filestub}'}
+        e.g. spool_settings = {'subdirectory': '{file_stub}'}
         """
         # substitute spool settings
         spool_settings = self.spool_settings.copy()

--- a/PYME/recipes/output.py
+++ b/PYME/recipes/output.py
@@ -60,7 +60,7 @@ class CSVOutput(OutputModule):
         context : dict
             Information about the source file to allow pattern substitution to generate the output name. At least
             'basedir' (which is the fully resolved directory name in which the input file resides) and
-            'filestub' (which is the filename without any extension) should be resolved.
+            'file_stub' (which is the filename without any extension) should be resolved.
 
         Returns
         -------
@@ -126,7 +126,7 @@ class XLSOutput(OutputModule):
         context : dict
             Information about the source file to allow pattern substitution to generate the output name. At least
             'basedir' (which is the fully resolved directory name in which the input file resides) and
-            'filestub' (which is the filename without any extension) should be resolved.
+            'file_stub' (which is the filename without any extension) should be resolved.
 
         Returns
         -------
@@ -187,7 +187,7 @@ class ImageOutput(OutputModule):
         context : dict
             Information about the source file to allow pattern substitution to generate the output name. At least
             'basedir' (which is the fully resolved directory name in which the input file resides) and
-            'filestub' (which is the filename without any extension) should be resolved.
+            'file_stub' (which is the filename without any extension) should be resolved.
 
         Returns
         -------
@@ -257,7 +257,7 @@ class RGBImageOutput(OutputModule):
         context : dict
             Information about the source file to allow pattern substitution to generate the output name. At least
             'basedir' (which is the fully resolved directory name in which the input file resides) and
-            'filestub' (which is the filename without any extension) should be resolved.
+            'file_stub' (which is the filename without any extension) should be resolved.
 
         Returns
         -------
@@ -319,7 +319,7 @@ class HDFOutput(OutputModule):
         context : dict
             Information about the source file to allow pattern substitution to generate the output name. At least
             'basedir' (which is the fully resolved directory name in which the input file resides) and
-            'filestub' (which is the filename without any extension) should be resolved.
+            'file_stub' (which is the filename without any extension) should be resolved.
 
         Returns
         -------
@@ -417,7 +417,7 @@ class ReportOutput(OutputModule):
         context : dict
             Information about the source file to allow pattern substitution to generate the output name. At least
             'basedir' (which is the fully resolved directory name in which the input file resides) and
-            'filestub' (which is the filename without any extension) should be resolved.
+            'file_stub' (which is the filename without any extension) should be resolved.
 
         Returns
         -------
@@ -486,7 +486,7 @@ class ReportForEachOutput(OutputModule):
         context : dict
             Information about the source file to allow pattern substitution to generate the output name. At least
             'basedir' (which is the fully resolved directory name in which the input file resides) and
-            'filestub' (which is the filename without any extension) should be resolved.
+            'file_stub' (which is the filename without any extension) should be resolved.
 
         Returns
         -------

--- a/PYME/reports/templates/colocalisation.html
+++ b/PYME/reports/templates/colocalisation.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- FIXME Should this be file_stub? -->
     <title>Colocalisation ({{ filestub }})</title>
 </head>
 <body>


### PR DESCRIPTION
Addresses issue #me trusting the docs which I may have even written but dropped the underscore

![image](https://user-images.githubusercontent.com/31105780/102365322-6b665180-3f85-11eb-9559-e053cdb27c94.png)

@David-Baddeley - I didn't chase down what happens/doesn't wherever the colocalisation report template gets used, just added a note for now