### PR TITLE
Run Ripley's K if we don't provide a mask

### DIFF
--- a/PYME/recipes/pointcloud.py
+++ b/PYME/recipes/pointcloud.py
@@ -308,10 +308,10 @@ class Ripleys(ModuleBase):
         if self.three_d:
             if np.count_nonzero(points_real['z']) == 0:
                 raise RuntimeError('Need a 3D dataset')
-            if mask.data.shape[2] < 2:
+            if mask and mask.data.shape[2] < 2:
                 raise RuntimeError('Need a 3D mask to run in 3D. Generate a 3D mask or select 2D.')
         else:
-            if mask.data.shape[2] > 1:
+            if mask and mask.data.shape[2] > 1:
                 raise RuntimeError('Need a 2D mask.')
 
         if self.statistics and mask is None:


### PR DESCRIPTION
Fixes error

```
Traceback (most recent call last):
  File "/Users/zachcm/python-microscopy/lib/python3.6/site-packages/PYME/ui/progress.py", line 107, in func
    return fcn(*args, **kwargs)
  File "/Users/zachcm/python-microscopy/lib/python3.6/site-packages/PYME/LMVis/Extras/clusterAnalysis.py", line 409, in OnRipleys
    result = r.apply(inputPositions=pipeline.selectedDataSource, inputMask=mask)[r.outputName]
  File "/Users/zachcm/python-microscopy/lib/python3.6/site-packages/PYME/recipes/base.py", line 185, in apply
    self.execute(namespace)
  File "/Users/zachcm/python-microscopy/lib/python3.6/site-packages/PYME/recipes/pointcloud.py", line 314, in execute
    if mask.data.shape[2] > 1:
AttributeError: 'NoneType' object has no attribute 'data'
```