### PR TITLE
reflection focus lock: time import collision fix / check on_target with lower tolerance

### DIFF
--- a/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
+++ b/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
@@ -381,8 +381,9 @@ class ReflectedLinePIDFocusLock(PID):
                                     output_is_json=False)
     def DisableLockAfterAcquiring(self):
         self.EnableLock()  # make sure we have the lock on
+        if not self.on_target(1):
+            time.sleep(0.5)
         if not self.LockOK():
-            import time
             logger.debug('lock not OK, pausing for 5 s')
             time.sleep(5)
             if not self.LockOK():

--- a/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
+++ b/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
@@ -396,6 +396,7 @@ class ReflectedLinePIDFocusLock(PID):
                     self.ReacquireLock(start_at=offset)
                 else:
                     self.ReacquireLock()
+                time.sleep(0.5)
             else:
                 logger.debug('lock OK')
         


### PR DESCRIPTION
Addresses issue #really wanting to be sure we start in the right place / dont have too much play in our focus lock between ROI (adjusting the offset adjusting the z range that gets imaged).

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- check on_target with high tolerance before we call things good
- if we do have to walk offset in search of lockable profile, and find it, give things a chance to settle rather than immediatley following EnableLock with DisableLock





**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
