### PR TITLE
extend default directory listing and get_file timeouts

### DIFF
--- a/PYME/IO/clusterIO.py
+++ b/PYME/IO/clusterIO.py
@@ -206,10 +206,10 @@ class _LimitedSizeDict(OrderedDict):
                 self.popitem(last=False)
 
 
-_locateCache = _LimitedSizeDict(size_limit=500)
-_dirCache = _LimitedSizeDict(size_limit=100)
+_locateCache = _LimitedSizeDict(size_limit=5000)
+_dirCache = _LimitedSizeDict(size_limit=500)
 DIR_CACHE_TIME = 1
-_fileCache = _LimitedSizeDict(size_limit=100)
+_fileCache = _LimitedSizeDict(size_limit=500)
 
 #use one session for each server (to allow http keep-alives)
 sessions = {}

--- a/PYME/IO/clusterIO.py
+++ b/PYME/IO/clusterIO.py
@@ -227,7 +227,7 @@ def _getSession(url):
     return session
 
 
-def _listSingleDir(dirurl, nRetries=1, timeout=5):
+def _listSingleDir(dirurl, nRetries=1, timeout=10):
     t = time.time()
 
     try:
@@ -748,7 +748,7 @@ def get_local_path(filename, serverfilter):
         if os.path.exists(localpath):
             return localpath
 
-def get_file(filename, serverfilter=local_serverfilter, numRetries=3, use_file_cache=True, local_short_circuit=True, timeout=0.5):
+def get_file(filename, serverfilter=local_serverfilter, numRetries=3, use_file_cache=True, local_short_circuit=True, timeout=5):
     """
     Get a file from the cluster.
     

--- a/PYME/IO/clusterIO.py
+++ b/PYME/IO/clusterIO.py
@@ -923,7 +923,7 @@ def mirror_file(filename, serverfilter=local_serverfilter):
     r.close()
 
 
-def put_file(filename, data, serverfilter=local_serverfilter, timeout=1):
+def put_file(filename, data, serverfilter=local_serverfilter, timeout=5):
     """
     Put a file to the cluster. The server on which the file resides is chosen by a crude load-balancing algorithm
     designed to uniformly distribute data across the servers within the cluster. The target file must not exist.

--- a/PYME/cluster/rules.py
+++ b/PYME/cluster/rules.py
@@ -568,7 +568,8 @@ class LocalisationRule(Rule):
         self._next_release_start = self.start_at
         numTotalFrames = self.ds.getNumSlices()
         self.frames_outstanding=numTotalFrames - self._next_release_start
-        
+        if self.data_complete:
+            return dict(max_tasks=self.ds.getNumSlices())
         return {}
 
     @property


### PR DESCRIPTION
Addresses issue #741 

**Is this a bugfix or an enhancement?**
makeshift bugfix?
**Proposed changes:**
- extend timeouts on clusterIO.get_file and clusterIO._listSingleDir






**Checklist:**

- [x] Tested 