### PR TITLE
add file handler to PYMEAcquire logger

### DIFF
--- a/PYME/Acquire/PYMEAcquire.py
+++ b/PYME/Acquire/PYMEAcquire.py
@@ -88,7 +88,12 @@ def main():
     
     from PYME import config
     
-    logger = logging.getLogger(__name__)
+    logger = logging.getLogger()
+    fh = logging.handlers.RotatingFileHandler(filename=os.path.join(config.get('dataserver-root'), 'LOGS', 'PYMEAcquire.log'), 
+                                              mode='w', maxBytes=1e6, backupCount=1)
+    fh.setLevel(logging.INFO)
+    logger.addHandler(fh)
+
     parser = OptionParser()
     parser.add_option("-i", "--init-file", dest="initFile",
                       help="Read initialisation from file [defaults to init.py]",


### PR DESCRIPTION
Addresses issue #853

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- get the root logger that we just set up rather than a __file__ logger
- add a rotatingfilehandler to said logger
- try and set file logging to INFO, though seems to still write debug to file...

