### PR TITLE
htsms focus lock/offset piezo fixes

### DIFF
--- a/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
+++ b/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
@@ -99,8 +99,8 @@ class OffsetPiezo(PiezoBase):
     def LogShifts(self, dx, dy, dz, active=True):
         import wx
         #eventLog.logEvent('ShiftMeasure', '%3.4f, %3.4f, %3.4f' % (dx, dy, dz))
-        wx.CallAfter(eventLog.logEvent, 'ShiftMeasure', '%3.4f, %3.4f, %3.4f' % (float(dx), float(dy), float(dz)))
-        wx.CallAfter(eventLog.logEvent, 'PiezoOffset', '%3.4f, %d' % (self.GetOffset(), int(active)))
+        wx.CallAfter(eventLog.logEvent, 'ShiftMeasure', '%3.4f, %3.4f, %3.4f' % (float(dx), float(dy), float(dz)), time.time())
+        wx.CallAfter(eventLog.logEvent, 'PiezoOffset', '%3.4f, %d' % (self.GetOffset(), int(active)), time.time())
 
     @webframework.register_endpoint('/OnTarget', output_is_json=False)
     def OnTarget(self):
@@ -109,7 +109,7 @@ class OffsetPiezo(PiezoBase):
     @webframework.register_endpoint('/LogFocusCorrection', output_is_json=False)
     def LogFocusCorrection(self, offset):
         import wx
-        wx.CallAfter(eventLog.logEvent, 'PiezoOffsetUpdate', '%3.4f' % float(offset))
+        wx.CallAfter(eventLog.logEvent, 'PiezoOffsetUpdate', '%3.4f' % float(offset), time.time())
     
     @webframework.register_endpoint('/GetMaxOffset', output_is_json=False)
     def GetMaxOffset(self):
@@ -174,6 +174,7 @@ class OffsetPiezoClient(PiezoBase):
         return bool(res.json())
 
     def LogFocusCorrection(self, offset):
+        logger.warning('timestamp will be off, log focus corrections directly in the server process')
         self._session.get(self.urlbase + '/LogFocusCorrection?offset=%3.3f' % (offset,))
     
     def GetMaxOffset(self):
@@ -281,9 +282,31 @@ class TargetOwningOffsetPiezo(OffsetPiezo):
     def GetTargetPos(self, iChannel=0):
         return self._target_position
 
-                
-    
-    
+
+class FocusLockingOffsetPiezo(TargetOwningOffsetPiezo):
+    def __init__(self, base_piezo, focus_lock):
+        TargetOwningOffsetPiezo.__init__(self, base_piezo)
+        self.focus_lock = focus_lock
+        
+    @webframework.register_endpoint('/CorrectOffset', output_is_json=False)
+    def CorrectOffset(self, correction):
+        if not self.focus_lock.lock_enabled:
+            logger.warning('focus lock is disabled, offset correction ignored')
+            return
+
+        # both gettarget and moveto account for offset, so make sure we only apply the change once
+        correction = float(correction)
+        with self._move_lock:
+            target = self.GetTargetPos(0)
+            # correct the offset; positive means push base pos higher than offsetpiezo pos
+            correction = max(min(self.basePiezo.max_travel - (target + self.offset), 
+                                 correction), -(target + self.offset))
+            self.offset += correction
+            # self.MoveTo(0, target)  # move the base piezo to correct position
+            self.basePiezo.MoveTo(0, target + self.offset, True)
+            self.LogFocusCorrection(self.offset)
+
+
 def main():
     """For testing only"""
     from PYME.Acquire.Hardware.Simulator import fakePiezo

--- a/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
+++ b/PYME/Acquire/Hardware/Piezos/offsetPiezoREST.py
@@ -294,17 +294,7 @@ class FocusLockingOffsetPiezo(TargetOwningOffsetPiezo):
             logger.warning('focus lock is disabled, offset correction ignored')
             return
 
-        # both gettarget and moveto account for offset, so make sure we only apply the change once
-        correction = float(correction)
-        with self._move_lock:
-            target = self.GetTargetPos(0)
-            # correct the offset; positive means push base pos higher than offsetpiezo pos
-            correction = max(min(self.basePiezo.max_travel - (target + self.offset), 
-                                 correction), -(target + self.offset))
-            self.offset += correction
-            # self.MoveTo(0, target)  # move the base piezo to correct position
-            self.basePiezo.MoveTo(0, target + self.offset, True)
-            self.LogFocusCorrection(self.offset)
+        OffsetPiezo.CorrectOffset(self, correction)
 
 
 def main():

--- a/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
+++ b/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
@@ -390,7 +390,7 @@ class ReflectedLinePIDFocusLock(PID):
                                     output_is_json=False)
     def DisableLockAfterAcquiring(self, target_tolerance=1):
         self.EnableLock()  # make sure we have the lock on
-        if not self.on_target(target_tolerance):
+        if not self.on_target(float(target_tolerance)):
             logger.info('not locked to target tolerance, waiting 0.5 s')
             time.sleep(0.5)
         if not self.LockOK():
@@ -421,7 +421,7 @@ class ReflectedLinePIDFocusLock(PID):
         use for manual imaging without the focus lock on/set up
         """
         if self.LockEnabled():
-            self.DisableLockAfterAcquiring(target_tolerance)
+            self.DisableLockAfterAcquiring(float(target_tolerance))
     
     @property
     def _failsafe_threshold(self):

--- a/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
+++ b/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
@@ -230,7 +230,6 @@ class ReflectedLinePIDFocusLock(PID):
             self.piezo.LogFocusCorrection(self.piezo.GetOffset())
             self.set_auto_mode(False)
             logger.debug('Disabling focus lock')
-            time.sleep(0.01)
 
     def register(self):
         if self.mode == 'time':

--- a/PYME/Acquire/protocol.py
+++ b/PYME/Acquire/protocol.py
@@ -204,7 +204,7 @@ class ZStackTaskListProtocol(TaskListProtocol):
             elif self.slice_order == 'triangle':
                 if len(self.zPoss) % 2:
                     # odd
-                    self.zPoss = np.concatenate([self.zPoss[1::2], self.zPoss[::-2]])
+                    self.zPoss = np.concatenate([self.zPoss[::2], self.zPoss[-2::-2]])
                 else:
                     # even
                     self.zPoss = np.concatenate([self.zPoss[::2], self.zPoss[-1::-2]])


### PR DESCRIPTION
Addresses issue # .

**Is this a bugfix or an enhancement?**
bugfix! finally drop corrections starting as soon as we send the disablelock command from main htsms scope
![image](https://user-images.githubusercontent.com/31105780/110065827-12b18400-7d3e-11eb-892f-7e89c9489937.png)

**Proposed changes:**


- make a focus-lock-aware offset piezo, which caches focus lock state with an attribute so if the main microscope (focus lock client, offset piezo server) tells the focus lock to disable we an immediately start ignoring offset corrections
- get the odd len triangle wave z starting on z[0] instead of z[1]
- log focus corrections with a timestamp of when they're made, not when wx logs them(note that this might want to be done in other offset piezos too)

```
In [26]: z = np.arange(0, 10.5, 0.5)

In [27]: len(z) % 2
Out[27]: 1

In [28]: np.concatenate([z[::2], z[-2::-2]])
Out[28]: 
array([ 0. ,  1. ,  2. ,  3. ,  4. ,  5. ,  6. ,  7. ,  8. ,  9. , 10. ,
        9.5,  8.5,  7.5,  6.5,  5.5,  4.5,  3.5,  2.5,  1.5,  0.5])

In [29]: len(np.concatenate([z[::2], z[-2::-2]]))
Out[29]: 21
```



**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
