### PR TITLE
relax zeroconf pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ ujson
 jinja2
 toposort
 pymecompress >=0.2
-zeroconf==0.17.7 #TODO - can we relax this pin?
+zeroconf<=0.26.3
 
 cython # do we need this for a non-dev install?
 


### PR DESCRIPTION
Addresses issue works up until the service info constructor drops the address bit in 0.27.0
**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
relax the pin on zeroconf, following the to-do / most of us using later versions by now anyway
