### PR TITLE
Dataserver locking tweaks to try and improve performance

### DIFF
--- a/PYME/cluster/HTTPDataServer.py
+++ b/PYME/cluster/HTTPDataServer.py
@@ -623,6 +623,11 @@ class PYMEHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
             js_dir, expiry = _dirCache[path]
             if expiry < curTime:
                 js_dir=None
+                try:
+                    # remove directory entry from cache as it's expired.
+                    _dirCache.pop(path)
+                except KeyError:
+                    pass
             
             #logger.debug('jsoned dir cache hit')
         except KeyError:


### PR DESCRIPTION
Potentially addresses #741.

Not really tested at this point. Attempts to address 2 separate but related potential issues.

### Issue 1

- `list_directory()` had a global lock around listing operations
- this had the effect of serialising all list_directory calls
- most punishing for performance was the fact that a request for a directory that was in the cache would have to wait for any non-cached requests to complete.

### Issue 2
- `put_file` takes out a lock on the directory cache to update it when adding a file
- this effectively serialises returns from put_file ops (i.e. put_file has to wait for all previous ops to complete before it returns and the calling process)
- the `__aggregate` endpoints do this for each frame / set of fit results
- the `__aggregate` endpoints can really hammer the dataserver
- if we are saving results to a dataserver, a spooling `put` can get stuck in the middle of a bunch of aggregate ops.


This PR addresses issue 1 for the cached json listings only, but not for the lower level caches.

We partially address issue 2 by not updating the caches for anything but the first __aggregate on a file.