### PR TITLE
allow  spooler metadata from recipe context

### DIFF
--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -344,7 +344,7 @@ class SpoolController(object):
                       zDwellTime=None, doPreflightCheck=True, 
                       maxFrames=sys.maxsize, pzf_compression_settings=None, 
                       cluster_h5=None, protocol=None, subdirectory=None,
-                      metadata=None):
+                      extra_metadata=None):
         """
 
         Parameters
@@ -383,7 +383,7 @@ class SpoolController(object):
         subdirectory : str, optional
             Directory within current set directory to spool this series. The
             directory will be created if it doesn't already exist.
-        metadata : dict, optional
+        extra_metadata : dict, optional
             metadata to supplement this series for entries known prior to
             acquisition which do not have handlers to hook start metadata
         """
@@ -463,8 +463,8 @@ class SpoolController(object):
         #        #the connection to the database will timeout if not present
         #        #FIXME: catch the right exception (or delegate handling to sampleInformation module)
         #        pass
-        if metadata is not None:
-            self.spooler.md.mergeEntriesFrom(MetaDataHandler.DictMDHandler(metadata))
+        if extra_metadata is not None:
+            self.spooler.md.mergeEntriesFrom(MetaDataHandler.DictMDHandler(extra_metadata))
             
         try:
             self.spooler.onSpoolStop.connect(self.SpoolStopped)
@@ -633,7 +633,7 @@ class SpoolControllerWrapper(object):
                       z_dwell=None, preflight_check=True, 
                       max_frames=sys.maxsize, pzf_compression_settings=None, 
                       cluster_h5=None, protocol=None, subdirectory=None,
-                      metadata=None):
+                      extra_metadata=None):
         """
 
         Parameters
@@ -672,14 +672,16 @@ class SpoolControllerWrapper(object):
         subdirectory : str, optional
             Directory within current set directory to spool this series. The
             directory will be created if it doesn't already exist.
-        metadata : dict, optional
+        extra_metadata : dict, optional
             metadata to supplement this series for entries known prior to
             acquisition which do not have handlers to hook start metadata
+            
+            FIXME: dict parameters will likely not be setable through the HTTP endpoint - change signature to accept json body instead? 
         """
         self.spool_controller.StartSpooling(filename, stack, hdf_comp_level, 
                                             z_dwell, preflight_check,
                                             max_frames, 
                                             pzf_compression_settings, 
                                             cluster_h5, protocol, subdirectory,
-                                            metadata)
+                                            extra_metadata)
         return 'OK'

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -343,7 +343,8 @@ class SpoolController(object):
     def StartSpooling(self, fn=None, stack=None, compLevel=None, 
                       zDwellTime=None, doPreflightCheck=True, 
                       maxFrames=sys.maxsize, pzf_compression_settings=None, 
-                      cluster_h5=None, protocol=None, subdirectory=None):
+                      cluster_h5=None, protocol=None, subdirectory=None,
+                      metadata=None):
         """
 
         Parameters
@@ -382,6 +383,9 @@ class SpoolController(object):
         subdirectory : str, optional
             Directory within current set directory to spool this series. The
             directory will be created if it doesn't already exist.
+        metadata : dict, optional
+            metadata to supplement this series for entries known prior to
+            acquisition which do not have handlers to hook start metadata
         """
         # these settings were managed by the GUI, but are now managed by the 
         # controller, still allow them to be passed in, but default to internals
@@ -459,6 +463,8 @@ class SpoolController(object):
         #        #the connection to the database will timeout if not present
         #        #FIXME: catch the right exception (or delegate handling to sampleInformation module)
         #        pass
+        if metadata is not None:
+            self.spooler.md.mergeEntriesFrom(metadata)
             
         try:
             self.spooler.onSpoolStop.connect(self.SpoolStopped)
@@ -626,7 +632,8 @@ class SpoolControllerWrapper(object):
     def start_spooling(self, filename=None, stack=None, hdf_comp_level=None, 
                       z_dwell=None, preflight_check=True, 
                       max_frames=sys.maxsize, pzf_compression_settings=None, 
-                      cluster_h5=None, protocol=None, subdirectory=None):
+                      cluster_h5=None, protocol=None, subdirectory=None,
+                      metadata=None):
         """
 
         Parameters
@@ -665,10 +672,14 @@ class SpoolControllerWrapper(object):
         subdirectory : str, optional
             Directory within current set directory to spool this series. The
             directory will be created if it doesn't already exist.
+        metadata : dict, optional
+            metadata to supplement this series for entries known prior to
+            acquisition which do not have handlers to hook start metadata
         """
         self.spool_controller.StartSpooling(filename, stack, hdf_comp_level, 
                                             z_dwell, preflight_check,
                                             max_frames, 
                                             pzf_compression_settings, 
-                                            cluster_h5, protocol, subdirectory)
+                                            cluster_h5, protocol, subdirectory,
+                                            metadata)
         return 'OK'

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -21,7 +21,7 @@ except:
 #import win32api
 from PYME.IO.FileUtils import nameUtils
 from PYME.IO.FileUtils.nameUtils import numToAlpha, getRelFilename, genHDFDataFilepath
-from PYME.IO import unifiedIO
+from PYME.IO import unifiedIO, MetaDataHandler
 
 
 #import PYME.Acquire.Protocols
@@ -464,7 +464,7 @@ class SpoolController(object):
         #        #FIXME: catch the right exception (or delegate handling to sampleInformation module)
         #        pass
         if metadata is not None:
-            self.spooler.md.mergeEntriesFrom(metadata)
+            self.spooler.md.mergeEntriesFrom(MetaDataHandler.DictMDHandler(metadata))
             
         try:
             self.spooler.onSpoolStop.connect(self.SpoolStopped)

--- a/PYME/LMVis/renderers.py
+++ b/PYME/LMVis/renderers.py
@@ -36,6 +36,7 @@ SAMPLE_MD_KEYS = [
     'Sample.SlideRef',
     'Sample.Creator',
     'Sample.Notes',
+    'Sample.Well',
     'Sample.Labelling',
     'AcquiringUser'
 ]

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -102,7 +102,7 @@ class QueueAcquisitions(OutputModule):
         -----
         str spool_settings values can context-substitute templated parameters,
         e.g. spool_settings = {'subdirectory': '{file_stub}',
-                               'metadata: {'Samples.Well': '{file_stub}'}}
+                               'extra_metadata: {'Samples.Well': '{file_stub}'}}
         """
         # substitute spool settings
         spool_settings = self.spool_settings.copy()

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -6,6 +6,12 @@ import json
 import numpy as np
 import time
 
+def format_values(d, context):
+    for k in d.keys():
+            if isinstance(d[k], str):
+                d[k] = d[k].format(**context)
+            elif isinstance(d[k], dict):
+                format_values(d[k], context)
 
 @register_module('QueueAcquisitions')
 class QueueAcquisitions(OutputModule):
@@ -95,13 +101,12 @@ class QueueAcquisitions(OutputModule):
         Notes
         -----
         str spool_settings values can context-substitute templated parameters,
-        e.g. spool_settings = {'subdirectory': '{file_stub}'}
+        e.g. spool_settings = {'subdirectory': '{file_stub}',
+                               'metadata: {'Samples.Well': '{file_stub}'}}
         """
         # substitute spool settings
         spool_settings = self.spool_settings.copy()
-        for k in spool_settings.keys():
-            if isinstance(spool_settings[k], str):
-                spool_settings[k] = spool_settings[k].format(**context)
+        format_values(spool_settings, context)
         
         try:  # get positions in units of micrometers
             positions = np.stack((namespace[self.input_positions]['x_um'], 

--- a/tests/PYME/recipes/test_acquisition.py
+++ b/tests/PYME/recipes/test_acquisition.py
@@ -31,9 +31,10 @@ def test_queue_acquisitions():
     rec = ModuleCollection()
     rec.namespace['input'] = d
 
-    rec.add_module(acquisition.QueueAcquisitions(rec))
-    rec.save()
+    spool_settings = {'metadata' : {'Sample.Well': '{file_stub}'}}
+
+    rec.add_module(acquisition.QueueAcquisitions(rec, spool_settings=spool_settings))
+    rec.save(context={'file_stub': 'A1'})
     time.sleep(1)
     task = action_manager.actionQueue.get_nowait()
-    
-    
+    assert 'A1' == task[1]._then.params['metadata']['Sample.Well']

--- a/tests/PYME/recipes/test_acquisition.py
+++ b/tests/PYME/recipes/test_acquisition.py
@@ -31,10 +31,10 @@ def test_queue_acquisitions():
     rec = ModuleCollection()
     rec.namespace['input'] = d
 
-    spool_settings = {'metadata' : {'Sample.Well': '{file_stub}'}}
+    spool_settings = {'extra_metadata' : {'Sample.Well': '{file_stub}'}}
 
     rec.add_module(acquisition.QueueAcquisitions(rec, spool_settings=spool_settings))
     rec.save(context={'file_stub': 'A1'})
     time.sleep(1)
     task = action_manager.actionQueue.get_nowait()
-    assert 'A1' == task[1]._then.params['metadata']['Sample.Well']
+    assert 'A1' == task[1]._then.params['extra_metadata']['Sample.Well']


### PR DESCRIPTION
Addresses issue wanting to use store tile filename in metadata of series queued from detections on it

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- add metadata kwarg to startspooling
- make spool_settings dict formatting of str values recursive to handle nested dict (metadata)
- check this works in the test




**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
