### PR TITLE
pass sample metadata through to rendered images

### DIFF
--- a/PYME/LMVis/renderers.py
+++ b/PYME/LMVis/renderers.py
@@ -32,7 +32,7 @@ import numpy as np
 
 renderMetadataProviders = []
 
-PASS_THROUGH_KEYS = [
+SAMPLE_MD_KEYS = [
     'Sample.SlideRef',
     'Sample.Creator',
     'Sample.Notes',
@@ -40,8 +40,8 @@ PASS_THROUGH_KEYS = [
     'AcquiringUser'
 ]
 
-def add_pass_through_metadata(old_mdh, new_mdh):
-    pass_through = [k for k in PASS_THROUGH_KEYS if k in old_mdh.keys()]
+def copy_sample_metadata(old_mdh, new_mdh):
+    pass_through = [k for k in SAMPLE_MD_KEYS if k in old_mdh.keys()]
     for k in pass_through:
         new_mdh[k] = old_mdh[k]
 
@@ -184,7 +184,7 @@ class CurrentRenderer:
 
     def Generate(self, settings):
         mdh = MetaDataHandler.NestedClassMDHandler()
-        add_pass_through_metadata(self.pipeline.mdh, mdh)
+        copy_sample_metadata(self.pipeline.mdh, mdh)
         mdh['Rendering.Method'] = self.name
         if 'imageID' in self.pipeline.mdh.getEntryNames():
             mdh['Rendering.SourceImageID'] = self.pipeline.mdh['imageID']
@@ -235,7 +235,7 @@ class ColourRenderer(CurrentRenderer):
     
     def Generate(self, settings):
         mdh = MetaDataHandler.NestedClassMDHandler()
-        add_pass_through_metadata(self.pipeline.mdh, mdh)
+        copy_sample_metadata(self.pipeline.mdh, mdh)
         mdh['Rendering.Method'] = self.name
         if 'imageID' in self.pipeline.mdh.getEntryNames():
             mdh['Rendering.SourceImageID'] = self.pipeline.mdh['imageID']

--- a/PYME/LMVis/renderers.py
+++ b/PYME/LMVis/renderers.py
@@ -32,6 +32,19 @@ import numpy as np
 
 renderMetadataProviders = []
 
+PASS_THROUGH_KEYS = [
+    'Sample.SlideRef',
+    'Sample.Creator',
+    'Sample.Notes',
+    'Sample.Labelling',
+    'AcquiringUser'
+]
+
+def add_pass_through_metadata(old_mdh, new_mdh):
+    pass_through = [k for k in PASS_THROUGH_KEYS if k in old_mdh.keys()]
+    for k in pass_through:
+        new_mdh[k] = old_mdh[k]
+
 class CurrentRenderer:
     """Renders current view (in black and white). Only renderer not to take care
     of colour channels. Simplest renderer and as such also the base class for all 
@@ -171,6 +184,7 @@ class CurrentRenderer:
 
     def Generate(self, settings):
         mdh = MetaDataHandler.NestedClassMDHandler()
+        add_pass_through_metadata(self.pipeline.mdh, mdh)
         mdh['Rendering.Method'] = self.name
         if 'imageID' in self.pipeline.mdh.getEntryNames():
             mdh['Rendering.SourceImageID'] = self.pipeline.mdh['imageID']
@@ -221,6 +235,7 @@ class ColourRenderer(CurrentRenderer):
     
     def Generate(self, settings):
         mdh = MetaDataHandler.NestedClassMDHandler()
+        add_pass_through_metadata(self.pipeline.mdh, mdh)
         mdh['Rendering.Method'] = self.name
         if 'imageID' in self.pipeline.mdh.getEntryNames():
             mdh['Rendering.SourceImageID'] = self.pipeline.mdh['imageID']


### PR DESCRIPTION
Addresses issue #725 .

**Is this a bugfix or an enhancement?**
enhancement 
**Proposed changes:**
pass sample metadata through to the top tree of rendered image metadata






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
