### PR TITLE
Add option to display mesh normals

### DIFF
--- a/PYME/LMVis/layers/mesh.py
+++ b/PYME/LMVis/layers/mesh.py
@@ -51,12 +51,9 @@ class WireframeEngine(BaseEngine):
                     vtemp = np.repeat((1./3)*(vertices[0::3]+vertices[1::3]+vertices[2::3]), 3, axis=0)
                     normal_buffer[0::2,:] = vtemp
                     normal_buffer[1::2,:] = vtemp
-                if layer.normal_scaling == -1:
-                    # Display actual normals
-                    normal_buffer[1::2,:] += normals
-                else:
-                    # Display normals with length scaled by normal_scaling
-                    normal_buffer[1::2,:] += layer.normal_scaling*normals*(((normals*normals).sum(1)**0.5)[:,None])
+                assert(np.allclose(np.linalg.norm(normals,axis=1),1))
+                normal_buffer[1::2,:] += layer.normal_scaling*normals
+                
                 glVertexPointerf(normal_buffer)
                 sc = np.array([1, 1, 1, 1])
                 glColorPointerf(np.ones((normal_buffer.shape[0],4))*sc[None,:])  # white normals

--- a/PYME/LMVis/layers/mesh.py
+++ b/PYME/LMVis/layers/mesh.py
@@ -56,9 +56,10 @@ class WireframeEngine(BaseEngine):
                 
                 glVertexPointerf(normal_buffer)
                 sc = np.array([1, 1, 1, 1])
-                glColorPointerf(np.ones((normal_buffer.shape[0],4))*sc[None,:])  # white normals
+                glColorPointerf(np.ones((normal_buffer.shape[0],4),dtype=colors.dtype)*sc[None,:])  # white normals
+                glNormalPointerf(np.ones((normal_buffer.shape[0],3),dtype=normals.dtype))
                 glLineWidth(3)  # slightly thick
-                glDrawArrays(GL_LINES, 0, n_vertices)
+                glDrawArrays(GL_LINES, 0, 2*n_vertices)
 
 
 

--- a/PYME/LMVis/layers/mesh.py
+++ b/PYME/LMVis/layers/mesh.py
@@ -56,7 +56,7 @@ class WireframeEngine(BaseEngine):
                     normal_buffer[1::2,:] += normals
                 else:
                     # Display normals with length scaled by normal_scaling
-                    normal_buffer[1::2,:] += layer.normal_scaling*normals/(normals.sum(1)[:,None])
+                    normal_buffer[1::2,:] += layer.normal_scaling*normals*(((normals*normals).sum(1)**0.5)[:,None])
                 glVertexPointerf(normal_buffer)
                 sc = np.array([1, 1, 1, 1])
                 glColorPointerf(np.ones((normal_buffer.shape[0],4))*sc[None,:])  # white normals

--- a/PYME/LMVis/layers/mesh.py
+++ b/PYME/LMVis/layers/mesh.py
@@ -347,9 +347,6 @@ class TriangleRenderLayer(EngineLayer):
                      Group([Item('clim', editor=HistLimitsEditor(data=self._get_cdata), show_label=False), ], visible_when='vertexColour != "constant"'),
                      Group([Item('cmap', label='LUT'),
                             Item('alpha', visible_when='method in ["flat", "tessel", "shaded"]')
-                            ]),
-                     Group([Item('display_normals'),
-                            Item('normal_scaling', visible_when='display_normals==True')
                             ])
                      ], )
         # buttons=['OK', 'Cancel'])


### PR DESCRIPTION
Mostly for debugging purposes, but kind of nifty. Allows a user to optionally display mesh normals by vertex or by face.


![image](https://user-images.githubusercontent.com/1263313/102934526-49cc0500-4472-11eb-82c6-0c8566b171a1.png)
