### PR TITLE
dirty hack to prevent recipe editor clickthrough

### DIFF
--- a/PYME/recipes/recipeGui.py
+++ b/PYME/recipes/recipeGui.py
@@ -304,6 +304,9 @@ class RecipeView(wx.Panel):
         
         self.recipes = recipes
         recipes.recipeView = self
+        
+        self._editing = False #are we currently editing a recipe module? used for a hack / workaround for a a traits/matplotlib bug to disable click-throughs
+        
         hsizer1 = wx.BoxSizer(wx.HORIZONTAL)
         
         vsizer = wx.BoxSizer(wx.VERTICAL)
@@ -538,7 +541,10 @@ class RecipeView(wx.Panel):
         from PYME.IO import tabular
         k = event.artist._data
         if not (isinstance(k, six.string_types)):
-            self.configureModule(k)
+            if not self._editing:
+                self._editing = True
+                self.configureModule(k)
+                self._editing = False
         else:
             outp = self.recipes.activeRecipe.namespace[k]
             if isinstance(outp, ImageStack):


### PR DESCRIPTION
Addresses issue #832.

A dirty hack/workaround which seems to prevent editor clickthrough. Hopefully good enough until we do a full editor refactor.