### PR TITLE
actually register the multiview channel extraction module

### DIFF
--- a/PYME/recipes/multiview.py
+++ b/PYME/recipes/multiview.py
@@ -382,6 +382,7 @@ class CalibrateShifts(ModuleBase):
         namespace[self.output_name].mdh = mdh
 
 
+@register_module('ExtractMultiviewChannel')
 class ExtractMultiviewChannel(ModuleBase):
     """Extract a single multiview channel
 


### PR DESCRIPTION
Addresses issue i forgot to register the module so can't actually use it from the GUI.

**Is this a bugfix or an enhancement?**
bugfix
