### PR TITLE
recommend new installs use django 2.0 or 2.1

### DIFF
--- a/PYME/cluster/cluster_of_one.py
+++ b/PYME/cluster/cluster_of_one.py
@@ -60,7 +60,7 @@ class ClusterOfOne(object):
         try:
             import django
         except ImportError:
-            logger.error('django is not installed, to use clusterUI install django (1.11.x, 2.0.x, 2.1.x)')
+            logger.error('django is not installed, to use clusterUI install django (2.0.x, 2.1.x)')
             
         if not self._cluster_ui is None:
             self._kill_procs([self._cluster_ui, ])

--- a/docs/cluster/cluster_install.rst
+++ b/docs/cluster/cluster_install.rst
@@ -134,7 +134,7 @@ just running the extra processes but it could also be a standalone machine.
 
 #. Checkout the PYME source from [github](github.com/python-microscopy/python-microscopy) to get the ``clusterUI`` sources. ``clusterUI`` is a Django web app for browsing the cluster.
 
-#. ``conda install django=1.11``
+#. ``conda install django=2.1``
 
 
 Running the software

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ git+https://github.com/olivierverdier/dispatch.git@master#egg=dispatch; python_v
 # django is used for the full-blown clusterUI (see cluster analysis docs) but is not required for most analysis tasks. Don't install by default as backwards
 # compatibility between django versions is not great and it's hard to keep this tracking the latest security fixes. Installing a (potentially old and insecure)
 # version of django should be a deliberate choice.  
-# django==1.11.29
+# django==2.1
 
 #networkx
 #pywin32 [win]


### PR DESCRIPTION
Addresses issue #803 fixes for sure work on 2.0 and 2.1, and I don't think there's harm in recommending people use what we have tested.

This is a reopening of a closed PR. I don't intend it to be sassy at all @David-Baddeley, and feel free to just close it again, but unless one of us feels like testing 1.11 I think it'd be a bummer for someone to find an issue we missed there