### PR TITLE
add SelectLargestLabel filter module

### DIFF
--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -120,7 +120,11 @@ class SelectLabel(Filter):
 
 @register_module('SelectLargestLabel') 
 class SelectLargestLabel(Filter):
-    """Creates a mask corresponding to all pixels with the largest label"""
+    """Creates a mask corresponding to all pixels with the largest label
+    
+    NOTE: the input image must be a labeled image (e.g. the output of `Processing.Label`) in which contiguous
+    areas have unique integer IDs
+    """
     
     def applyFilter(self, data, chanNum, frNum, im):
         uni, counts = np.unique(data[data > 0], return_counts=True)

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -118,6 +118,19 @@ class SelectLabel(Filter):
     def completeMetadata(self, im):
         im.mdh['Processing.SelectedLabel'] = self.label
 
+@register_module('SelectLargestLabel') 
+class SelectLargestLabel(Filter):
+    """Creates a mask corresponding to all pixels with the largest label"""
+    
+    def applyFilter(self, data, chanNum, frNum, im):
+        uni, counts = np.unique(data[data > 0], return_counts=True)
+        self.label = uni[np.argmax(counts)]
+        mask = (data == self.label)
+        return mask
+
+    def completeMetadata(self, im):
+        im.mdh['Processing.SelectedLabel'] = self.label
+
 @register_module('LocalMaxima')         
 class LocalMaxima(Filter):
     threshold = Float(.3)


### PR DESCRIPTION
Addresses issue #just wanting the largest label if one is trying to e.g. grab a nucleus mask when there's an edge of a neighbor in the field of view.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
add SelectLargestLabel module






**Checklist:**

- [x] Tested 
- [ ] with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
