### PR TITLE
(temporarily) increase directory cache time in clusterIO when listSingleDir takes > 1 s

### DIFF
--- a/PYME/IO/clusterIO.py
+++ b/PYME/IO/clusterIO.py
@@ -208,6 +208,7 @@ class _LimitedSizeDict(OrderedDict):
 
 _locateCache = _LimitedSizeDict(size_limit=500)
 _dirCache = _LimitedSizeDict(size_limit=100)
+global DIR_CACHE_TIME 
 DIR_CACHE_TIME = 1
 _fileCache = _LimitedSizeDict(size_limit=100)
 
@@ -228,6 +229,7 @@ def _getSession(url):
 
 
 def _listSingleDir(dirurl, nRetries=1, timeout=10):
+    global DIR_CACHE_TIME
     t = time.time()
 
     try:

--- a/PYME/IO/clusterIO.py
+++ b/PYME/IO/clusterIO.py
@@ -259,6 +259,9 @@ def _listSingleDir(dirurl, nRetries=1, timeout=10):
         
         if dt > 1:
             logger.warning('_listSingleDir(%s) took longer than 1s (%3.2fs)'% (url, dt))
+            DIR_CACHE_TIME = min(DIR_CACHE_TIME + 1, 10)
+        else:
+            DIR_CACHE_TIME = 1
         
         if not r.status_code in [200, 404]: # if a directory is only on one node, we'll get 404s from all of the others. This is expected and not worth logging
             logger.debug('Request for %s failed with error: %d' % (url, r.status_code))


### PR DESCRIPTION
Addresses issue #clusterIO performance.

**Proposed changes:**
things are fine until they get slammed, when things get slammed it takes longer than 1 s to listsingle, and that's when it'd be really nice to ease off a bit. We don't even necessarily take a performance hit if we're backed up on the dataservers since chances are a higher fraction of directories are stagnant/we're done writing to them for the rest of forever, so an older cache should get us far.


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
