### PR TITLE
if we know the final number of frames in rules.LocalisationRule, let the ruleserver know

### DIFF
--- a/PYME/cluster/rules.py
+++ b/PYME/cluster/rules.py
@@ -568,7 +568,8 @@ class LocalisationRule(Rule):
         self._next_release_start = self.start_at
         numTotalFrames = self.ds.getNumSlices()
         self.frames_outstanding=numTotalFrames - self._next_release_start
-        
+        if self.data_complete:
+            return dict(max_tasks=self.ds.getNumSlices())
         return {}
 
     @property


### PR DESCRIPTION
Addresses issue #789 .

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- don't allocate more resources on the ruleserver than necessary if we know the number of frames already






**Checklist:**

- [x] Tested 