### PR TITLE
More bugfixes for acquisition on py3

### DIFF
--- a/PYME/Acquire/Hardware/AndorNeo/ZylaControlPanel.py
+++ b/PYME/Acquire/Hardware/AndorNeo/ZylaControlPanel.py
@@ -32,7 +32,7 @@ class EnumControl(wx.Panel):
         self.parent.update()
         
     def update(self):
-        choices = self.target.getAvailableValues()
+        choices = list(self.target.getAvailableValues())
         self.cChoice.SetItems(choices)
         self.cChoice.SetSelection(choices.index(self.target.getString()))
         

--- a/PYME/Acquire/Hardware/Mercury/mercuryStepperGCS.py
+++ b/PYME/Acquire/Hardware/Mercury/mercuryStepperGCS.py
@@ -79,6 +79,10 @@ class mercuryStepper(base_piezo.PiezoBase):
             self.minTravel = [float(self.query('TMN?', a)) for a in self.axes]
             self.maxTravel = [float(self.query('TMX?', a)) for a in self.axes]
 
+            # turn joystick off (if on)
+            for i, a in enumerate(self.axes):
+                self.set('JON', a, '1 0', omit_axis=True)
+
             #initialise and calibrate axes
             for a in self.axes:
                 self.set('SVO', a, 1)
@@ -88,8 +92,8 @@ class mercuryStepper(base_piezo.PiezoBase):
             self.onTarget = False
 
             #set joystick to use parabolic lookup table
-            for a in self.axes:
-                self.set('JDT', a, 2)
+            #for a in self.axes:
+            #    self.set('JDT', a, 2, omit_axis=True)
 
 
 
@@ -103,6 +107,9 @@ class mercuryStepper(base_piezo.PiezoBase):
         with self.lock:
             for i, a in enumerate(self.axes):
                 self.set('JAX', a, '1 1 %s' %a, omit_axis=True)
+
+                #set joystick to use parabolic loopup table
+                self.set('JDT', a, '1 2', omit_axis=True)
 
 
     def _get_status(self):

--- a/PYME/Acquire/Hardware/driftTracking.py
+++ b/PYME/Acquire/Hardware/driftTracking.py
@@ -14,8 +14,8 @@ from scipy import ndimage
 from PYME.Acquire import eventLog
 #from PYME.gohlke import tifffile as tif
 
-import Pyro.core
-import Pyro.naming
+#import Pyro.core
+#import Pyro.naming
 import threading
 from PYME.misc.computerName import GetComputerName
 
@@ -63,9 +63,8 @@ def correlateAndCompareFrames(A, B):
     return (As -B).mean(), dx, dy
     
     
-class correlator(Pyro.core.ObjBase):
+class Correlator(object):
     def __init__(self, scope, piezo=None):
-        Pyro.core.ObjBase.__init__(self)
         self.scope = scope
         self.piezo = piezo
         
@@ -394,11 +393,24 @@ class correlator(Pyro.core.ObjBase):
     #     time.sleep(0.5)
     #     self.setRefC()
     #     piezo.MoveTo(0, p)
-    
+
+
+def correlator(scope, piezo=None):
+    # API compatible constructor for Py2
+    import Pyro.core
+    class klass(Pyro.core.ObjBase):
+        def __init__(self, scope, piezo=None):
+            Pyro.core.ObjBase.__init__(self)
+            Correlator.__init__(self, scope, piezo=piezo)
+
+    return klass
+
 
 class ServerThread(threading.Thread):
     def __init__(self, driftTracker):
         threading.Thread.__init__(self)
+        import Pyro.core
+        import Pyro.naming
 
         import socket
         ip_addr = socket.gethostbyname(socket.gethostname())

--- a/PYME/Acquire/Hardware/splitter.py
+++ b/PYME/Acquire/Hardware/splitter.py
@@ -107,6 +107,43 @@ class Unmixer:
             return red_chan
 
 
+    def Unmix_(self, data, mixMatrix, offset, ROI=[0,0,512, 512]):
+        import scipy.linalg
+        from PYME.localisation import splitting
+        #from pylab import *
+        #from PYME.DSView.dsviewer_npy import View3D
+
+        umm = scipy.linalg.inv(mixMatrix)
+
+        dsa = data.squeeze() - offset
+        g_, r_ = [dsa[roi[0]:roi[2], roi[1]:roi[3]] for roi in rois]
+        
+        if self.flip:
+            if self.axis == 'up_down':
+                r_ = numpy.fliplr(r_)
+            else:
+                r_ = numpy.flipud(r_)
+
+            r_ = self._deshift(r_, ROI)
+
+        #print g_.shape, r_.shape
+
+        g = umm[0,0]*g_ + umm[0,1]*r_
+        r = umm[1,0]*g_ + umm[1,1]*r_
+
+        g = g*(g > 0)
+        r = r*(r > 0)
+
+#        figure()
+#        subplot(211)
+#        imshow(g.T, cmap=cm.hot)
+#
+#        subplot(212)
+#        imshow(r.T, cmap=cm.hot)
+
+        #View3D([r.reshape(r.shape + (1,)),g.reshape(r.shape + (1,))])
+        return [r.reshape(r.shape + (1,)),g.reshape(r.shape + (1,))]
+
     def Unmix(self, data, mixMatrix, offset, ROI=[0,0,512, 512]):
         import scipy.linalg
         
@@ -151,7 +188,7 @@ class Unmixer:
 
 class Splitter:
     def __init__(self, parent, scope, cam, dir='up_down', flipChan=1, dichroic = 'Unspecified', transLocOnCamera = 'Top',
-                 constrain=True, flip = True, cam_name=''):
+                 constrain=True, flip = True, cam_name='', rois=None):
         self.dir = dir
         self.scope = scope
         self.cam = cam
@@ -159,6 +196,7 @@ class Splitter:
         self.parent = parent
         self.unmixer = Unmixer(flip=flip, axis = dir)
         self.flip = flip
+        self._rois=rois
 
         #which dichroic mirror is installed
         self.dichroic = dichroic
@@ -215,6 +253,17 @@ class Splitter:
             #self.menu.Check(idConstROI, True)
         
 
+    @property
+    def rois(self):
+        if self._rois is not None:
+            return self._rois
+        if self.dir == 'up_down':
+            return [[0,0,self.cam.GetCCDWidth(), self.cam.GetCCDHeight()/2], 
+                    [0,self.cam.GetCCDHeight()/2,self.cam.GetCCDWidth(), self.cam.GetCCDHeight()/2]]
+        else: #dir == 'left_right'
+            return [[0,0,self.cam.GetCCDWidth()/2, self.cam.GetCCDHeight()],
+                    [self.cam.GetCCDWidth()/2,0,self.cam.GetCCDWidth()/2, self.cam.GetCCDHeight()]]
+    
     def ProvideMetadata(self, mdh):
         from PYME.LMVis import dyeRatios #TODO - move to somewhere common
         
@@ -228,12 +277,7 @@ class Splitter:
             except (KeyError, AttributeError):
                 pass
             
-            if self.dir == 'up_down':
-                mdh['Splitter.Channel0ROI'] = [0,0,self.cam.GetCCDWidth(), self.cam.GetCCDHeight()/2]
-                mdh['Splitter.Channel1ROI'] = [0,self.cam.GetCCDHeight()/2,self.cam.GetCCDWidth(), self.cam.GetCCDHeight()/2]
-            else: #dir == 'left_right'
-                mdh['Splitter.Channel0ROI'] = [0,0,self.cam.GetCCDWidth()/2, self.cam.GetCCDHeight()]
-                mdh['Splitter.Channel1ROI'] = [self.cam.GetCCDWidth()/2,0,self.cam.GetCCDWidth()/2, self.cam.GetCCDHeight()]
+            mdh['Splitter.Channel0ROI'], mdh['Splitter.Channel1ROI'] = self.rois
 
             if 'shiftField' in dir(self):
                 mdh.setEntry('chroma.ShiftFilename', self.shiftFieldName)

--- a/PYME/Acquire/Hardware/splitter.py
+++ b/PYME/Acquire/Hardware/splitter.py
@@ -118,14 +118,14 @@ class Unmixer:
         dsa = data.squeeze() - offset
         
         if self.axis == 'up_down':
-            g_ = dsa[:, :(dsa.shape[1]/2)]
-            r_ = dsa[:, (dsa.shape[1]/2):]
+            g_ = dsa[:, :int(dsa.shape[1]/2)]
+            r_ = dsa[:, int(dsa.shape[1]/2):]
             if self.flip:
                 r_ = numpy.fliplr(r_)
             r_ = self._deshift(r_, ROI)
         else:
-            g_ = dsa[:(dsa.shape[0]/2), :]
-            r_ = dsa[(dsa.shape[0]/2):, :]
+            g_ = dsa[:int(dsa.shape[0]/2), :]
+            r_ = dsa[int(dsa.shape[0]/2):, :]
             if self.flip:
                 r_ = numpy.flipud(r_)
             r_ = self._deshift(r_, ROI)

--- a/PYME/Acquire/Scripts/init_UOA_n2.py
+++ b/PYME/Acquire/Scripts/init_UOA_n2.py
@@ -193,10 +193,10 @@ def focus_keys(MainFrame, scope):
 @init_gui('Splitter')
 def splitter(MainFrame, scope):
     from PYME.Acquire.Hardware import splitter
-    splt1 = splitter.Splitter(MainFrame, scope, scope.cameras['EMCCD'], flipChan = 1, dichroic = 'Unspecified' ,
+    splt1 = splitter.Splitter(MainFrame, scope, scope.cameras['EMCCD'], flipChan = 1, dichroic = 'FF700-Di01' ,
                               transLocOnCamera = 'Top', flip=True, dir='up_down', constrain=False, cam_name='EMCCD')
-    splt2 = splitter.Splitter(MainFrame, scope, scope.cameras['sCMOS'], flipChan = 1, dichroic = 'FF700-Di01' ,
-                              transLocOnCamera = 'Right', flip=False, dir='left_right', constrain=False, cam_name='sCMOS')
+    splt2 = splitter.Splitter(MainFrame, scope, scope.cameras['sCMOS'], flipChan = 1, dichroic = 'T686lpxr' ,
+                              transLocOnCamera = 'Right', flip=False, dir='left_right', constrain=False, cam_name='sCMOS', rois=[[70,0,800,2046], [880,0,800,2046]])
 
 
 #InitGUI("""

--- a/PYME/Acquire/Scripts/init_UOA_n2.py
+++ b/PYME/Acquire/Scripts/init_UOA_n2.py
@@ -28,24 +28,20 @@ import time
 
 @init_hardware('Z Piezo')
 def pz(scope):
-    from PYME.Acquire.Hardware.Piezos import piezo_e816#, offsetPiezo
+    from PYME.Acquire.Hardware.Piezos import piezo_e816, offsetPiezoREST
 
-    scope.piFoc = piezo_e816.piezo_e816T('COM1', 400, -0.399)
+    scope._piFoc = piezo_e816.piezo_e816T('COM1', 400, -0.399)
     #scope.hardwareChecks.append(scope._piFoc.OnTarget)
-    scope.CleanupFunctions.append(scope.piFoc.close)
+    scope.CleanupFunctions.append(scope._piFoc.close)
 
-    #scope.piFoc = offsetPiezo.piezoOffsetProxy(scope._piFoc)
+    scope.piFoc = offsetPiezoREST.server_class()(scope._piFoc)
     scope.register_piezo(scope.piFoc, 'z', needCamRestart=True)
 
-    # server so drift correction can connect to the piezo
-    #pst = offsetPiezo.ServerThread(scope.piFoc)
-    #pst.start()
-    #scope.CleanupFunctions.append(pst.cleanup)
     
 @init_hardware('XY Stage')
 def stage(scope):
-    from PYME.Acquire.Hardware.Mercury import mercuryStepper
-    scope.stage = mercuryStepper.mercuryStepper(comPort=6, axes=['A', 'B'], steppers=['M-229.25S', 'M-229.25S'])
+    from PYME.Acquire.Hardware.Mercury import mercuryStepperGCS
+    scope.stage = mercuryStepperGCS.mercuryStepper(comPort='COM6', baud=115200, axes=['X', 'Y'], steppers=['M-229.25S', 'M-229.25S'])
     scope.stage.SetSoftLimits(0, [1.06, 20.7])
     scope.stage.SetSoftLimits(1, [.8, 17.6])
 
@@ -57,18 +53,18 @@ def stage(scope):
     
     scope.CleanupFunctions.append(scope.stage.Cleanup)
 
-# @init_hardware('sCMOS Camera')
-# def sCMOS_cam(scope):
-#     from PYME.Acquire.Hardware.AndorNeo import AndorZyla
+@init_hardware('sCMOS Camera')
+def sCMOS_cam(scope):
+    from PYME.Acquire.Hardware.AndorNeo import AndorZyla
 
-#     cam = AndorZyla.AndorZyla(0)
-#     cam.Init()
-#     cam.port = 'R100'
-#     #cam.SetActive(False)
-#     cam.orientation = dict(rotate=True, flipx=True, flipy=False)
-#     cam.DefaultEMGain = 0  # hack to make camera work with standard protocols
+    cam = AndorZyla.AndorZyla(0)
+    cam.Init()
+    cam.port = 'R100'
+    #cam.SetActive(False)
+    cam.orientation = dict(rotate=True, flipx=True, flipy=False)
+    cam.DefaultEMGain = 0  # hack to make camera work with standard protocols
 
-#     scope.register_camera(cam, 'sCMOS')
+    scope.register_camera(cam, 'sCMOS')
 
 @init_hardware('EMCCD Camera')
 def EMCCD_cam(scope):
@@ -81,11 +77,11 @@ def EMCCD_cam(scope):
 
 #scope.EnableJoystick = 'foo'
 
-# @init_gui('sCMOS Camera controls')
-# def cam_controls(MainFrame, scope):
-#     from PYME.Acquire.Hardware.AndorNeo import ZylaControlPanel
-#     scope.camControls['sCMOS'] = ZylaControlPanel.ZylaControl(MainFrame, scope.cameras['sCMOS'], scope)
-#     MainFrame.camPanels.append((scope.camControls['sCMOS'], 'sCMOS Properties', False, False))
+@init_gui('sCMOS Camera controls')
+def cam_controls(MainFrame, scope):
+    from PYME.Acquire.Hardware.AndorNeo import ZylaControlPanel
+    scope.camControls['sCMOS'] = ZylaControlPanel.ZylaControl(MainFrame, scope.cameras['sCMOS'], scope)
+    MainFrame.camPanels.append((scope.camControls['sCMOS'], 'sCMOS Properties', False, False))
 
 @init_gui('EMCCD Camera controls')
 def cam_controls1(MainFrame, scope):

--- a/PYME/Acquire/Scripts/init_drift_tracking.py
+++ b/PYME/Acquire/Scripts/init_drift_tracking.py
@@ -22,7 +22,6 @@
 ##################
 from PYME.Acquire.ExecTools import joinBGInit, HWNotPresent, init_gui, init_hardware
 
-
 from PYME.Acquire.Hardware import fakeShutters
 import time
 import os
@@ -49,14 +48,18 @@ def cam(scope):
 #PIFoc
 @init_hardware('PIFoc')
 def pifoc(scope):
-    from PYME.Acquire.Hardware.Piezos import offsetPiezo
+    import sys
+    if sys.version_info.major > 2:
+        from PYME.Acquire.Hardware.Piezos import offsetPiezoREST as offsetPiezo
+    else:
+        from PYME.Acquire.Hardware.Piezos import offsetPiezo
     scope.piFoc = offsetPiezo.getClient()
     scope.register_piezo(scope.piFoc, 'z')
 
 @init_gui('Drift tracking')
 def drift_tracking(MainFrame, scope):
     from PYME.Acquire.Hardware import driftTracking, driftTrackGUI
-    scope.dt = driftTracking.correlator(scope, scope.piFoc)
+    scope.dt = driftTracking.Correlator(scope, scope.piFoc)
     dtp = driftTrackGUI.DriftTrackingControl(MainFrame, scope.dt)
     MainFrame.camPanels.append((dtp, 'Focus Lock'))
     MainFrame.time1.WantNotification.append(dtp.refresh)

--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -165,7 +165,7 @@ class PanSpool(afp.foldingPane):
         hsizer.Add(self.cbCompress, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
     
         self.cbQuantize = wx.CheckBox(pan, -1, 'Quantization')
-        self.cbQuantize.SetValue(config.get('Acquire-quantize_by_default', False))
+        self.cbQuantize.SetValue(config.get('spooler-quantize_by_default', False))
     
         hsizer.Add(self.cbQuantize, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
     

--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -36,6 +36,7 @@ import glob
 from PYME.IO import PZFFormat
 import sys
 
+from PYME import config
 
 [wxID_FRSPOOL, wxID_FRSPOOLBSETSPOOLDIR, wxID_FRSPOOLBSTARTSPOOL, 
  wxID_FRSPOOLBSTOPSPOOLING, wxID_FRSPOOLCBCOMPRESS, wxID_FRSPOOLCBQUEUE, 
@@ -164,7 +165,7 @@ class PanSpool(afp.foldingPane):
         hsizer.Add(self.cbCompress, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
     
         self.cbQuantize = wx.CheckBox(pan, -1, 'Quantization')
-        self.cbQuantize.SetValue(True)
+        self.cbQuantize.SetValue(config.get('Acquire-quantize_by_default', False))
     
         hsizer.Add(self.cbQuantize, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
     

--- a/PYME/DSView/modules/splitter.py
+++ b/PYME/DSView/modules/splitter.py
@@ -137,7 +137,7 @@ class Unmixer(Plugin):
         else:
             mode = 'lite'
             
-        print(im.data[:,:,1,1].shape)
+        #print(im.data[:,:,0,1].shape)
 
         dv = ViewIm3D(im, mode=mode, glCanvas=self.dsviewer.glCanvas, parent=wx.GetTopLevelParent(self.dsviewer))
 

--- a/PYME/experimental/scanner_control.py
+++ b/PYME/experimental/scanner_control.py
@@ -58,7 +58,14 @@ class ScannerController(object):
             raise RuntimeError('waveform %s not supported' % waveform)
         
         
-        self._sound = pygame.sndarray.make_sound(y.astype('int16'))
+        if pygame.mixer.get_init()[2]  == 2:
+            #hack for when we can't get a mono mixer
+            print(y.shape)
+            y = np.tile(y.astype('int16')[:,None], (1,2))
+            print(y.shape)
+            self._sound = pygame.sndarray.make_sound(y)
+        else:
+            self._sound = pygame.sndarray.make_sound(y.astype('int16'))
         self._sound.play(-1)
         
         return ''


### PR DESCRIPTION
@barentine - this makes quantization **off** by default in the spool frame (as this is a safer option - particularly on systems with EMCCD cameras or other cases where the noise model may not have been setup correctly). Current behavior / high throughput behavior can be set with the `Acquire-quantize_by_default` config option. Will need a suitable modification to HT init file to set this config option prior to merging on the HT system.