### PR TITLE
start offset piezo offset mapping at the first offset logged and log every correction

### DIFF
--- a/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
+++ b/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
@@ -93,6 +93,7 @@ class OffsetPiezo(PiezoBase):
             self.offset += correction
             # self.MoveTo(0, target)  # move the base piezo to correct position
             self.basePiezo.MoveTo(0, target + self.offset, True)
+            self.LogFocusCorrection(self.offset)
 
     @webframework.register_endpoint('/LogShifts', output_is_json=False)
     def LogShifts(self, dx, dy, dz, active=True):

--- a/PYME/Analysis/piezo_movement_correction.py
+++ b/PYME/Analysis/piezo_movement_correction.py
@@ -120,16 +120,21 @@ def spoof_focus_events_from_ontarget(events, metadata):
 
     """
     ontarget_times, ontarget_positions = [], []
+    offset_start, first_offset_time = 0, np.finfo(float).max
     for event in events:
         if event['EventName'] == b'PiezoOnTarget':
             ontarget_times.append(float(event['Time']))
             ontarget_positions.append(float(event['EventDescr']))
+        elif event['EventName'] == b'PiezoOffsetUpdate':
+            if float(event['Time']) < first_offset_time:
+                first_offset_time = float(event['Time'])
+                offset_start = float(event['EventDescr'].decode('ascii').split(', ')[0])
 
     if len(ontarget_times) == 0:
         # nothing to do
         return events
 
-    offset_map = piecewise_mapping.GeneratePMFromEventList(events, metadata, 0, 0, eventName=b'PiezoOffsetUpdate',
+    offset_map = piecewise_mapping.GeneratePMFromEventList(events, metadata, 0, offset_start, eventName=b'PiezoOffsetUpdate',
                                                            dataPos=0)
 
     ontarget_times = np.asarray(ontarget_times)


### PR DESCRIPTION
Addresses issue #766 

**Proposed changes:**
- best guess for offset before we have an offset update event is probably the first offset update event we get
- update/fix test
- log piezo offset update on each focus correction



Tested:
- [x] mapping stuff
- [ ] performance of piezo offset update