### PR TITLE
allow shortcircuit for pyme-cluster:///

### DIFF
--- a/PYME/IO/clusterIO.py
+++ b/PYME/IO/clusterIO.py
@@ -746,7 +746,7 @@ def get_local_path(filename, serverfilter):
     filename = (filename)
     serverfilter = (serverfilter)
     
-    if serverfilter == local_serverfilter and local_dataroot:
+    if (serverfilter == local_serverfilter or serverfilter == '') and local_dataroot:
         #look for the file in the local server folder (short-circuit the server)
         localpath = os.path.join(local_dataroot, filename)
         if os.path.exists(localpath):


### PR DESCRIPTION
Addresses issue `unifiedIO.local_or_temp_filename('pyme-cluster:///something') will not work if you have a localserverfilter config'd, which is I think more cruel than we need to be there - if you specify you want it from a given cluster fine, but if you don't include it that's just annoying

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**







**Checklist:**

- [x] Tested with numpy=1.19 and 3.7
