### PR TITLE
increase clusterIO timeouts, make long times generate warnings

### DIFF
--- a/PYME/IO/clusterIO.py
+++ b/PYME/IO/clusterIO.py
@@ -227,7 +227,7 @@ def _getSession(url):
     return session
 
 
-def _listSingleDir(dirurl, nRetries=1, timeout=5):
+def _listSingleDir(dirurl, nRetries=1, timeout=10):
     t = time.time()
 
     try:
@@ -256,6 +256,10 @@ def _listSingleDir(dirurl, nRetries=1, timeout=5):
                     raise
 
         dt = time.time() - t
+        
+        if dt > 1:
+            logger.warning('_listSingleDir(%s) took longer than 1s (%3.2fs)'% (url, dt))
+        
         if not r.status_code == 200:
             logger.debug('Request for %s failed with error: %d' % (url, r.status_code))
 
@@ -748,7 +752,7 @@ def get_local_path(filename, serverfilter):
         if os.path.exists(localpath):
             return localpath
 
-def get_file(filename, serverfilter=local_serverfilter, numRetries=3, use_file_cache=True, local_short_circuit=True, timeout=0.5):
+def get_file(filename, serverfilter=local_serverfilter, numRetries=3, use_file_cache=True, local_short_circuit=True, timeout=5):
     """
     Get a file from the cluster.
     
@@ -813,7 +817,11 @@ def get_file(filename, serverfilter=local_serverfilter, numRetries=3, use_file_c
         try:
             nTries += 1
             s = _getSession(url)
+            t = time.time()
             r = s.get(url, timeout=timeout)
+            dt = time.time() - t
+            if dt > 1:
+                logger.warning('get_file(%s) took > 1s (%3.2fs)' % (url, dt))
             haveResult = True
         except (requests.Timeout, requests.ConnectionError):
             # s.get sometimes raises ConnectionError instead of ReadTimeoutError
@@ -923,7 +931,7 @@ def mirror_file(filename, serverfilter=local_serverfilter):
     r.close()
 
 
-def put_file(filename, data, serverfilter=local_serverfilter, timeout=1):
+def put_file(filename, data, serverfilter=local_serverfilter, timeout=10):
     """
     Put a file to the cluster. The server on which the file resides is chosen by a crude load-balancing algorithm
     designed to uniformly distribute data across the servers within the cluster. The target file must not exist.
@@ -982,6 +990,9 @@ def put_file(filename, data, serverfilter=local_serverfilter, timeout=1):
                 raise RuntimeError('Put failed with %d: %s' % (r.status_code, r.content))
 
             _lastwritespeed[name] = len(data) / (dt + .001)
+            
+            if dt > 1:
+                logger.warning('put_file(%s) on %s took more than 1s (%3.2f s)' % (filename, url, dt))
             
             success = True
 
@@ -1094,7 +1105,7 @@ if USE_RAW_SOCKETS:
         return status, reason, data
                 
     
-    def put_files(files, serverfilter=local_serverfilter):
+    def put_files(files, serverfilter=local_serverfilter, timeout=30):
         """
         Put a bunch of files to a single server in the cluster (chosen by algorithm)
         
@@ -1132,7 +1143,7 @@ if USE_RAW_SOCKETS:
                 t = time.time()
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-                s.settimeout(5.0)
+                s.settimeout(30)
         
                 #conect to the server
                 s.connect((socket.inet_ntoa(info.address), info.port))


### PR DESCRIPTION
potentially helpful for issue #741.

Alternative to #788 which has undesirable cache changes and also seems to have obtained bits of other PRs / have a messed up history.