### PR TITLE
check for subdirectories instead of detection h5s in requeue_missed

### DIFF
--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -388,7 +388,7 @@ class MultiwellProtocolQueuePanel(wx.Panel):
         imaged_wells = [im.split('/')[-1].split('_detections.h5')[0] for im in imaged]
         detected = set([fn.split('_')[0] for fn in imaged_wells])
         logger.debug('detection h5 present for an additional %d wells' % (len(detected) - len(to_pop.intersection(detected))))
-        to_pop.union_update(detected)
+        to_pop = to_pop.union(detected)
         x_wells, y_wells, names = self._pop_wells(x_wells, y_wells, names, list(to_pop))
 
         if len(names) < 1:

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -355,7 +355,7 @@ class MultiwellProtocolQueuePanel(wx.Panel):
         cb = event.GetEventObject()
         self.fast_axis = cb.GetValue()
     
-    def requeue_missed(self, n_x, n_y, x_spacing, y_spacing, start_pos, protocol_name, nice=20, sleep=5):
+    def requeue_missed(self, n_x, n_y, x_spacing, y_spacing, start_pos, protocol_name, nice=20, sleep=600):
         from PYME.Acquire.actions import FunctionAction
         from PYME.IO import clusterIO
         import posixpath

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -375,6 +375,18 @@ class MultiwellProtocolQueuePanel(wx.Panel):
         to_pop = [fn.split('_')[0] for fn in imaged_wells]
         x_wells, y_wells, names = self._pop_wells(x_wells, y_wells, names, to_pop)
 
+        # if a node dies we might lose the detections file, but likely won't
+        # lose the entire subdirectory
+        to_pop = set()
+        for name in names:
+            if clusterIO.isdir(posixpath.join(spooldir, name)):
+                to_pop.add(name)
+            else:
+                for shame in range(1, self._shame_index):
+                    if clusterIO.isdir(posixpath.join(spooldir, name + '_%d' % shame)):
+                        to_pop.add(name)
+        x_wells, y_wells, names = self._pop_wells(x_wells, y_wells, names, set(to_pop))
+
         if len(names) < 1:
             return
         

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -355,7 +355,7 @@ class MultiwellProtocolQueuePanel(wx.Panel):
         cb = event.GetEventObject()
         self.fast_axis = cb.GetValue()
     
-    def requeue_missed(self, n_x, n_y, x_spacing, y_spacing, start_pos, protocol_name, nice=20, sleep=600):
+    def requeue_missed(self, n_x, n_y, x_spacing, y_spacing, start_pos, protocol_name, nice=20, sleep=1000):
         from PYME.Acquire.actions import FunctionAction
         from PYME.IO import clusterIO
         import posixpath

--- a/PYME/cluster/PYMERuleNodeServer.py
+++ b/PYME/cluster/PYMERuleNodeServer.py
@@ -111,13 +111,24 @@ def main():
     nodeserverLog.debug('Launching worker processors')
     numWorkers = conf.get('nodeserver-num_workers', cpu_count())
 
-    workerProcs = [subprocess.Popen('"%s" -m PYME.cluster.taskWorkerHTTP -s %d' % (sys.executable, serverPort), shell=True, stdin=subprocess.PIPE)
-                   for i in range(numWorkers -1)]
+    profiledir = os.path.join(nodeserver_log_dir, 'mProf')
 
-    #last worker has profiling enabled
-    profiledir = os.path.join(nodeserver_log_dir, 'mProf')      
-    workerProcs.append(subprocess.Popen('"%s" -m PYME.cluster.taskWorkerHTTP -s % d -p --profile-dir="%s"' % (sys.executable, serverPort, profiledir), shell=True,
-                                        stdin=subprocess.PIPE))
+    if 'win' in sys.platform:
+        workerProcs = [subprocess.Popen('"%s" -m PYME.cluster.taskWorkerHTTP -s %d' % (sys.executable, serverPort), shell=True, stdin=subprocess.PIPE)
+                    for i in range(numWorkers -1)]
+
+        #last worker has profiling enabled
+        workerProcs.append(subprocess.Popen('"%s" -m PYME.cluster.taskWorkerHTTP -s % d -p --profile-dir="%s"' % (sys.executable, serverPort, profiledir), shell=True,
+                                            stdin=subprocess.PIPE))
+    else: # ulimit at 90% of system RAM so we fail tasks instead of crashing computers
+        import psutil
+        ram_limit = int(0.9 * psutil.virtual_memory()[0])
+        workerProcs = [subprocess.Popen('ulimit -v %d; "%s" -m PYME.cluster.taskWorkerHTTP -s %d' % (ram_limit, sys.executable, serverPort), shell=True, stdin=subprocess.PIPE)
+                    for i in range(numWorkers -1)]
+
+        #last worker has profiling enabled
+        workerProcs.append(subprocess.Popen('ulimit -v %d; "%s" -m PYME.cluster.taskWorkerHTTP -s % d -p --profile-dir="%s"' % (ram_limit, sys.executable, serverPort, profiledir), shell=True,
+                                            stdin=subprocess.PIPE))
 
     try:
         while proc.is_alive():


### PR DESCRIPTION
Addresses issue if a node is MIA the spooled subdirectories are better to look for than the h5's. Maybe runaway memory concerns
**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- look for spooled subdirectories for wells rather than _detections.h5 since the subdirectories get spread across all nodes while the h5's disappear if a node goes missing
- ulimit workers to 90% of ram. I wrote/tested this briefly in a notebook, committed it, then forgot it was there. I'll include it for discussion, but I don't think it actually addresses the problem I encounter where two detection tasks getting assigned to the same node seems to knock it over. a better approach seems to me to be for RAM-heavy recipe module to check whether they can execute. Something like 
```
class MemoryAwareMRCNNDetect(MRCNNDetect):
    n_retries = Int(1)
    fractional_memory_needed = Float(0.5)
    sleep_time = Float(60)

    def execute(self, namespace):
        import psutil
        n_tries = 0
        while n_tries < n_tries:
            if (1 - psutil.virtual_memory().percent) > self.fractional_memory_needed:
                MRCNNDetect.execute(self, namespace)
                return
            else:
                time.sleep(self.sleep_time)

        raise MemoryError('We do not have adequate memory to execute')
```
except it'd be nice if the module calculated for itself how much it'll likely draw





**Checklist:**

- [ ] Tested 