### PR TITLE
document that django now only works on 2.0 or 2.1

### DIFF
--- a/PYME/cluster/cluster_of_one.py
+++ b/PYME/cluster/cluster_of_one.py
@@ -60,7 +60,7 @@ class ClusterOfOne(object):
         try:
             import django
         except ImportError:
-            logger.error('django is not installed, to use clusterUI install django (1.11.x, 2.0.x, 2.1.x)')
+            logger.error('django is not installed, to use clusterUI install django (2.0.x, 2.1.x)')
             
         if not self._cluster_ui is None:
             self._kill_procs([self._cluster_ui, ])

--- a/docs/cluster/cluster_install.rst
+++ b/docs/cluster/cluster_install.rst
@@ -134,7 +134,7 @@ just running the extra processes but it could also be a standalone machine.
 
 #. Checkout the PYME source from [github](github.com/python-microscopy/python-microscopy) to get the ``clusterUI`` sources. ``clusterUI`` is a Django web app for browsing the cluster.
 
-#. ``conda install django=1.11``
+#. ``conda install django=2.1``
 
 
 Running the software

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ git+https://github.com/olivierverdier/dispatch.git@master#egg=dispatch; python_v
 # django is used for the full-blown clusterUI (see cluster analysis docs) but is not required for most analysis tasks. Don't install by default as backwards
 # compatibility between django versions is not great and it's hard to keep this tracking the latest security fixes. Installing a (potentially old and insecure)
 # version of django should be a deliberate choice.  
-# django==1.11.29
+# django==2.1
 
 #networkx
 #pywin32 [win]


### PR DESCRIPTION
Addresses issue on django 1.11.29
```
Unhandled exception in thread started by <function check_errors.<locals>.wrapper at 0x7fdc858e73b0>
Traceback (most recent call last):
  File "/opt/miniconda3/lib/python3.7/site-packages/django/utils/autoreload.py", line 228, in wrapper
    fn(*args, **kwargs)
  File "/opt/miniconda3/lib/python3.7/site-packages/django/core/management/commands/runserver.py", line 124, in inner_run
    self.check(display_num_errors=True)
  File "/opt/miniconda3/lib/python3.7/site-packages/django/core/management/base.py", line 359, in check
    include_deployment_checks=include_deployment_checks,
  File "/opt/miniconda3/lib/python3.7/site-packages/django/core/management/base.py", line 346, in _run_checks
    return checks.run_checks(**kwargs)
  File "/opt/miniconda3/lib/python3.7/site-packages/django/core/checks/registry.py", line 81, in run_checks
    new_errors = check(app_configs=app_configs)
  File "/opt/miniconda3/lib/python3.7/site-packages/django/core/checks/urls.py", line 16, in check_url_config
    return check_resolver(resolver)
  File "/opt/miniconda3/lib/python3.7/site-packages/django/core/checks/urls.py", line 26, in check_resolver
    return check_method()
  File "/opt/miniconda3/lib/python3.7/site-packages/django/urls/resolvers.py", line 256, in check
    for pattern in self.url_patterns:
  File "/opt/miniconda3/lib/python3.7/site-packages/django/utils/functional.py", line 35, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/opt/miniconda3/lib/python3.7/site-packages/django/urls/resolvers.py", line 407, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "/opt/miniconda3/lib/python3.7/site-packages/django/utils/functional.py", line 35, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/opt/miniconda3/lib/python3.7/site-packages/django/urls/resolvers.py", line 400, in urlconf_module
    return import_module(self.urlconf_name)
  File "/opt/miniconda3/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/Andrew/code/python-microscopy/PYME/cluster/clusterUI/clusterUI/urls.py", line 17, in <module>
    from django.urls import include, path
ImportError: cannot import name 'include' from 'django.urls' (/opt/miniconda3/lib/python3.7/site-packages/django/urls/__init__.py)

```
following #774 

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
make the docs right

