### PR TITLE
pop our httpspooling threads to remove references and let them be gc'd

### DIFF
--- a/PYME/Acquire/HTTPSpooler.py
+++ b/PYME/Acquire/HTTPSpooler.py
@@ -252,8 +252,11 @@ class Spooler(sp.Spooler):
             # The alternative - letting spooling continue during the acquisition of the next series - has the potential
             # to result in runaway memory and thread usage when things go pear shaped (i.e. spooling is not fast enough)
             # TODO - is there actually a performance impact that justifies this config option, or is it purely theoretical
-            for ind in range(len(self._pollThreads))[::-1]:
-                self._pollThreads.pop(ind).join()  # pop off the back and join
+            for pt in self._pollThreads:
+                pt.join()
+
+        # remove our reference to the threads which hold back-references preventing garbage collection
+        del(self._pollThreads)
         
         # save events and final metadata
         # TODO - use a binary format for saving events - they can be quite

--- a/PYME/Acquire/HTTPSpooler.py
+++ b/PYME/Acquire/HTTPSpooler.py
@@ -252,8 +252,8 @@ class Spooler(sp.Spooler):
             # The alternative - letting spooling continue during the acquisition of the next series - has the potential
             # to result in runaway memory and thread usage when things go pear shaped (i.e. spooling is not fast enough)
             # TODO - is there actually a performance impact that justifies this config option, or is it purely theoretical
-            for pt in self._pollThreads:
-                pt.join()
+            for ind in range(len(self._pollThreads))[::-1]:
+                self._pollThreads.pop(ind).join()  # pop off the back and join
         
         # save events and final metadata
         # TODO - use a binary format for saving events - they can be quite


### PR DESCRIPTION
Addresses issue ideally SpoolController.spooler would ideally get garbage collected shortly after a new one takes its reference, but somehow that isn't happening and we accumulate an obnoxious amount of threads. 

<details>

```
-1680 1680 -1
(1608693364, 940666) 1679 0
Traceback (most recent call last):
  File "c:\users\bergamot\code\python-microscopy\PYME\Acquire\frameWrangler.py", line 227, in onExpReady
    d = self.getFrame()
  File "c:\users\bergamot\code\python-microscopy\PYME\Acquire\frameWrangler.py", line 198, in getFrame
    self.cam.ExtractColor(cs,0)
  File "c:\users\bergamot\code\python-microscopy\PYME\Acquire\Hardware\Camera.py", line 1048, in ExtractColor
    self.camera_class.ExtractColor(self, self.chip_data, mode)
  File "c:\users\bergamot\code\python-microscopy\PYME\Acquire\Hardware\HamamatsuDCAM\HamamatsuORCA.py", line 295, in ExtractColor
    raise DCAMZeroBufferedException()
PYME.Acquire.Hardware.HamamatsuDCAM.HamamatsuORCA.DCAMZeroBufferedException
INFO:root:Shutting down piezo

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

INFO:root:Piezo USB connection closed

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:PYME.Acquire.Hardware.AAOptoelectronics.MDS:Shutting down AAOptoMDS

Shutting down OBIS405
Shutting down OBIS488
Shutting down MPB560
Shutting down MPB642
DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

INFO:root:All cleanup functions called

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

INFO:root:Remaining Threads:
MainThread, None, daemon=False, <code object run at 0x00000187378060C0, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\threading.py", line 853>
Thread-1, <function worker at 0x000001873BA4C378>, daemon=True, <code object worker at 0x000001873BA20B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-2, <function worker at 0x000001873BA4C378>, daemon=True, <code object worker at 0x000001873BA20B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-3, <function Pool._handle_workers at 0x000001873BA4CF28>, daemon=True, <code object _handle_workers at 0x000001873BA2F5D0, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 398>
Thread-4, <function Pool._handle_tasks at 0x000001873BA4D048>, daemon=True, <code object _handle_tasks at 0x000001873BA2F780, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 411>
Thread-5, <function Pool._handle_results at 0x000001873BA4D0D0>, daemon=True, <code object _handle_results at 0x000001873BA2F810, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 457>
zeroconf-Engine-19316, None, daemon=True, <code object run at 0x000001873CCBB4B0, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\zeroconf\__init__.py", line 1226>
zeroconf-Reaper_17256, None, daemon=True, <code object run at 0x000001873CCBB9C0, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\zeroconf\__init__.py", line 1334>
Thread-9, <bound method ZCListener._poll_services_open of <PYME.misc.pyme_zeroconf.ZCListener object at 0x000001873CDC0668>>, daemon=True, <code object _poll_services_open at 0x000001873CC9E780, file "c:\users\bergamot\code\python-microscopy\PYME\misc\pyme_zeroconf.py", line 135>
zeroconf-ServiceBrowser__pyme-http._tcp.local._15864, None, daemon=True, <code object run at 0x000001873CCBF9C0, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\zeroconf\__init__.py", line 1559>
Thread-11, <function worker at 0x000001873BA4C378>, daemon=True, <code object worker at 0x000001873BA20B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-12, <function worker at 0x000001873BA4C378>, daemon=True, <code object worker at 0x000001873BA20B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-13, <function worker at 0x000001873BA4C378>, daemon=True, <code object worker at 0x000001873BA20B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-14, <function worker at 0x000001873BA4C378>, daemon=True, <code object worker at 0x000001873BA20B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-15, <function worker at 0x000001873BA4C378>, daemon=True, <code object worker at 0x000001873BA20B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-16, <function worker at 0x000001873BA4C378>, daemon=True, <code object worker at 0x000001873BA20B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-17, <function worker at 0x000001873BA4C378>, daemon=True, <code object worker at 0x000001873BA20B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-18, <function worker at 0x000001873BA4C378>, daemon=True, <code object worker at 0x000001873BA20B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-19, <function worker at 0x000001873BA4C378>, daemon=True, <code object worker at 0x000001873BA20B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-20, <function worker at 0x000001873BA4C378>, daemon=True, <code object worker at 0x000001873BA20B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-21, <function Pool._handle_workers at 0x000001873BA4CF28>, daemon=True, <code object _handle_workers at 0x000001873BA2F5D0, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 398>
Thread-22, <function Pool._handle_tasks at 0x000001873BA4D048>, daemon=True, <code object _handle_tasks at 0x000001873BA2F780, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 411>
Thread-23, <function Pool._handle_results at 0x000001873BA4D0D0>, daemon=True, <code object _handle_results at 0x000001873BA2F810, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 457>
Thread-24, <bound method ActionManager._monitor_defunct of <PYME.Acquire.ActionManager.ActionManager object at 0x000001873F35D128>>, daemon=True, <code object _monitor_defunct at 0x000001873CD296F0, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\ActionManager.py", line 147>
Thread-31, <bound method LazyScopeTweeter._poll of <PYME.Acquire.tweeter.LazyScopeTweeter object at 0x000001873F81F7B8>>, daemon=False, <code object _poll at 0x000001873F4AA0C0, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\tweeter.py", line 165>
Thread-33, <bound method generate_offset_piezo_server.<locals>.OffsetPiezoServer._thread_target of <PYME.Acquire.Hardware.Piezos.offsetPiezoREST.generate_offset_piezo_server.<locals>.OffsetPiezoServer object at 0x00000187400CF9E8>>, daemon=False, <code object _thread_target at 0x000001873FB4D9C0, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\Hardware\Piezos\offsetPiezoREST.py", line 218>
Thread-35, <bound method ActionManagerServer._serve of <PYME.Acquire.ActionManager.ActionManagerServer object at 0x000001873D389780>>, daemon=False, <code object _serve at 0x000001873CD33150, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\ActionManager.py", line 254>
Thread-36, <function _poll_status at 0x000001875646B8C8>, daemon=False, <code object _poll_status at 0x000001875646DAE0, file "c:\users\bergamot\code\python-microscopy\PYME\cluster\status.py", line 92>
Thread-37, <bound method ThreadingMixIn.process_request_thread of <PYME.Acquire.Hardware.Piezos.offsetPiezoREST.generate_offset_piezo_server.<locals>.OffsetPiezoServer object at 0x00000187400CF9E8>>, daemon=True, <code object process_request_thread at 0x000001873CD87270, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\socketserver.py", line 647>
Thread-38, <bound method ThreadingMixIn.process_request_thread of <PYME.Acquire.Hardware.Piezos.offsetPiezoREST.generate_offset_piezo_server.<locals>.OffsetPiezoServer object at 0x00000187400CF9E8>>, daemon=True, <code object process_request_thread at 0x000001873CD87270, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\socketserver.py", line 647>
zeroconf-Engine-20064, None, daemon=True, <code object run at 0x000001873CCBB4B0, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\zeroconf\__init__.py", line 1226>
zeroconf-Reaper_7648, None, daemon=True, <code object run at 0x000001873CCBB9C0, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\zeroconf\__init__.py", line 1334>
Thread-51, <bound method ZCListener._poll_services_open of <PYME.misc.pyme_zeroconf.ZCListener object at 0x00000187041A1B38>>, daemon=True, <code object _poll_services_open at 0x000001873CC9E780, file "c:\users\bergamot\code\python-microscopy\PYME\misc\pyme_zeroconf.py", line 135>
zeroconf-ServiceBrowser__pyme-taskdist._tcp.local._9888, None, daemon=True, <code object run at 0x000001873CCBF9C0, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\zeroconf\__init__.py", line 1559>
Thread-85, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710065B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-86, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710065B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-87, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710065B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-88, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710065B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-89, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710065B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-90, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710065B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-91, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710065B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-92, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710065B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-93, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710065B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-94, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710065B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-95, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871005F128>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-96, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871005F128>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-97, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871005F128>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-98, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871005F128>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-99, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871005F128>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-100, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871005F128>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-101, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871005F128>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-102, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871005F128>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-103, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871005F128>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-104, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871005F128>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-105, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187104424E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-106, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187104424E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-107, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187104424E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-108, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187104424E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-109, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187104424E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-110, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187104424E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-111, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187104424E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-112, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187104424E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-113, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187104424E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-114, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187104424E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-115, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018712C824A8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-116, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018712C824A8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-117, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018712C824A8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-118, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018712C824A8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-119, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018712C824A8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-120, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018712C824A8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-121, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018712C824A8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-122, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018712C824A8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-123, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018712C824A8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-124, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018712C824A8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-125, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871297F208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-126, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871297F208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-127, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871297F208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-128, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871297F208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-129, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871297F208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-130, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871297F208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-131, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871297F208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-132, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871297F208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-133, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871297F208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-134, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871297F208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-135, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870475E6D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-136, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870475E6D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-137, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870475E6D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-138, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870475E6D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-139, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870475E6D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-140, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870475E6D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-141, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870475E6D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-142, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870475E6D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-143, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870475E6D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-144, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870475E6D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-145, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870485EE80>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-146, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870485EE80>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-147, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870485EE80>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-148, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870485EE80>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-149, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870485EE80>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-150, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870485EE80>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-151, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870485EE80>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-152, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870485EE80>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-153, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870485EE80>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-154, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001870485EE80>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-155, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871490B898>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-156, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871490B898>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-157, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871490B898>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-158, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871490B898>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-159, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871490B898>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-160, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871490B898>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-161, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871490B898>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-162, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871490B898>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-163, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871490B898>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-164, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x000001871490B898>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-166, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-167, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-168, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-169, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-170, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-171, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-172, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-173, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-174, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-175, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-176, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760160>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-177, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760160>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-178, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760160>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-179, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760160>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-180, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760160>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-181, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760160>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-182, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760160>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-183, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760160>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-184, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760160>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-185, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760160>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-186, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760828>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-187, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760828>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-188, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760828>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-189, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760828>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-190, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760828>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-191, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760828>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-192, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760828>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-193, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760828>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-194, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760828>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-195, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704760828>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-197, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F860F0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-198, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F860F0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-199, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F860F0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-200, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F860F0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-201, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F860F0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-202, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F860F0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-203, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F860F0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-204, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F860F0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-205, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F860F0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-206, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F860F0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-207, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F69DD8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-208, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F69DD8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-209, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F69DD8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-210, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F69DD8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-211, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F69DD8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-212, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F69DD8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-213, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F69DD8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-214, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F69DD8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-215, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F69DD8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-216, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703F69DD8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-217, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187129266D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-218, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187129266D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-219, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187129266D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-220, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187129266D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-221, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187129266D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-222, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187129266D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-223, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187129266D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-224, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187129266D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-225, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187129266D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-226, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187129266D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-227, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100ABCC0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-228, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100ABCC0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-229, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100ABCC0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-230, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100ABCC0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-231, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100ABCC0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-232, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100ABCC0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-233, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100ABCC0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-234, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100ABCC0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-235, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100ABCC0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-236, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100ABCC0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-237, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711762208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-238, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711762208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-239, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711762208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-240, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711762208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-241, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711762208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-242, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711762208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-243, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711762208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-244, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711762208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-245, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711762208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-246, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711762208>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-247, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187458A86D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-248, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187458A86D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-249, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187458A86D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-250, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187458A86D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-251, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187458A86D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-252, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187458A86D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-253, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187458A86D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-254, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187458A86D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-255, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187458A86D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-256, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187458A86D8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-257, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FF8668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-258, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FF8668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-259, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FF8668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-260, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FF8668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-261, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FF8668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-262, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FF8668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-263, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FF8668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-264, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FF8668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-265, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FF8668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-266, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FF8668>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-267, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710317940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-268, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710317940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-269, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710317940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-270, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710317940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-271, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710317940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-272, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710317940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-273, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710317940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-274, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710317940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-275, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710317940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-276, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710317940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-277, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD7B38>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-278, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD7B38>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-279, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD7B38>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-280, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD7B38>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-281, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD7B38>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-282, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD7B38>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-283, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD7B38>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-284, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD7B38>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-285, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD7B38>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-286, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD7B38>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-287, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710381F98>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-288, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710381F98>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-289, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710381F98>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-290, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710381F98>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-291, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710381F98>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-292, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710381F98>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-293, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710381F98>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-294, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710381F98>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-295, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710381F98>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-296, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710381F98>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-297, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD18D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-298, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD18D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-299, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD18D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-300, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD18D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-301, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD18D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-302, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD18D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-303, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD18D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-304, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD18D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-305, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD18D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-306, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FD18D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-307, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FC5710>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-308, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FC5710>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-309, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FC5710>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-310, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FC5710>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-311, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FC5710>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-312, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FC5710>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-313, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FC5710>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-314, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FC5710>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-315, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FC5710>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-316, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018703FC5710>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-317, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710328940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-318, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710328940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-319, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710328940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-320, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710328940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-321, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710328940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-322, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710328940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-323, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710328940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-324, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710328940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-325, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710328940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-326, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018710328940>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-447, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187044A64E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-448, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187044A64E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-449, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187044A64E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-450, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187044A64E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-451, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187044A64E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-452, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187044A64E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-453, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187044A64E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-455, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187044A64E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-456, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187044A64E0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-468, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711721B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-469, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711721B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-470, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711721B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-471, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711721B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-472, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711721B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-474, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711721B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-475, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711721B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-476, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711721B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-477, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018711721B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-687, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100D32E8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-689, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100D32E8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-690, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100D32E8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-691, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100D32E8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-693, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100D32E8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-694, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100D32E8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-695, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100D32E8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-696, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100D32E8>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-752, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704833358>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-753, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704833358>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-754, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704833358>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-756, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704833358>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-757, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704833358>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-758, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704833358>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-759, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704833358>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-760, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704833358>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-761, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704833358>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-784, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100A1860>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-785, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100A1860>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-786, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100A1860>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-787, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100A1860>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-788, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100A1860>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-789, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100A1860>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-790, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100A1860>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-791, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100A1860>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-792, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100A1860>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-793, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x00000187100A1860>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-838, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018718DA48D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-839, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018718DA48D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-840, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018718DA48D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-841, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018718DA48D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-842, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018718DA48D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-843, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018718DA48D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-844, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018718DA48D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-845, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018718DA48D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-846, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018718DA48D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-847, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018718DA48D0>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-860, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018705269400>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-861, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018705269400>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-862, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018705269400>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-863, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018705269400>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-864, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018705269400>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-865, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018705269400>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-866, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018705269400>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-867, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018705269400>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-868, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018705269400>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-869, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018705269400>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-870, <bound method Rule._poll_loop of <PYME.cluster.rules.LocalisationRule object at 0x00000187054BC470>>, daemon=False, <code object _poll_loop at 0x000001873D3ACC90, file "c:\users\bergamot\code\python-microscopy\PYME\cluster\rules.py", line 301>
Thread-892, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704D2CC88>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-893, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704D2CC88>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-894, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704D2CC88>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-895, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704D2CC88>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-896, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704D2CC88>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-897, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704D2CC88>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-898, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704D2CC88>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-899, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704D2CC88>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-900, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704D2CC88>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-901, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704D2CC88>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-902, <bound method Rule._poll_loop of <PYME.cluster.rules.LocalisationRule object at 0x000001870417DD30>>, daemon=False, <code object _poll_loop at 0x000001873D3ACC90, file "c:\users\bergamot\code\python-microscopy\PYME\cluster\rules.py", line 301>
Thread-935, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704838B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-936, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704838B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-937, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704838B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-938, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704838B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-939, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704838B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-940, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704838B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-942, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704838B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-943, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704838B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>
Thread-944, <bound method Spooler._queuePoll of <PYME.Acquire.HTTPSpooler.Spooler object at 0x0000018704838B70>>, daemon=False, <code object _queuePoll at 0x000001873C928E40, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\HTTPSpooler.py", line 175>


c:\users\bergamot\code\python-microscopy\PYME\ui\manualFoldPanel.py:37: wxPyDeprecationWarning: Using deprecated class. Use Colour instead.
  col = wx.NamedColour(col)
DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000

DEBUG:root:numTotalFrames: 20000, _next_release_start: 20000
```

</details>

I'm not saying we shouldn't figure out why that is, and clean things up even more, but I _am_ saying I don't want thousands of threads hanging around in a list or dict or anything somewhere, and this takes care of that :

<details>

```
NFO:root:Remaining Threads:
MainThread, None, daemon=False, <code object run at 0x000002A30C1360C0, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\threading.py", line 853>
Thread-1, <function worker at 0x000002A31037C488>, daemon=True, <code object worker at 0x000002A31034FD20, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-2, <function worker at 0x000002A31037C488>, daemon=True, <code object worker at 0x000002A31034FD20, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-3, <function Pool._handle_workers at 0x000002A31037D0D0>, daemon=True, <code object _handle_workers at 0x000002A310360780, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 398>
Thread-4, <function Pool._handle_tasks at 0x000002A31037D158>, daemon=True, <code object _handle_tasks at 0x000002A310360930, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 411>
Thread-5, <function Pool._handle_results at 0x000002A31037D1E0>, daemon=True, <code object _handle_results at 0x000002A3103609C0, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 457>
zeroconf-Engine-700, None, daemon=True, <code object run at 0x000002A3115EC660, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\zeroconf\__init__.py", line 1226>
zeroconf-Reaper_18540, None, daemon=True, <code object run at 0x000002A3115ECB70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\zeroconf\__init__.py", line 1334>
Thread-9, <bound method ZCListener._poll_services_open of <PYME.misc.pyme_zeroconf.ZCListener object at 0x000002A3116F0710>>, daemon=True, <code object _poll_services_open at 0x000002A3115CF930, file "c:\users\bergamot\code\python-microscopy\PYME\misc\pyme_zeroconf.py", line 135>
zeroconf-ServiceBrowser__pyme-http._tcp.local._1144, None, daemon=True, <code object run at 0x000002A3115F0B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\zeroconf\__init__.py", line 1559>
Thread-11, <function worker at 0x000002A31037C488>, daemon=True, <code object worker at 0x000002A31034FD20, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-12, <function worker at 0x000002A31037C488>, daemon=True, <code object worker at 0x000002A31034FD20, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-13, <function worker at 0x000002A31037C488>, daemon=True, <code object worker at 0x000002A31034FD20, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-14, <function worker at 0x000002A31037C488>, daemon=True, <code object worker at 0x000002A31034FD20, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-15, <function worker at 0x000002A31037C488>, daemon=True, <code object worker at 0x000002A31034FD20, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-16, <function worker at 0x000002A31037C488>, daemon=True, <code object worker at 0x000002A31034FD20, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-17, <function worker at 0x000002A31037C488>, daemon=True, <code object worker at 0x000002A31034FD20, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-18, <function worker at 0x000002A31037C488>, daemon=True, <code object worker at 0x000002A31034FD20, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-19, <function worker at 0x000002A31037C488>, daemon=True, <code object worker at 0x000002A31034FD20, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-20, <function worker at 0x000002A31037C488>, daemon=True, <code object worker at 0x000002A31034FD20, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 93>
Thread-21, <function Pool._handle_workers at 0x000002A31037D0D0>, daemon=True, <code object _handle_workers at 0x000002A310360780, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 398>
Thread-22, <function Pool._handle_tasks at 0x000002A31037D158>, daemon=True, <code object _handle_tasks at 0x000002A310360930, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 411>
Thread-23, <function Pool._handle_results at 0x000002A31037D1E0>, daemon=True, <code object _handle_results at 0x000002A3103609C0, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\multiprocessing\pool.py", line 457>
Thread-24, <bound method ActionManager._monitor_defunct of <PYME.Acquire.ActionManager.ActionManager object at 0x000002A313C5A668>>, daemon=True, <code object _monitor_defunct at 0x000002A311669DB0, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\ActionManager.py", line 147>
Thread-31, <bound method LazyScopeTweeter._poll of <PYME.Acquire.tweeter.LazyScopeTweeter object at 0x000002A313DD09E8>>, daemon=False, <code object _poll at 0x000002A313DDE300, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\tweeter.py", line 165>
Thread-33, <bound method generate_offset_piezo_server.<locals>.OffsetPiezoServer._thread_target of <PYME.Acquire.Hardware.Piezos.offsetPiezoREST.generate_offset_piezo_server.<locals>.OffsetPiezoServer object at 0x000002A314952B38>>, daemon=False, <code object _thread_target at 0x000002A315142660, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\Hardware\Piezos\offsetPiezoREST.py", line 218>
Thread-34, <bound method ThreadingMixIn.process_request_thread of <PYME.Acquire.Hardware.Piezos.offsetPiezoREST.generate_offset_piezo_server.<locals>.OffsetPiezoServer object at 0x000002A314952B38>>, daemon=True, <code object process_request_thread at 0x000002A3116B7420, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\socketserver.py", line 647>
Thread-36, <bound method ActionManagerServer._serve of <PYME.Acquire.ActionManager.ActionManagerServer object at 0x000002A31263CCF8>>, daemon=False, <code object _serve at 0x000002A311662300, file "c:\users\bergamot\code\python-microscopy\PYME\Acquire\ActionManager.py", line 254>
Thread-37, <function _poll_status at 0x000002A32B600D08>, daemon=False, <code object _poll_status at 0x000002A32B603ED0, file "c:\users\bergamot\code\python-microscopy\PYME\cluster\status.py", line 92>
zeroconf-Engine-18436, None, daemon=True, <code object run at 0x000002A3115EC660, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\zeroconf\__init__.py", line 1226>
zeroconf-Reaper_15572, None, daemon=True, <code object run at 0x000002A3115ECB70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\zeroconf\__init__.py", line 1334>
Thread-71, <bound method ZCListener._poll_services_open of <PYME.misc.pyme_zeroconf.ZCListener object at 0x000002A32B94D2B0>>, daemon=True, <code object _poll_services_open at 0x000002A3115CF930, file "c:\users\bergamot\code\python-microscopy\PYME\misc\pyme_zeroconf.py", line 135>
zeroconf-ServiceBrowser__pyme-taskdist._tcp.local._12564, None, daemon=True, <code object run at 0x000002A3115F0B70, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\site-packages\zeroconf\__init__.py", line 1559>
Thread-413, <bound method ThreadingMixIn.process_request_thread of <PYME.Acquire.Hardware.Piezos.offsetPiezoREST.generate_offset_piezo_server.<locals>.OffsetPiezoServer object at 0x000002A314952B38>>, daemon=True, <code object process_request_thread at 0x000002A3116B7420, file "c:\Users\Bergamot\Anaconda2\envs\chaos\lib\socketserver.py", line 647>

```

</details>

**Is this a bugfix or an enhancement?**
Hopefully a bugfix. I haven't chased down why they still exist, but I wonder if the spooler doesn't get gc'd because these threads still hold refs to it?

**Checklist:**

- [ ] Tested with numpy=1.14

1.16
- [ ] Tested on python 2.7 and 3.6

3.6
