### PR TITLE
Fix tablefilter.RandomSubset, add optional pass-through for len < n

### DIFF
--- a/PYME/recipes/tablefilters.py
+++ b/PYME/recipes/tablefilters.py
@@ -5,6 +5,8 @@ import numpy as np
 #import pandas as pd
 from PYME.IO import tabular, MetaDataHandler
 #from PYME.LMVis import renderers
+import logging
+logger = logging.getLogger(__name__)
 
 @register_module('Mapping')
 class Mapping(ModuleBase):
@@ -178,21 +180,44 @@ class SelectTableColumns(ModuleBase):
 
 @register_module('RandomSubset')
 class RandomSubset(ModuleBase):
-    """Select a random subset of rows from a table"""
+    """Select a random subset of rows from a table
+    
+    Parameters:
+    -----------
+    
+    input :
+    output :
+    num_to_select : int
+        The number of samples rows to return
+    strict: bool
+        How strict are we about the number of rows - governs what happens when the number of rows in the original data
+        set is less than or equal to the number we want. If strict=False, the number of rows is truncated to the length
+        of the original data. If strict=True trying to take a number of samples > the number of rows will generate an
+        error. A warning will also be displayed if num_to_select is > n_rows/2. Monte-Carlo (or similar) applications
+        should use strict=True.
+    
+    """
+    
     input = Input('input')
     output = Output('output')
     num_to_select = Int(100)
-    require_at_least_n = Bool(False)
+    strict = Bool(False)
     
     def execute(self, namespace):
         data = namespace[self.input]
         
-        if self.require_at_least_n:
-            n_to_select = self.num_to_select
-        else:
-            n_to_select = min(len(data), self.num_to_select)
+        n_rows = len(data)
         
-        out = tabular.RandomSelectionFilter(data, num_Samples=n_to_select)
+        if n_rows < num_to_select:
+            if self.strict:
+                raise IndexError('Trying to select %d from data with only %d rows. To allow truncation, use strict=False' % (self.num_to_select, n_rows))
+            else:
+                logger.info('RandomSubset: Truncating from %d to %d rows as data only has %d rows. To make this an error, use strict=True' % (self.num_to_select, n_rows, n_rows)) 
+        
+        if self.strict and (num_to_select > 0.5*n_rows):
+            logger.warning('RandomSubset: Selecting %d from %d rows will not be very random' % (self.num_to_select, n_rows))
+        
+        out = tabular.RandomSelectionFilter(data, num_Samples=min(n_rows, self.num_to_select)
         
         try:
             out.mdh = MetaDataHandler.DictMDHandler(data.mdh)

--- a/PYME/recipes/tablefilters.py
+++ b/PYME/recipes/tablefilters.py
@@ -181,16 +181,16 @@ class RandomSubset(ModuleBase):
     """Select a random subset of rows from a table"""
     input = Input('input')
     output = Output('output')
-    n_to_select = Int(100)
+    num_to_select = Int(100)
     require_at_least_n = Bool(False)
     
     def execute(self, namespace):
         data = namespace[self.input]
         
         if self.require_at_least_n:
-            n_to_select = self.n_to_select
+            n_to_select = self.num_to_select
         else:
-            n_to_select = min(len(data), self.n_to_select)
+            n_to_select = min(len(data), self.num_to_select)
         
         out = tabular.RandomSelectionFilter(data, num_Samples=n_to_select)
         

--- a/PYME/recipes/tablefilters.py
+++ b/PYME/recipes/tablefilters.py
@@ -179,13 +179,13 @@ class SelectTableColumns(ModuleBase):
 @register_module('RandomSubset')
 class RandomSubset(ModuleBase):
     """Select a random subset of rows from a table"""
-    input_name = Input('input')
-    output_name = Output('output')
+    input = Input('input')
+    output = Output('output')
     n_to_select = Int(100)
     require_at_least_n = Bool(False)
     
     def execute(self, namespace):
-        data = namespace[self.input_name]
+        data = namespace[self.input]
         
         if self.require_at_least_n:
             n_to_select = self.n_to_select
@@ -199,4 +199,4 @@ class RandomSubset(ModuleBase):
         except AttributeError:
             pass
 
-        namespace[self.output_name] = out
+        namespace[self.output] = out

--- a/PYME/recipes/tablefilters.py
+++ b/PYME/recipes/tablefilters.py
@@ -3,7 +3,7 @@ from .traits import Input, Output, Float, Enum, CStr, Bool, Int, List, DictStrSt
 
 import numpy as np
 #import pandas as pd
-from PYME.IO import tabular
+from PYME.IO import tabular, MetaDataHandler
 #from PYME.LMVis import renderers
 
 @register_module('Mapping')
@@ -179,21 +179,24 @@ class SelectTableColumns(ModuleBase):
 @register_module('RandomSubset')
 class RandomSubset(ModuleBase):
     """Select a random subset of rows from a table"""
-    input = Input('input')
-    output = Output('output')
-    numToSelect = Int(100)
+    input_name = Input('input')
+    output_name = Output('output')
+    n_to_select = Int(100)
+    require_at_least_n = Bool(False)
     
     def execute(self, namespace):
-        data = namespace[self.input]
+        data = namespace[self.input_name]
         
-        out = tabular.RandomSelectionFilter(data, num_Samples=self.numToSelect)
+        if self.require_at_least_n:
+            n_to_select = self.n_to_select
+        else:
+            n_to_select = min(len(data), self.n_to_select)
+        
+        out = tabular.RandomSelectionFilter(data, num_Samples=n_to_select)
         
         try:
-            out.mdh = data.mdh
+            out.mdh = MetaDataHandler.DictMDHandler(data.mdh)
         except AttributeError:
             pass
 
-        namespace[self.outputName] = out
-        
-
-
+        namespace[self.output_name] = out

--- a/tests/PYME/recipes/test_tablefilters.py
+++ b/tests/PYME/recipes/test_tablefilters.py
@@ -1,0 +1,15 @@
+
+from PYME.recipes import tablefilters
+
+def test_random_selection():
+    from PYME.IO import tabular
+    import numpy as np
+    d = tabular.DictSource({'test': np.arange(100)})
+
+    out = tablefilters.RandomSubset(n_to_select=5,
+                                    require_at_least_n=True).apply_simple(input_name=d)
+    assert len(out) == 5
+    
+    out = tablefilters.RandomSubset(n_to_select=150,
+                                    require_at_least_n=False).apply_simple(input_name=d)
+    assert len(out) == 100

--- a/tests/PYME/recipes/test_tablefilters.py
+++ b/tests/PYME/recipes/test_tablefilters.py
@@ -7,9 +7,9 @@ def test_random_selection():
     d = tabular.DictSource({'test': np.arange(100)})
 
     out = tablefilters.RandomSubset(n_to_select=5,
-                                    require_at_least_n=True).apply_simple(input_name=d)
+                                    require_at_least_n=True).apply_simple(input=d)
     assert len(out) == 5
     
     out = tablefilters.RandomSubset(n_to_select=150,
-                                    require_at_least_n=False).apply_simple(input_name=d)
+                                    require_at_least_n=False).apply_simple(input=d)
     assert len(out) == 100

--- a/tests/PYME/recipes/test_tablefilters.py
+++ b/tests/PYME/recipes/test_tablefilters.py
@@ -6,10 +6,10 @@ def test_random_selection():
     import numpy as np
     d = tabular.DictSource({'test': np.arange(100)})
 
-    out = tablefilters.RandomSubset(n_to_select=5,
+    out = tablefilters.RandomSubset(num_to_select=5,
                                     require_at_least_n=True).apply_simple(input=d)
     assert len(out) == 5
     
-    out = tablefilters.RandomSubset(n_to_select=150,
+    out = tablefilters.RandomSubset(num_to_select=150,
                                     require_at_least_n=False).apply_simple(input=d)
     assert len(out) == 100

--- a/tests/PYME/recipes/test_tablefilters.py
+++ b/tests/PYME/recipes/test_tablefilters.py
@@ -7,9 +7,9 @@ def test_random_selection():
     d = tabular.DictSource({'test': np.arange(100)})
 
     out = tablefilters.RandomSubset(num_to_select=5,
-                                    require_at_least_n=True).apply_simple(input=d)
+                                    strict=True).apply_simple(input=d)
     assert len(out) == 5
     
     out = tablefilters.RandomSubset(num_to_select=150,
-                                    require_at_least_n=False).apply_simple(input=d)
+                                    strict=False).apply_simple(input=d)
     assert len(out) == 100


### PR DESCRIPTION
Addresses issue #appears this module has never actually worked.
![image](https://user-images.githubusercontent.com/31105780/103377945-cc764500-4aae-11eb-8f13-12b3794de367.png)
![Screen Shot 2020-12-30 at 2 56 00 PM](https://user-images.githubusercontent.com/31105780/103378083-24ad4700-4aaf-11eb-9044-92f2e7f86f6d.png)

**NOTE**
not trying to be snarky by including the blame, but want to point out we might get away with changing the traits names this time

**Is this a bugfix or an enhancement?**
both now
**Proposed changes:**
- don't attribute error instead of putting the output into the namespace
- while we have the flexibility to rename things, do a little of that
- add flag to allow pass through in cases when the input length is shorter than the selected number
- add unit test
