### PR TITLE
remFitBuf / buffers maitenance/fixes

### DIFF
--- a/PYME/IO/buffers.py
+++ b/PYME/IO/buffers.py
@@ -63,7 +63,7 @@ class SliceBuffer(object): #buffer our io to avoid decompressing multiple times
     
     def getSlice(self, ind):
         try:
-            sl = self.buffer[ind]
+            sl = self._buffer[ind]
             return sl
         except KeyError:
             #get from our data source and store in buffer
@@ -72,7 +72,7 @@ class SliceBuffer(object): #buffer our io to avoid decompressing multiple times
             self._bufferedSlices.append(ind)
             
             # if our buffer is now full, drop the oldest entry
-            if len(self._bufferedSlices > self._bLen):
+            if len(self._bufferedSlices) > self._bLen:
                 ind_to_remove = self._bufferedSlices.pop(0)
                 self._buffer.pop(ind_to_remove)
             

--- a/PYME/IO/buffers.py
+++ b/PYME/IO/buffers.py
@@ -23,7 +23,12 @@ class dataBuffer: #buffer our io to avoid decompressing multiple times
         #return self.dataSource.getSlice(ind)
         if ind in self.bufferedSlices: #return from buffer
             #print int(np.where(self.bufferedSlices == ind)[0])
-            return np.copy(self.buffer[int(np.where(self.bufferedSlices == ind)[0]),:,:])
+            sl = self.buffer[int(np.where(self.bufferedSlices == ind)[0]),:,:]
+            
+            # FIXME - because sl is a view into the the underlying buffer it is possible for it to get
+            # over-written before it is used, hence the copy. This copy is, however, not great for either performance
+            # or memory usage, and it would be good to avoid if at all possible.
+            return np.copy(sl)
         else: #get from our data source and store in buffer
             sl = self.dataSource.getSlice(ind)
             self.bufferedSlices[self.insertAt] = ind
@@ -40,7 +45,38 @@ class dataBuffer: #buffer our io to avoid decompressing multiple times
             #if bufferMisses % 10 == 0:
             #    print nTasksProcessed, bufferMisses
 
+            # FIXME - because sl is a view into the the underlying buffer it is possible for it to get
+            # over-written before it is used, hence the copy. This copy is, however, not great for either performance
+            # or memory usage, and it would be good to avoid if at all possible.
             return np.copy(sl)
+
+
+class SliceBuffer(object): #buffer our io to avoid decompressing multiple times
+    '''
+    Replacement candidate for dataBuffer which avoids memory copying
+    '''
+    def __init__(self, dataSource, bLen=12):
+        self._bLen = bLen
+        self._buffer = {} # type : dict
+        self._bufferedSlices = []
+        self.dataSource = dataSource
+    
+    def getSlice(self, ind):
+        try:
+            sl = self.buffer[ind]
+            return sl
+        except KeyError:
+            #get from our data source and store in buffer
+            sl = self.dataSource.getSlice(ind)
+            self._buffer[ind] = sl
+            self._bufferedSlices.append(ind)
+            
+            # if our buffer is now full, drop the oldest entry
+            if len(self._bufferedSlices > self._bLen):
+                ind_to_remove = self._bufferedSlices.pop(0)
+                self._buffer.pop(ind_to_remove)
+            
+            return sl
         
 class backgroundBuffer:
     def __init__(self, dataBuffer):

--- a/PYME/IO/buffers.py
+++ b/PYME/IO/buffers.py
@@ -23,7 +23,7 @@ class dataBuffer: #buffer our io to avoid decompressing multiple times
         #return self.dataSource.getSlice(ind)
         if ind in self.bufferedSlices: #return from buffer
             #print int(np.where(self.bufferedSlices == ind)[0])
-            return self.buffer[int(np.where(self.bufferedSlices == ind)[0]),:,:]
+            return np.copy(self.buffer[int(np.where(self.bufferedSlices == ind)[0]),:,:])
         else: #get from our data source and store in buffer
             sl = self.dataSource.getSlice(ind)
             self.bufferedSlices[self.insertAt] = ind
@@ -40,7 +40,7 @@ class dataBuffer: #buffer our io to avoid decompressing multiple times
             #if bufferMisses % 10 == 0:
             #    print nTasksProcessed, bufferMisses
 
-            return sl
+            return np.copy(sl)
         
 class backgroundBuffer:
     def __init__(self, dataBuffer):

--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -594,7 +594,7 @@ class fitTask(taskDef.Task):
             (per-pixel) variance, readout noise [e-^2]
         """
         var = np.atleast_3d(cameraMaps.getVarianceMap(md)) # this must be float type!! Should we enforce with an 'astype' call?
-        return np.sqrt(var + (float(md.Camera.NoiseFactor)**2)*(float(md.Camera.ElectronsPerCount)*float(md.Camera.TrueEMGain)*np.maximum(data, 1.0) + float(md.Camera.TrueEMGain)*float(md.Camera.TrueEMGain)))/float(md.Camera.ElectronsPerCount)
+        return np.sqrt(var + (float(md['Camera.NoiseFactor'])**2)*(float(md['Camera.ElectronsPerCount'])*float(md['Camera.TrueEMGain'])*np.maximum(data, 1.0) + float(md['Camera.TrueEMGain'])*float(md['Camera.TrueEMGain'])))/float(md['Camera.ElectronsPerCount'])
     
     def calcThreshold(self):
         #from scipy import ndimage

--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -91,7 +91,7 @@ class BufferManager(object):
 
         #read the data
         if not self.dataSourceID == md.dataSourceID: #avoid unnecessary opening and closing 
-            self.dBuffer = buffers.dataBuffer(DataSource(md.dataSourceID, md.taskQueue), bufferLen)
+            self.dBuffer = buffers.SliceBuffer(DataSource(md.dataSourceID, md.taskQueue), bufferLen)
             self.bBuffer = None
         
         #fix our background buffers
@@ -343,7 +343,7 @@ class fitTask(taskDef.Task):
             drift_ind = [0,0]
         # a fix for Analysis.BGRange[0] == Analysis.BGRange[1], i.e. '0:0' as we tend to do in DNA-PAINT
         # makes bufferLen at least 1
-        self.bufferLen = max(1,max(self.md['Analysis.BGRange'][1], drift_ind[-1]) - min(self.md['Analysis.BGRange'][0], drift_ind[0]))
+        self.bufferLen = max(0, max(self.md['Analysis.BGRange'][1], drift_ind[-1]) - min(self.md['Analysis.BGRange'][0], drift_ind[0])) + 1
         
     @property
     def fitMod(self):


### PR DESCRIPTION
Addresses issue #985 , #984, #selecting GPUPCTBackground=False does not currently work,

**Is this a bugfix or an enhancement?**
bugfixes + enhancement
**Proposed changes:**
- return a copy from buffers.dataBuffer rather than a view
- use __getitem___ metadata access instead of __getattr__ in calcSigma
- allow gpu/cpu background to be toggled






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
