### PR TITLE
fix chart colouring on py3 by forcing key to bytes.

### DIFF
--- a/PYME/DSView/eventLogViewer.py
+++ b/PYME/DSView/eventLogViewer.py
@@ -226,6 +226,9 @@ class eventLogPanel(wx.Panel):
             cname = c[0]
             cmapping = c[1]
             sourceEv = c[2]
+            
+            if not isinstance(sourceEv, bytes):
+                sourceEv = sourceEv.encode()
 
             dc.SetTextForeground(self.lineColours[sourceEv])
 


### PR DESCRIPTION
Addresses issue #944.

