### PR TITLE
generate informative errors  if trying to save oversize TIFFs

### DIFF
--- a/PYME/IO/dataExporter.py
+++ b/PYME/IO/dataExporter.py
@@ -230,6 +230,12 @@ class OMETiffExporter(Exporter):
                 return data.astype('uint8')
             else:
                 return data
+            
+        if data.nbytes > 2e9:
+            warnings.warn('Data is larger than 2GB, generated TIFF may not read in all software')
+            
+        if data.nbytes > 4e9:
+            raise RuntimeError('TIFF has a maximum file size of 4GB, crop data or save as HDF')
         
         dw = dataWrap.ListWrap([numpy.atleast_3d(_bool_to_uint8(data[xslice, yslice, zslice, i].squeeze())) for i in range(data.shape[3])])
         #xmd = None


### PR DESCRIPTION
Addresses issue #784 .

**Proposed changes:**

Generate more helpful error messages when user tries to save a >4GB TIFF