### PR TITLE
make clusterUI work on django 2.0, 2.1, warn django not present

### DIFF
--- a/PYME/cluster/clusterUI/accounts/urls.py
+++ b/PYME/cluster/clusterUI/accounts/urls.py
@@ -5,15 +5,15 @@ from django.contrib.auth import views
 
 urlpatterns = [
     url(r'^register/$', RegistrationView.as_view(), name='register'),
-    url(r'^register/done/$', views.password_reset_done, {
+    url(r'^register/done/$', views.PasswordResetDoneView.as_view(), {
         'template_name': 'registration/initial_done.html',
     }, name='register-done'),
 
-    url(r'^register/password/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$', views.password_reset_confirm, {
+    url(r'^register/password/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$', views.PasswordResetConfirmView.as_view(), {
         'template_name': 'registration/initial_confirm.html',
         'post_reset_redirect': 'accounts:register-complete',
     }, name='register-confirm'),
-    url(r'^register/complete/$', views.password_reset_complete, {
+    url(r'^register/complete/$', views.PasswordResetCompleteView.as_view(), {
         'template_name': 'registration/initial_complete.html',
     }, name='register-complete'),
 ]

--- a/PYME/cluster/clusterUI/clusterUI/urls.py
+++ b/PYME/cluster/clusterUI/clusterUI/urls.py
@@ -20,7 +20,7 @@ from django.views.generic.base import RedirectView
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^accounts/', include('django.contrib.auth.urls')),
-    url(r'^registration/', include('accounts.urls', namespace='accounts')),
+    url(r'^registration/', include(('accounts.urls', 'accounts'), namespace='accounts')),
     url(r'^files/', include('clusterbrowser.urls')),
     url(r'^status/', include('clusterstatus.urls')),
     url(r'^localization/', include('localization.urls')),

--- a/PYME/cluster/cluster_of_one.py
+++ b/PYME/cluster/cluster_of_one.py
@@ -57,6 +57,11 @@ class ClusterOfOne(object):
         self._node_server = subprocess.Popen('"%s" -m PYME.cluster.PYMERuleNodeServer -a local -p 0' % sys.executable, shell=True)
         
     def _launch_cluster_ui(self, gui=False):
+        try:
+            import django
+        except ImportError:
+            logger.error('django is not installed, to use clusterUI install django (1.11.x, 2.0.x, 2.1.x)')
+            
         if not self._cluster_ui is None:
             self._kill_procs([self._cluster_ui, ])
 


### PR DESCRIPTION
Addresses issue #708.

- minor django version compat changes for clusterUI code
- make cluster_of_one warn when run with `--clusterUI` flag and you don't have django 

Needs a bit more work to support 2.2.x