### PR TITLE
allow config for local tasks only

### DIFF
--- a/PYME/cluster/rulenodeserver.py
+++ b/PYME/cluster/rulenodeserver.py
@@ -225,7 +225,7 @@ class NodeServer(object):
                     if n_tasks >= n_tasks_to_request:
                         break
                         
-                if n_tasks < 1:
+                if n_tasks < 1 and config.get('rulenodeserver-nonlocal', True):
                     # only bid on non-local if we haven't found any local tasks
                     #logger.debug('Found %d local tasks' % n_tasks)
                     #logger.debug('Could not find enough local tasks, bidding on non-local')

--- a/PYME/config.py
+++ b/PYME/config.py
@@ -207,6 +207,9 @@ nodeserver-num_workers : default= CPU count. Number of workers to launch on an i
 
 ruleserver-retries : default = 3. [new-style task distribution]. The number of times to retry a given task before it is deemed to have failed.
 
+rulenodeserver-nonlocal : toggle whether to bid for non-local tasks if no local
+    tasks are found. Uses should default to True.
+
 httpspooler-chunksize : default=50, how many frames we spool in each chunk 
     before (potentially) switching which PYMEDataServer we send the next chunk
     to. Increasing the chunksize can increase data-locality for faster analysis,

--- a/PYME/config.py
+++ b/PYME/config.py
@@ -207,8 +207,10 @@ nodeserver-num_workers : default= CPU count. Number of workers to launch on an i
 
 ruleserver-retries : default = 3. [new-style task distribution]. The number of times to retry a given task before it is deemed to have failed.
 
-rulenodeserver-nonlocal : toggle whether to bid for non-local tasks if no local
-    tasks are found. Uses should default to True.
+rulenodeserver-nonlocal : default = True. Whether to bid for non-local tasks if no local tasks are found. Disabling
+    non-local bidding (setting this to False) will make task distribution less robust, but is potentially a viable
+    workarond if trying to e.g. run recipes which use stupid ammounts of memory and will crash when run non-locally.
+    The need for this should be removed by better recipe costing.
 
 httpspooler-chunksize : default=50, how many frames we spool in each chunk 
     before (potentially) switching which PYMEDataServer we send the next chunk


### PR DESCRIPTION
Addresses issue #really slamming nodes on big RAM-slaying recipes makes them not so responsive to network I/O / susceptible to timeouts.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- allow whether to look for nonlocal tasks to be config'd in rulenodeserver






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
