### PR TITLE
don't display glcanvas for 3D images.

### DIFF
--- a/PYME/DSView/modules/visgui.py
+++ b/PYME/DSView/modules/visgui.py
@@ -137,7 +137,9 @@ def Plug(dsviewer):
         dsviewer.civp.ivps = dsviewer.ivps
         dsviewer.AddPage(page=dsviewer.civp, select=False, caption='Composite')
 
-    dsviewer._gl_im = GLImageView(dsviewer, image=dsviewer.image, glCanvas=dsviewer.glCanvas, display_opts=dsviewer.do)
-    dsviewer.AddPage(page=dsviewer._gl_im, select=True, caption='GLComp')
+    if dsviewer.image.data.shape[2] == 1:
+        # gl canvas doesn't currently work for 3D images, crashes on linux
+        dsviewer._gl_im = GLImageView(dsviewer, image=dsviewer.image, glCanvas=dsviewer.glCanvas, display_opts=dsviewer.do)
+        dsviewer.AddPage(page=dsviewer._gl_im, select=True, caption='GLComp')
     
 


### PR DESCRIPTION
Addresses issue #851.

should prevent glCanvas 3D issues on linux, at least until we fix it properly.
