### PR TITLE
Add Help>Documentation to PYMEVis

### DIFF
--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -276,6 +276,11 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
 
         wx.adv.AboutBox(dlg)
 
+    def OnDocumentation(self, event):
+        import webbrowser
+        webbrowser.open('https://python-microscopy.org/doc/')
+        event.Skip()
+
 #    def OnToggleWindow(self, event):
 #        self._mgr.ShowPane(self._leftWindow1,not self._leftWindow1.IsShown())
 #        self.glCanvas.Refresh()  

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -313,6 +313,7 @@ class VisGUICore(object):
             pass
 
         if not subMenu:
+            self.AddMenuItem('Help', "&Documentation", self.OnDocumentation)
             self.AddMenuItem('Help', "&About", self.OnAbout)
             
     def create_tool_bar(self, parent):


### PR DESCRIPTION
Addresses issue #915.

**Is this a bugfix or an enhancement?**
Enhancement

**Proposed changes:**
- Add link to online documentation to PYMEVis `Help` menu

There's no help menu in the other programs at the moment. Ideally we'd create a default help menu that was in all of our programs and included `Documentation` and `About`. Can I add this change to this PR, @David-Baddeley? Or would you prefer to leave help menus out of `PYMEImage` and `PYMEAcquire`?