### PR TITLE
Outsavedoc

### DIFF
--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -24,7 +24,7 @@ from PYME.recipes.traits import HasTraits, Float, List, Bool, Int, CStr, Enum, F
 
 from PYME.IO.image import ImageStack
 import numpy as np
-
+from PYME.contrib import dispatch
 import logging
 logger = logging.getLogger(__name__)
 
@@ -461,12 +461,33 @@ class OutputModule(ModuleBase):
 
     def execute(self, namespace):
         """
-        Output modules be definition do nothing when executed - they act as a sink and implement a save method instead.
+        Output modules by definition do nothing when executed - they act as a sink and implement a save method instead.
 
         """
         pass
 
-from PYME.contrib import dispatch
+    def save(self, namespace, context={}):
+        """
+        Save recipes output(s) to CSV
+
+        Parameters
+        ----------
+        namespace : dict
+            The recipe namespace
+        context : dict
+            Information about the source file to allow pattern substitution to
+            generate the output name. At least 'basedir' (which is the fully-
+            resolved directory name in which the input file resides) and 
+            'file_stub' (which is the filename without any extension) should be
+            resolved.
+
+        Returns
+        -------
+
+        """
+        raise NotImplementedError
+
+
 class ModuleCollection(HasTraits):
     modules = List()
     execute_on_invalidation = Bool(False)

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -468,7 +468,6 @@ class OutputModule(ModuleBase):
 
     def save(self, namespace, context={}):
         """
-        Save recipes output(s) to CSV
 
         Parameters
         ----------


### PR DESCRIPTION
Addresses issue no save doc in base class, small typo, dispatch import being in the middle of the file

**Is this a bugfix or an enhancement?**
non-functional enhancement

**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
