### PR TITLE
finalise before onSpoolStop signal send

### DIFF
--- a/PYME/Acquire/Spooler.py
+++ b/PYME/Acquire/Spooler.py
@@ -171,10 +171,9 @@ class Spooler:
         self.spoolOn = False
         if not self.guiUpdateCallback is None:
             self.guiUpdateCallback()
-            
-        self.onSpoolStop.send(self)
         
-        self.finalise() #TODO - should this be before we send the onStopSpool signal?
+        self.finalise()
+        self.onSpoolStop.send(self)
         self.spool_complete = True
         
     def finalise(self):


### PR DESCRIPTION
Addresses issue TODO, #898, kinda related to #850 and #857
we either need to 1) swap finalise and onSpoolStop signal, b) add another signal to say when we're really really done and can e.g. hook recipe pushing, or c) rules would handle for themselves in the pushing whether they're ready to start or waiting on a file to arrive.

c is ideal, but for recipes its a bit harder than for localization where we've already got it. I'm suggesting we do option a) now and c) when we can

**Is this a bugfix or an enhancement?**
robustness improvement
**Proposed changes:**
- swap finalise and onSpoolStop send






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
