### PR TITLE
django widgets fix

### DIFF
--- a/PYME/misc/django_widgets.py
+++ b/PYME/misc/django_widgets.py
@@ -4,13 +4,13 @@ from django.forms.utils import flatatt
 from django.utils.html import format_html
 
 class ClusterFileInput(TextInput):
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ''
         final_attrs = self.build_attrs(attrs, {'type': self.input_type, name: name})
         if value != '':
             # Only add the 'value' attribute if a value is non-empty.
-            final_attrs['value'] = force_text(self._format_value(value))
+            final_attrs['value'] = force_text(self.format_value(value))
         # return format_html('''<div class="input-group">
         #                         <span class="input-group-addon">pyme-cluster:///</span>
         #                         <input class="form-control" {} />


### PR DESCRIPTION
Addresses issue #803 

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
`TextInput._format_value` doesn't exist, and renderer must be passed even if null
