### PR TITLE
timeout taskWorker io loop so we loop every ~5 s even if there are no tasks in the queue

### DIFF
--- a/PYME/cluster/taskWorkerHTTP.py
+++ b/PYME/cluster/taskWorkerHTTP.py
@@ -206,15 +206,11 @@ class taskWorker(object):
                     if not r.status_code == 200:
                         logger.error('Returning task failed with error: %s' % r.status_code)
 
-    def _get_tasks(self, local_queue_name):
+    def _get_tasks(self, timeout=5):
         """
 
-        Query nodeserver for tasks and place them in the queue for this worker, if available
-
-        Parameters
-        ----------
-        local_queue_name : str
-            computer name prepended by 'PYMENodeServer: '
+        Query nodeserver for tasks and place them in the queue for this worker,
+        if available
 
         Returns
         -------
@@ -222,42 +218,28 @@ class taskWorker(object):
             flag to report whether _get_tasks added new tasks to the taskWorker queue
 
         """
-        #queue_URLs = distribution.getNodeInfo()
-        #queue_URLs = {k: v for k, v in queue_URLs.items() if k == local_queue_name}
-
-        # loop over all queues, looking for tasks to process
         tasks = []
-        
-        while len(tasks) == 0:# and len(queue_URLs) > 0:
-            # try queue on current machine first
-            # print queueNames
+        queueURL = self._local_queue_url
 
-            # if local_queue_name in queue_URLs.keys():
-            #     qName = local_queue_name
-            #     queueURL = queue_URLs.pop(qName)
-            # else:
-            #     logger.error('Could not find local node server')
-                
-            queueURL = self._local_queue_url
+        try:
+            # ask the queue for tasks
+            print('getting tasks')
+            s = clusterIO._getSession(queueURL)
+            r = s.get(queueURL + 'node/tasks?workerID=%s&numWant=50' % self.procName, timeout=timeout)
+            if r.status_code == 200:
+                resp = r.json()
+                if resp['ok']:
+                    res = resp['result']
+                    if isinstance(res, list):
+                        tasks += [(queueURL, t) for t in res]
+                    else:
+                        tasks.append((queueURL, res))
+        except requests.Timeout:
+            logger.info('Read timout requesting tasks from %s' % queueURL)
 
-            try:
-                # ask the queue for tasks
-                s = clusterIO._getSession(queueURL)
-                r = s.get(queueURL + 'node/tasks?workerID=%s&numWant=50' % self.procName)  # , timeout=0)
-                if r.status_code == 200:
-                    resp = r.json()
-                    if resp['ok']:
-                        res = resp['result']
-                        if isinstance(res, list):
-                            tasks += [(queueURL, t) for t in res]
-                        else:
-                            tasks.append((queueURL, res))
-            except requests.Timeout:
-                logger.info('Read timout requesting tasks from %s' % queueURL)
-
-            except Exception:
-                import traceback
-                logger.exception(traceback.format_exc())
+        except Exception:
+            import traceback
+            logger.exception(traceback.format_exc())
 
         if len(tasks) != 0:
             for t in tasks:
@@ -291,7 +273,7 @@ class taskWorker(object):
             # if our queue for computing is empty, try to get more tasks
             if self.inputQueue.empty():
                 # if we don't have any new tasks, sleep to avoid constant polling
-                if not self._get_tasks(localQueueName):
+                if not self._get_tasks(timeout=5):
                     # no queues had tasks
                     time.sleep(0.1)
 

--- a/PYME/cluster/taskWorkerHTTP.py
+++ b/PYME/cluster/taskWorkerHTTP.py
@@ -206,7 +206,7 @@ class taskWorker(object):
                     if not r.status_code == 200:
                         logger.error('Returning task failed with error: %s' % r.status_code)
 
-    def _get_tasks(self, timeout=5):
+    def _get_tasks(self):
         """
 
         Query nodeserver for tasks and place them in the queue for this worker,
@@ -225,7 +225,7 @@ class taskWorker(object):
             # ask the queue for tasks
             print('getting tasks')
             s = clusterIO._getSession(queueURL)
-            r = s.get(queueURL + 'node/tasks?workerID=%s&numWant=50' % self.procName, timeout=timeout)
+            r = s.get(queueURL + 'node/tasks?workerID=%s&numWant=50' % self.procName)
             if r.status_code == 200:
                 resp = r.json()
                 if resp['ok']:
@@ -273,7 +273,7 @@ class taskWorker(object):
             # if our queue for computing is empty, try to get more tasks
             if self.inputQueue.empty():
                 # if we don't have any new tasks, sleep to avoid constant polling
-                if not self._get_tasks(timeout=5):
+                if not self._get_tasks():
                     # no queues had tasks
                     time.sleep(0.1)
 


### PR DESCRIPTION
Addresses issue #693.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- don't hang on `while len(tasks)==0`
- don't hang on get tasks request which currently doesn't have a timeout





**Checklist:**

- [x] Tested with osx 10.15, py3.7