### PR TITLE
typo on makedirs in recipe output stuff

### DIFF
--- a/PYME/recipes/output.py
+++ b/PYME/recipes/output.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 def _ensure_output_directory(filename):
     dirname = os.path.dirname(filename)
     if not os.path.exists(dirname):
-        os.path.makedirs(dirname)
+        os.makedirs(dirname)
 
 @register_module('CSVOutput')
 class CSVOutput(OutputModule):


### PR DESCRIPTION
Addresses issue # .
```
In [2]: os.path.makedirs
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-723b303552b4> in <module>
----> 1 os.path.makedirs

AttributeError: module 'posixpath' has no attribute 'makedirs'

In [3]: os.makedirs
Out[3]: <function os.makedirs(name, mode=511, exist_ok=False)>

```