### PR TITLE
Adjust display option flags to be non-conflicting for wx 4.1

### DIFF
--- a/PYME/DSView/DisplayOptionsPanel.py
+++ b/PYME/DSView/DisplayOptionsPanel.py
@@ -125,7 +125,7 @@ class OptionsPanel(wx.Panel):
             hsizer.Add(self.cbScale, 0, wx.ALL|wx.ALIGN_CENTER, 5)
             vsizer.Add(hsizer, 0, wx.ALL|wx.ALIGN_CENTER, 0)
         else:
-            vsizer.Add(self.bOptimise, 0, wx.LEFT|wx.RIGHT|wx.TOP|wx.ALIGN_CENTER|wx.EXPAND, 5)
+            vsizer.Add(self.bOptimise, 0, wx.EXPAND, 5)
 
             hsizer = wx.BoxSizer(wx.HORIZONTAL)
 

--- a/PYME/DSView/DisplayOptionsPanel.py
+++ b/PYME/DSView/DisplayOptionsPanel.py
@@ -125,7 +125,7 @@ class OptionsPanel(wx.Panel):
             hsizer.Add(self.cbScale, 0, wx.ALL|wx.ALIGN_CENTER, 5)
             vsizer.Add(hsizer, 0, wx.ALL|wx.ALIGN_CENTER, 0)
         else:
-            vsizer.Add(self.bOptimise, 0, wx.EXPAND, 5)
+            vsizer.Add(self.bOptimise, 0, wx.LEFT|wx.RIGHT|wx.TOP|wx.EXPAND, 5)
 
             hsizer = wx.BoxSizer(wx.HORIZONTAL)
 
@@ -423,6 +423,5 @@ class OptionsPanel(wx.Panel):
     def OnDoChange(self):
         #print 'c'
         self.cbScale.SetSelection(self.do.scale + self.scale_11)
-
 
 

--- a/PYME/DSView/voxSizeDialog.py
+++ b/PYME/DSView/voxSizeDialog.py
@@ -36,7 +36,7 @@ class VoxSizeDialog(wx.Dialog):
 
         sizer2.Add(self.tVoxX, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 
-        sizer1.Add(sizer2, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 0)
+        sizer1.Add(sizer2, 0, wx.ALL, 0)
 
         sizer2 = wx.BoxSizer(wx.HORIZONTAL)
         sizer2.Add(wx.StaticText(self, -1, u'y\u00A0[\u00B5m]:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
@@ -44,7 +44,7 @@ class VoxSizeDialog(wx.Dialog):
 
         sizer2.Add(self.tVoxY, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 
-        sizer1.Add(sizer2, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 0)
+        sizer1.Add(sizer2, 0, wx.ALL, 0)
 
         sizer2 = wx.BoxSizer(wx.HORIZONTAL)
         sizer2.Add(wx.StaticText(self, -1, u'z\u00A0[\u00B5m]:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
@@ -52,7 +52,7 @@ class VoxSizeDialog(wx.Dialog):
 
         sizer2.Add(self.tVoxZ, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 
-        sizer1.Add(sizer2, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 0)
+        sizer1.Add(sizer2, 0, wx.ALL, 0)
 
         btSizer = wx.StdDialogButtonSizer()
 
@@ -67,7 +67,7 @@ class VoxSizeDialog(wx.Dialog):
 
         btSizer.Realize()
 
-        sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALL, 5)
 
         self.SetSizer(sizer1)
         sizer1.Fit(self)


### PR DESCRIPTION
Addresses comment in issue #657.

**Is this a bugfix or an enhancement?**
Bugfix

**Proposed changes:**
- Remove extraneous alignment flags.

