### PR TITLE
make rulenodeserver safer for directory trees with spaces

### DIFF
--- a/PYME/ParallelTasks/Loft/PYMENodeServer.py
+++ b/PYME/ParallelTasks/Loft/PYMENodeServer.py
@@ -106,14 +106,14 @@ def main():
     time.sleep(2)
     logging.debug('Launching worker processors')
     numWorkers = config.get('numWorkers', cpu_count())
-
-    workerProcs = [subprocess.Popen('python -m PYME.cluster.taskWorkerHTTP', shell=True, stdin=subprocess.PIPE)
+    subprocess.Popen('"%s" -m PYME.cluster.PYMERuleNodeServer -a local -p 0' % sys.executable, shell=True)
+    workerProcs = [subprocess.Popen('"%s" -m PYME.cluster.taskWorkerHTTP' % sys.executable, shell=True, stdin=subprocess.PIPE)
                    for i in range(numWorkers -1)]
 
     #last worker has profiling enabled
     profiledir = os.path.join(nodeserver_log_dir, 'mProf')      
-    workerProcs.append(subprocess.Popen('python -m PYME.cluster.taskWorkerHTTP -p %s' % profiledir, shell=True,
-                                        stdin=subprocess.PIPE))
+    workerProcs.append(subprocess.Popen('"%s" -m PYME.cluster.taskWorkerHTTP -p "%s"' % (sys.executable, profiledir),
+                                        shell=True, stdin=subprocess.PIPE))
 
     try:
         while not proc.poll():

--- a/PYME/cluster/PYMERuleNodeServer.py
+++ b/PYME/cluster/PYMERuleNodeServer.py
@@ -116,7 +116,7 @@ def main():
 
     #last worker has profiling enabled
     profiledir = os.path.join(nodeserver_log_dir, 'mProf')      
-    workerProcs.append(subprocess.Popen('"%s" -m PYME.cluster.taskWorkerHTTP -s % d -p --profile-dir=%s' % (sys.executable, serverPort, profiledir), shell=True,
+    workerProcs.append(subprocess.Popen('"%s" -m PYME.cluster.taskWorkerHTTP -s % d -p --profile-dir="%s"' % (sys.executable, serverPort, profiledir), shell=True,
                                         stdin=subprocess.PIPE))
 
     try:


### PR DESCRIPTION
Addresses issue #816 .

**Is this a bugfix or an enhancement?**
depends on your point of view
**Proposed changes:**
- enclose profile directory in double quotes
- use sys.executable instead of `python`






**Checklist:**

- [x] Tested on my machine which doesn't actually have spaces in root/python directories