### PR TITLE
Tidy up csv saving, handling of recipe outputs in dh5view

### DIFF
--- a/PYME/DSView/modules/recipes.py
+++ b/PYME/DSView/modules/recipes.py
@@ -155,7 +155,7 @@ class RecipePlugin(recipeGui.RecipeManager, Plugin):
                 import six
                 
                 cache = tabular.CachingResultsFilter(self.outp)
-                self.dsviewer.pipeline.OpenFile(ds = cache)
+                self.dsviewer.pipeline.OpenFile(ds = cache, clobber_recipe=False)
                 self.dsviewer.pipeline.filterKeys = {}
                 self.dsviewer.pipeline.Rebuild()
                 self.dsviewer.view.filter = self.dsviewer.pipeline

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -165,9 +165,13 @@ class TabularBase(object):
         
         def fmt(d):
             if np.isscalar(d):
-                return '%e' % d
+                if isinstance(d, six.string_types):
+                    return str(d)
+                else:
+                    return '%e' % d
             else:
-                return '"%s"' % str(d)
+                # try to make sure odd objects don't break file formatting
+                return ('"%s"' % str(d).strip(delim).strip('\n'))
     
         of = open(outFile, 'w')
     

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -912,6 +912,10 @@ class CachingResultsFilter(TabularBase):
 
     def keys(self):
         return list(self.resultsSource.keys())
+    
+    @property
+    def mdh(self):
+        return self.resultsSource.mdh
 
 @deprecated_name('mappingFilter')
 class MappingFilter(TabularBase):

--- a/PYME/recipes/measurement.py
+++ b/PYME/recipes/measurement.py
@@ -663,6 +663,13 @@ class Measure2D(ModuleBase):
                     
                     self._keys.remove('euler_number') #buggy!
                     
+                    # remove all the image measurements - as these will potentially generate export errors
+                    # and are not super-useful
+                    self._keys.remove('convex_image')
+                    self._keys.remove('filled_image')
+                    self._keys.remove('image')
+                    self._keys.remove('intensity_image')
+                    
                     if not contours is None:
                         self._keys += ['contour']
                         


### PR DESCRIPTION
Addresses issues #845, #846 .

- Tidy up CSV saving
- Remove a couple of problematic `Measure2D` outputs
- Make dh5view recipe output handling behave as it used to prior to pipeline refactor