### PR TITLE
small astigmatism calibration fixes

### DIFF
--- a/PYME/DSView/modules/filtering.py
+++ b/PYME/DSView/modules/filtering.py
@@ -323,7 +323,7 @@ class Filterer(Plugin):
 
         dialog = wx.TextEntryDialog(None, 'Z Spacing [um]:', 'Enter Desired Spacing', str(0.05))
         if dialog.ShowModal() == wx.ID_OK:
-            regular = ResampleZ().apply_simple(input=self.image, z_sampling=float(dialog.GetValue()))
+            regular = ResampleZ(z_sampling=float(dialog.GetValue())).apply_simple(input=self.image)
 
             ViewIm3D(regular, glCanvas=self.dsviewer.glCanvas, parent=wx.GetTopLevelParent(self.dsviewer))
 

--- a/PYME/localization/FitFactories/BeadConvolvedAstigGaussFit.py
+++ b/PYME/localization/FitFactories/BeadConvolvedAstigGaussFit.py
@@ -17,7 +17,7 @@
 ##################
 
 import numpy as np
-from .fitCommon import fmtSlicesUsed
+from .fitCommon import fmtSlicesUsed, pack_results
 from . import FFBase
 from PYME.Analysis._fithelpers import FitModelWeighted
 from scipy.signal import convolve2d
@@ -124,19 +124,6 @@ fresultdtype = [('tIndex', '<i4'),
                 ]
 
 
-def GaussianFitResultR(fitResults, startParams, metadata, slicesUsed=None, resultCode=-1, fitErr=None, background=0, mse=0):
-    slicesUsed = fmtSlicesUsed(slicesUsed)
-    # print slicesUsed
-
-    if fitErr is None:
-        fitErr = -5e3 * np.ones(fitResults.shape, 'f')
-
-    res = np.array([(metadata.tIndex, fitResults.astype('f'), fitErr.astype('f'), startParams.astype('f'), resultCode,
-                     slicesUsed, background, mse)], dtype=fresultdtype)
-    # print res
-    return res
-
-
 class GaussianFitFactory(FFBase.FitFactory):
     def __init__(self, data, metadata, fitfcn=f_gaussAstigBead, background=None, noiseSigma=None, **kwargs):
         """Create a fit factory which will operate on image data (data), potentially using voxel sizes etc contained in
@@ -182,10 +169,13 @@ class GaussianFitFactory(FFBase.FitFactory):
                 fitErrors = None
         except Exception:
             pass
-
-        # package results
-        return GaussianFitResultR(res, np.array(startParameters), self.metadata, (xslice, yslice, zslice), resCode,
-                                  fitErrors, bgm, np.mean(infodict['fvec']**2))
+        
+        tIndex = int(self.metadata.getOrDefault('tIndex', 0))
+        return pack_results(fresultdtype, tIndex=tIndex, fitResults=res, 
+                            fitError=fitErrors, startParams=np.array(startParameters), 
+                            resultCode=resCode, slicesUsed=(xslice, yslice, zslice),
+                            subtractedBackground=bgm, 
+                            meanSquaredError=np.mean(infodict['fvec']**2))
 
     @classmethod
     def evalModel(cls, params, md, x=0, y=0, roiHalfSize=5):
@@ -202,7 +192,6 @@ class GaussianFitFactory(FFBase.FitFactory):
 
 # so that fit tasks know which class to use
 FitFactory = GaussianFitFactory
-FitResult = GaussianFitResultR
 FitResultsDType = fresultdtype  # only defined if returning data as numarray
 
 import PYME.localization.MetaDataEdit as mde


### PR DESCRIPTION
Addresses issue #not setting the z resampling (#805) and 
```
 Error whilst running Processing>Perform Astigmatic Calibration
==============================================
python-microscopy=20.12.10
python=3.6.9, platform=linux
numpy=1.16.5, wx=4.0.4 gtk2 (phoenix) wxWidgets 3.0.5
Traceback
=========
Traceback (most recent call last):
  File "/home/smeagol/code/python-microscopy/PYME/ui/progress.py", line 107, in func
    return fcn(*args, **kwargs)
  File "/home/smeagol/code/python-microscopy/PYME/DSView/modules/psfTools.py", line 355, in OnCalibrateAstigmatism
    ptFitter.execute(namespace)
  File "/home/smeagol/code/python-microscopy/PYME/recipes/measurement.py", line 230, in execute
    r[i] = ff.FromPoint(x/ps, y/ps, roiHalfSize=self.roiHalfSize)
  File "/home/smeagol/code/python-microscopy/PYME/localization/FitFactories/BeadConvolvedAstigGaussFit.py", line 188, in FromPoint
    fitErrors, bgm, np.mean(infodict['fvec']**2))
  File "/home/smeagol/code/python-microscopy/PYME/localization/FitFactories/BeadConvolvedAstigGaussFit.py", line 135, in GaussianFitResultR
    slicesUsed, background, mse)], dtype=fresultdtype)
ValueError: setting an array element with a sequence.
```

**Is this a bugfix or an enhancement?**
bugfixes
**Proposed changes:**
- use pack_results in beadconvolvedastiggaussfit
- set traits parameters in class instantiation rather than as ignored kwargs in apply_simple






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] 
1.16
- [ ] Tested on python 2.7 and 3.6
3.6
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

