### PR TITLE
Issue731

### DIFF
--- a/PYME/DSView/dsviewer.py
+++ b/PYME/DSView/dsviewer.py
@@ -160,6 +160,7 @@ class DSViewFrame(AUIFrame):
         self.Bind(wx.EVT_MENU, self.OnOpen, id=wx.ID_OPEN)
         self.Bind(wx.EVT_MENU, self.OnSave, id=wx.ID_SAVE)
         self.Bind(wx.EVT_MENU, self.OnExport, id=wx.ID_SAVEAS)
+        self.Bind(wx.EVT_MENU, lambda e: self.Close(), id=wx.ID_CLOSE)
         self.Bind(wx.EVT_CLOSE, self.OnCloseWindow)
         
 

--- a/PYME/DSView/dsviewer.py
+++ b/PYME/DSView/dsviewer.py
@@ -143,9 +143,10 @@ class DSViewFrame(AUIFrame):
         self._menus['Save'] = self.save_menu
         tmp_menu.AppendMenu(-1, 'Save &Results', self.save_menu)
         
-        tmp_menu.AppendSeparator()
-        tmp_menu.Append(wx.ID_CLOSE, "Close", "", wx.ITEM_NORMAL)
+        #tmp_menu.AppendSeparator()
+        #tmp_menu.Append(wx.ID_CLOSE, "Close", "", wx.ITEM_NORMAL)
         self.menubar.Append(tmp_menu, "File")
+        self._menus['File'] = tmp_menu
 
         self.view_menu = wx.Menu()
         self.menubar.Append(self.view_menu, "&View")
@@ -160,10 +161,9 @@ class DSViewFrame(AUIFrame):
         self.Bind(wx.EVT_MENU, self.OnOpen, id=wx.ID_OPEN)
         self.Bind(wx.EVT_MENU, self.OnSave, id=wx.ID_SAVE)
         self.Bind(wx.EVT_MENU, self.OnExport, id=wx.ID_SAVEAS)
-        self.Bind(wx.EVT_MENU, lambda e: self.Close(), id=wx.ID_CLOSE)
-        self.Bind(wx.EVT_CLOSE, self.OnCloseWindow)
+        #self.Bind(wx.EVT_MENU, lambda e: self.Close(), id=wx.ID_CLOSE)
         
-
+        self.Bind(wx.EVT_CLOSE, self.OnCloseWindow)
 		
         self.statusbar = self.CreateStatusBar(1, wx.STB_SIZEGRIP)
 
@@ -172,7 +172,7 @@ class DSViewFrame(AUIFrame):
         modules.loadMode(self.mode, self)
         self.CreateModuleMenu()
 
-        
+        self.add_common_menu_items()
 
         self.optionspanel = OptionsPanel(self, self.do, thresholdControls=True)
         self.optionspanel.SetSize(self.optionspanel.GetBestSize())

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -167,7 +167,7 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
 
         #self.Bind(wx.EVT_SIZE, self.OnSize)
         self.Bind(wx.EVT_MOVE, self.OnMove)
-        self.Bind(wx.EVT_CLOSE, self.OnQuit)
+        self.Bind(wx.EVT_CLOSE, self.OnClose)
 
         #self.Bind(wx.EVT_IDLE, self.OnIdle)
         #self.refv = False
@@ -208,6 +208,7 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
 
         nb = self._mgr.GetNotebooks()[0]
         nb.SetSelection(0)
+        self.add_common_menu_items()
         
     def reconstruct_pipeline_from_image(self, image):
         self._recipe_manager.load_recipe_from_mdh(image.mdh)
@@ -238,13 +239,15 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
         self.Update()
         event.Skip()      
 
-    def OnQuit(self, event):
+    def OnClose(self, event):
         while len(self.pipeline.filesToClose) > 0:
             self.pipeline.filesToClose.pop().close()
 
         # pylab.close('all')
         matplotlib.pyplot.close('all')
         self._cleanup()
+        
+        #AUIFrame.OnQuit(self, event)
 
 
     def OnAbout(self, event):

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -262,9 +262,8 @@ class VisGUICore(object):
             self.AddMenuItem('File', itemType='separator')
             self.AddMenuItem('File', "&Save Measurements", self.OnSaveMeasurements)
 
-            self.AddMenuItem('File', itemType='separator')
-
-            self.AddMenuItem('File', "&Exit", self.OnQuit,id = wx.ID_EXIT)
+            #self.AddMenuItem('File', itemType='separator')
+            #self.AddMenuItem('File', "&Exit", self.OnQuit,id = wx.ID_EXIT)
 
 
         if not self._new_layers:

--- a/PYME/ui/AUIFrame.py
+++ b/PYME/ui/AUIFrame.py
@@ -198,6 +198,26 @@ class AUIFrame(wx.Frame):
             menu.AppendSeparator()
             
         return mItem
+    
+    def add_common_menu_items(self):
+        """
+        Adds File-->Close and File-->Quit
+        
+        TODO - add about and help here as well
+        
+        Returns
+        -------
+
+        """
+        
+        self.AddMenuItem('File', itemType='separator')
+        self.AddMenuItem('File', 'Close', lambda e : self.Close(), id=wx.ID_CLOSE)
+        self.AddMenuItem('File', 'Quit', self.OnQuit, id=wx.ID_EXIT)
+        
+    def OnQuit(self, event):
+        for w in wx.GetTopLevelWindows():
+            w.Close()
+        
         
     def _cleanup(self):
         #self.timer.Stop()


### PR DESCRIPTION
Addresses issue #731. Partial fix for #732

- fixes `File-->Close` (#731) in dh5view
- adds re-usable `File-->Close` and `File-->Quit` functions to `AUIFrame` (so they work across all PYME programs) (Partial #732 fix)
- To fully fix #732, we would additionally need to change a bunch of `View3D()` and `ViewIm3D()` calls to use `parent=None`
- This is potentially slightly risky for PYMEAcquire - if a user chooses `File-->Quit` in an image displayed in PYMEAcquire, it will quit everything. TODO - do we need to modify this behaviour? Intercept `EVT_CLOSE` in PYMEAcquire and warn?