### PR TITLE
use ImageStack for locking h5's in recipes

### DIFF
--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -1098,7 +1098,7 @@ class ModuleCollection(HasTraits):
         import os
 
         extension = os.path.splitext(filename)[1]
-        if extension in ['.h5r', '.h5', '.hdf']: #TODO - should `.h5` be processed here, or via ImageStack
+        if extension in ['.h5r', '.hdf']:
             import tables
             from PYME.IO import h5rFile
             try:


### PR DESCRIPTION
Addresses issue #709 following @David-Baddeley 's recommendation. 


**Checklist:**

- [ ] Tested 
will try and remember to test this evening