### PR TITLE
allow spherical harmonic shell tabular to be loaded in recipe, add shell coordinate module

### DIFF
--- a/PYME/Analysis/points/spherical_harmonics.py
+++ b/PYME/Analysis/points/spherical_harmonics.py
@@ -385,7 +385,7 @@ class ScaledShell(object):
         self.x_cs, self.y_cs, self.z_cs, = coordinate_tools.scaled_projection(self.x_c, self.y_c, self.z_c,
                                                                               self.scaling_factors, self.principal_axes)
 
-    def scale_points(self, points):
+    def shell_coordinates(self, points):
         """Scale query points, projecting them onto the basis used in shell-
         fitting. Return in scaled spherical coordinates
 
@@ -551,7 +551,7 @@ class ScaledShell(object):
         
         """
         # project points into scaled-space spherical coordinates
-        azimuth_qs, zenith_qs, r_qs = self.scale_points(points)
+        azimuth_qs, zenith_qs, r_qs = self.shell_coordinates(points)
 
         # get scaled shell radius at those angles
         r_shell = reconstruct_shell(self.modes, self.coefficients, azimuth_qs, zenith_qs)

--- a/PYME/recipes/surface_fitting.py
+++ b/PYME/recipes/surface_fitting.py
@@ -325,8 +325,10 @@ class AddSphericalHarmonicShellMappedCoords(ModuleBase):
 
     def execute(self, namespace):
         from PYME.Analysis.points import spherical_harmonics
+        from PYME.IO import MetaDataHandler
 
-        points = tabular.MappingFilter(namespace[self.input_localizations])
+        inp = namespace[self.input_localizations]
+        points = tabular.MappingFilter(inp)
         shell = namespace[self.input_shell]
         if isinstance(shell, tabular.TabularBase):
             shell = spherical_harmonics.ScaledShell.from_tabular(shell)
@@ -343,7 +345,11 @@ class AddSphericalHarmonicShellMappedCoords(ModuleBase):
         points.addColumn(self.name_scaled_zenith, zenith)
         points.addColumn(self.name_scaled_radius, r)
         points.addColumn(self.name_normalized_radius, r / r_shell)
-
+        
+        try:
+            points.mdh = MetaDataHandler.DictMDHandler(inp.mdh)
+        except AttributeError:
+            pass
         namespace[self.output_mapped] = points
 
 

--- a/PYME/recipes/surface_fitting.py
+++ b/PYME/recipes/surface_fitting.py
@@ -306,6 +306,47 @@ class SphericalHarmonicShell(ModuleBase):
         namespace[self.output_name_mapped] = points
 
 
+@register_module('AddSphericalHarmonicShellMappedCoords')
+class AddSphericalHarmonicShellMappedCoords(ModuleBase):
+    """Add scaled spherical coordinates and harmonic shell radius to an input
+    tabular datasource, returning a copy
+    
+    """
+    input_localizations = Input('input')
+    input_shell = Input('harmonic_shell')
+
+    name_scaled_azimuth = CStr('scaled_azimuth')
+    name_scaled_zenith = CStr('scaled_zenith')
+    name_scaled_radius = CStr('scaled_radius')
+    name_normalized_radius = CStr('normalized_radius')
+
+    output_mapped = Output('harmonic_shell_mapped')
+
+
+    def execute(self, namespace):
+        from PYME.Analysis.points import spherical_harmonics
+
+        points = tabular.MappingFilter(namespace[self.input_localizations])
+        shell = namespace[self.input_shell]
+        if isinstance(shell, tabular.TabularBase):
+            shell = spherical_harmonics.ScaledShell.from_tabular(shell)
+        
+        # map points to scaled spherical coordinates
+        azimuth, zenith, r = shell.scale_points((points['x'], points['y'],
+                                                 points['z']))
+        # lookup shell radius at those angles
+        r_shell = spherical_harmonics.reconstruct_shell(shell.modes,
+                                                        shell.coefficients,
+                                                        azimuth, zenith)
+
+        points.addColumn(self.name_scaled_azimuth, azimuth)
+        points.addColumn(self.name_scaled_zenith, zenith)
+        points.addColumn(self.name_scaled_radius, r)
+        points.addColumn(self.name_normalized_radius, r / r_shell)
+
+        namespace[self.output_mapped] = points
+
+
 @register_module('ImageMaskFromSphericalHarmonicShell')
 class ImageMaskFromSphericalHarmonicShell(ModuleBase):
     """

--- a/PYME/recipes/surface_fitting.py
+++ b/PYME/recipes/surface_fitting.py
@@ -311,6 +311,8 @@ class AddSphericalHarmonicShellMappedCoords(ModuleBase):
     """Add scaled spherical coordinates and harmonic shell radius to an input
     tabular datasource, returning a copy
     
+    TODO: Rename and/or refactor
+    
     """
     input_localizations = Input('input')
     input_shell = Input('harmonic_shell')
@@ -334,8 +336,8 @@ class AddSphericalHarmonicShellMappedCoords(ModuleBase):
             shell = spherical_harmonics.ScaledShell.from_tabular(shell)
         
         # map points to scaled spherical coordinates
-        azimuth, zenith, r = shell.scale_points((points['x'], points['y'],
-                                                 points['z']))
+        azimuth, zenith, r = shell.shell_coordinates((points['x'], points['y'],
+                                                      points['z']))
         # lookup shell radius at those angles
         r_shell = spherical_harmonics.reconstruct_shell(shell.modes,
                                                         shell.coefficients,


### PR DESCRIPTION
Addresses issue #fitting a shell using a shell channel but wanting to know the scaled radial positions of points in another channel.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- fix to valueerror when m is negative, as numpy doesn't like (-1)**anything, only (-1.0)**anything.
- refactor loading slightly so we can make a shell from a tabular type which we e.g. throw into the recipe namespace at least when shell fitting in PYMEVis gui
- module to add scaled spherical coordinates and a normalized radius mappings






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
