### PR TITLE
allow stack settings to be per-series

### DIFF
--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -414,7 +414,8 @@ class SpoolController(object):
         if stack:
             protocol = protocol_z
             protocol.dwellTime = z_dwell
-            #print(protocol)
+            stack_settings = stack if hasattr(stack, 'keys') else None
+            protocol.set_stack_positions(stack_settings)
         else:
             protocol = protocol
 

--- a/PYME/Acquire/protocol.py
+++ b/PYME/Acquire/protocol.py
@@ -195,10 +195,11 @@ class ZStackTaskListProtocol(TaskListProtocol):
     
     def set_stack_positions(self, stack_mdh=None):
         stack_mdh = dict() if stack_mdh is None else stack_mdh
-        step_size = stack_mdh.get('StackSettings.StepSize', scope.stackSettings.GetStepSize())
-        self.zPoss = np.arange(stack_mdh.get('StackSettings.StartPos', scope.stackSettings.GetStartPos()),
-                               stack_mdh.get('StackSettings.EndPos', scope.stackSettings.GetEndPos()) + .95 * step_size,
-                               step_size * scope.stackSettings.GetDirection())
+        start = stack_mdh.get('StackSettings.StartPos', scope.stackSettings.GetStartPos())
+        stop = stack_mdh.get('StackSettings.EndPos', scope.stackSettings.GetEndPos())
+        direction = 1 if stop > start else -1
+        step = direction * stack_mdh.get('StackSettings.StepSize', scope.stackSettings.GetStepSize())
+        self.zPoss = np.arange(start, stop + .95 * step, step)
 
         if self.slice_order != 'saw':
             if self.slice_order == 'random':

--- a/PYME/Acquire/protocol.py
+++ b/PYME/Acquire/protocol.py
@@ -211,7 +211,7 @@ class ZStackTaskListProtocol(TaskListProtocol):
                     # even
                     self.zPoss = np.concatenate([self.zPoss[::2], self.zPoss[-1::-2]])
         
-        self.piezoName = 'Positioning.%s' % stack_mdh.get('StackSettings.ScanPiezo', GetScanChannel())
+        self.piezoName = 'Positioning.%s' % stack_mdh.get('StackSettings.ScanPiezo', scope.stackSettings.GetScanChannel())
 
     def Init(self, spooler):
         self.startPos = scope.state[self.piezoName + '_target'] #FIXME - _target positions shouldn't be part of scope state


### PR DESCRIPTION
Addresses issue #osmalarity changes cell height

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- grab stack settings for the protocol fresh each time so we can spec it for a single series without changing the global stacksettings






**Checklist:**

- [x] Tested on sim PYMEAcquire