### PR TITLE
change installation instructions to use pyme-depends-strict

### DIFF
--- a/PYME/DSView/modules/annotation.py
+++ b/PYME/DSView/modules/annotation.py
@@ -36,7 +36,7 @@ class myListCtrl(wx.ListCtrl, listmix.ListCtrlAutoWidthMixin):#, listmix.TextEdi
     def OnLabelActivate(self, event):
         newLabel = wx.GetTextFromUser("Enter new category name", "Rename")
         if not newLabel == '':
-            self.SetStringItem(event.m_itemIndex, 1, newLabel)
+            self.SetStringItem(event.GetIndex(), 1, newLabel)
 
 
 class LabelPanel(wx.Panel):
@@ -96,7 +96,7 @@ class LabelPanel(wx.Panel):
         self.SetSizer(vsizer)
     
     def OnChangeStructure(self, event):
-        self.labeler.cur_label_index = event.m_itemIndex
+        self.labeler.cur_label_index = event.GetIndex()
     
     def OnChangeLineWidth(self, event):
         self.labeler.line_width = float(self.tLineWidth.GetValue())

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -8,7 +8,8 @@ The best to install PYME will depend on your background and whether you are alre
 Executable installers (Windows and OSX)
 =======================================
 
-Recommended if you don't already have python on your computer and/or are unfamiliar with python. Download the latest installer from https://python-microscopy.org/downloads/. Double-click the installer and follow instructions. 
+Recommended if you don't already have python on your computer and/or are unfamiliar with python. Download the latest
+installer from https://python-microscopy.org/downloads/. Double-click the installer and follow instructions.
 
 
 Installing using conda
@@ -21,28 +22,24 @@ Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 	
     conda config --append channels anaconda
     conda config --add channels david_baddeley
-    conda create -n PYME python=3.6 pyme-depends-strict python-microscopy
+    conda create -n pyme python=3.6 pyme-depends-strict python-microscopy
 
-.. note::
-
-    **Which Python version?** As of 2020/12/07, we recommend python 3.6 or 3.7 for new installs. We plan to add support for
-    python=3.8 (as installed by default in miniconda) in the near future, but until such time downgrading to either 3.6 or 3.7
-    with and explicit python=3.x argument to conda install is required.
-
-    Having recently made the py2-> py3 transition, there are a still few components which might work better / are better tested on python 2.7
-    (likely to only effect instrument control). As we are no longer building updated packages on 2.7 we recommend a source
-    install in this case.
+To run programs from the command prompt, you will need to run `conda activate pyme` before running the program.
 
 .. note::
 
    The inclusion of `pyme-depends-strict` above pins all the PYME dependencies as well as their dependencies to fixed,
    known good versions. This blunt way of avoiding dependency conflicts was introduced after having been burnt once too
-   often by packaging issues in one of our dependencies, but might make it hard to install other packages (e.g. keras)
-   that you might want to use in conjunction with PYME. In general omitting `pyme-depends-strict`, and simply running
-   `conda create -n PYME python=3.6 python-microscopy` should be enough to give a functioning install, but there is a
-   small chance that you will need to fix dependency conflicts. `traits`, `traitsui` and `pyface` have been
-   the most consistent offenders, with a version of `traitsui` being installed which requires an older version of `pyface`.
+   often by packaging issues in our dependencies. It is particularly useful if you are also using uncurated channels such
+   as `conda-forge`. In general omitting `pyme-depends-strict`, and simply running
+   `conda create -n pyme python=3.6 python-microscopy` should be enough to give a functioning install, but there is a
+   small chance that you will need to fix dependency conflicts.
 
+.. note::
+
+    **Which Python version?** As of 2020/12/07, we recommend python 3.6 or 3.7 for new installs. We plan to add support for
+    python=3.8 in the near future, but until such time downgrading to either 3.6 or 3.7
+    with and explicit python=3.x argument to conda create is required.
 
 Updating
 ========

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -21,7 +21,7 @@ Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
 	
     conda config --append channels anaconda
     conda config --add channels david_baddeley
-    conda install python=3.7 python-microscopy
+    conda create -n PYME python=3.6 pyme-depends-strict python-microscopy
 
 .. note::
 
@@ -32,6 +32,16 @@ Then, open the *Anaconda prompt* [#anacondaprompt]_ and enter
     Having recently made the py2-> py3 transition, there are a still few components which might work better / are better tested on python 2.7
     (likely to only effect instrument control). As we are no longer building updated packages on 2.7 we recommend a source
     install in this case.
+
+.. note::
+
+   The inclusion of `pyme-depends-strict` above pins all the PYME dependencies as well as their dependencies to fixed,
+   known good versions. This blunt way of avoiding dependency conflicts was introduced after having been burnt once too
+   often by packaging issues in one of our dependencies, but might make it hard to install other packages (e.g. keras)
+   that you might want to use in conjunction with PYME. In general omitting `pyme-depends-strict`, and simply running
+   `conda create -n PYME python=3.6 python-microscopy` should be enough to give a functioning install, but there is a
+   small chance that you will need to fix dependency conflicts. `traits`, `traitsui` and `pyface` have been
+   the most consistent offenders, with a version of `traitsui` being installed which requires an older version of `pyface`.
 
 
 Updating


### PR DESCRIPTION
A bit of a brute-force cludge to the installation instructions to try and ensure we get a functional install when conda packaging is stuffed up / packages specify their dependencies incorrectly.

TODO:
Do we need to add instructions about activating the environment (or does this automatically create a shortcut for the relevant conda prompt).

@zacsimile - to go with the new pyme-depends stuff.