### PR TITLE
fix a bunch of serverfilter typos, include it in recipe file glob

### DIFF
--- a/PYME/cluster/clusterUI/recipes/templates/recipes/extra_inputs.html
+++ b/PYME/cluster/clusterUI/recipes/templates/recipes/extra_inputs.html
@@ -10,7 +10,7 @@
     <div class="form-group">
             <label class="control-label" for="{{ file_input }}">{{ file_input }}</label>
             <div class="input-group">
-                <span class="input-group-addon">pyme-cluster://{{ clusterfilter }}/</span>
+                <span class="input-group-addon">pyme-cluster://{{ serverfilter }}/</span>
                 <input type="text" class="form-control" id="{{ file_input }}" name="{{ file_input }}URL">
                 <span class="input-group-btn">
                     <button class="btn btn-default" type="button" id="select_{{ file_input }}">select</button>

--- a/PYME/cluster/clusterUI/recipes/templates/recipes/form_recipe.html
+++ b/PYME/cluster/clusterUI/recipes/templates/recipes/form_recipe.html
@@ -9,7 +9,7 @@
         <div class="form-group">
             <label class="control-label" for="inputRecipeURL">Recipe</label>
             <div class="input-group">
-                <span class="input-group-addon">pyme-cluster://{{ clusterfilter }}/</span>
+                <span class="input-group-addon">pyme-cluster://{{ serverfilter }}/</span>
                 <input type="text" class="form-control" id="inputRecipeURL" name="recipeURL">
                 <span class="input-group-btn">
                     <button class="btn btn-default" type="button" id="select_recipe">select</button>
@@ -20,7 +20,7 @@
         <div class="form-group">
             <label class="control-label" for="recipeOutputPath">Output path</label>
             <div class="input-group">
-                <span class="input-group-addon">pyme-cluster:///</span>
+                <span class="input-group-addon">pyme-cluster://{{ serverfilter }}/</span>
                 <input type="text" class="form-control" id="recipeOutputPath" name="recipeOutputPath">
                 <!-- <span class="input-group-btn">
                     <button class="btn btn-default" type="button" id="select_output">select</button>

--- a/PYME/cluster/clusterUI/recipes/templates/recipes/input_list.html
+++ b/PYME/cluster/clusterUI/recipes/templates/recipes/input_list.html
@@ -2,6 +2,6 @@
     <p>Found {{ filepaths|length }} files</p>
     <br>
     {% for file in filepaths %}
-        {{ file }}<input name="files" class="cu-hidden-filename" type="hidden" value="pyme-cluster:///{{ file }}">,
+        {{ file }}<input name="files" class="cu-hidden-filename" type="hidden" value="pyme-cluster://{{ serverfilter }}/{{ file }}">,
     {% endfor %}
 </table>

--- a/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_editrun.html
+++ b/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_editrun.html
@@ -24,7 +24,7 @@
         <div class="form-group">
             <label class="control-label" for="inputFileGlob">Input glob</label>
             <div class="input-group">
-                <span class="input-group-addon">pyme-cluster://{{ clusterfilter }}/</span>
+                <span class="input-group-addon">pyme-cluster://{{ serverfilter }}/</span>
                 <input type="text" class="form-control" id="inputFileGlob" name="inputGlob">
                 <span class="input-group-btn">
                     <button class="btn btn-default" type="button" id="inputGlob">find matching files</button>

--- a/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_standalone.html
+++ b/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_standalone.html
@@ -12,7 +12,7 @@
         <div class="form-group">
             <label class="control-label" for="inputRecipeURL">Recipe</label>
             <div class="input-group">
-                <span class="input-group-addon">pyme-cluster://{{ clusterfilter }}/</span>
+                <span class="input-group-addon">pyme-cluster://{{ serverfilter }}/</span>
                 <input type="text" class="form-control" id="inputRecipeURL" name="recipeURL">
                 <span class="input-group-btn">
                     <button class="btn btn-default" type="button" id="select_recipe">select</button>
@@ -25,7 +25,7 @@
         <div class="form-group">
             <label class="control-label" for="inputFileGlob">Input glob</label>
             <div class="input-group">
-                <span class="input-group-addon">pyme-cluster://{{ clusterfilter }}/</span>
+                <span class="input-group-addon">pyme-cluster://{{ serverfilter }}/</span>
                 <input type="text" class="form-control" id="inputFileGlob" name="inputGlob">
                 <span class="input-group-btn">
                     <button class="btn btn-default" type="button" id="inputGlob">find matching files</button>

--- a/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_template.html
+++ b/PYME/cluster/clusterUI/recipes/templates/recipes/recipe_template.html
@@ -13,7 +13,7 @@
         <div class="form-group">
             <label class="control-label" for="inputRecipeURL">Recipe</label>
             <div class="input-group">
-                <span class="input-group-addon">pyme-cluster://{{ clusterfilter }}/</span>
+                <span class="input-group-addon">pyme-cluster://{{ serverfilter }}/</span>
                 <input type="text" class="form-control" id="inputRecipeURL" name="recipeURL">
                 <span class="input-group-btn">
                     <button class="btn btn-default" type="button" id="select_recipe">select</button>
@@ -34,7 +34,7 @@
         <div class="form-group">
             <label class="control-label" for="inputFileGlob">Input glob</label>
             <div class="input-group">
-                <span class="input-group-addon">pyme-cluster://{{ clusterfilter }}/</span>
+                <span class="input-group-addon">pyme-cluster://{{ serverfilter }}/</span>
                 <input type="text" class="form-control" id="inputFileGlob" name="inputGlob">
                 <span class="input-group-btn">
                     <button class="btn btn-default" type="button" id="inputGlob">find matching files</button>
@@ -48,7 +48,7 @@
         <div class="form-group">
             <label class="control-label" for="recipeOutputPath">Output directory</label>
             <div class="input-group">
-                <span class="input-group-addon">pyme-cluster:///</span>
+                <span class="input-group-addon">pyme-cluster://{{ serverfilter }}/</span>
                 <input type="text" class="form-control" id="recipeOutputPath" name="recipeOutputPath">
                 <!--<span class="input-group-btn">-->
                     <!--<button class="btn btn-default" type="button" id="select_output">select</button>-->


### PR DESCRIPTION
Addresses issue #983 but for recipes.

**Is this a bugfix or an enhancement?**
kind of a bugfix I guess
**Proposed changes:**
- use the serverfilter for clusterUI recipe file inputs
- correct `clusterfilter` to `serverfilter` in recipe htmls so it actually gets used rather than `''`






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
