### PR TITLE
thread-polled get_status to hide latency on randomly slow windows requests

### DIFF
--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -281,8 +281,8 @@ class SpoolController(object):
 
         """
         if self.spoolType == 'Cluster':
-            from PYME.IO import clusterIO
-            nodes = clusterIO.get_status()
+            from PYME.cluster import status
+            nodes = status.get_polled_status()
             free_storage = sum([n['Disk']['free'] for n in nodes])
             return free_storage / 1e9
         else:

--- a/PYME/cluster/clusterUI/clusterstatus/views.py
+++ b/PYME/cluster/clusterUI/clusterstatus/views.py
@@ -4,8 +4,8 @@ from django.shortcuts import render
 # Create your views here.
 
 def status(request):
-    from PYME.IO import clusterIO
-    nodes = clusterIO.get_status()
+    from PYME.cluster.status import get_polled_status
+    nodes = get_polled_status()
 
     total_storage = 0
     free_storage = 0
@@ -28,9 +28,9 @@ def status(request):
 
 
 def load(request):
-    from PYME.IO import clusterIO
-
-    nodes = clusterIO.get_status()
+    from PYME.cluster.status import get_polled_status
+    
+    nodes = get_polled_status()
 
     total_storage = 0
     free_storage = 0

--- a/PYME/cluster/status.py
+++ b/PYME/cluster/status.py
@@ -2,11 +2,7 @@
 import threading
 from PYME.IO.clusterIO import get_status, local_serverfilter
 
-_INFO = {
-    local_serverfilter: {
-        'lock': threading.Lock(),
-    }
-}
+_INFO = dict()
 
 def get_polled_status(serverfilter=local_serverfilter, poll_wait=3):
     """ Polled version of PYME.IO.clusterIO.get_status
@@ -19,7 +15,8 @@ def get_polled_status(serverfilter=local_serverfilter, poll_wait=3):
         the cluster name (optional), to select a specific cluster
     poll_wait: float
         number of seconds for polling thread to wait before updating the
-        status again.
+        status again. Only has an effect if this is the first call for
+        a given `serverfilter`.
 
     Returns
     -------

--- a/PYME/cluster/status.py
+++ b/PYME/cluster/status.py
@@ -21,7 +21,7 @@ class StatusInfo(dict):
 
 _INFO = StatusInfo()
 
-def get_polled_status(serverfilter=local_serverfilter, poll_wait=3):
+def get_polled_status(serverfilter=local_serverfilter, poll_wait=1):
     """ Polled version of PYME.IO.clusterIO.get_status
     Get status of cluster servers (currently only used in the clusterIO web 
     service)

--- a/PYME/cluster/status.py
+++ b/PYME/cluster/status.py
@@ -1,0 +1,86 @@
+
+import threading
+from PYME.IO.clusterIO import get_status, local_serverfilter
+
+_INFO = {
+    local_serverfilter: {
+        'lock': threading.Lock(),
+    }
+}
+
+def get_polled_status(serverfilter=local_serverfilter, poll_wait=3):
+    """ Polled version of PYME.IO.clusterIO.get_status
+    Get status of cluster servers (currently only used in the clusterIO web 
+    service)
+    
+    Parameters
+    ----------
+    serverfilter: str
+        the cluster name (optional), to select a specific cluster
+    poll_wait: float
+        number of seconds for polling thread to wait before updating the
+        status again.
+
+    Returns
+    -------
+    status_list: list
+        a status dictionary for each node. See 
+        PYME.cluster.HTTPDataServer.updateStatus
+            Disk: dict
+                total: int
+                    storage on the node [bytes]
+                used: int
+                    used storage on the node [bytes]
+                free: int
+                    available storage on the node [bytes]
+            CPUUsage: float
+                cpu usage as a percentile
+            MemUsage: dict
+                total: int
+                    total RAM [bytes]
+                available: int
+                    free RAM [bytes]
+                percent: float
+                    percent usage
+                used: int
+                    used RAM [bytes], calculated differently depending on platform
+                free: int
+                    RAM which is zero'd and ready to go [bytes]
+                [other]:
+                    more platform-specific fields
+            Network: dict
+                send: int
+                    bytes sent per second since the last status update
+                recv: int
+                    bytes received per second since the last status update
+            GPUUsage: list of float
+                [optional] returned for NVIDIA GPUs only. Should be compute usage per gpu as percent?
+            GPUMem: list of float
+                [optional] returned for NVIDIA GPUs only. Should be memory usage per gpu as percent?
+
+
+    """
+    global _INFO
+
+    if serverfilter not in _INFO.keys():
+        _INFO[serverfilter] = {
+            'lock': threading.Lock(),
+            'status': get_status(serverfilter),
+            'thread': threading.Thread(target=_poll_status, 
+                                       args=(serverfilter, poll_wait))
+        }
+        _INFO[serverfilter]['thread'].start()
+    
+    with _INFO[serverfilter]['lock']:
+        return _INFO[serverfilter]['status']
+
+def _poll_status(serverfilter, poll_wait):
+    import time
+
+    global _INFO
+
+    while True:
+        status = get_status(serverfilter)
+        with _INFO[serverfilter]['lock']:
+            _INFO[serverfilter]['status'] = status
+        time.sleep(poll_wait)


### PR DESCRIPTION
Addresses issue #545. forgot to comment out the freespace update last time I merged main and it was pretty painful - finally crossing this one off the to-do list.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- use a thread to poll clusterIO.get_status to hide any latency in retrieving it.

**Checklist:**

- [ ] Tested with numpy=1.14
1.16
- [ ] Tested on python 2.7 and 3.6
- [ ] 
3.6

- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
