### PR TITLE
htsmlm focus lock / pifoc improvements

### DIFF
--- a/PYME/Acquire/Hardware/Piezos/piezo_e816_dll.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_e816_dll.py
@@ -35,6 +35,8 @@ from PYME.Acquire.eventLog import logEvent
 from .base_piezo import PiezoBase
 from PYME.Acquire.Hardware.GCS import gcs
 
+logger = logging.getLogger(__name__)
+
 def get_connected_devices():
     n, devs= gcs.EnumerateUSB('E-816')
 
@@ -231,8 +233,8 @@ class piezo_e816T(PiezoBase):
         if identifier is None:
             devices = get_connected_devices()
             identifier = devices[0]
-
-        self.id = gcs.ConnectUSB(identifier)
+        self._identifier = identifier
+        self.id = gcs.ConnectUSB(self._identifier)
         
         if not Osen is None:
             # self.ser_port.write('SPA A8 %3.4f\n' % Osen)
@@ -257,8 +259,6 @@ class piezo_e816T(PiezoBase):
         self.driftCompensation = False
         self.hasTrigger = hasTrigger
 
-        self.loopActive = True
-        self.stopMove = False
         self.position = np.array([0.])
         # self.velocity = np.array([self.maxvelocity, self.maxvelocity])
 
@@ -266,8 +266,10 @@ class piezo_e816T(PiezoBase):
         # self.targetVelocity = self.velocity.copy()
 
         self.lastTargetPosition = self.position.copy()
-
-
+        self._start_loop()
+    
+    def _start_loop(self):
+        self.loopActive = True
         self.tloop = threading.Thread(target=self._Loop)
         self.tloop.daemon=True
         self.tloop.start()
@@ -284,7 +286,7 @@ class piezo_e816T(PiezoBase):
 
                 self.errCode = int(gcs.qERR(self.id))
 
-                if not self.errCode == 0:
+                if not self.errCode == 0:  # I have yet to see this work
                     logging.info(('Stage Error: %d' % self.errCode))
 
                 # print self.targetPosition, self.stopMove
@@ -319,12 +321,32 @@ class piezo_e816T(PiezoBase):
                 #    logging.exception('Value error on response from ONT')
 
                 # time.sleep(.1)
-
-
-            except IndexError:
-                print('IndexException')
+            except RuntimeError as e:
+                # gcs.fcnWrap.HandleError throws Runtimes for everything
+                logger.error(str(e))
+                try:
+                    self.errCode = int(gcs.qERR(self.id))
+                    logger.error('error code: %s' % str(self.errCode))
+                except:
+                    logger.error('no error code retrieved')
+                if '-1' in str(e):
+                    logger.debug('reinitializing GCS connection, 10 s pause')
+                    gcs.CloseConnection(self.id)
+                    time.sleep(10.0)
+                    try:
+                        self.id = gcs.ConnectUSB(self._identifier)
+                        logger.debug('restablished connection to piezo')
+                    except RuntimeError as e:
+                        logger.error('trying to get new device ID')
+                        devices = get_connected_devices()
+                        self._identifier = devices[0]
+                        logger.debug('new device ID acquired')
+                        self.id = gcs.ConnectUSB(self._identifier)
+                    time.sleep(1.0)
+                    logger.debug('turning on servo')
+                    gcs.SVO(self.id, b'A', [1])
+                    time.sleep(1.0)
             finally:
-                self.stopMove = False
                 self.lock.release()
 
         # close port on loop exit
@@ -342,11 +364,22 @@ class piezo_e816T(PiezoBase):
             # self.ser_port.close()
 
     def ReInit(self):
+        """
+        Reinitialize a closed connection to the pifoc. Note the pifoc
+        connection must have already been closed, whether by using `close`
+        or the polling loop failing.
+        """
         with self.lock:
-            #self.ser_port.write('WTO A0\n')
+            logging.info('restarting e816')
+            self.loopActive = False
+            time.sleep(1.0)
+            self.id = gcs.ConnectUSB(self._identifier)
             gcs.SVO(self.id, b'A', [1])
-            time.sleep(1)
+            time.sleep(1.0)
             self.lastPos = self.GetPos()
+        
+        logging.info('reinitialized, starting loop')
+        self._start_loop()
 
     def OnTarget(self):
         return self.onTarget

--- a/PYME/Acquire/Hardware/Piezos/piezo_e816_dll.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_e816_dll.py
@@ -332,7 +332,7 @@ class piezo_e816T(PiezoBase):
                 if '-1' in str(e):
                     logger.debug('reinitializing GCS connection, 10 s pause')
                     gcs.CloseConnection(self.id)
-                    time.sleep(10.0)
+                    time.sleep(10.0)  # this takes at least more than 1 s
                     try:
                         self.id = gcs.ConnectUSB(self._identifier)
                         logger.debug('restablished connection to piezo')

--- a/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
+++ b/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
@@ -447,7 +447,7 @@ class ReflectedLinePIDFocusLock(PID):
             self.scope.failsafe.kill(message='focus lock profile suggests heat danger')
         
         try:
-            assert np.std(cf, axis=0) < self._min_lateral_sigma
+            assert np.std(cf.sum(axis=1)) > self._min_lateral_sigma
             
             if self.subtraction_profile is not None:
                 peak_position, success = self.find_peak(profile - self.subtraction_profile)

--- a/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
+++ b/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
@@ -322,7 +322,7 @@ class ReflectedLinePIDFocusLock(PID):
 
         Parameters
         ----------
-        start_art: float, optional
+        start_at: float, optional
             offset to start the scan at (10 positions chosen 'spirally' out
             before linearly stepping through the range from bottom up)
         step_size : float, optional

--- a/PYME/Acquire/Protocols/htsms-tile.py
+++ b/PYME/Acquire/Protocols/htsms-tile.py
@@ -50,6 +50,7 @@ taskList = [
         'Multiview.ROISize': [256, 256],
         'Camera.IntegrationTime': 0.005,
     }),
+    T(-1, scope._stage_leveler.reacquire_focus_lock),
     T(-1, scanner.setup),
     T(-1, scope.l405.TurnOn),
     T(0, scanner.start),

--- a/PYME/Acquire/stage_leveling.py
+++ b/PYME/Acquire/stage_leveling.py
@@ -133,7 +133,7 @@ class StageLeveler(object):
         else:
             logger.error('short axes must be "x" or "y"')
 
-    def measure_offsets(self, optimize_path=True):
+    def measure_offsets(self, optimize_path=True, use_previous_scan=True):
         """
         Visit each position and log the offset
 
@@ -163,8 +163,15 @@ class StageLeveler(object):
             time.sleep(self._pause_on_relocate)
             if hasattr(self, '_focus_lock') and not self._focus_lock.LockOK():
                 logger.debug('focus lock not OK, scanning offset')
-                # self.scan_offset_until_ok()
-                self._focus_lock.ReacquireLock(start_at=-25)
+                if use_previous_scan:
+                    try:
+                        start_at = self.lookup_offset(positions[ind, 0],
+                                                      positions[ind, 1])
+                    except:
+                        start_at = -25
+                else:
+                    start_at = -25
+                self._focus_lock.ReacquireLock(start_at=start_at)
                 time.sleep(1.)
 
                 if self._focus_lock.LockOK():
@@ -269,3 +276,7 @@ class StageLeveler(object):
             return 0
         f = interp2d(scan['x'], scan['y'], scan['offset'])
         return f(x, y)[0]
+    
+    def reacquire_focus_lock(self):
+        p = self._scope.GetPos()
+        self._scope.focus_lock.ReacquireLock(self.lookup_offset(p['x'], p['y']))

--- a/PYME/Acquire/stage_leveling.py
+++ b/PYME/Acquire/stage_leveling.py
@@ -231,3 +231,41 @@ class StageLeveler(object):
         if len(self._scans) < 1:
             raise UserWarning('no scans available, call StageLeveler.measure_offsets() first')
         StageLeveler.plot_scan(self._scans[index], interpolation_factor=interpolation_factor)
+
+    def store_scan(self, index=-1):
+        self._current_scan = self._scans[index]
+
+    @property
+    def current_scan(self):
+        try:
+            return self._current_scan
+        except AttributeError:
+            if len(self._scans) > 0:
+                return self._scans[-1]
+            else:
+                raise UserWarning('run a scan first')
+
+    def lookup_offset(self, x, y):
+        """use a stored scan to estimate what the z offset should be at a given
+        xy position
+
+        Parameters
+        ----------
+        x : float
+            x position in micrometers
+        y : float
+            y position in micrometers
+
+        Returns
+        -------
+        float
+            offset at xy from interpolated scan
+        """
+        from scipy.interpolate import interp2d
+        try:
+            scan = self.current_scan
+        except AttributeError:
+            logger.error('no scan, returning 0 for offset lookup')
+            return 0
+        f = interp2d(scan['x'], scan['y'], scan['offset'])
+        return f(x, y)[0]

--- a/PYME/Acquire/stage_leveling.py
+++ b/PYME/Acquire/stage_leveling.py
@@ -277,6 +277,11 @@ class StageLeveler(object):
         f = interp2d(scan['x'], scan['y'], scan['offset'])
         return f(x, y)[0]
     
-    def reacquire_focus_lock(self):
-        p = self._scope.GetPos()
-        self._scope.focus_lock.ReacquireLock(self.lookup_offset(p['x'], p['y']))
+    def acquire_focus_lock(self):
+        self._focus_lock.EnableLock()
+        if self._focus_lock.LockOK():
+            return
+        time.sleep(1)
+        if not self._focus_lock.LockOK():
+            p = self._scope.GetPos()
+            self._scope.focus_lock.ReacquireLock(self.lookup_offset(p['x'], p['y']))

--- a/PYME/Acquire/stage_leveling.py
+++ b/PYME/Acquire/stage_leveling.py
@@ -64,7 +64,7 @@ class StageLeveler(object):
         """
         self._positions.append(self._scope.GetPos())
 
-    def add_grid(self, x_length, y_length, x_spacing, y_spacing, center=True):
+    def add_grid(self, x_length, y_length, x_spacing, y_spacing, center):
         """
         Add a grid of set spacings to the list of positions to scan when measuring offsets.
 

--- a/PYME/Acquire/stage_leveling.py
+++ b/PYME/Acquire/stage_leveling.py
@@ -164,7 +164,7 @@ class StageLeveler(object):
             if hasattr(self, '_focus_lock') and not self._focus_lock.LockOK():
                 logger.debug('focus lock not OK, scanning offset')
                 # self.scan_offset_until_ok()
-                self._focus_lock.ReacquireLock()
+                self._focus_lock.ReacquireLock(start_at=-25)
                 time.sleep(1.)
 
                 if self._focus_lock.LockOK():


### PR DESCRIPTION

**Proposed changes:**
- use stage_leveler scans to bootstrap offset estimates when we need to reacquire focus
- create a flag to allow stage_leveler to use previous scan to bootstrap reacquire focus
- fix the e816Tdll pifoc reinit
- have the pifoc restart itself on what had previously been a hard crash (and currently requires a disconnect/reconnect)
- add a method in stage_leveler we can call from a task protocol list to reacquire lock with the current scope position (little gross, but lets reacquire lock method itself be simpler
