### PR TITLE
Make it harder to crash pco. cameras

### DIFF
--- a/PYME/Acquire/Hardware/pco/pco_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_cam.py
@@ -199,22 +199,29 @@ class PcoCam(Camera):
         if y1 < y0:
             y0, y1 = y1, y0
 
+        # Don't let the ROI go out of bounds
+        # See pco.sdk manual chapter 3: IMAGE AREA SELECTION (ROI)
+        x0 = np.clip(x0, 1, lx_max-dx+1)
+        y0 = np.clip(y0, 1, ly_max-dy+1)
+        x1 = np.clip(x1, 1+dx, lx_max)
+        y1 = np.clip(y1, 1+dy, ly_max)
+
         # Don't let us choose too small an ROI
-        if (x1-x0+1) < lx_min:
+        if (x1-x0) < lx_min:
             logger.debug('Selected ROI width is too small, automatically adjusting to {}.'.format(lx_min))
-            guess_pos = x0+lx_min-1
+            guess_pos = x0+lx_min
             # Deal with boundaries
             if guess_pos <= lx_max:
                 x1 = guess_pos
             else:
-                x0 = x1-lx_min+1
-        if (y1-y0+1) < ly_min:
+                x0 = x1-lx_min-1
+        if (y1-y0) < ly_min:
             logger.debug('Selected ROI height is too small, automatically adjusting to {}.'.format(ly_min))
-            guess_pos = y0+ly_min-1
+            guess_pos = y0+ly_min
             if guess_pos <= ly_max:
                 y1 = guess_pos
             else:
-                y0 = y1-ly_min+1
+                y0 = y1-ly_min-1
 
         # Round to a multiple of dx, dy
         # TODO: Why do I need the 1 correction only on x0, y0???
@@ -222,13 +229,6 @@ class PcoCam(Camera):
         y0 = 1+int(np.floor((y0-1)/dy)*dy)
         x1 = int(np.floor(x1/dx)*dx)
         y1 = int(np.floor(y1/dy)*dy)
-
-        # Don't let the ROI go out of bounds
-        # See pco.sdk manual chapter 3: IMAGE AREA SELECTION (ROI)
-        x0 = np.clip(x0, 1, lx_max-dx+1)
-        y0 = np.clip(y0, 1, ly_max-dy+1)
-        x1 = np.clip(x1, 1+dx, lx_max)
-        y1 = np.clip(y1, 1+dy, ly_max)
 
         self.cam.sdk.set_roi(x0, y0, x1, y1)
         self._roi = [x0, y0, x1, y1]

--- a/PYME/Acquire/Hardware/pco/pco_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_cam.py
@@ -76,7 +76,7 @@ class PcoCam(Camera):
     def ExtractColor(self, chSlice, mode):
         # Somehow this check matters... shouldn't this be taken care of by ExpReady???
         if (not self.recording) or (self.GetNumImsBuffered() < 1):
-            return True
+            raise RuntimeError('Trying to grab a frame when there is no frame to grab.')
 
         if self.n_read < self.buffer_size:
             curr_frame = self.n_read

--- a/PYME/Acquire/Hardware/pco/pco_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_cam.py
@@ -207,7 +207,7 @@ class PcoCam(Camera):
         y1 = np.clip(y1, 1+dy, ly_max)
 
         # Don't let us choose too small an ROI
-        if (x1-x0) < lx_min:
+        if (x1-x0+1) < lx_min:
             logger.debug('Selected ROI width is too small, automatically adjusting to {}.'.format(lx_min))
             guess_pos = x0+lx_min
             # Deal with boundaries
@@ -215,7 +215,7 @@ class PcoCam(Camera):
                 x1 = guess_pos
             else:
                 x0 = x1-lx_min-1
-        if (y1-y0) < ly_min:
+        if (y1-y0+1) < ly_min:
             logger.debug('Selected ROI height is too small, automatically adjusting to {}.'.format(ly_min))
             guess_pos = y0+ly_min
             if guess_pos <= ly_max:

--- a/PYME/Acquire/Hardware/pco/pco_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_cam.py
@@ -119,7 +119,7 @@ class PcoCam(Camera):
         self.cam.set_exposure_time(time)
 
         # This is going to reset the recorder, so we need to change ring buffer position
-        self.n_read = 0
+        # self.n_read = 0
 
     def GetIntegTime(self):
         d = self.cam.sdk.get_delay_exposure_time()
@@ -153,7 +153,7 @@ class PcoCam(Camera):
 
         self.cam.sdk.set_binning(value, self.GetVerticalBin())
 
-        self.n_read = 0
+        # self.n_read = 0
 
     def GetHorizontalBin(self):
         return self.cam.sdk.get_binning()['binning x']
@@ -171,7 +171,7 @@ class PcoCam(Camera):
 
         self.cam.sdk.set_binning(self.GetHorizontalBin(), value)
 
-        self.n_read = 0
+        # self.n_read = 0
 
     def GetVerticalBin(self):
         return self.cam.sdk.get_binning()['binning y']
@@ -245,7 +245,7 @@ class PcoCam(Camera):
         logger.debug('ROI set: x0 %3.1f, y0 %3.1f, w %3.1f, h %3.1f' % (x0, y0, x1-x0+1, y1-y0+1))
 
         # Recording state is reset, so set to 0
-        self.n_read = 0
+        # self.n_read = 0
 
     def GetROI(self):
         return self._roi

--- a/PYME/Acquire/Hardware/pco/pco_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_cam.py
@@ -75,7 +75,6 @@ class PcoCam(Camera):
 
     def ExtractColor(self, chSlice, mode):
         # Somehow this check matters... shouldn't this be taken care of by ExpReady???
-        # if self.GetNumImsBuffered() < 1:
         if (not self.recording) or (self.GetNumImsBuffered() < 1):
             return True
 

--- a/PYME/Acquire/Hardware/pco/pco_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_cam.py
@@ -54,7 +54,6 @@ class PcoCam(Camera):
         self._ccd_temp = 0  # Store the sensor temperature
         self._cycle_time = 0
         self.recording = False
-        self.__image_frame_bytes = 0
 
     @property
     def noise_properties(self):
@@ -88,7 +87,7 @@ class PcoCam(Camera):
 
         ctypes.cdll.msvcrt.memcpy(chSlice.ctypes.data_as(ctypes.POINTER(ctypes.c_uint16)),
                    image.ctypes.data_as(ctypes.POINTER(ctypes.c_uint16)), 
-                   self.__image_frame_bytes)
+                   chSlice.nbytes)
 
         self.n_read += 1
 
@@ -271,10 +270,6 @@ class PcoCam(Camera):
         d = self.cam.sdk.get_delay_exposure_time()
         self._cycle_time = d['exposure']*timebase[d['exposure timebase']] \
                            + d['delay']*timebase[d['delay timebase']]
-        # __image_frame_bytes from pco.sdk manual 2.10.1
-        self.__image_frame_bytes = ctypes.c_ssize_t(int(self.GetPicWidth()
-                                                        *self.GetPicHeight()
-                                                        *ctypes.sizeof(ctypes.c_uint16)))
         if self._mode == self.MODE_SINGLE_SHOT:
             self.cam.record(number_of_images=1, mode='sequence')
         elif self._mode == self.MODE_CONTINUOUS:

--- a/PYME/Acquire/Hardware/pco/pco_edge_42_lt.py
+++ b/PYME/Acquire/Hardware/pco/pco_edge_42_lt.py
@@ -20,8 +20,8 @@ noiseProperties = {
 }
 
 class PcoEdge42LT(pco_cam.PcoCam):
-    def __init__(self, camNum):
-        pco_cam.PcoCam.__init__(self, camNum)
+    def __init__(self, camNum, debuglevel='off'):
+        pco_cam.PcoCam.__init__(self, camNum, debuglevel)
 
     def Init(self):
         pco_cam.PcoCam.Init(self)

--- a/PYME/Acquire/Scripts/init_pco.py
+++ b/PYME/Acquire/Scripts/init_pco.py
@@ -4,6 +4,20 @@ from PYME.Acquire.ExecTools import joinBGInit, init_gui, init_hardware
 
 from PYME import config
 
+@init_hardware('Fake Piezos')
+def pz(scope):
+    from PYME.Acquire.Hardware.Simulator import fakePiezo
+    scope.fakePiezo = fakePiezo.FakePiezo(100)
+    scope.register_piezo(scope.fakePiezo, 'z', needCamRestart=True)
+    
+    scope.fakeXPiezo = fakePiezo.FakePiezo(100)
+    scope.register_piezo(scope.fakeXPiezo, 'x')
+    
+    scope.fakeYPiezo = fakePiezo.FakePiezo(100)
+    scope.register_piezo(scope.fakeYPiezo, 'y')
+
+pz.join() #piezo must be there before we start camera
+
 @init_hardware('PcoEdge42LT')
 def pco_cam(scope):
     from PYME.Acquire.Hardware.pco.pco_edge_42_lt import PcoEdge42LT


### PR DESCRIPTION
General fixes to the pco. camera class. I'm having a reasonably difficult time crashing the camera at this point.  

It is still possible to crash the camera after a while if you run z-stacking with a low frame average (30 frames). None of the standard errors that would be caught by us or pco. cause this: I've verified it's it's not a problem with `memcpy` and not a problem with the image number we pass to the camera in the `cam.image()` call. I do think it's something with pco.recorder that isn't caught by the log, which I think means it's something sinister with the timer or the DLL.

These camera fixes resolve all other previously-identified sources of crashing and make the pco. generally usable.