### PR TITLE
use localization rule factory in clusterUI localization view

### DIFF
--- a/PYME/cluster/clusterUI/localization/views.py
+++ b/PYME/cluster/clusterUI/localization/views.py
@@ -122,7 +122,7 @@ def localize(request, analysisModule='LatGaussFitFR'):
 
     #print json.dumps(f.cleaned_data)
     # NB - any metadata entries given here will override the series metadata later: pass analysis settings only
-    analysisMDH = MetaDataHandler.DictMDHandler()
+    analysisMDH = MetaDataHandler.NestedClassMDHandler()
     analysisMDH.update(f.cleaned_data)
 
     #print request.GET
@@ -168,4 +168,3 @@ def localize(request, analysisModule='LatGaussFitFR'):
         raise RuntimeError('Failed to push %d of %d series' % (nFailed, nSeries))
 
     return HttpResponseRedirect('/status/queues/')
-


### PR DESCRIPTION
Addresses issue #786 .

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- use the localization rule factory to instantiate rules to push themselves



**Checklist:**

- Tested with numpy=1.19
- Tested on python 3.7
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
