### PR TITLE
fix all places where StartSpooling still occurrs

### DIFF
--- a/PYME/Acquire/ActionManager.py
+++ b/PYME/Acquire/ActionManager.py
@@ -81,12 +81,12 @@ class ActionManager(object):
         
         functionName : string
             The name of a function relative to the microscope object.
-            e.g. to `call scope.spoolController.StartSpooling()`, you would use
-            a functionName of 'spoolController.StartSpooling'.
+            e.g. to `call scope.spoolController.start_spooling()`, you would use
+            a functionName of 'spoolController.start_spooling'.
             
             The function should either return `None` if the operation has already
             completed, or function which evaluates to True once the operation
-            has completed. See `scope.spoolController.StartSpooling()` for an
+            has completed. See `scope.spoolController.start_spooling()` for an
             example.
             
         args : dict
@@ -286,13 +286,13 @@ class ActionManagerWebWrapper(object):
             json.dumps(dict) with the following keys:
                 function_name : str
                     The name of a function relative to the microscope object.
-                    e.g. to `call scope.spoolController.StartSpooling()`, you 
-                    would use a functionName of 'spoolController.StartSpooling'.
+                    e.g. to `call scope.spoolController.start_spooling()`, you 
+                    would use a functionName of 'spoolController.start_spooling'.
                     
                     The function should either return `None` if the operation 
                     has already completed, or function which evaluates to True 
                     once the operation has completed. See 
-                    `scope.spoolController.StartSpooling()` for an example.
+                    `scope.spoolController.start_spooling()` for an example.
                 args : dict, optional
                     a dictionary of arguments to pass to `function_name`
                 nice : int, optional

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -291,7 +291,7 @@ class SpoolController(object):
         else:
             from PYME.IO.FileUtils.freeSpace import get_free_space
             # avoid dirname property here so we can differ building
-            # 'acquire-spool_subdirectories' to `StartSpooling`
+            # 'acquire-spool_subdirectories' to `start_spooling`
             return get_free_space(self._dirname)/1e9
         
     def _update_series_counter(self):

--- a/PYME/Acquire/actions.py
+++ b/PYME/Acquire/actions.py
@@ -46,7 +46,7 @@ class StateAction(Action):
     ''' Base class for actions which modify scope state, with chaining support
 
     NOTE: we currently do not support chaining off the end of actions (e.g. spooling) which are likely to take some time.
-    This is because functions such as StartSpooling are non-blocking - they return a callback instead.
+    This is because functions such as start_spooling are non-blocking - they return a callback instead.
     '''
     
     def __init__(self, **kwargs):

--- a/PYME/Acquire/tweeter.py
+++ b/PYME/Acquire/tweeter.py
@@ -93,7 +93,7 @@ class LazyScopeTweeter(object):
                     1: trigger when count is above trigger_counts, 0: trigger when count is equal to trigger_counts,
                     -1: trigger when count is below trigger_counts
                 action_filter: str
-                    Type of task to count, e.g. 'spoolController.StartSpooling'. A null string, '', will count all
+                    Type of task to count, e.g. 'spoolController.start_spooling'. A null string, '', will count all
                     tasks.
                 message: str
                     Message to tweet once triggered

--- a/PYME/Acquire/ui/actionUI.py
+++ b/PYME/Acquire/ui/actionUI.py
@@ -45,7 +45,7 @@ class ActionList(wx.ListCtrl):
         self.SetItemCount(len(self._queueItems))
         self.Refresh()
 
-ACTION_DEFAULTS = ['spoolController.StartSpooling',
+ACTION_DEFAULTS = ['spoolController.start_spooling',
                    'state.update',
                    ]
 
@@ -242,7 +242,7 @@ class ActionPanel(wx.Panel):
             args = {'state': {'Positioning.x': positions[ri, 0], 'Positioning.y': positions[ri, 1]}}
             self.actionManager.QueueAction('state.update', args, nice, timeout, 10)
             args = {'maxFrames': n_frames, 'stack': bool(self.rbZStepped.GetValue())}
-            self.actionManager.QueueAction('spoolController.StartSpooling', args, nice, timeout, 2 * time_est)
+            self.actionManager.QueueAction('spoolController.start_spooling', args, nice, timeout, 2 * time_est)
     
     def OnROIsFromFile(self, event):
         import wx

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -28,7 +28,7 @@ class QueueAcquisitions(OutputModule):
     action_server_url : CStr
         URL of the microscope-side action server process.
     spool_settings : DictStrAny
-        settings to be passed to `PYME.Acquire.SpoolController.StartSpooling` as
+        settings to be passed to `PYME.Acquire.SpoolController.start_spooling` as
         key-word arguments. Ones that make sense in the context of this recipe
         module include:
             max_frames : int


### PR DESCRIPTION
Relates to support issue #988. New `start_spooling` syntax seemed to be not fully adopted across modules in the repo.

**Is this a bugfix or an enhancement?**

bugfix

**Proposed changes:**

In recent code, the method `StartSpooling` of `SpoolController` has been replaced by a new function `start_spooling` which has a different syntax; to avoid confusion this PR fixes all remaining occurrences of `StartSpooling`, even if in docstrings etc.

Note that the fixes in `actionUI.py` were required to fix bugs resulting from the old function invocation stll being used. There may be further fixes needed for args handling for `start_spooling` but I am not familiar enough with the intended interface of `actionUI` to be certain.

**Checklist:**

- [x ] Tested with numpy=1.19
- [x ] Tested on python 3.7
- [ x] Tested with wx=4.0.4
- [ x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
