### PR TITLE
add cropping recipe module

### DIFF
--- a/PYME/IO/DataSources/CropDataSource.py
+++ b/PYME/IO/DataSources/CropDataSource.py
@@ -38,7 +38,7 @@ class DataSource(BaseDataSource):
             x0 = xrange[0] if xrange[0] > -1 else self.dataSource.shape[0] + xrange[0]
             x1 = xrange[1] if xrange[1] > -1 else self.dataSource.shape[0] + xrange[1]
             assert x1 - x0 > 0 and x1 - x0 <= self.dataSource.shape[0]
-            assert x0 < self.dataSource.shape[0] and x0 > 0
+            assert x0 < self.dataSource.shape[0] and x0 >= 0
             assert x1 < self.dataSource.shape[0] and x1 > 0
             self.xrange = (x0, x1)
             
@@ -49,7 +49,7 @@ class DataSource(BaseDataSource):
             y0 = yrange[0] if yrange[0] > -1 else self.dataSource.shape[1] + yrange[0]
             y1 = yrange[1] if yrange[1] > -1 else self.dataSource.shape[1] + yrange[1]
             assert y1 - y0 > 0 and y1 - y0 <= self.dataSource.shape[1]
-            assert y0 < self.dataSource.shape[1] and y0 > 0
+            assert y0 < self.dataSource.shape[1] and y0 >= 0
             assert y1 < self.dataSource.shape[1] and y1 > 0
             self.yrange = (y0, y1)
             
@@ -61,7 +61,7 @@ class DataSource(BaseDataSource):
             t0 = trange[0] if trange[0] > -1 else n_slices + trange[0]
             t1 = trange[1] if trange[1] > -1 else n_slices + trange[1]
             assert t1 - t0 > 0 and t1 - t0 <= n_slices
-            assert t0 < n_slices and t0 > 0
+            assert t0 < n_slices and t0 >= 0
             assert t1 < n_slices and t1 > 0
             self.trange = (t0, t1)
         

--- a/PYME/IO/DataSources/CropDataSource.py
+++ b/PYME/IO/DataSources/CropDataSource.py
@@ -29,20 +29,41 @@ class DataSource(BaseDataSource):
         #self.unmixer = unmixer
         self.dataSource = dataSource
         
-        if xrange is None:
+        sizeC = self.dataSource.sizeC
+
+        if xrange is None or tuple(xrange) == (0, -1):
             self.xrange = (0, self.dataSource.shape[0])
         else:
-            self.xrange = xrange
+            # force to positive values we can handle simply in getSliceShape
+            x0 = xrange[0] if xrange[0] > -1 else self.dataSource.shape[0] + xrange[0]
+            x1 = xrange[1] if xrange[1] > -1 else self.dataSource.shape[0] + xrange[1]
+            assert x1 - x0 > 0 and x1 - x0 <= self.dataSource.shape[0]
+            assert x0 < self.dataSource.shape[0] and x0 > 0
+            assert x1 < self.dataSource.shape[0] and x1 > 0
+            self.xrange = (x0, x1)
             
-        if yrange is None:
+        if yrange is None or tuple(yrange) == (0, -1):
             self.yrange = (0, self.dataSource.shape[1])
         else:
-            self.yrange = yrange
+            # force to positive values we can handle simply in getSliceShape
+            y0 = yrange[0] if yrange[0] > -1 else self.dataSource.shape[1] + yrange[0]
+            y1 = yrange[1] if yrange[1] > -1 else self.dataSource.shape[1] + yrange[1]
+            assert y1 - y0 > 0 and y1 - y0 <= self.dataSource.shape[1]
+            assert y0 < self.dataSource.shape[1] and y0 > 0
+            assert y1 < self.dataSource.shape[1] and y1 > 0
+            self.yrange = (y0, y1)
             
-        if trange is None:
+        if trange is None or tuple(trange) == (0, -1):
             self.trange = (0, self.dataSource.getNumSlices())
         else:
-            self.trange = trange
+            # force to positive values we can handle simply in getNumSlices
+            n_slices = self.dataSource.getNumSlices()
+            t0 = trange[0] if trange[0] > -1 else n_slices + trange[0]
+            t1 = trange[1] if trange[1] > -1 else n_slices + trange[1]
+            assert t1 - t0 > 0 and t1 - t0 <= n_slices
+            assert t0 < n_slices and t0 > 0
+            assert t1 < n_slices and t1 > 0
+            self.trange = (t0, t1)
         
     
     def getSlice(self,ind):

--- a/PYME/IO/DataSources/CropDataSource.py
+++ b/PYME/IO/DataSources/CropDataSource.py
@@ -39,7 +39,7 @@ class DataSource(BaseDataSource):
             x1 = xrange[1] if xrange[1] > -1 else self.dataSource.shape[0] + xrange[1]
             assert x1 - x0 > 0 and x1 - x0 <= self.dataSource.shape[0]
             assert x0 < self.dataSource.shape[0] and x0 >= 0
-            assert x1 < self.dataSource.shape[0] and x1 > 0
+            assert x1 <= self.dataSource.shape[0] and x1 > 0
             self.xrange = (x0, x1)
             
         if yrange is None or tuple(yrange) == (0, -1):
@@ -50,7 +50,7 @@ class DataSource(BaseDataSource):
             y1 = yrange[1] if yrange[1] > -1 else self.dataSource.shape[1] + yrange[1]
             assert y1 - y0 > 0 and y1 - y0 <= self.dataSource.shape[1]
             assert y0 < self.dataSource.shape[1] and y0 >= 0
-            assert y1 < self.dataSource.shape[1] and y1 > 0
+            assert y1 <= self.dataSource.shape[1] and y1 > 0
             self.yrange = (y0, y1)
             
         if trange is None or tuple(trange) == (0, -1):
@@ -62,7 +62,7 @@ class DataSource(BaseDataSource):
             t1 = trange[1] if trange[1] > -1 else n_slices + trange[1]
             assert t1 - t0 > 0 and t1 - t0 <= n_slices
             assert t0 < n_slices and t0 >= 0
-            assert t1 < n_slices and t1 > 0
+            assert t1 <= n_slices and t1 > 0
             self.trange = (t0, t1)
         
     

--- a/tests/PYME/recipes/test_base.py
+++ b/tests/PYME/recipes/test_base.py
@@ -1,0 +1,37 @@
+
+from PYME.recipes import base
+
+def test_crop():
+    from PYME.IO.DataSources.ArrayDataSource import ArrayDataSource
+    from PYME.IO.image import ImageStack
+    import numpy as np
+    d = np.arange(10) * np.ones((5, 4))[:, :, None]
+    im = ImageStack(data=ArrayDataSource(d), haveGUI=False)
+    
+    # test null crop
+    out = base.Crop().apply_simple(im)
+    np.testing.assert_array_equal(d.shape, out.data.shape[:-1])
+    
+    # test x crop
+    out = base.Crop(x_range=[1, d.shape[0] - 1]).apply_simple(im)
+    assert out.data.shape[0] == d.shape[0] - 2
+    np.testing.assert_array_equal(d.shape[1:], out.data.shape[1:-1])
+
+    # test z/t crop
+    out = base.Crop(t_range=[3, d.shape[2] - 3]).apply_simple(im)
+    assert out.data.shape[2] == d.shape[2] - 6
+    np.testing.assert_array_equal(d.shape[:2], out.data.shape[:2])
+
+def test_bad_crop_catch():
+    from PYME.IO.DataSources.ArrayDataSource import ArrayDataSource
+    from PYME.IO.image import ImageStack
+    import numpy as np
+    d = np.arange(10) * np.ones((5, 4))[:, :, None]
+    im = ImageStack(data=ArrayDataSource(d), haveGUI=False)
+    
+    try:
+        out = base.Crop(t_range=[7, d.shape[2] - 7]).apply_simple(im)
+    except AssertionError:
+        pass
+    else:
+        raise ValueError


### PR DESCRIPTION
Addresses issue #no recipe module for cropping.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- add a recipe module wrapping the crop datasource
- add a unit test for said module
- template applyFilter on filtermodule (irrelevant, but there. oops)






**Checklist:**

- [x] Tested with numpy=1.19 python 3.7 wx=4
