### PR TITLE
defer indication of series completion until after events have been saved

### DIFF
--- a/PYME/Acquire/HDFSpooler.py
+++ b/PYME/Acquire/HDFSpooler.py
@@ -110,9 +110,8 @@ class Spooler(sp.Spooler):
         
         sp.Spooler.__init__(self, filename, frameSource, **kwargs)
 
-    def StopSpool(self):
-        """Stop spooling and close file"""
-        sp.Spooler.StopSpool(self)
+    def finalise(self):
+        """ close files"""
            
         self.h5File.flush()
         self.h5File.close()

--- a/PYME/Acquire/HTTPSpooler.py
+++ b/PYME/Acquire/HTTPSpooler.py
@@ -236,9 +236,7 @@ class Spooler(sp.Spooler):
         else:
             clusterIO.put_file(self.seriesName + '/metadata.json', self.md.to_JSON().encode(), serverfilter=self.clusterFilter)
     
-    def StopSpool(self):
-        sp.Spooler.StopSpool(self)
-
+    def finalise(self):
         # wait until our input queue is empty rather than immediately stopping saving.
         self._stopping=True
         logger.debug('Stopping spooling %s' % self.seriesName)

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -470,7 +470,7 @@ class SpoolController(object):
         self.onSpoolStart.send(self)
         
         #return a function which can be called to indicate if we are done
-        return lambda : not self.spooler.spoolOn
+        return lambda : self.spooler.spool_complete
 
     @property
     def display_dirname(self):

--- a/PYME/Acquire/Spooler.py
+++ b/PYME/Acquire/Spooler.py
@@ -114,6 +114,8 @@ class Spooler:
         self.spoolOn = False
         self.imNum = 0
         
+        self.spool_complete = False
+        
         self._spooler_uuid = uuid.uuid4()
             
         if not fakeCamCycleTime is None:
@@ -171,6 +173,16 @@ class Spooler:
             self.guiUpdateCallback()
             
         self.onSpoolStop.send(self)
+        
+        self.finalise() #TODO - should this be before we send the onStopSpool signal?
+        self.spool_complete = True
+        
+    def finalise(self):
+        """
+        Over-ride in derived classes to do any spooler specific tidy up - e.g. sending events to server
+
+        """
+        pass
         
     def abort(self):
         """

--- a/PYME/Acquire/Spooler.py
+++ b/PYME/Acquire/Spooler.py
@@ -138,7 +138,7 @@ class Spooler:
 
         self.protocol.Init(self)
 
-        self.doStartLog()
+        self._collect_start_metadata()
    
         self.frameSource.connect(self.OnFrame, dispatch_uid=self._spooler_uuid)
         self.spoolOn = True
@@ -158,7 +158,7 @@ class Spooler:
         try:
             self.protocol.OnFinish()#this may still cause events
             self.FlushBuffer()
-            self.doStopLog()
+            self._collect_stop_metadata()
         except:
             import traceback
             traceback.print_exc()
@@ -237,7 +237,7 @@ class Spooler:
             self.StopSpool()
             
 
-    def doStartLog(self):
+    def _collect_start_metadata(self):
         """Record pertinant information to metadata at start of acquisition.
         
         Loops through all registered sources of start metadata and adds their entries.
@@ -265,7 +265,7 @@ class Spooler:
         self.md.copyEntriesFrom(mdt)
        
 
-    def doStopLog(self):
+    def _collect_stop_metadata(self):
         """Record information to metadata at end of acquisition"""
         self.md.setEntry('EndTime', time.time())
         


### PR DESCRIPTION
Addresses issue #822.

Alternative to #850 which avoids a new race condition / makes sure that being recognised as complete by the `ActionManager` only happens at the very end of `StopSpool()` 
