### PR TITLE
Add recipe module to get image mask from spherical harmonic shell

### DIFF
--- a/PYME/IO/MetaDataHandler.py
+++ b/PYME/IO/MetaDataHandler.py
@@ -178,6 +178,8 @@ def origin_nm(mdh, default_pixel_size=1.):
     
         if 'AcquisitionType' in mdh.getEntryNames() and mdh['AcquisitionType'] == 'Stack':
             oz = mdh['StackSettings.StartPos'] * 1e3
+        elif 'Positioning.z' in mdh.getEntryNames():	
+            oz = mdh['Positioning.z'] * 1e3        
         elif 'Positioning.PIFoc' in mdh.getEntryNames():
             oz = mdh['Positioning.PIFoc'] * 1e3
     

--- a/PYME/IO/MetaDataHandler.py
+++ b/PYME/IO/MetaDataHandler.py
@@ -178,8 +178,8 @@ def origin_nm(mdh, default_pixel_size=1.):
     
         if 'AcquisitionType' in mdh.getEntryNames() and mdh['AcquisitionType'] == 'Stack':
             oz = mdh['StackSettings.StartPos'] * 1e3
-        elif 'Positioning.z' in mdh.getEntryNames():	
-            oz = mdh['Positioning.z'] * 1e3        
+        elif 'Positioning.z' in mdh.getEntryNames():
+            oz = mdh['Positioning.z'] * 1e3
         elif 'Positioning.PIFoc' in mdh.getEntryNames():
             oz = mdh['Positioning.PIFoc'] * 1e3
     

--- a/PYME/IO/MetaDataHandler.py
+++ b/PYME/IO/MetaDataHandler.py
@@ -178,8 +178,6 @@ def origin_nm(mdh, default_pixel_size=1.):
     
         if 'AcquisitionType' in mdh.getEntryNames() and mdh['AcquisitionType'] == 'Stack':
             oz = mdh['StackSettings.StartPos'] * 1e3
-        elif 'Positioning.z' in mdh.getEntryNames():
-            oz = mdh['Positioning.z'] * 1e3
         elif 'Positioning.PIFoc' in mdh.getEntryNames():
             oz = mdh['Positioning.PIFoc'] * 1e3
     

--- a/PYME/recipes/modules.py
+++ b/PYME/recipes/modules.py
@@ -21,6 +21,7 @@ from . import multiview
 from . import surface_fitting
 from . import acquisition
 from . import supertile
+from . import pointcloud
 try:
     from . import skfilters
 except:

--- a/PYME/recipes/surface_fitting.py
+++ b/PYME/recipes/surface_fitting.py
@@ -323,7 +323,7 @@ class ImageMaskFromSphericalHarmonicShell(ModuleBase):
         boolean mask True inside, False outside
     """
     input_shell = Input('harmonic_shell')
-    image_bound_source = Input('input')
+    input_image_bound_source = Input('input')
     voxelsize_nm = ListInt([75, 75, 75])
     output = Output('output')
 
@@ -333,7 +333,7 @@ class ImageMaskFromSphericalHarmonicShell(ModuleBase):
         from PYME.IO.MetaDataHandler import DictMDHandler
 
         shell = namespace[self.input_shell]
-        b = ImageBounds.estimateFromSource(namespace[self.image_bound_source])
+        b = ImageBounds.estimateFromSource(namespace[self.input_image_bound_source])
         
         nx = np.ceil((np.ceil(b.x1) - np.floor(b.x0)) / self.voxelsize_nm[0]) + 1
         ny = np.ceil((np.ceil(b.y1) - np.floor(b.y0)) / self.voxelsize_nm[1]) + 1

--- a/PYME/recipes/surface_fitting.py
+++ b/PYME/recipes/surface_fitting.py
@@ -338,6 +338,7 @@ class ImageMaskFromSphericalHarmonicShell(ModuleBase):
 
         shell = namespace[self.input_shell]
         image_bound_source = namespace[self.input_image_bound_source]
+        # TODO - make bounds estimation more generic - e.g. to match an existing image.
         b = ImageBounds.estimateFromSource(image_bound_source)
         ox, oy, _ = origin_nm(image_bound_source.mdh)
         

--- a/PYME/recipes/surface_fitting.py
+++ b/PYME/recipes/surface_fitting.py
@@ -1,6 +1,6 @@
 
 from .base import register_module, ModuleBase
-from .traits import Input, Output, Float, Int, Bool, CStr, ListInt
+from .traits import Input, Output, Float, Int, Bool, CStr, ListFloat
 import numpy as np
 from PYME.IO import tabular
 import logging
@@ -328,7 +328,7 @@ class ImageMaskFromSphericalHarmonicShell(ModuleBase):
     """
     input_shell = Input('harmonic_shell')
     input_image_bound_source = Input('input')
-    voxelsize_nm = ListInt([75, 75, 75])
+    voxelsize_nm = ListFloat([75, 75, 75])
     output = Output('output')
 
 

--- a/PYME/recipes/surface_fitting.py
+++ b/PYME/recipes/surface_fitting.py
@@ -339,7 +339,7 @@ class ImageMaskFromSphericalHarmonicShell(ModuleBase):
         shell = namespace[self.input_shell]
         image_bound_source = namespace[self.input_image_bound_source]
         b = ImageBounds.estimateFromSource(image_bound_source)
-        ox, oy, oz = origin_nm(image_bound_source.mdh)
+        ox, oy, _ = origin_nm(image_bound_source.mdh)
         
         nx = np.ceil((np.ceil(b.x1) - np.floor(b.x0)) / self.voxelsize_nm[0]) + 1
         ny = np.ceil((np.ceil(b.y1) - np.floor(b.y0)) / self.voxelsize_nm[1]) + 1
@@ -364,7 +364,7 @@ class ImageMaskFromSphericalHarmonicShell(ModuleBase):
             'ImageBounds.z0': z.min(), 'ImageBounds.z1': z.max(),
             'Origin.x': ox + b.x0,
             'Origin.y': oy + b.y0,
-            'Origin.z': oz + b.z0
+            'Origin.z': b.z0
         })
 
         namespace[self.output] = ImageStack(data=inside, mdh=mdh, 


### PR DESCRIPTION
Addresses issue #ripleys takes image mask

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- register the surface fitting module in recipes.modules so it shows up in the guis
- add recipe module to generate an image mask from a spherical harmonic shell



**Checklist:**

- [ ] Tested with numpy

1.19.2
- [ ] Tested on python 2.7 and 3.6

3.7.7
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
