### PR TITLE
fix pipeline wrapping of measurements + replace newlines in CSV output

### DIFF
--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -171,11 +171,11 @@ class TabularBase(object):
                     return '%e' % d
             else:
                 # try to make sure odd objects don't break file formatting
-                return ('"%s"' % str(d).strip(delim).strip('\n'))
+                return ('"%s"' % str(d).replace(delim,' ').replace('\n',' '))
     
         of = open(outFile, 'w')
     
-        of.write('#' + delim.join(['%s' % k for k in keys]) + '\n')
+        of.write('# ' + delim.join(['%s' % k for k in keys]) + '\n')
     
         for row in zip(*[self[k] for k in keys]):
             of.write(delim.join([fmt(c) for c in row]) + '\n')

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -824,7 +824,10 @@ class Pipeline:
         
         self.recipe.execute()
         self.filterKeys = {}
-        self.selectDataSource('filtered_localizations') #NB - this rebuilds the pipeline
+        if 'filtered_localizations' in self.dataSources.keys():
+            self.selectDataSource('filtered_localizations') #NB - this rebuilds the pipeline
+        else:
+            self.selectDataSource(self.dataSources.keys()[0])
 
         # FIXME - we do this already in pipelinify, maybe we can avoid doubling up?
         self.ev_mappings, self.eventCharts = _processEvents(ds, self.events,

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -827,7 +827,11 @@ class Pipeline:
         if 'filtered_localizations' in self.dataSources.keys():
             self.selectDataSource('filtered_localizations') #NB - this rebuilds the pipeline
         else:
-            self.selectDataSource(self.dataSources.keys()[0])
+            # TODO - replace / remove this fallback with something better. This is currently required
+            # when we use/abuse the pipeline in dh5view, but that should ideally be replaced with
+            # something cleaner. This (and case above) should probably also be conditional on `clobber_recipe`
+            # as if opening with an existing recipe we would likely want to keep selectedDataSource constant as well.
+            self.selectDataSource('FitResults')
 
         # FIXME - we do this already in pipelinify, maybe we can avoid doubling up?
         self.ev_mappings, self.eventCharts = _processEvents(ds, self.events,
@@ -1118,7 +1122,6 @@ class Pipeline:
 
         
     
-
 
 
 


### PR DESCRIPTION
Addresses issues #845 and #846.

**Is this a bugfix or an enhancement?**

Remaining bugfix tweaks for above issues.

**Proposed changes:**

- fix pipeline wrappings for measurements
- for CSV output replace newlines (and delimiters) in stringified measures as ML strings


**Checklist:**

- [x ] Tested with numpy=1.14
- [ x] Tested on python 2.7 and 3.6
- [ N/A] Tested with wx=3.x and wx=4.x [if UI code]
- [x ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
