### PR TITLE
density estimate for spherical harmonic shell normalized radius

### DIFF
--- a/PYME/Analysis/points/spherical_harmonics.py
+++ b/PYME/Analysis/points/spherical_harmonics.py
@@ -732,6 +732,18 @@ class ScaledShell(object):
             errors[ind] = self._distance_error(query, vector, starting_point)
 
         return guess_distances[np.argmin(np.abs(errors))]
+    
+    def approximate_image_bounds(self, d_zenith=0.1, d_azimuth=0.1):
+        from PYME.IO.image import ImageBounds
+        
+        zenith, azimuth = np.mgrid[0:(np.pi + d_zenith):d_zenith,
+                                   0:(2 * np.pi + d_azimuth):d_azimuth]
+
+        x_shell, y_shell, z_shell = self.get_fitted_shell(azimuth, zenith)
+
+        return ImageBounds(x_shell.min(), y_shell.min(), 
+                           x_shell.max(), y_shell.max(),
+                           z_shell.min(), z_shell.max())
 
 class SHShell(ScaledShell):
     '''

--- a/PYME/recipes/surface_fitting.py
+++ b/PYME/recipes/surface_fitting.py
@@ -364,6 +364,8 @@ class SHShellRadiusDensityEstimate(ModuleBase):
     Also estimates the volume of the shell, the anisotropy of the shell, and
     the standard deviation along its principle axes (if filled with a uniform
     distribution)
+    
+    TODO - rename/refactor. This has too much logic in the recipe module itself, it also feels very special case and the name might make it hard to discover.
     """
     input_shell = Input('harmonic_shell')
 

--- a/PYME/recipes/surface_fitting.py
+++ b/PYME/recipes/surface_fitting.py
@@ -394,9 +394,9 @@ class SHShellRadiusDensityEstimate(ModuleBase):
         
         for _ in range(self.jitter_iterations):
             xr, yr, zr = np.random.rand(len(x), len(y), len(z)), np.random.rand(len(x), len(y), len(z)), np.random.rand(len(x), len(y), len(z))
-            xr = xr * self.sampling_nm[0] + x
-            yr = yr * self.sampling_nm[1] + y
-            zr = zr * self.sampling_nm[2] + z
+            xr = (xr - 0.5) * self.sampling_nm[0] + x
+            yr = (yr - 0.5) * self.sampling_nm[1] + y
+            zr = (zr - 0.5) * self.sampling_nm[2] + z
             azi, zen, r = shell.shell_coordinates((xr, yr, zr))
             r_shell = spherical_harmonics.reconstruct_shell(shell.modes,
                                                             shell.coefficients,

--- a/tests/PYME/Analysis/points/test_spherical_harmonics.py
+++ b/tests/PYME/Analysis/points/test_spherical_harmonics.py
@@ -116,3 +116,13 @@ def test_distance_to_shell_along_vector_from_points():
     dist = FITTER.distance_to_shell_along_vector_from_point(up, query, guess)
     ground_truth = np.sqrt((R_SPHERE ** 2) - ((xq - FITTER.x0) ** 2))
     np.testing.assert_array_almost_equal(ground_truth, dist, decimal=0)
+
+def test_density_estimate():
+    from PYME.recipes.surface_fitting import SHShellRadiusDensityEstimate
+
+    hist_out = SHShellRadiusDensityEstimate(sampling_nm=[1, 1, 1],
+                                            jitter_iterations=10).apply_simple(FITTER)
+    r2norm = hist_out['counts'] / (hist_out['bin_centers']**2)
+    rel = r2norm / r2norm[-1]
+    # drop the lowest bin and check that we're within 5% of the rest
+    assert np.all(np.abs(rel[1:] - 1) < 0.05)


### PR DESCRIPTION
Addresses issue # .

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
estimate the expected distribution of normalized radius for a uniform distribution inside a spherical harmonic shell





**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
