### PR TITLE
More dataserver / clusterIO performance tweaks

### DIFF
--- a/PYME/cluster/cluster_of_one.py
+++ b/PYME/cluster/cluster_of_one.py
@@ -39,7 +39,7 @@ class ClusterOfOne(object):
             self._kill_procs([self._data_server,])
             
         logger.info('Launching data server: root=%s' % self._root_dir)
-        self._data_server = subprocess.Popen('"%s" -m PYME.cluster.HTTPDataServer -a local -p 0 -r "%s" --thread-profile' % (sys.executable, self._root_dir), shell=True)
+        self._data_server = subprocess.Popen('"%s" -m PYME.cluster.HTTPDataServer -a local -p 0 -r "%s"' % (sys.executable, self._root_dir), shell=True)
         
     def _launch_rule_server(self):
         if not self._rule_server is None:

--- a/PYME/cluster/cluster_of_one.py
+++ b/PYME/cluster/cluster_of_one.py
@@ -39,7 +39,7 @@ class ClusterOfOne(object):
             self._kill_procs([self._data_server,])
             
         logger.info('Launching data server: root=%s' % self._root_dir)
-        self._data_server = subprocess.Popen('"%s" -m PYME.cluster.HTTPDataServer -a local -p 0 -r "%s"' % (sys.executable, self._root_dir), shell=True)
+        self._data_server = subprocess.Popen('"%s" -m PYME.cluster.HTTPDataServer -a local -p 0 -r "%s" --thread-profile' % (sys.executable, self._root_dir), shell=True)
         
     def _launch_rule_server(self):
         if not self._rule_server is None:


### PR DESCRIPTION
- use expired directory cache entries is it's unlikely we'd get fresh ones in a reasonable time
- tweaks to `PZFDataSource` to make it behave better for fully spooled series.