### PR TITLE
Avoid spurious circular reference detection, output name collisions

### DIFF
--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -92,6 +92,24 @@ class ModuleBase(HasTraits):
 
         HasTraits.__init__(self)
 
+        
+        if (parent is not None):
+            # make sure that the default output name does not collide with any outputs
+            # already in the recipe
+            for k, v in self._output_traits.items():
+                if v in parent.module_outputs:
+                    duplicate_num = 0
+                    val = v
+            
+                    while (val in parent.module_outputs):
+                        # we already have an output of that name in the recipe
+                        # increase the subscript until we get a unique value
+                        duplicate_num += 1
+                        val = v + '_%d' % duplicate_num
+                        
+                    self.trait_set(**{k:val})
+                
+
         # if an input matches the default value for an output, our circular reference check will fail, even if we are
         # setting both values to good values in the kwargs (see issue #695). To mitigate, we first set without validation
         # to overwrite any default values which may be modified, and then re-set with validation turned on to catch any
@@ -225,11 +243,14 @@ class ModuleBase(HasTraits):
 
         Returns
         -------
-        input_dict : dict
-            input names (keys) and modules (values)
+        set of input names
         """
         return {v for k, v in self.trait_get().items() if (k.startswith('input') or isinstance(k, Input)) and not v == ''}
 
+    @property
+    def _output_traits(self):
+        return {k:v for k, v in self.trait_get().items() if (k.startswith('output') or isinstance(k, Output)) and not v ==''}
+    
     @property
     def outputs(self):
         """
@@ -237,10 +258,9 @@ class ModuleBase(HasTraits):
 
         Returns
         -------
-        output_dict : dict
-            output names (keys) and modules (values)
+        set of output names
         """
-        return {v for k, v in self.trait_get().items() if (k.startswith('output') or isinstance(k, Output)) and not v ==''}
+        return set(self._output_traits.values())
     
     @property
     def file_inputs(self):

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -97,7 +97,7 @@ class ModuleBase(HasTraits):
         # to overwrite any default values which may be modified, and then re-set with validation turned on to catch any
         # circular references in the final values.
         self._initial_set = False
-        self.trait_set(trait_change_notify=False, **kwargs)
+        self.trait_set(trait_change_notify=False, **kwargs) #don't notify here - next set will do notification.
         self._initial_set = True
         
         # validate input and outputs now that output names have been set.

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -897,13 +897,12 @@ class ModuleCollection(HasTraits):
         for mdd in l:
             mn, md = list(mdd.items())[0]
             try:
-                mod = all_modules[mn](self)
+                mod = all_modules[mn](self, **md)
             except KeyError:
                 # still support loading old recipes which do not use hierarchical names
                 # also try and support modules which might have moved
-                mod = _legacy_modules[mn.split('.')[-1]](self)
+                mod = _legacy_modules[mn.split('.')[-1]](self, **md)
         
-            mod.set(**md)
             mc.append(mod)
         
         self.modules = mc

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -93,9 +93,9 @@ class ModuleBase(HasTraits):
         HasTraits.__init__(self)
 
         # if an input matches the default value for an output, our circular reference check will fail, even if we are
-        # setting both values to good values in the kwargs (see issue #695). To mitigate, turn off circular reference checking
-        # in the initial module creation. We will validate against circular references in _check_outputs, below, after
-        # all traits have their initial values.
+        # setting both values to good values in the kwargs (see issue #695). To mitigate, we first set without validation
+        # to overwrite any default values which may be modified, and then re-set with validation turned on to catch any
+        # circular references in the final values.
         self._initial_set = False
         self.trait_set(trait_change_notify=False, **kwargs)
         self._initial_set = True

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -91,6 +91,17 @@ class ModuleBase(HasTraits):
         self._invalidate_parent = invalidate_parent
 
         HasTraits.__init__(self)
+
+        # if an input matches the default value for an output, our circular reference check will fail, even if we are
+        # setting both values to good values in the kwargs (see issue #695). To mitigate, turn off circular reference checking
+        # in the initial module creation. We will validate against circular references in _check_outputs, below, after
+        # all traits have their initial values.
+        self._initial_set = False
+        self.trait_set(trait_change_notify=False, **kwargs)
+        self._initial_set = True
+        
+        # validate input and outputs now that output names have been set.
+        # for now, just set all the values again to re-trigger validation
         self.trait_set(**kwargs)
         
         self._check_outputs()

--- a/PYME/recipes/recipeGui.py
+++ b/PYME/recipes/recipeGui.py
@@ -587,8 +587,8 @@ class RecipeView(wx.Panel):
     
     def configureModule(self, k):
         p = self
-        from traitsui.api import Controller
-        class MControl(Controller):
+        from traitsui.api import Controller, Handler
+        class MControl(Handler):
             def closed(self, info, is_ok):
                 wx.CallLater(10, p.update)
         

--- a/PYME/recipes/recipeGui.py
+++ b/PYME/recipes/recipeGui.py
@@ -193,10 +193,20 @@ class ModuleSelectionDialog(wx.Dialog):
         modNames.sort()
 
         self.rootNodes = {}
-        self.modnames = {}
+        #self.modnames = {}
 
         vsizer = wx.BoxSizer(wx.VERTICAL)
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        vsizer2 = wx.BoxSizer(wx.VERTICAL)
+        
+        hsizer2 = wx.BoxSizer(wx.HORIZONTAL)
+        
+        hsizer2.Add(wx.StaticText(self.pan, -1, 'Filter:'), 0, wx.RIGHT, 5)
+        
+        self.tFilter = wx.TextCtrl(self.pan, -1, '')
+        self.tFilter.Bind(wx.EVT_TEXT, self.OnSearchChange)
+        hsizer2.Add(self.tFilter, 1, wx.EXPAND|wx.ALL, 0)
+        vsizer2.Add(hsizer2, 0, wx.ALL|wx.EXPAND, 2)
 
         self.tree_list = wx.gizmos.TreeListCtrl(self.pan, -1, size=(250, 400), style=wx.TR_DEFAULT_STYLE|wx.TR_HIDE_ROOT|wx.TR_FULL_ROW_HIGHLIGHT|
                                                             wx.TR_LINES_AT_ROOT)
@@ -209,6 +219,8 @@ class ModuleSelectionDialog(wx.Dialog):
 
         root = self.tree_list.AddRoot('root')
         self.tree_list.SetItemText(root, "root", 0)
+        
+        self.items = []
 
         for mn in modNames:
             basename, modname = mn.split('.')
@@ -220,6 +232,7 @@ class ModuleSelectionDialog(wx.Dialog):
                 self.rootNodes[basename] = base
 
             item = self.tree_list.AppendItem(base, modname)
+            self.items.append((basename, modname, item))
             self.tree_list.SetPyData(item, mn)
             self.tree_list.SetItemText(item, modname, 0)
             #try:
@@ -238,7 +251,8 @@ class ModuleSelectionDialog(wx.Dialog):
         #self.tree_list.GetMainWindow().Bind(wx.EVT_LEFT_UP, self.OnSelect)
         self.tree_list.Bind(wx.EVT_TREE_SEL_CHANGED, self.OnSelect)
 
-        hsizer.Add(self.tree_list, 1, wx.EXPAND|wx.ALL, 2)
+        vsizer2.Add(self.tree_list, 1, wx.EXPAND | wx.ALL, 2)
+        hsizer.Add(vsizer2, 1, wx.EXPAND|wx.ALL, 2)
 
         self.stModuleHelp = wx.html.HtmlWindow(self.pan, -1, size=(400, -1))#wx.StaticText(self, -1, '', size=(400, -1))
         hsizer.Add(self.stModuleHelp, 0, wx.EXPAND|wx.ALL, 5)
@@ -296,6 +310,19 @@ class ModuleSelectionDialog(wx.Dialog):
 
     def GetSelectedModule(self):
         return self.tree_list.GetPyData(self.tree_list.GetSelection())
+    
+    def OnSearchChange(self, evt):
+        filter = self.tFilter.GetValue()
+        
+        for k, item in self.rootNodes.items():
+            self.tree_list.HideItem(item)
+        
+        for base, modname, item in self.items:
+            show = (filter.upper() in modname.upper())
+            self.tree_list.HideItem(item, not show)
+            
+            if show:
+                self.tree_list.HideItem(self.rootNodes[base], False)
 
 
 class RecipeView(wx.Panel):

--- a/PYME/recipes/recipeGui.py
+++ b/PYME/recipes/recipeGui.py
@@ -526,7 +526,13 @@ class RecipeView(wx.Panel):
         self.update_recipe_text()
         
     def OnApplyText(self, event):
-        self.recipes.UpdateRecipeText(self.tRecipeText.GetValue())
+        from PYME.ui import progress
+        with progress.ComputationInProgress(self, 'Updating recipe'):
+            #wrap in computationInProgress so that we get an error
+            try:
+                self.recipes.UpdateRecipeText(self.tRecipeText.GetValue())
+            except:
+                self.tRecipeText.SetBackgroundColour()
         
     def OnNewRecipe(self, event):
         if wx.MessageBox("Clear recipe?", "Confirm", wx.YES_NO | wx.CANCEL, self) == wx.YES:

--- a/PYME/recipes/traits.py
+++ b/PYME/recipes/traits.py
@@ -21,20 +21,23 @@ class Input(CStr):
     
     def validate(self, object, name, value):
         value = CStr.validate(self, object, name, value)
-        
-        # make sure we're not assigning to an output of this module
-        mod_outputs = getattr(object, 'outputs', [])
-        if value in mod_outputs:
-            # trying to assign input to output
-            raise TraitError('Assigning "%s" to input "%s" would result in a circular reference (value is in module outputs).' % (value, name))
+
+        if getattr(object, '_initial_set', True):
+            # defer validation when performed in constructor to avoid detection of spurious circular references with default values (see issue #695)
             
-        # make sure we are not assigning to any downstream outputs
-        recipe = getattr(object, '_parent', None)
-        if recipe is not None:
-            if value in recipe.downstream_outputs(list(object.outputs)):
+            # make sure we're not assigning to an output of this module
+            mod_outputs = getattr(object, 'outputs', [])
+            if value in mod_outputs:
                 # trying to assign input to output
-                raise TraitError('Assigning "%s" to input "%s" would result in a circular reference (value is in downstream outputs).' % (value, name))
-            
+                raise TraitError('Assigning "%s" to input "%s" would result in a circular reference (value is in module outputs).' % (value, name))
+                
+            # make sure we are not assigning to any downstream outputs
+            recipe = getattr(object, '_parent', None)
+            if recipe is not None:
+                if value in recipe.downstream_outputs(list(object.outputs)):
+                    # trying to assign input to output
+                    raise TraitError('Assigning "%s" to input "%s" would result in a circular reference (value is in downstream outputs).' % (value, name))
+                
         return value
     
         
@@ -45,22 +48,25 @@ class Output(CStr):
     def validate(self, object, name, value):
         value = CStr.validate(self, object, name, value)
         
-        # make sure we're not assigning to an input of this module
-        mod_inputs = getattr(object, 'inputs', [])
-        if value in mod_inputs:
-            # trying to assign input to output
-            raise TraitError(
-                'Assigning "%s" to output "%s" would result in a circular reference (value is in module inputs).' % (value, name))
-            
+        if getattr(object, '_initial_set', True):
+            # defer validation when performed in constructor to avoid detection of spurious circular references with default values (see issue #695)
         
-        # make sure we are not assigning to any downstream outputs
-        recipe = getattr(object, '_parent', None)
-        if recipe is not None:
-            if value in recipe.upstream_inputs(list(object.inputs)):
+            # make sure we're not assigning to an input of this module
+            mod_inputs = getattr(object, 'inputs', [])
+            if value in mod_inputs:
                 # trying to assign input to output
                 raise TraitError(
-                    'Assigning "%s" to output "%s" would result in a circular reference (value is in upstream inputs).' % (
-                    value, name))
+                    'Assigning "%s" to output "%s" would result in a circular reference (value is in module inputs).' % (value, name))
+                
+            
+            # make sure we are not assigning to any downstream outputs
+            recipe = getattr(object, '_parent', None)
+            if recipe is not None:
+                if value in recipe.upstream_inputs(list(object.inputs)):
+                    # trying to assign input to output
+                    raise TraitError(
+                        'Assigning "%s" to output "%s" would result in a circular reference (value is in upstream inputs).' % (
+                        value, name))
                 
         
         return value

--- a/PYME/recipes/traits.py
+++ b/PYME/recipes/traits.py
@@ -22,7 +22,7 @@ class Input(CStr):
     def validate(self, object, name, value):
         value = CStr.validate(self, object, name, value)
 
-        if getattr(object, '_initial_set', True):
+        if getattr(object, '_initial_set', False):
             # defer validation when performed in constructor to avoid detection of spurious circular references with default values (see issue #695)
             
             # make sure we're not assigning to an output of this module
@@ -48,7 +48,7 @@ class Output(CStr):
     def validate(self, object, name, value):
         value = CStr.validate(self, object, name, value)
         
-        if getattr(object, '_initial_set', True):
+        if getattr(object, '_initial_set', False):
             # defer validation when performed in constructor to avoid detection of spurious circular references with default values (see issue #695)
         
             # make sure we're not assigning to an input of this module


### PR DESCRIPTION
Addresses issue #695.

**Is this a bugfix or an enhancement?**

Both - also includes UI controls to filter module list as finding a specific module is painful on wx4