### PR TITLE
use excessive timeout for HTTP acquisition event put

### DIFF
--- a/PYME/Acquire/HTTPSpooler.py
+++ b/PYME/Acquire/HTTPSpooler.py
@@ -255,21 +255,23 @@ class Spooler(sp.Spooler):
             for pt in self._pollThreads:
                 pt.join()
         
+        # save events and final metadata
+        # TODO - use a binary format for saving events - they can be quite
+        # numerous, and can trip the standard 1 s clusterIO.put_file timeout.
+        # Use long timeouts as a temporary hack because failing these can ruin
+        # a dataset
         if self._aggregate_h5:
-            clusterIO.put_file('__aggregate_h5/' + self.seriesName + '/final_metadata.json', self.md.to_JSON().encode(),
-                               serverfilter=self.clusterFilter)
-    
-            #save the acquisition events as json - TODO - consider a binary format as the events
-            #can be quite numerous
-            clusterIO.put_file('__aggregate_h5/' + self.seriesName + '/events.json', self.evtLogger.to_JSON().encode(),
-                               serverfilter=self.clusterFilter)
-        
+            clusterIO.put_file('__aggregate_h5/' + self.seriesName + '/final_metadata.json', 
+                               self.md.to_JSON().encode(), self.clusterFilter)
+            clusterIO.put_file('__aggregate_h5/' + self.seriesName + '/events.json', 
+                               self.evtLogger.to_JSON().encode(),
+                               self.clusterFilter, 10)
         else:
-            clusterIO.put_file(self.seriesName + '/final_metadata.json', self.md.to_JSON().encode(), serverfilter=self.clusterFilter)
-            
-            #save the acquisition events as json - TODO - consider a binary format as the events
-            #can be quite numerous
-            clusterIO.put_file(self.seriesName + '/events.json', self.evtLogger.to_JSON().encode(), serverfilter=self.clusterFilter)
+            clusterIO.put_file(self.seriesName + '/final_metadata.json', 
+                               self.md.to_JSON().encode(), self.clusterFilter)
+            clusterIO.put_file(self.seriesName + '/events.json', 
+                               self.evtLogger.to_JSON().encode(), 
+                               self.clusterFilter, 10)
         
         
     def OnFrame(self, sender, frameData, **kwargs):

--- a/PYME/Acquire/HTTPSpooler.py
+++ b/PYME/Acquire/HTTPSpooler.py
@@ -265,13 +265,13 @@ class Spooler(sp.Spooler):
                                self.md.to_JSON().encode(), self.clusterFilter)
             clusterIO.put_file('__aggregate_h5/' + self.seriesName + '/events.json', 
                                self.evtLogger.to_JSON().encode(),
-                               self.clusterFilter, 10)
+                               self.clusterFilter, timeout=10)
         else:
             clusterIO.put_file(self.seriesName + '/final_metadata.json', 
                                self.md.to_JSON().encode(), self.clusterFilter)
             clusterIO.put_file(self.seriesName + '/events.json', 
                                self.evtLogger.to_JSON().encode(), 
-                               self.clusterFilter, 10)
+                               self.clusterFilter, timeout=10)
         
         
     def OnFrame(self, sender, frameData, **kwargs):


### PR DESCRIPTION
Addresses issue failing for ~11 MB event files typical of large tile acquisitions.
```
Traceback (most recent call last):
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\urllib3\connectionpool.py", line 426, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\urllib3\connectionpool.py", line 421, in _make_request
    httplib_response = conn.getresponse()
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\http\client.py", line 1379, in getresponse
    response.begin()
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\http\client.py", line 311, in begin
    version, status, reason = self._read_status()
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\http\client.py", line 272, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\socket.py", line 586, in readinto
    return self._sock.recv_into(b)
socket.timeout: timed out
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\requests\adapters.py", line 449, in send
    timeout=timeout
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\urllib3\connectionpool.py", line 727, in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\urllib3\util\retry.py", line 403, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\urllib3\packages\six.py", line 735, in reraise
    raise value
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\urllib3\connectionpool.py", line 677, in urlopen
    chunked=chunked,
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\urllib3\connectionpool.py", line 428, in _make_request
    self._raise_timeout(err=e, url=url, timeout_value=read_timeout)
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\urllib3\connectionpool.py", line 336, in _raise_timeout
    self, url, "Read timed out. (read timeout=%s)" % timeout_value
urllib3.exceptions.ReadTimeoutError: HTTPConnectionPool(host='10.150.7.4', port=15348): Read timed out. (read timeout=1)
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "c:\users\bergamot\code\python-microscopy\PYME\Acquire\frameWrangler.py", line 235, in onExpReady
    self.onFrame.send(sender=self, frameData=d)
  File "c:\users\bergamot\code\python-microscopy\PYME\contrib\dispatch\dispatcher.py", line 174, in send
    for receiver in self._live_receivers(sender)
  File "c:\users\bergamot\code\python-microscopy\PYME\contrib\dispatch\dispatcher.py", line 174, in <listcomp>
    for receiver in self._live_receivers(sender)
  File "c:\users\bergamot\code\python-microscopy\PYME\Acquire\Utils\pointScanner.py", line 198, in tick
    self._stop()
  File "c:\users\bergamot\code\python-microscopy\PYME\Acquire\Utils\pointScanner.py", line 247, in _stop
    self.on_stop.send(self)
  File "c:\users\bergamot\code\python-microscopy\PYME\contrib\dispatch\dispatcher.py", line 174, in send
    for receiver in self._live_receivers(sender)
  File "c:\users\bergamot\code\python-microscopy\PYME\contrib\dispatch\dispatcher.py", line 174, in <listcomp>
    for receiver in self._live_receivers(sender)
  File "c:\users\bergamot\code\python-microscopy\PYME\Acquire\SpoolController.py", line 492, in StopSpooling
    self.spooler.StopSpool()
  File "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 272, in StopSpool
    clusterIO.put_file(self.seriesName + '/events.json', self.evtLogger.to_JSON().encode(), serverfilter=self.clusterFilter)
  File "c:\users\bergamot\code\python-microscopy\PYME\IO\clusterIO.py", line 978, in put_file
    r = s.put(url, data=data, timeout=timeout)
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\requests\sessions.py", line 590, in put
    return self.request('PUT', url, data=data, **kwargs)
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\requests\sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\requests\sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\requests\adapters.py", line 529, in send
    raise ReadTimeout(e, request=request)
requests.exceptions.ReadTimeout: HTTPConnectionPool(host='10.150.7.4', port=15348): Read timed out. (read timeout=1)
```

**Is this a bugfix or an enhancement?**
hacky workaround
**Proposed changes:**
- use 10 second timeout for event files (obviously should return faster if all goes well)
- consolidate the repeated todo (note - touched the metadata put lines because I was originally going to bump those to 10 s too, but realized I don't really have a good argument why we need that, so left it [functionally] alone)


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
