### PR TITLE
Isosurface improvements

### DIFF
--- a/PYME/DSView/modules/vis3D.py
+++ b/PYME/DSView/modules/vis3D.py
@@ -26,6 +26,7 @@ import matplotlib.cm
 
 from PYME.ui.AUIFrame import AUIFrame
 import wx.lib.agw.aui as aui
+from PYME.LMVis import view_clipping_pane
 
 class MeshViewFrame(AUIFrame):
     def __init__(self, *args, **kwargs):
@@ -38,12 +39,21 @@ class MeshViewFrame(AUIFrame):
 
         
         self.panesToMinimise = []
+        
         self.layerpanel = layer_panel.LayerPane(self, self.canvas, caption=None, add_button=False)
         self.layerpanel.SetSize(self.layerpanel.GetBestSize())
         pinfo = aui.AuiPaneInfo().Name("layerPanel").Right().Caption('Layers').CloseButton(
             False).MinimizeButton(True).MinimizeMode(
             aui.AUI_MINIMIZE_CAPT_SMART | aui.AUI_MINIMIZE_POS_RIGHT)#.CaptionVisible(False)
         self._mgr.AddPane(self.layerpanel, pinfo)
+
+        self.panesToMinimise.append(pinfo)
+        
+        self._clip_pane = view_clipping_pane.ViewClippingPanel(self, self.canvas)
+        pinfo = aui.AuiPaneInfo().Name("ClippingPanel").Right().Caption('Clipping').CloseButton(
+            False).MinimizeButton(True).MinimizeMode(
+            aui.AUI_MINIMIZE_CAPT_SMART | aui.AUI_MINIMIZE_POS_RIGHT)
+        self._mgr.AddPane(self._clip_pane, pinfo)
 
         self.panesToMinimise.append(pinfo)
 


### PR DESCRIPTION
- Adds view clipping to isosurface display for voxel-based data
- Performance improvements for isosurface generation (`.march()` goes from ~1.8s -> ~0.15 s on `test_er_data.hdf`) 

@zacsimile - a quick rundown of where the performance impovement comes from below:

- removing an "anti-optimisation" where we used `np.unique` in an attempt to avoid repeated calculations of edge intercepts. It turns out that the sorting used by np.unique was taking longer than the computations (and scaled poorly with data set size)
- replacing it with a different optimisation which also avoids calculating un-neccesary edge intercepts (it turns out that most of the intercepts which were actually being optimised with the np.unique call were null intercepts on the"fake" 0-0 edge which we didn't need to calculate in the first place).
- making the optimisation where we restrict ourselves to those cells that the isosurface actually passes through work on the dual grid (as a consequence/side effect of the above optimisation).

