### PR TITLE
Make action manager polling thread a daemon thread

### DIFF
--- a/PYME/Acquire/ActionManager.py
+++ b/PYME/Acquire/ActionManager.py
@@ -65,6 +65,7 @@ class ActionManager(object):
 
         self._monitoring = True
         self._monitor = threading.Thread(target=self._monitor_defunct)
+        self._monitor.daemon = True
         self._monitor.start()
         
     def QueueAction(self, functionName, args, nice=10, timeout=1e6, 

--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -666,9 +666,22 @@ class PYMEMainFrame(AUIFrame):
         msg = 'Remaining Threads:\n'
         for t in threading.enumerate():
             if six.PY3:
-                msg += '%s, %s\n' % (t.name, t._target)
+                cd = None
+                if hasattr(t._target, '__code__'):
+                    cd = t._target.__code__
+                elif hasattr(t._target, '__func__'):
+                    cd = t._target.__func__.__code__
+                elif hasattr(t, '__code__'):
+                    cd = t.__code__
+                else:
+                    # Thread sub-class
+                    try:
+                        cd = t.__class__.run.__code__
+                    except AttributeError:
+                        pass
+                msg += '%s, %s, daemon=%s, %s\n' % (t.name, t._target, t.daemon, cd)
             else:
-                msg += '%s, %s\n' % (t, t._Thread__target)
+                msg += '%s, %s, daemon=%s\n' % (t, t._Thread__target, t.daemon)
             
         logging.info(msg)
 


### PR DESCRIPTION
Addresses issue #727.

Small bugfix (also expands PYMEAcquire thread debugging info). 

TODO - if the code in `__del__` on the`ActionManager` was actually called, we shouldn't need this (is there a circular reference somewhere which is preventing this?)
