### PR TITLE
biplaneEst: fix to integer arithmetic; biplane FF: metadata access fix

### DIFF
--- a/PYME/localization/FitFactories/SplitterFitInterpBNR.py
+++ b/PYME/localization/FitFactories/SplitterFitInterpBNR.py
@@ -206,11 +206,8 @@ class InterpFitFactory(InterpFitR.PSFFitFactory):
         #generate grid to evaluate function on
         #setModel(md.PSFFile, md)
         interpolator = __import__('PYME.localization.FitFactories.Interpolators.' + md.getOrDefault('Analysis.InterpModule', 'CSInterpolator') , fromlist=['PYME', 'localization', 'FitFactories', 'Interpolators']).interpolator
-        
-        if 'Analysis.EstimatorModule' in md.getEntryNames():
-            estimatorModule = md['Analysis.EstimatorModule']
-        else:
-            estimatorModule = 'astigEstimator'
+                    
+        estimatorModule = md.getOrDefault('Analysis.EstimatorModule', 'astigEstimator')
 
         #this is just here to make sure we clear our calibration when we change models        
         startPosEstimator = __import__('PYME.localization.FitFactories.zEstimators.' + estimatorModule , fromlist=['PYME', 'localization', 'FitFactories', 'zEstimators'])        

--- a/PYME/localization/FitFactories/SplitterFitInterpBNR.py
+++ b/PYME/localization/FitFactories/SplitterFitInterpBNR.py
@@ -208,33 +208,33 @@ class InterpFitFactory(InterpFitR.PSFFitFactory):
         interpolator = __import__('PYME.localization.FitFactories.Interpolators.' + md.getOrDefault('Analysis.InterpModule', 'CSInterpolator') , fromlist=['PYME', 'localization', 'FitFactories', 'Interpolators']).interpolator
         
         if 'Analysis.EstimatorModule' in md.getEntryNames():
-            estimatorModule = md.Analysis.EstimatorModule
+            estimatorModule = md['Analysis.EstimatorModule']
         else:
             estimatorModule = 'astigEstimator'
 
         #this is just here to make sure we clear our calibration when we change models        
         startPosEstimator = __import__('PYME.localization.FitFactories.zEstimators.' + estimatorModule , fromlist=['PYME', 'localization', 'FitFactories', 'zEstimators'])        
         
-        if interpolator.setModelFromFile(md.PSFFile, md):
+        if interpolator.setModelFromFile(md['PSFFile'], md):
             print('model changed')
             startPosEstimator.splines.clear()
 
         Xg, Yg, Zg, safeRegion = interpolator.getCoords(md, xs, ys, slice(0,1))
         
-        DeltaX = md.chroma.dx.ev(x, y)
-        DeltaY = md.chroma.dy.ev(x, y)
+        DeltaX = md['chroma.dx'].ev(x, y)
+        DeltaY = md['chroma.dy'].ev(x, y)
         
-        vx, vy, _ = md.voxelsize_nm
+        vx, vy, _ = md['voxelsize_nm']
         
         dxp = int(DeltaX/vx)
         dyp = int(DeltaY/vy)
 
         Xr = Xg + DeltaX - vx*dxp
         Yr = Yg + DeltaY - vx*dyp
-        Zr = Zg + md.Analysis.AxialShift
+        Zr = Zg + md['Analysis.AxialShift']
         #print ratio
 
-        return f_Interp3d2cr(params, interpolator, Xg, Yg, Zg, Xr, Yr, Zr, safeRegion, md.Analysis.AxialShift, ratio), Xg.ravel()[0], Yg.ravel()[0], Zg.ravel()[0]
+        return f_Interp3d2cr(params, interpolator, Xg, Yg, Zg, Xr, Yr, Zr, safeRegion, md['Analysis.AxialShift'], ratio), Xg.ravel()[0], Yg.ravel()[0], Zg.ravel()[0]
 
         
     def FromPoint(self, x, y, z=None, roiHalfSize=5, axialHalfSize=15):

--- a/PYME/localization/FitFactories/zEstimators/biplaneEstimator.py
+++ b/PYME/localization/FitFactories/zEstimators/biplaneEstimator.py
@@ -131,7 +131,8 @@ def calibrate(interpolator, md, roiSize=5):
 
     #take central bit having, the same gradient sign
 
-    imn = len(sgn)/2
+    # must be integer division!
+    imn = len(sgn) // 2
     imx  =  imn
     
     sg =  sgn[imn]


### PR DESCRIPTION
Partially addresses issue #976. Rather than addressing MetaData handlers fix at the source to dict like access. Will raise depracation MD handler fix seperately (if I get round to it).

**Is this a bugfix or an enhancement?**
Bugfix.

**Proposed changes:**
- in `SplitterFitInterpBNR `change to  dictionary like access
- fix an index arithmetic issue in `biplaneEstimator`

**Checklist:**

Tested with

- python-microscopy=21.03.10
- python=3.7.6, platform=darwin
- numpy=1.19.2, wx=4.0.4 osx-cocoa (phoenix) wxWidgets 3.0.5
