### PR TITLE
Interlock / triggering off of focus lock IR camera saturation

### DIFF
--- a/PYME/Acquire/Hardware/uc480/uCam480.py
+++ b/PYME/Acquire/Hardware/uc480/uCam480.py
@@ -750,7 +750,8 @@ class uc480Camera(Camera):
     def noise_properties(self):
         return {'ElectronsPerCount': self.GetElectronsPerCount(),
                 'ReadNoise': self.GetReadNoise(),
-                'ADOffset': self.GetADOffset()}
+                'ADOffset': self.GetADOffset(),
+                'SaturationThreshold': 2 ** self.nbits  - 1}
 
     def GenStartMetadata(self, mdh):
         if self.active: #we are active -> write metadata

--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -179,6 +179,20 @@ def laser_controls(MainFrame, scope):
     MainFrame.time1.WantNotification.append(lsf.update)
     MainFrame.camPanels.append((lsf, 'Laser Powers'))
 
+@init_gui('Interlock')
+def interlock(MainFrame, scope):
+    from PYME import config
+    from PYME.Acquire.interlock import InterlockServer
+    import yaml
+
+    email_info = config['email-info-path']
+    with open(email_info, 'r') as f:
+        email_info = yaml.safe_load(f)
+
+    address = config.get('interlockserver-address', '127.0.0.1')
+    port = config.get('interlockserver-port', 9119)
+    InterlockServer(scope, email_info, port, address)
+
 @init_gui('Multiview Selection')
 def multiview_selection(MainFrame, scope):
     from PYME.Acquire.ui import multiview_select

--- a/PYME/Acquire/Scripts/init_htsms.py
+++ b/PYME/Acquire/Scripts/init_htsms.py
@@ -191,7 +191,7 @@ def interlock(MainFrame, scope):
 
     address = config.get('interlockserver-address', '127.0.0.1')
     port = config.get('interlockserver-port', 9119)
-    InterlockServer(scope, email_info, port, address)
+    scope.interlock = InterlockServer(scope, email_info, port, address)
 
 @init_gui('Multiview Selection')
 def multiview_selection(MainFrame, scope):

--- a/PYME/Acquire/Scripts/init_htsms_focus_lock.py
+++ b/PYME/Acquire/Scripts/init_htsms_focus_lock.py
@@ -117,6 +117,16 @@ def focus_lock(MainFrame, scope):
     MainFrame.camPanels.append((focus_log_panel, 'Focus Logger'))
 
 
+@init_gui('Interlock')
+def interlock(MainFrame, scope):
+    from PYME import config
+    from PYME.Acquire.interlock import InterlockClient
+
+    address = config.get('interlockserver-address', '127.0.0.1')
+    port = config.get('interlockserver-port', 9119)
+    scope.interlock = InterlockClient(address, port)
+
+
 #must be here!!!
 joinBGInit() #wait for anyhting which was being done in a separate thread
 

--- a/PYME/Acquire/interlock.py
+++ b/PYME/Acquire/interlock.py
@@ -1,0 +1,93 @@
+
+import weakref
+from PYME.util import webframework
+import threading
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Interlock(object):
+    def __init__(self, microscope, email_info=None):
+        """ 
+
+        Parameters
+        ----------
+        microscope : PYME.Acquire.microscope.Microscope
+        email_info : dict
+            sender : str
+                email address to send from
+            password : str
+                password for sender
+            receiver : str
+                destination email address
+        """
+        self.scope = weakref.ref(microscope)
+        self.email_info = email_info
+    
+    @webframework.register_endpoint('/kill', output_is_json=False)
+    def kill(self, message=''):
+        """
+        kill the lasers
+
+        Parameters
+        ----------
+        message : str
+            something about why you needed to kill using the interlock
+        """
+        self.scope().turnAllLasersOff()
+        logger.error('shutting off lasers: %s' % message)
+        if self.email_info is not None:
+            try:
+                import smtplib, ssl
+                context = ssl.create_default_context()
+                with smtplib.SMTP_SSL("smtp.gmail.com", context=context) as server:
+                    server.login(self.email_info['sender'],
+                                self.email_info['password'])
+                    server.sendmail(self.email_info['sender'], 
+                                    self.email_info['receiver'], message)
+            except Exception as e:
+                logger.error(str(e))
+
+class InterlockServer(webframework.APIHTTPServer, Interlock):
+    def __init__(self, microscope, email_info=None, port=9119, 
+                 bind_address=''):
+        """
+
+        NOTE - this will likely not be around long, as it would be preferable to
+        add the interlock endpoints to `PYME.acquire_server.AcquireHTTPServer` 
+        and run a single server process on the microscope computer.
+
+        Parameters
+        ----------
+        microscope: PYME.Acquire.microscope.Microscope
+        email_info : dict
+            sender : str
+                email address to send from
+            password : str
+                password for sender
+            receiver : str
+                destination email address
+        port : int
+            port to listen on
+        bind_address : str, optional
+            specifies ip address to listen on, by default '' will bind to local 
+            host.
+        """
+        webframework.APIHTTPServer.__init__(self, (bind_address, port))
+        Interlock.__init__(self, microscope, email_info)
+        
+        self.daemon_threads = True
+        self._server_thread = threading.Thread(target=self._serve)
+        self._server_thread.daemon_threads = True
+        self._server_thread.start()
+
+    def _serve(self):
+        try:
+            logger.info('Starting Interlock server on %s:%s' % (self.server_address[0], 
+                                                                self.server_address[1]))
+            self.serve_forever()
+        finally:
+            logger.info('Shutting down Interlock server ...')
+            self.shutdown()
+            self.server_close()


### PR DESCRIPTION
Addresses issue #burning things 

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- add an interlock server / client
- trigger a microscope hault on my focus lock camera mostly saturating





**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
