### PR TITLE
make multiview.ExtractMultiviewChannel output ImageStack instead of DataSource

### DIFF
--- a/PYME/recipes/multiview.py
+++ b/PYME/recipes/multiview.py
@@ -408,6 +408,7 @@ class ExtractMultiviewChannel(ModuleBase):
     def execute(self, namespace):
         from PYME.IO.DataSources.CropDataSource import DataSource
         from PYME.IO.MetaDataHandler import DictMDHandler
+        from PYME.IO.image import ImageStack
 
         source = namespace[self.input_name]
         roi_size = source.mdh['Multiview.ROISize']
@@ -417,4 +418,4 @@ class ExtractMultiviewChannel(ModuleBase):
 
         mdh = DictMDHandler(source.mdh)
         mdh['Multiview.Extracted'] = ind
-        namespace[self.output_name] = extracted
+        namespace[self.output_name] = ImageStack(data=extracted, mdh=mdh)

--- a/tests/PYME/Analysis/points/test_multiview.py
+++ b/tests/PYME/Analysis/points/test_multiview.py
@@ -63,5 +63,5 @@ def test_extract_channel():
     d = ImageStack(data=d, mdh=mdh)
     out = ExtractMultiviewChannel(view_number=1).apply_simple(input_name=d)
 
-    np.testing.assert_equal(out.getSlice(0).squeeze(), 1)
-    np.testing.assert_equal(roi_size, out.shape[:2])
+    np.testing.assert_equal(out.data.getSlice(0).squeeze(), 1)
+    np.testing.assert_equal(roi_size, out.data.shape[:2])


### PR DESCRIPTION
Addresses issue I forgot to wrap it - thought I'd fixed this but apparently not on this machine nor in my earlier PR.

**Is this a bugfix or an enhancement?**
bugfix now, my bad
**Proposed changes:**
- wrap the extracted datasource as an ImageStack
- update the test too


**Checklist:**

- [ ] Tested with numpy=1.14
1.16
- [ ] Tested on python 2.7 and 3.6
3.6

- [x ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
