### PR TITLE
pco. camera using pco.sdk only

### DIFF
--- a/PYME/Acquire/Hardware/ARCoptix/lcdriver.py
+++ b/PYME/Acquire/Hardware/ARCoptix/lcdriver.py
@@ -15,14 +15,16 @@ Pre-flight to create the 32-bit server:
         - conda create -n py37_32 python=3.7.9  # change this to the python used in your pyme install
         - set CONDA_FORCE_32BIT=1
         - activate py37_32
-        - pip install msl-loadlib pyinstaller comtypes pythonnet
+        - pip install msl-loadlib pyinstaller comtypes pythonnet numpy  # make sure the versions match the versions in your 64-bit environment
+                                                                        # numpy is optional, but if you don't use it make sure you cast everything
+                                                                        # to float before passing to the server
     - python
         - from msl.loadlib import freeze_server32
         - freeze_server32.main()
         ... PyInstaller logging messages ...
         Server saved to: ...
     - Copy the generated server32-windows.exe file to 
-      miniconda3\envs\<pyme environment>\lib\site-packages\msl\loadlib
+      miniconda3\envs\<64-bit pyme environment>\lib\site-packages\msl\loadlib
     - Copy C:\Program Files\ARCoptix\ARCoptix LC Driver 1.2\CyUSB.dll to
       miniconda3\envs\<pyme environment>\lib\site-packages\msl\loadlib.
       NOTE: We shouldn't need to do this, but setting os.environ['PATH'] doesn't

--- a/PYME/Acquire/Hardware/pco/pco_edge_42_lt.py
+++ b/PYME/Acquire/Hardware/pco/pco_edge_42_lt.py
@@ -6,7 +6,8 @@ Created on Mon August 12 2020
 @author: zacsimile
 """
 
-from PYME.Acquire.Hardware.pco import pco_cam
+# from PYME.Acquire.Hardware.pco import pco_cam
+from PYME.Acquire.Hardware.pco import pco_sdk_cam
 
 noiseProperties = {
 '61003940' : {
@@ -19,10 +20,10 @@ noiseProperties = {
         },
 }
 
-class PcoEdge42LT(pco_cam.PcoCam):
+class PcoEdge42LT(pco_sdk_cam.PcoSdkCam):
     def __init__(self, camNum, debuglevel='off'):
-        pco_cam.PcoCam.__init__(self, camNum, debuglevel)
+        pco_sdk_cam.PcoSdkCam.__init__(self, camNum, debuglevel)
 
     def Init(self):
-        pco_cam.PcoCam.Init(self)
+        pco_sdk_cam.PcoSdkCam.Init(self)
         self.noiseProps = noiseProperties[self.GetSerialNumber()]

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -39,9 +39,6 @@ except:
 # ---------------------------------------------------------------------
 # Structures and types
 # ---------------------------------------------------------------------
-HANDLE = ctypes.c_void_p
-PHANDLE = ctypes.POINTER(HANDLE)
-
 class PCO_Description(ctypes.Structure):
     # _pack_ = 1
     _fields_ = [("wSize", ctypes.wintypes.WORD),
@@ -268,7 +265,7 @@ def check_status(err, function_name=None):
 # ---------------------------------------------------------------------
 # 2.1.1 PCO_OpenCamera
 # ---------------------------------------------------------------------
-sc2_cam.PCO_OpenCamera.argtypes = [PHANDLE, 
+sc2_cam.PCO_OpenCamera.argtypes = [ctypes.POINTER(ctypes.wintypes.HANDLE), 
                                    ctypes.wintypes.WORD]
 def open_camera():
     """
@@ -281,7 +278,7 @@ def open_camera():
 
     Returns
     -------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     """
     handle = ctypes.c_void_p(0)
@@ -300,14 +297,14 @@ def open_camera_ex(**kwargs):
 # ---------------------------------------------------------------------
 # 2.1.3 PCO_CloseCamera
 # ---------------------------------------------------------------------
-sc2_cam.PCO_CloseCamera.argtypes = [HANDLE]
+sc2_cam.PCO_CloseCamera.argtypes = [ctypes.wintypes.HANDLE]
 def close_camera(handle):
     """
     Close a pco. camera.
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     """
     check_status(sc2_cam.PCO_CloseCamera(handle))
@@ -325,7 +322,7 @@ def reset_lib():
 # ---------------------------------------------------------------------
 # 2.2.1 PCO_GetCameraDescription
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetCameraDescription.argtypes = [HANDLE,
+sc2_cam.PCO_GetCameraDescription.argtypes = [ctypes.wintypes.HANDLE,
                                              ctypes.POINTER(PCO_Description)]
 def get_camera_description(handle):
     """
@@ -334,7 +331,7 @@ def get_camera_description(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
 
     Returns
@@ -350,14 +347,14 @@ def get_camera_description(handle):
 # ---------------------------------------------------------------------
 # 2.3.3 PCO_GetCameraType
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetCameraType.argtypes = [HANDLE, ctypes.POINTER(PCO_CameraType)]
+sc2_cam.PCO_GetCameraType.argtypes = [ctypes.wintypes.HANDLE, ctypes.POINTER(PCO_CameraType)]
 def get_camera_type(handle):
     """
     Get camera name, serial number, etc.
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     
     Returns
@@ -373,7 +370,7 @@ def get_camera_type(handle):
 # ---------------------------------------------------------------------
 # 2.3.3 PCO_GetCameraHealthStatus
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetCameraHealthStatus.argtypes = [HANDLE,
+sc2_cam.PCO_GetCameraHealthStatus.argtypes = [ctypes.wintypes.HANDLE,
                                               ctypes.wintypes.PDWORD,
                                               ctypes.wintypes.PDWORD,
                                               ctypes.wintypes.PDWORD]
@@ -386,7 +383,7 @@ def get_camera_health_status(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
 
     Returns
@@ -407,7 +404,8 @@ def get_camera_health_status(handle):
 # ---------------------------------------------------------------------
 # 2.3.4 PCO_GetTemperature
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetTemperature.argtypes = [HANDLE, ctypes.POINTER(ctypes.c_short),
+sc2_cam.PCO_GetTemperature.argtypes = [ctypes.wintypes.HANDLE, 
+                                       ctypes.POINTER(ctypes.c_short),
                                        ctypes.POINTER(ctypes.c_short), 
                                        ctypes.POINTER(ctypes.c_short)]
 def get_temperature(handle):
@@ -416,7 +414,7 @@ def get_temperature(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
 
     Returns
@@ -438,7 +436,7 @@ def get_temperature(handle):
 # ---------------------------------------------------------------------
 # 2.4.1 PCO_ArmCamera
 # ---------------------------------------------------------------------
-sc2_cam.PCO_ArmCamera.argtypes = [HANDLE]
+sc2_cam.PCO_ArmCamera.argtypes = [ctypes.wintypes.HANDLE]
 def arm_camera(handle):
     """
     Prepare the camera for recording. Must be called after the change of 
@@ -446,7 +444,7 @@ def arm_camera(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     """
     check_status(sc2_cam.PCO_ArmCamera(handle))
@@ -454,7 +452,8 @@ def arm_camera(handle):
 # ---------------------------------------------------------------------
 # 2.4.3 PCO_SetImageParameters
 # ---------------------------------------------------------------------
-sc2_cam.PCO_SetImageParameters.argtypes = [HANDLE, ctypes.wintypes.WORD,
+sc2_cam.PCO_SetImageParameters.argtypes = [ctypes.wintypes.HANDLE, 
+                                           ctypes.wintypes.WORD,
                                            ctypes.wintypes.WORD,
                                            ctypes.wintypes.DWORD,
                                            ctypes.c_void_p,
@@ -467,7 +466,7 @@ def set_image_parameters(handle, lx, ly, image_flag):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     lx : int
         Image width
@@ -486,7 +485,7 @@ def set_image_parameters(handle, lx, ly, image_flag):
 # ---------------------------------------------------------------------
 # 2.4.4 PCO_ResetSettingsToDefault
 # ---------------------------------------------------------------------
-sc2_cam.PCO_ResetSettingsToDefault.argtypes = [HANDLE]
+sc2_cam.PCO_ResetSettingsToDefault.argtypes = [ctypes.wintypes.HANDLE]
 def reset_settings_to_default(handle):
     """
     Reset the camera settings to default. Executed by default during
@@ -494,14 +493,15 @@ def reset_settings_to_default(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     """
     check_status(sc2_cam.PCO_ResetSettingsToDefault(handle))
 # ---------------------------------------------------------------------
 # 2.5.3 PCO_GetSizes
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetSizes.argtypes = [HANDLE, ctypes.wintypes.PWORD, 
+sc2_cam.PCO_GetSizes.argtypes = [ctypes.wintypes.HANDLE, 
+                                 ctypes.wintypes.PWORD, 
                                  ctypes.wintypes.PWORD, 
                                  ctypes.wintypes.PWORD,
                                  ctypes.wintypes.PWORD]
@@ -511,7 +511,7 @@ def get_sizes(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
 
     Returns
@@ -535,7 +535,8 @@ def get_sizes(handle):
 # ---------------------------------------------------------------------
 # 2.5.6 PCO_GetROI
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetROI.argtypes = [HANDLE, ctypes.wintypes.PWORD,
+sc2_cam.PCO_GetROI.argtypes = [ctypes.wintypes.HANDLE, 
+                               ctypes.wintypes.PWORD,
                                ctypes.wintypes.PWORD,
                                ctypes.wintypes.PWORD,
                                ctypes.wintypes.PWORD]
@@ -546,7 +547,7 @@ def get_roi(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     
     Returns
@@ -570,7 +571,8 @@ def get_roi(handle):
 # ---------------------------------------------------------------------
 # 2.5.7 PCO_SetROI
 # ---------------------------------------------------------------------
-sc2_cam.PCO_SetROI.argtypes = [HANDLE, ctypes.wintypes.WORD,
+sc2_cam.PCO_SetROI.argtypes = [ctypes.wintypes.HANDLE, 
+                               ctypes.wintypes.WORD,
                                ctypes.wintypes.WORD,
                                ctypes.wintypes.WORD,
                                ctypes.wintypes.WORD]
@@ -581,7 +583,7 @@ def set_roi(handle, x0, y0, x1, y1):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     x0 : int
         Horizontal (column) start coordinate
@@ -600,7 +602,8 @@ def set_roi(handle, x0, y0, x1, y1):
 # ---------------------------------------------------------------------
 # 2.5.8 PCO_GetBinning
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetBinning.argtypes = [HANDLE, ctypes.wintypes.PWORD,
+sc2_cam.PCO_GetBinning.argtypes = [ctypes.wintypes.HANDLE, 
+                                   ctypes.wintypes.PWORD,
                                    ctypes.wintypes.PWORD]
 def get_binning(handle):
     """
@@ -608,7 +611,7 @@ def get_binning(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
 
     Returns
@@ -626,7 +629,8 @@ def get_binning(handle):
 # ---------------------------------------------------------------------
 # 2.5.9 PCO_SetBinning
 # ---------------------------------------------------------------------
-sc2_cam.PCO_SetBinning.argtypes = [HANDLE, ctypes.wintypes.WORD,
+sc2_cam.PCO_SetBinning.argtypes = [ctypes.wintypes.HANDLE, 
+                                   ctypes.wintypes.WORD,
                                    ctypes.wintypes.WORD]
 def set_binning(handle, bin_horiz, bin_vert):
     """
@@ -638,7 +642,7 @@ def set_binning(handle, bin_horiz, bin_vert):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     bin_horiz : int
         Horizontal (column) binning in pixels
@@ -651,14 +655,14 @@ def set_binning(handle, bin_horiz, bin_vert):
 # ---------------------------------------------------------------------
 # 2.5.10 PCO_GetPixelRate
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetPixelRate.argtypes = [HANDLE, ctypes.wintypes.PDWORD]
+sc2_cam.PCO_GetPixelRate.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.PDWORD]
 def get_pixel_rate(handle):
     """
     Get the current pixel rate (sensor readout speed) of the camera in Hz.
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     
     Returns
@@ -673,14 +677,14 @@ def get_pixel_rate(handle):
 # ---------------------------------------------------------------------
 # 2.5.10 PCO_SetPixelRate
 # ---------------------------------------------------------------------
-sc2_cam.PCO_SetPixelRate.argtypes = [HANDLE, ctypes.wintypes.DWORD]
+sc2_cam.PCO_SetPixelRate.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.DWORD]
 def set_pixel_rate(handle, pixel_rate):
     """
     Set the current pixel rate (sensor readout speed) of the camera in Hz.
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     pixel_rate : int
         Pixel rate of the camera in Hz
@@ -690,7 +694,7 @@ def set_pixel_rate(handle, pixel_rate):
 # ---------------------------------------------------------------------
 # 2.5.20 PCO_GetCoolingSetpointTemperature
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetCoolingSetpointTemperature.argtypes = [HANDLE, 
+sc2_cam.PCO_GetCoolingSetpointTemperature.argtypes = [ctypes.wintypes.HANDLE, 
                                                       ctypes.POINTER(ctypes.c_short)]
 def get_cooling_setpoint_temperature(handle):
     """
@@ -698,7 +702,7 @@ def get_cooling_setpoint_temperature(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
 
     Returns
@@ -713,14 +717,14 @@ def get_cooling_setpoint_temperature(handle):
 # ---------------------------------------------------------------------
 # 2.5.21 PCO_SetCoolingSetpointTemperature
 # ---------------------------------------------------------------------
-sc2_cam.PCO_SetCoolingSetpointTemperature.argtypes = [HANDLE, ctypes.c_short]
+sc2_cam.PCO_SetCoolingSetpointTemperature.argtypes = [ctypes.wintypes.HANDLE, ctypes.c_short]
 def set_cooling_setpoint_temperature(handle, temp):
     """
     Set temperature set point for image sensor. 
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     temp : int
         Setpoint in degrees C. Must be in between sMinCoolSetDESC and
@@ -730,7 +734,8 @@ def set_cooling_setpoint_temperature(handle, temp):
 # ---------------------------------------------------------------------
 # 2.6.4 PCO_GetDelayExposureTime
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetDelayExposureTime.argtypes = [HANDLE, ctypes.wintypes.PDWORD,
+sc2_cam.PCO_GetDelayExposureTime.argtypes = [ctypes.wintypes.HANDLE, 
+                                             ctypes.wintypes.PDWORD,
                                              ctypes.wintypes.PDWORD,
                                              ctypes.wintypes.PWORD,
                                              ctypes.wintypes.PWORD]
@@ -743,7 +748,7 @@ def get_delay_exposure_time(handle):
     
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     
     Returns
@@ -768,7 +773,8 @@ def get_delay_exposure_time(handle):
 # ---------------------------------------------------------------------
 # 2.6.5 PCO_SetDelayExposureTime
 # ---------------------------------------------------------------------
-sc2_cam.PCO_SetDelayExposureTime.argtypes = [HANDLE, ctypes.wintypes.DWORD,
+sc2_cam.PCO_SetDelayExposureTime.argtypes = [ctypes.wintypes.HANDLE, 
+                                             ctypes.wintypes.DWORD,
                                              ctypes.wintypes.DWORD,
                                              ctypes.wintypes.WORD,
                                              ctypes.wintypes.WORD]
@@ -778,7 +784,7 @@ def set_delay_exposure_time(handle, delay, exposure, timebase_delay, timebase_ex
     
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     delay : unsigned long int
         Delay time in units of timebase_delay. In range 
@@ -801,7 +807,7 @@ def set_delay_exposure_time(handle, delay, exposure, timebase_delay, timebase_ex
 # ---------------------------------------------------------------------
 # 2.6.26 PCO_GetImageTiming
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetImageTiming.argtypes = [HANDLE, ctypes.POINTER(PCO_ImageTiming)]
+sc2_cam.PCO_GetImageTiming.argtypes = [ctypes.wintypes.HANDLE, ctypes.POINTER(PCO_ImageTiming)]
 def get_image_timing(handle):
     """
     Get image timing with nanosecond resolution, plus additional trigger
@@ -809,7 +815,7 @@ def get_image_timing(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
 
     Returns
@@ -824,7 +830,7 @@ def get_image_timing(handle):
 # ---------------------------------------------------------------------
 # 2.7.3 PCO_GetRecordingState
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetRecordingState.argtypes = [HANDLE, ctypes.wintypes.PWORD]
+sc2_cam.PCO_GetRecordingState.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.PWORD]
 PCO_CAMERA_STOPPED = 0x0000
 PCO_CAMERA_RUNNING = 0x0001
 def get_recording_state(handle):
@@ -833,7 +839,7 @@ def get_recording_state(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
 
     Returns
@@ -848,14 +854,14 @@ def get_recording_state(handle):
 # ---------------------------------------------------------------------
 # 2.7.4 PCO_SetRecordingState
 # ---------------------------------------------------------------------
-sc2_cam.PCO_SetRecordingState.argtypes = [HANDLE, ctypes.wintypes.WORD]
+sc2_cam.PCO_SetRecordingState.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.WORD]
 def set_recording_state(handle, state):
     """
     Set the current recording state of the camera.
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     state : int
         Recording state, one of PCO_CAMERA_STOPPED (0), PCO_CAMERA_RUNNING (1).
@@ -865,7 +871,7 @@ def set_recording_state(handle, state):
 # ---------------------------------------------------------------------
 # 2.7.5 PCO_GetStorageMode
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetStorageMode.argtypes = [HANDLE, ctypes.wintypes.PWORD]
+sc2_cam.PCO_GetStorageMode.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.PWORD]
 PCO_STORAGE_RECORDER = 0x0000
 PCO_STORAGE_FIFO = 0x0001
 def get_storage_mode(handle):
@@ -874,7 +880,7 @@ def get_storage_mode(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
 
     Returns
@@ -889,14 +895,14 @@ def get_storage_mode(handle):
 # ---------------------------------------------------------------------
 # 2.7.6 PCO_SetStorageMode
 # ---------------------------------------------------------------------
-sc2_cam.PCO_SetStorageMode.argtypes = [HANDLE, ctypes.wintypes.WORD]
+sc2_cam.PCO_SetStorageMode.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.WORD]
 def set_storage_mode(handle, mode):
     """
     Get camera image storage mode. One of "recorder" or "FIFO buffer".
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     mode : unsigned short int
         Camera image storage mode. One of PCO_STORAGE_RECORDER (0) or PCO_STORAGE_FIFO (1).
@@ -906,7 +912,7 @@ def set_storage_mode(handle, mode):
 # ---------------------------------------------------------------------
 # 2.7.9 PCO_GetAcquireMode
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetAcquireMode.argtypes = [HANDLE, ctypes.wintypes.PWORD]
+sc2_cam.PCO_GetAcquireMode.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.PWORD]
 PCO_ACQUIRE_AUTO = 0x0000
 PCO_ACQUIRE_EXTERNAL = 0x0000
 PCO_ACQUIRE_EXTERNAL_MODULATE = 0x0000
@@ -917,7 +923,7 @@ def get_acquire_mode(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
 
     Returns
@@ -933,7 +939,7 @@ def get_acquire_mode(handle):
 # ---------------------------------------------------------------------
 # 2.7.10 PCO_SetAcquireMode
 # ---------------------------------------------------------------------
-sc2_cam.PCO_SetAcquireMode.argtypes = [HANDLE, ctypes.wintypes.WORD]
+sc2_cam.PCO_SetAcquireMode.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.WORD]
 def set_acquire_mode(handle, mode):
     """
     Set the current acquisition mode of the camera. One of "auto",
@@ -941,7 +947,7 @@ def set_acquire_mode(handle, mode):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     mode : unsigned short int
         Camera acquisiton mode. One of PCO_ACQUIRE_AUTO (0), PCO_ACQUIRE_EXTERNAL (1), 
@@ -952,7 +958,8 @@ def set_acquire_mode(handle, mode):
 # ---------------------------------------------------------------------
 # 2.7.14 PCO_GetMetaDataMode
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetMetaDataMode.argtypes = [HANDLE, ctypes.wintypes.PWORD,
+sc2_cam.PCO_GetMetaDataMode.argtypes = [ctypes.wintypes.HANDLE, 
+                                        ctypes.wintypes.PWORD,
                                         ctypes.wintypes.PWORD,
                                         ctypes.wintypes.PWORD]
 PCO_METADATA_OFF = 0x0000
@@ -964,7 +971,7 @@ def get_metadata_mode(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     
     Returns
@@ -985,7 +992,8 @@ def get_metadata_mode(handle):
 # ---------------------------------------------------------------------
 # 2.7.15 PCO_SetMetaDataMode
 # ---------------------------------------------------------------------
-sc2_cam.PCO_SetMetaDataMode.argtypes = [HANDLE, ctypes.wintypes.WORD,
+sc2_cam.PCO_SetMetaDataMode.argtypes = [ctypes.wintypes.HANDLE, 
+                                        ctypes.wintypes.WORD,
                                         ctypes.wintypes.PWORD,
                                         ctypes.wintypes.PWORD]
 def set_metadata_mode(handle, mode):
@@ -995,7 +1003,7 @@ def set_metadata_mode(handle, mode):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     mode : unsigned short int
         Metadata mode. One of PCO_METADATA_OFF (0) or PCO_METADATA_ON (1).
@@ -1016,7 +1024,7 @@ def set_metadata_mode(handle, mode):
 # ---------------------------------------------------------------------
 # 2.9.5 PCO_GetBitAlignment
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetBitAlignment.argtypes = [HANDLE, ctypes.wintypes.PWORD]
+sc2_cam.PCO_GetBitAlignment.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.PWORD]
 PCO_ALIGNMENT_MSB = 0x0000  # align to most significant bit
 PCO_ALIGNMENT_LSB = 0x0001  # align to least significant bit
 def get_bit_alignment(handle):
@@ -1025,7 +1033,7 @@ def get_bit_alignment(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
 
     Returns
@@ -1041,14 +1049,14 @@ def get_bit_alignment(handle):
 # ---------------------------------------------------------------------
 # 2.9.6 PCO_SetBitAlignment
 # ---------------------------------------------------------------------
-sc2_cam.PCO_SetBitAlignment.argtypes = [HANDLE, ctypes.wintypes.WORD]
+sc2_cam.PCO_SetBitAlignment.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.WORD]
 def set_bit_alignment(handle, alignment):
     """
     Set the bit alignment of the transferred image data.
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     alignment : unsigned short int
         Bit alignment of the transferred image data. One of PCO_ALIGNMENT_MSB (0)
@@ -1059,7 +1067,7 @@ def set_bit_alignment(handle, alignment):
 # ---------------------------------------------------------------------
 # 2.9.7 PCO_GetHotPixelCorrectionMode
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetHotPixelCorrectionMode.argtypes = [HANDLE, ctypes.wintypes.PWORD]
+sc2_cam.PCO_GetHotPixelCorrectionMode.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.PWORD]
 PCO_HOTPIXELCORRECTION_OFF = 0x0000
 PCO_HOTPIXELCORRECTION_ON = 0x0001
 def get_hot_pixel_correction_mode(handle):
@@ -1068,7 +1076,7 @@ def get_hot_pixel_correction_mode(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
 
     Returns
@@ -1084,14 +1092,14 @@ def get_hot_pixel_correction_mode(handle):
 # ---------------------------------------------------------------------
 # 2.9.8 PCO_SetHotPixelCorrectionMode
 # ---------------------------------------------------------------------
-sc2_cam.PCO_SetHotPixelCorrectionMode.argtypes = [HANDLE, ctypes.wintypes.WORD]
+sc2_cam.PCO_SetHotPixelCorrectionMode.argtypes = [ctypes.wintypes.HANDLE, ctypes.wintypes.WORD]
 def set_hot_pixel_correction_mode(handle, mode):
     """
     Set camera chip hot pixel correction mode. 
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     mode : unsigned short int
         Hot pixel correction mode. One of PCO_HOTPIXELCORRECTION_OFF (0) or 
@@ -1102,10 +1110,10 @@ def set_hot_pixel_correction_mode(handle, mode):
 # ---------------------------------------------------------------------
 # 2.10.1 PCO_AllocateBuffer
 # ---------------------------------------------------------------------
-sc2_cam.PCO_AllocateBuffer.argtypes = [HANDLE, ctypes.POINTER(ctypes.c_short),
+sc2_cam.PCO_AllocateBuffer.argtypes = [ctypes.wintypes.HANDLE, ctypes.POINTER(ctypes.c_short),
                                        ctypes.wintypes.DWORD,
                                        ctypes.POINTER(ctypes.wintypes.PWORD),
-                                       PHANDLE]
+                                       ctypes.POINTER(ctypes.wintypes.HANDLE)]
 
 def allocate_buffer(handle, index, size, buffer=None, event=None):
     """
@@ -1113,7 +1121,7 @@ def allocate_buffer(handle, index, size, buffer=None, event=None):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     index : int
         Buffer index to access from a previous call 
@@ -1141,19 +1149,20 @@ def allocate_buffer(handle, index, size, buffer=None, event=None):
         event = ctypes.c_void_p(0)
     check_status(sc2_cam.PCO_AllocateBuffer(handle, index, ctypes.wintypes.DWORD(size), 
                                             buffer, event))
-    return index.contents, buffer, event
+    if buffer is None and event is None:
+        return index.contents, buffer, event
 
 # ---------------------------------------------------------------------
 # 2.10.2 PCO_FreeBuffer
 # ---------------------------------------------------------------------
-sc2_cam.PCO_FreeBuffer.argtypes = [HANDLE, ctypes.c_short]
+sc2_cam.PCO_FreeBuffer.argtypes = [ctypes.wintypes.HANDLE, ctypes.c_short]
 def free_buffer(handle, index):
     """
     Release a previously-allocated buffer with the given index.
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     index : int
         Buffer index to free
@@ -1163,7 +1172,8 @@ def free_buffer(handle, index):
 # ---------------------------------------------------------------------
 # 2.10.3 PCO_GetBufferStatus
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetBufferStatus.argtypes = [HANDLE, ctypes.c_short,
+sc2_cam.PCO_GetBufferStatus.argtypes = [ctypes.wintypes.HANDLE, 
+                                        ctypes.c_short,
                                         ctypes.wintypes.PDWORD,
                                         ctypes.wintypes.PDWORD]
 PCO_BUFFER_ALLOCATED = 0x80000000  # Buffer is allocated
@@ -1174,7 +1184,7 @@ def get_buffer_status(handle, index):
     """
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     index : int
         Buffer index to get status
@@ -1197,16 +1207,16 @@ def get_buffer_status(handle, index):
 # ---------------------------------------------------------------------
 # 2.10.4 PCO_GetBuffer
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetBuffer.argtypes = [HANDLE, ctypes.c_short, 
+sc2_cam.PCO_GetBuffer.argtypes = [ctypes.wintypes.HANDLE, ctypes.c_short, 
                                   ctypes.POINTER(ctypes.wintypes.PWORD),
-                                  PHANDLE]
+                                  ctypes.POINTER(ctypes.wintypes.HANDLE)]
 def get_buffer(handle, index):
     """
     Get the buffer at index.
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     index : int
         Buffer index to get
@@ -1226,7 +1236,7 @@ def get_buffer(handle, index):
 # ---------------------------------------------------------------------
 # 2.11.1 PCO_GetImageEx
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetImageEx.argtypes = [HANDLE, 
+sc2_cam.PCO_GetImageEx.argtypes = [ctypes.wintypes.HANDLE, 
                                    ctypes.wintypes.WORD,
                                    ctypes.wintypes.DWORD,
                                    ctypes.wintypes.DWORD,
@@ -1241,7 +1251,7 @@ def get_image_ex(handle, segment, first_image, buffer_index, lx, ly,
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     segment : int
         Index of memory segment. 1 is the default memory segment
@@ -1264,7 +1274,7 @@ def get_image_ex(handle, segment, first_image, buffer_index, lx, ly,
 # ---------------------------------------------------------------------
 # 2.11.3 PCO_AddBufferEx
 # ---------------------------------------------------------------------
-sc2_cam.PCO_AddBufferEx.argtypes = [HANDLE, 
+sc2_cam.PCO_AddBufferEx.argtypes = [ctypes.wintypes.HANDLE, 
                                     ctypes.wintypes.DWORD,
                                     ctypes.wintypes.DWORD,
                                     ctypes.c_short,
@@ -1279,7 +1289,7 @@ def add_buffer_ex(handle, first_image, buffer_index, lx, ly,
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     first_image : int
         Image number. 1 if PCO_GetRecordingState is PCO_CAMERA_STOPPED, 0 if it is PCO_CAMERA_RUNNING
@@ -1300,7 +1310,7 @@ def add_buffer_ex(handle, first_image, buffer_index, lx, ly,
 # ---------------------------------------------------------------------
 # 2.11.6 PCO_CancelImages
 # ---------------------------------------------------------------------
-sc2_cam.PCO_CancelImages.argtypes = [HANDLE]
+sc2_cam.PCO_CancelImages.argtypes = [ctypes.wintypes.HANDLE]
 def cancel_images(handle):
     """
 
@@ -1309,7 +1319,7 @@ def cancel_images(handle):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     """
     check_status(sc2_cam.PCO_CancelImages(handle))
@@ -1317,7 +1327,7 @@ def cancel_images(handle):
 # ---------------------------------------------------------------------
 # 2.11.9 PCO_WaitforBuffer
 # ---------------------------------------------------------------------
-sc2_cam.PCO_WaitforBuffer.argtypes = [HANDLE, ctypes.c_int, 
+sc2_cam.PCO_WaitforBuffer.argtypes = [ctypes.wintypes.HANDLE, ctypes.c_int, 
                                       ctypes.POINTER(PCO_Buflist),
                                       ctypes.c_int]
 def wait_for_buffer(handle, num_buffers, buffer_list, timeout):
@@ -1326,7 +1336,7 @@ def wait_for_buffer(handle, num_buffers, buffer_list, timeout):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     num_buffers : int
         How many buffers in buffer_list?
@@ -1342,7 +1352,7 @@ def wait_for_buffer(handle, num_buffers, buffer_list, timeout):
 # ---------------------------------------------------------------------
 # 2.11.9 PCO_GetMetaData
 # ---------------------------------------------------------------------
-sc2_cam.PCO_GetMetaData.argtypes = [HANDLE, ctypes.c_short, PCO_Metadata_Struct,
+sc2_cam.PCO_GetMetaData.argtypes = [ctypes.wintypes.HANDLE, ctypes.c_short, PCO_Metadata_Struct,
                                     ctypes.wintypes.DWORD, ctypes.wintypes.DWORD]
 def get_metadata(handle, index):
     """
@@ -1350,7 +1360,7 @@ def get_metadata(handle, index):
 
     Parameters
     ----------
-    handle : HANDLE
+    handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     index : int
         Buffer index to get metadata

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -1452,7 +1452,7 @@ sc2_cam.PCO_AddBufferExtern.argtypes = [ctypes.wintypes.HANDLE,
                                         ctypes.c_void_p,         # alternatively numpy.ctypeslib.ndpointer
                                         ctypes.wintypes.DWORD,
                                         ctypes.wintypes.PDWORD]
-def add_buffer_extern(handle, event, segment, first_image, buf, n_bytes):
+def add_buffer_extern(handle, event, segment, first_image, buf, n_bytes, status):
     """
     Set up buffer for single image transfer from the camera. Can add multiple
     buffers for fast live recording. This function lets us use buffers we
@@ -1477,19 +1477,15 @@ def add_buffer_extern(handle, event, segment, first_image, buf, n_bytes):
         https://numpy.org/doc/stable/reference/routines.ctypeslib.html
     n_bytes : int
         Number of bytes in the 2D image buffer, buf
-
-    Returns
-    -------
-    status : unisgned long int
-        Buffer status
+    status : ctypes.wintypes.PDWORD
+        Pointer to buffer status bit
     """
     image_index = ctypes.wintypes.DWORD(first_image)
     synch = ctypes.wintypes.DWORD(0)
-    status = ctypes.wintypes.DWORD()
     check_status(sc2_cam.PCO_AddBufferExtern(handle, event, ctypes.wintypes.WORD(segment), 
                                              image_index, image_index, synch, buf, 
-                                             ctypes.wintypes.DWORD(n_bytes), status))
-    return status.value
+                                             ctypes.wintypes.DWORD(n_bytes), 
+                                             status))
 
 # ---------------------------------------------------------------------
 # 2.11.6 PCO_CancelImages

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+
+"""
+Created on Fri May 14 2021
+
+@author: zacsimile
+"""
+
+# NOTE: I cheated a little off https://pypi.org/project/pco/
+
+# For more information, see the pco.sdk manual,
+# https://www.pco.de/fileadmin/fileadmin/user_upload/pco-manuals/pco.sdk_manual.pdf
+
+import ctypes
+import ctypes.wintypes
+import platform
+import os
+import sys
+
+os_desc = platform.system()
+if os_desc != 'Windows':
+    raise Exception("Operating system is not supported.")
+
+dll = 'SC2_Cam.dll'
+dll_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), dll)
+try:
+    sc2_cam = ctypes.windll.LoadLibrary(dll_path)
+except:
+    raise OSError(f"{dll} not found in {dll_path}.")
+
+# ---------------------------------------------------------------------
+# Structures and types
+# ---------------------------------------------------------------------
+HANDLE = ctypes.c_void_p
+HANDLE_P = ctypes.POINTER(HANDLE)
+
+class PCO_Description(ctypes.Structure):
+    # _pack_ = 1
+    _fields_ = [("wSize", ctypes.wintypes.WORD),
+                ("wSensorTypeDESC", ctypes.wintypes.WORD),
+                ("wSensorSubTypeDESC", ctypes.wintypes.WORD),
+                ("wMaxHorzResStdDESC", ctypes.wintypes.WORD),
+                ("wMaxVertResStdDESC", ctypes.wintypes.WORD),
+                ("wMaxHorzResExtDESC", ctypes.wintypes.WORD),
+                ("wMaxVertResExtDESC", ctypes.wintypes.WORD),
+                ("wDynResDESC", ctypes.wintypes.WORD),
+                ("wMaxBinHorzDESC", ctypes.wintypes.WORD),
+                ("wBinHorzSteppingDESC", ctypes.wintypes.WORD),
+                ("wMaxBinVertDESC", ctypes.wintypes.WORD),
+                ("wBinVertSteppingDESC", ctypes.wintypes.WORD),
+                ("wRoiHorStepsDESC", ctypes.wintypes.WORD),
+                ("wRoiVertStepsDESC", ctypes.wintypes.WORD),
+                ("wNumADCsDESC", ctypes.wintypes.WORD),
+                ("wMinSizeHorzDESC", ctypes.wintypes.WORD),
+                ("wMinSizeVertDESC", ctypes.wintypes.WORD),
+                ("dwPixelRateDESC", ctypes.wintypes.DWORD * 4),
+                ("ZzdwDummy", ctypes.wintypes.DWORD),
+                ("wConvFactDESC", ctypes.wintypes.WORD * 4),
+                ("sCoolingSetpoints", ctypes.c_short * 10),
+                ("ZZdwDummycv", ctypes.wintypes.WORD),
+                ("wSoftRoiHorStepsDESC", ctypes.wintypes.WORD),
+                ("wSoftRoiVertStepsDESC", ctypes.wintypes.WORD),
+                ("wIRDESC", ctypes.wintypes.WORD),
+                ("dwMinDelayDESC", ctypes.wintypes.DWORD),
+                ("dwMaxDelayDESC", ctypes.wintypes.DWORD),
+                ("dwMinDelayStepDESC", ctypes.wintypes.DWORD),
+                ("dwMinExposDESC", ctypes.wintypes.DWORD),
+                ("dwMaxExposDESC", ctypes.wintypes.DWORD),
+                ("dwMinExposStepDESC", ctypes.wintypes.DWORD),
+                ("dwMinDelayIRDESC", ctypes.wintypes.DWORD),
+                ("dwMaxDelayIRDESC", ctypes.wintypes.DWORD),
+                ("dwMinExposIRDESC", ctypes.wintypes.DWORD),
+                ("dwMaxExposIRDESC", ctypes.wintypes.DWORD),
+                ("wTimeTableDESC", ctypes.wintypes.WORD),
+                ("wDoubleImageDESC", ctypes.wintypes.WORD),
+                ("sMinCoolSetDESC", ctypes.c_short),
+                ("sMaxCoolSetDESC", ctypes.c_short),
+                ("sDefaultCoolSetDESC", ctypes.c_short),
+                ("wPowerDownModeDESC", ctypes.wintypes.WORD),
+                ("wOffsetRegulationDESC", ctypes.wintypes.WORD),
+                ("wColorPatternDESC", ctypes.wintypes.WORD),
+                ("wPatternTypeDESC", ctypes.wintypes.WORD),
+                ("wDummy1", ctypes.wintypes.WORD),
+                ("wDummy2", ctypes.wintypes.WORD),
+                ("wNumCoolingSetpoints", ctypes.wintypes.WORD),
+                ("dwGeneralCapsDESC1", ctypes.wintypes.DWORD),
+                ("dwGeneralCapsDESC2", ctypes.wintypes.DWORD),
+                ("dwExtSyncFrequency", ctypes.wintypes.DWORD * 4),
+                ("dwGeneralCapsDESC3", ctypes.wintypes.DWORD),
+                ("dwGeneralCapsDESC4", ctypes.wintypes.DWORD),
+                ("ZzdwDummy", ctypes.wintypes.DWORD)]
+
+# ---------------------------------------------------------------------
+# Function prototypes
+# ---------------------------------------------------------------------
+sc2_cam.PCO_OpenCamera.argtypes = [HANDLE_P, 
+                                   ctypes.wintypes.WORD]
+sc2_cam.PCO_GetCameraDescription.argtypes = [HANDLE,
+                                             ctypes.POINTER(PCO_Description)]
+sc2_cam.PCO_GetCameraHealthStatus.argtypes = [HANDLE,
+                                              ctypes.wintypes.PDWORD,
+                                              ctypes.wintypes.PDWORD,
+                                              ctypes.wintypes.PDWORD]
+sc2_cam.PCO_ArmCamera.argtypes = [HANDLE]
+sc2_cam.PCO_GetRecordingState.argtypes = [HANDLE, ctypes.wintypes.PWORD]
+sc2_cam.PCO_SetRecordingState.argtypes = [HANDLE, ctypes.wintypes.WORD]
+sc2_cam.PCO_GetImageEx.argtypes = [HANDLE, 
+                                   ctypes.wintypes.WORD,
+                                   ctypes.wintypes.DWORD,
+                                   ctypes.wintypes.DWORD,
+                                   ctypes.c_short,
+                                   ctypes.wintypes.WORD,
+                                   ctypes.wintypes.WORD,
+                                   ctypes.wintypes.WORD]
+sc2_cam.PCO_AddBufferEx.argtypes = [HANDLE, 
+                                    ctypes.wintypes.DWORD,
+                                    ctypes.wintypes.DWORD,
+                                    ctypes.c_short,
+                                    ctypes.wintypes.WORD,
+                                    ctypes.wintypes.WORD,
+                                    ctypes.wintypes.WORD]
+sc2_cam.PCO_CancelImages.argtypes = [HANDLE]
+sc2_cam.PCO_GetErrorText.argtypes = [ctypes.wintypes.DWORD,
+                                     ctypes.c_char_p,
+                                     ctypes.wintypes.DWORD]
+
+# ---------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------
+class PcoSDKException(Exception):
+    def __init__(self, message):
+        Exception.__init__(self, message)
+
+def check_status(err, function_name="unknown function"):
+    if err:
+        err_desc = get_error_text(err)
+        raise PcoSDKException(f"Error during {function_name}: {err_desc}")
+
+# ---------------------------------------------------------------------
+# 2.1.1 PCO_OpenCamera
+# ---------------------------------------------------------------------
+def open_camera(handle=ctypes.c_void_p(0), cam_num=0):
+    check_status(sc2_cam.PCO_OpenCamera(handle, cam_num), 
+                 sys._getframe().f_code.co_name)
+
+# ---------------------------------------------------------------------
+# 2.2.1 PCO_GetCameraDescription
+# ---------------------------------------------------------------------
+def get_camera_description(handle=ctypes.c_void_p(0)):
+    desc = PCO_Description()
+    check_status(sc2_cam.PCO_GetCameraDescription(handle, desc),
+                 sys._getframe().f_code.co_name)
+    return desc
+
+# ---------------------------------------------------------------------
+# 2.3.3 PCO_GetCameraHealthStatus
+# ---------------------------------------------------------------------
+def get_camera_health_status(handle=ctypes.c_void_p(0)):
+    warn = ctypes.wintypes.DWORD()
+    err = ctypes.wintypes.DWORD()
+    status = ctypes.wintypes.DWORD()
+    check_status(sc2_cam.PCO_GetCameraHealthStatus(handle, warn, err, status),
+                 sys._getframe().f_code.co_name)
+    return warn, err, status
+
+# ---------------------------------------------------------------------
+# 2.4.1 PCO_ArmCamera
+# ---------------------------------------------------------------------
+def arm_camera(handle=ctypes.c_void_p(0)):
+    check_status(sc2_cam.PCO_ArmCamera(handle), sys._getframe().f_code.co_name)
+
+# ---------------------------------------------------------------------
+# 2.7.3 PCO_GetRecordingState
+# ---------------------------------------------------------------------
+def get_recording_state(handle=ctypes.c_void_p(0)):
+    state = ctypes.wintypes.WORD()
+    check_status(sc2_cam.PCO_GetRecordingState(handle, state),
+                 sys._getframe().f_code.co_name)
+    return state
+
+# ---------------------------------------------------------------------
+# 2.7.4 PCO_SetRecordingState
+# ---------------------------------------------------------------------
+def set_recording_state(handle=ctypes.c_void_p(0), state=0):
+    check_status(sc2_cam.PCO_SetRecordingState(handle, state), 
+                 sys._getframe().f_code.co_name)
+
+# ---------------------------------------------------------------------
+# 2.11.1 PCO_GetImageEx
+# ---------------------------------------------------------------------
+def get_image_ex(handle=ctypes.c_void_p(0), segment=1, first_image=0, 
+                 buffer_index=0, lx=256, ly=256, bits_per_pixel=16):
+    check_status(sc2_cam.PCO_GetImageEx(handle, segment, first_image,
+                 first_image, buffer_index, lx, ly, bits_per_pixel))
+# ---------------------------------------------------------------------
+# 2.11.3 PCO_AddBufferEx
+# ---------------------------------------------------------------------
+def add_buffer_ex(handle=ctypes.c_void_p(0), first_image=0, last_image=0,
+                  buffer_index=0, lx=256, ly=256, bits_per_pixel=16):
+    check_status(sc2_cam.PCO_AddBufferEx(handle, first_image, last_image,
+                 buffer_index, lx, ly, bits_per_pixel))
+# ---------------------------------------------------------------------
+# 2.11.6 PCO_CancelImages
+# ---------------------------------------------------------------------
+def cancel_images(handle=ctypes.c_void_p(0)):
+    check_status(sc2_cam.PCO_CancelImages(handle), sys._getframe().f_code.co_name)
+
+# ---------------------------------------------------------------------
+# 5.1 PCO_GetErrorText
+# ---------------------------------------------------------------------
+def get_error_text(err):
+    c_buf_len = 512
+    c_buf = ctypes.create_string_buffer(c_buf_len)
+    sc2_cam.PCO_GetErrorText(err, c_buf, c_buf_len)
+
+    return c_buf.value.decode('ascii')
+    

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -60,15 +60,15 @@ class PCO_Description(ctypes.Structure):
                 ("wRoiVertStepsDESC", ctypes.wintypes.WORD),
                 ("wNumADCsDESC", ctypes.wintypes.WORD),
                 ("wMinSizeHorzDESC", ctypes.wintypes.WORD),
-                ("wMinSizeVertDESC", ctypes.wintypes.WORD),
                 ("dwPixelRateDESC", ctypes.wintypes.DWORD * 4),
-                ("ZzdwDummy", ctypes.wintypes.DWORD),
+                ("ZzdwDummypr", ctypes.wintypes.DWORD * 20),
                 ("wConvFactDESC", ctypes.wintypes.WORD * 4),
                 ("sCoolingSetpoints", ctypes.c_short * 10),
-                ("ZZdwDummycv", ctypes.wintypes.WORD),
+                ("ZZdwDummycv", ctypes.wintypes.WORD * 8),
                 ("wSoftRoiHorStepsDESC", ctypes.wintypes.WORD),
                 ("wSoftRoiVertStepsDESC", ctypes.wintypes.WORD),
                 ("wIRDESC", ctypes.wintypes.WORD),
+                ("wMinSizeVertDESC", ctypes.wintypes.WORD),
                 ("dwMinDelayDESC", ctypes.wintypes.DWORD),
                 ("dwMaxDelayDESC", ctypes.wintypes.DWORD),
                 ("dwMinDelayStepDESC", ctypes.wintypes.DWORD),
@@ -97,7 +97,6 @@ class PCO_Description(ctypes.Structure):
                 ("dwGeneralCapsDESC3", ctypes.wintypes.DWORD),
                 ("dwGeneralCapsDESC4", ctypes.wintypes.DWORD),
                 ("ZzdwDummy", ctypes.wintypes.DWORD)]
-
 class PCO_SC2_Hardware_DESC(ctypes.Structure):
     # _pack_ = 1
     _fields_ = [
@@ -330,8 +329,8 @@ sc2_cam.PCO_GetCameraDescription.argtypes = [HANDLE,
                                              ctypes.POINTER(PCO_Description)]
 def get_camera_description(handle):
     """
-    Get camera description. Includes properties such as image size, pixel rate, etc.,
-    but not camera names, serial numbers, etc. For the latter, call get_camera_type().
+    Get camera description. Includes properties such as image size, pixel rate, etctypes.,
+    but not camera names, serial numbers, etctypes. For the latter, call get_camera_type().
 
     Parameters
     ----------

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -248,6 +248,18 @@ PCO_INTERFACE_TYPES = {
     0x0007 : 'CLHS'
 }
 
+PCO_TRIGGER_MODES = {
+    0x0000 : 'auto sequence',
+    0x0001 : 'software trigger',
+    0x0002 : 'external exposure start & software trigger',
+    0x0003 : 'external exposure control',
+    0x0004 : 'external synchronized',
+    0x0005 : 'fast external exposure control',
+    0x0006 : 'external CDS control',
+    0x0007 : 'slow external exposure control',
+    0x0102 : 'external synchronized HDSDI'
+}
+
 # ---------------------------------------------------------------------
 # Error handling
 # ---------------------------------------------------------------------
@@ -831,6 +843,99 @@ def set_delay_exposure_time(handle, delay, exposure, timebase_delay, timebase_ex
                                                   ctypes.wintypes.DWORD(exposure),
                                                   ctypes.wintypes.WORD(timebase_delay), 
                                                   ctypes.wintypes.WORD(timebase_exposure)))
+
+# ---------------------------------------------------------------------
+# 2.6.12 PCO_GetTriggerMode
+# ---------------------------------------------------------------------
+sc2_cam.PCO_GetTriggerMode.argtypes = [ctypes.wintypes.HANDLE,
+                                       ctypes.wintypes.PWORD]
+def get_trigger_mode(handle, mode):
+    """
+    Get the camera trigger mode. See pco.sdk for details.
+
+    Parameters
+    ----------
+    handle : ctypes.wintypes.HANDLE
+        Unique pco. camera handle (pointer).
+    
+    Returns
+    -------
+    mode : unsigned short int
+        Trigger mode. One of PCO_TRIGGER_MODES.
+    """
+    mode = ctypes.wintypes.WORD()
+    check_status(sc2_cam.PCO_GetTriggerMode(handle, mode))
+
+    return mode.value
+# ---------------------------------------------------------------------
+# 2.6.13 PCO_SetTriggerMode
+# ---------------------------------------------------------------------
+sc2_cam.PCO_SetTriggerMode.argtypes = [ctypes.wintypes.HANDLE,
+                                       ctypes.wintypes.WORD]
+def set_trigger_mode(handle, mode):
+    """
+    Set the camera trigger mode. See pco.sdk for details.
+
+    Parameters
+    ----------
+    handle : ctypes.wintypes.HANDLE
+        Unique pco. camera handle (pointer).
+    mode : int
+        Trigger mode. One of PCO_TRIGGER_MODES.
+    """
+    check_status(sc2_cam.PCO_SetTriggerMode(handle, ctypes.wintypes.WORD(mode)))
+
+# ---------------------------------------------------------------------
+# 2.6.14 PCO_ForceTrigger
+# ---------------------------------------------------------------------
+sc2_cam.PCO_ForceTrigger.argtypes = [ctypes.wintypes.HANDLE,
+                                     ctypes.wintypes.PWORD]
+TRIGGER_FAIL = 0x0000
+TRIGGER_SUCCESS = 0x0001  # NOTE: This is counter to every other function
+                          # where a 0 indicates success
+def force_trigger(handle):
+    """
+    Trigger image acquisition in software triggered mode.
+
+    Parameters
+    ----------
+    handle : ctypes.wintypes.HANDLE
+        Unique pco. camera handle (pointer).
+
+    Returns
+    -------
+    triggered : unsigned short int
+        Sucess of trigger call, one of TRIGGER_FAIL (0), TRIGGER_SUCCESS (1)
+    """
+    triggered = ctypes.wintypes.WORD()
+    check_status(sc2_cam.PCO_ForceTrigger(handle, triggered))
+    return triggered.value
+
+# ---------------------------------------------------------------------
+# 2.6.15 PCO_GetCameraBusyStatus
+# ---------------------------------------------------------------------
+sc2_cam.PCO_GetCameraBusyStatus.argtypes = [ctypes.wintypes.HANDLE,
+                                            ctypes.wintypes.PWORD]
+PCO_CAMERA_NOT_BUSY = 0x0000
+PCO_CAMERA_BUSY = 0x0001
+def get_camera_busy_status(handle):
+    """
+    Return the busy status of the camera. Ideally checked before
+    a force_trigger() call.
+
+    Parameters
+    ----------
+    handle : ctypes.wintypes.HANDLE
+        Unique pco. camera handle (pointer).
+
+    Returns
+    -------
+    state : unsigned short int
+        Camera busy status, one of PCO_CAMERA_NOT_BUSY (0), PCO_CAMERA_BUSY (1)
+    """
+    state = ctypes.wintypes.WORD()
+    check_status(sc2_cam.PCO_GetCameraBusyStatus(handle, state))
+    return state.value
 
 # ---------------------------------------------------------------------
 # 2.6.26 PCO_GetImageTiming

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -90,6 +90,107 @@ class PCO_Description(ctypes.Structure):
                 ("dwGeneralCapsDESC4", ctypes.wintypes.DWORD),
                 ("ZzdwDummy", ctypes.wintypes.DWORD)]
 
+class PCO_SC2_Hardware_DESC(ctypes.Structure):
+    # _pack_ = 1
+    _fields_ = [
+        ("szName", ctypes.c_char * 16),
+        ("wBatchNo", ctypes.wintypes.WORD),
+        ("wRevision", ctypes.wintypes.WORD),
+        ("wVariant", ctypes.wintypes.WORD),
+        ("ZZwDummy", ctypes.wintypes.WORD * 20)]
+
+class PCO_SC2_Firmware_DESC(ctypes.Structure):
+    # _pack_ = 1
+    _fields_ = [("szName", ctypes.c_char * 16),
+                ("bMinorRev", ctypes.c_byte),
+                ("bMajorRev", ctypes.c_byte),
+                ("wVariant", ctypes.wintypes.WORD),
+                ("ZZwDummy", ctypes.wintypes.WORD * 22)]
+
+class PCO_HW_Vers(C.Structure):
+    #_pack_ = 1
+    _fields_ = [
+        ("wBoardNum", ctypes.wintypes.WORD),
+        ("Board", PCO_SC2_Hardware_DESC * 10)]
+
+class PCO_FW_Vers(ctypes.Structure):
+    # _pack_ = 1
+    _fields_ = [("wDeviceNum", ctypes.wintypes.WORD),
+                ("Device", PCO_SC2_Firmware_DESC * 10)]
+
+class PCO_CameraType(ctypes.Structure):
+    # _pack_ = 1
+    _fields_ = [("wSize", ctypes.wintypes.WORD),
+                ("wCamType", ctypes.wintypes.WORD),
+                ("wCamSubType", ctypes.wintypes.WORD),
+                ("ZZwAlignDummy1", ctypes.wintypes.WORD),
+                ("dwSerialNumber", ctypes.wintypes.DWORD),
+                ("dwHWVersion", ctypes.wintypes.DWORD),
+                ("dwFWVersion", ctypes.wintypes.DWORD),
+                ("wInterfaceType", ctypes.wintypes.WORD),
+                ("strHardwareVersion", PCO_HW_Vers),
+                ("strFirmwareVersion", PCO_FW_Vers),
+                ("ZZwDummy", ctypes.wintypes.PWORD)]  # ("ZZwDummy", ctypes.wintypes.WORD * 39)
+
+class PCO_Recording(ctypes.Structure):
+    # _pack_ = 1
+    _fields_ = [("wSize", ctypes.wintypes.WORD),
+                ("wStorageMode", ctypes.wintypes.WORD),
+                ("wRecSubmode", ctypes.wintypes.WORD),
+                ("wRecState", ctypes.wintypes.WORD),
+                ("wAcquMode", ctypes.wintypes.WORD),
+                ("wAcquEnableStatus", ctypes.wintypes.WORD),
+                ("ucDay", ctypes.c_byte),
+                ("ucMonth", ctypes.c_byte),
+                ("wYear", ctypes.wintypes.WORD),
+                ("wHour", ctypes.wintypes.WORD),
+                ("ucMin", ctypes.c_byte),
+                ("ucSec", ctypes.c_byte),
+                ("wTimeStampMode", ctypes.wintypes.WORD),
+                ("wRecordStopEventMode", ctypes.wintypes.WORD),
+                ("dwRecordStopDelayImages", ctypes.wintypes.DWORD),
+                ("wMetaDataMode", ctypes.wintypes.WORD),
+                ("wMetaDataSize", ctypes.wintypes.WORD),
+                ("wMetaDataVersion", ctypes.wintypes.WORD),
+                ("ZZwDummy1", ctypes.wintypes.WORD),
+                ("dwAcquModeExNumberImages", ctypes.wintypes.DWORD),
+                ("dwAcquModeExReserved", ctypes.wintypes.DWORD * 4),
+                ("ZZwDummy", ctypes.wintypes.WORD * 22)]
+
+class PCO_Metadata_Struct(ctypes.Structure):
+    # _pack_ = 1
+    _fields_ = [("wSize", ctypes.wintypes.WORD),
+                ("wVersion", ctypes.wintypes.WORD),
+                ("bIMAGE_COUNTER_BCD", ctypes.c_byte * 4),
+                ("bIMAGE_TIME_US_BCD", ctypes.c_byte * 3),
+                ("bIMAGE_TIME_SEC_BCD", ctypes.c_byte),
+                ("bIMAGE_TIME_MIN_BCD", ctypes.c_byte),
+                ("bIMAGE_TIME_HOUR_BCD", ctypes.c_byte),
+                ("bIMAGE_TIME_DAY_BCD", ctypes.c_byte),
+                ("bIMAGE_TIME_MON_BCD", ctypes.c_byte),
+                ("bIMAGE_TIME_YEAR_BCD", ctypes.c_byte),
+                ("bIMAGE_TIME_STATUS", ctypes.c_byte),
+                ("wEXPOSURE_TIME_BASE", ctypes.wintypes.WORD),
+                ("dwEXPOSURE_TIME", ctypes.wintypes.DWORD),
+                ("dwFRAMERATE_MILLIHZ", ctypes.wintypes.DWORD),
+                ("sSENSOR_TEMPERATURE", ctypes.c_short),
+                ("wIMAGE_SIZE_X", ctypes.wintypes.WORD),
+                ("wIMAGE_SIZE_Y", ctypes.wintypes.WORD),
+                ("bBINNING_X", ctypes.c_byte),
+                ("bBINNING_Y", ctypes.c_byte),
+                ("dwSENSOR_READOUT_FREQUENCY", ctypes.wintypes.DWORD),
+                ("wSENSOR_CONV_FACTOR", ctypes.wintypes.WORD),
+                ("dwCAMERA_SERIAL_NO", ctypes.wintypes.DWORD),
+                ("wCAMERA_TYPE", ctypes.wintypes.WORD),
+                ("bBIT_RESOLUTION", ctypes.c_byte),
+                ("bSYNC_STATUS", ctypes.c_byte),
+                ("wDARK_OFFSET", ctypes.wintypes.WORD),
+                ("bTRIGGER_MODE", ctypes.c_byte),
+                ("bDOUBLE_IMAGE_MODE", ctypes.c_byte),
+                ("bCAMERA_SYNC_MODE", ctypes.c_byte),
+                ("bIMAGE_TYPE", ctypes.c_byte),
+                ("wCOLOR_PATTERN", ctypes.wintypes.WORD)]
+
 # ---------------------------------------------------------------------
 # Function prototypes
 # ---------------------------------------------------------------------
@@ -144,6 +245,14 @@ def open_camera(handle=ctypes.c_void_p(0), cam_num=0):
                  sys._getframe().f_code.co_name)
 
 # ---------------------------------------------------------------------
+# 2.1.3 PCO_CloseCamera
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.1.4 PCO_ResetLib
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
 # 2.2.1 PCO_GetCameraDescription
 # ---------------------------------------------------------------------
 def get_camera_description(handle=ctypes.c_void_p(0)):
@@ -151,6 +260,10 @@ def get_camera_description(handle=ctypes.c_void_p(0)):
     check_status(sc2_cam.PCO_GetCameraDescription(handle, desc),
                  sys._getframe().f_code.co_name)
     return desc
+
+# ---------------------------------------------------------------------
+# 2.3.3 PCO_GetCameraType
+# ---------------------------------------------------------------------
 
 # ---------------------------------------------------------------------
 # 2.3.3 PCO_GetCameraHealthStatus
@@ -162,6 +275,10 @@ def get_camera_health_status(handle=ctypes.c_void_p(0)):
     check_status(sc2_cam.PCO_GetCameraHealthStatus(handle, warn, err, status),
                  sys._getframe().f_code.co_name)
     return warn, err, status
+
+# ---------------------------------------------------------------------
+# 2.3.4 PCO_GetTemperature
+# ---------------------------------------------------------------------
 
 # ---------------------------------------------------------------------
 # 2.4.1 PCO_ArmCamera
@@ -186,6 +303,86 @@ def set_recording_state(handle=ctypes.c_void_p(0), state=0):
                  sys._getframe().f_code.co_name)
 
 # ---------------------------------------------------------------------
+# 2.7.5 PCO_GetStorageMode
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.7.6 PCO_SetStorageMode
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.7.7 PCO_GetRecorderSubmode
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.7.8 PCO_SetRecorderSubmode
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.7.9 PCO_GetAcquireMode
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.7.10 PCO_SetAcquireMode
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.7.11 PCO_GetAcquireModeEx
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.7.12 PCO_SetAcquireModeEx
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.7.14 PCO_GetMetaDataMode
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.7.15 PCO_SetMetaDataMode
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.7.20 PCO_GetTimestampMode
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.7.21 PCO_SetTimestampMode
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.9.5 PCO_GetBitAlignment
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.9.6 PCO_SetBitAlignment
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.9.7 PCO_GetHotPixelCorrectionMode
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.9.8 PCO_SetHotPixelCorrectionMode
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.10.1 PCO_AllocateBuffer
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.10.2 PCO_FreeBuffer
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.10.3 PCO_GetBufferStatus
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.10.4 PCO_GetBuffer
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
 # 2.11.1 PCO_GetImageEx
 # ---------------------------------------------------------------------
 def get_image_ex(handle=ctypes.c_void_p(0), segment=1, first_image=0, 
@@ -206,6 +403,14 @@ def cancel_images(handle=ctypes.c_void_p(0)):
     check_status(sc2_cam.PCO_CancelImages(handle), sys._getframe().f_code.co_name)
 
 # ---------------------------------------------------------------------
+# 2.11.9 PCO_WaitforBuffer
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# 2.11.9 PCO_GetMetaData
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
 # 5.1 PCO_GetErrorText
 # ---------------------------------------------------------------------
 def get_error_text(err):
@@ -214,4 +419,3 @@ def get_error_text(err):
     sc2_cam.PCO_GetErrorText(err, c_buf, c_buf_len)
 
     return c_buf.value.decode('ascii')
-    

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -4,12 +4,17 @@
 Created on Fri May 14 2021
 
 @author: zacsimile
+
+The goal of this file is to provide Python access to pco.sdk as closely to how it
+is implemented in pco.sdk as possible. There's no mapping of flags to readable
+strings such as "on"/"off". The idea is to have raw access to the DLL. For a
+friendlier--but less comprehensive--version, see sdk.py in https://pypi.org/project/pco/.
+
+For more information, see the pco.sdk manual,
+https://www.pco.de/fileadmin/fileadmin/user_upload/pco-manuals/pco.sdk_manual.pdf
+
+NOTE: I cheated a little off https://pypi.org/project/pco/.
 """
-
-# NOTE: I cheated a little off https://pypi.org/project/pco/
-
-# For more information, see the pco.sdk manual,
-# https://www.pco.de/fileadmin/fileadmin/user_upload/pco-manuals/pco.sdk_manual.pdf
 
 import ctypes
 import ctypes.wintypes

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -5,6 +5,9 @@ Created on Fri May 14 2021
 
 @author: zacsimile
 
+To run, install the pco. sdk, available at 
+https://www.pco.de/software/development-tools/pcosdk/, as admin.
+
 The goal of this file is to provide Python access to pco.sdk as closely to how it
 is implemented in pco.sdk as possible. There's no mapping of flags to readable
 strings such as "on"/"off". The idea is to have raw access to the DLL. For a
@@ -27,11 +30,11 @@ if os_desc != 'Windows':
     raise Exception("Operating system is not supported.")
 
 dll = 'SC2_Cam.dll'
-dll_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), dll)
+dll_path = "C:\\Program Files (x86)\\PCO Digital Camera Toolbox\\pco.sdk\\bin64\\" + dll
 try:
     sc2_cam = ctypes.windll.LoadLibrary(dll_path)
 except:
-    raise OSError(f"{dll} not found in {dll_path}.")
+    raise
 
 # ---------------------------------------------------------------------
 # Structures and types
@@ -112,7 +115,7 @@ class PCO_SC2_Firmware_DESC(ctypes.Structure):
                 ("wVariant", ctypes.wintypes.WORD),
                 ("ZZwDummy", ctypes.wintypes.WORD * 22)]
 
-class PCO_HW_Vers(C.Structure):
+class PCO_HW_Vers(ctypes.Structure):
     #_pack_ = 1
     _fields_ = [
         ("wBoardNum", ctypes.wintypes.WORD),
@@ -210,7 +213,7 @@ class PCO_Metadata_Struct(ctypes.Structure):
                 ("bIMAGE_TYPE", ctypes.c_byte),
                 ("wCOLOR_PATTERN", ctypes.wintypes.WORD)]
 
-PCO_NOERROR = ctypes.wintypes.DWORD(int("0x00000000", 0))
+PCO_NOERROR = 0x00000000
 class PCO_Buflist(ctypes.Structure):
     # _pack_ = 1
     _fields_ = [("SBufNr", ctypes.c_short),
@@ -219,34 +222,34 @@ class PCO_Buflist(ctypes.Structure):
                 ("dwStatusDrv", ctypes.wintypes.DWORD)]  # PCO_NOERROR or see pco.sdk for error codes
 
 PCO_CAMERA_TYPES = {
-    ctypes.wintypes.WORD(int("0x1300",0)) : 'pco.edge 5.5 CL',
-    ctypes.wintypes.WORD(int("0x1302",0)) : 'pco.edge 4.2 CL',
-    ctypes.wintypes.WORD(int("0x1310",0)) : 'pco.edge GL',
-    ctypes.wintypes.WORD(int("0x1320",0)) : 'pco.edge USB3',
-    ctypes.wintypes.WORD(int("0x1340",0)) : 'pco.edge CLHS',
-    ctypes.wintypes.WORD(int("0x1304",0)) : 'pco.edge MT',
-    ctypes.wintypes.WORD(int("0x1000",0)) : 'pco.dimax',
-    ctypes.wintypes.WORD(int("0x1010",0)) : 'pco.dimax_TV',
-    ctypes.wintypes.WORD(int("0x1020",0)) : 'pco.dimax CS',
-    ctypes.wintypes.WORD(int("0x1400",0)) : 'pco.flim',
-    ctypes.wintypes.WORD(int("0x1500",0)) : 'pco.panda',
-    ctypes.wintypes.WORD(int("0x0800",0)) : 'pco.pixelfly usb',
-    ctypes.wintypes.WORD(int("0x0100",0)) : 'pco.1200HS',
-    ctypes.wintypes.WORD(int("0x0200",0)) : 'pco.1300',
-    ctypes.wintypes.WORD(int("0x0220",0)) : 'pco.1600',
-    ctypes.wintypes.WORD(int("0x0240",0)) : 'pco.2000',
-    ctypes.wintypes.WORD(int("0x0260",0)) : 'pco.4000',
-    ctypes.wintypes.WORD(int("0x0830",0)) : 'pco.1400'
+    0x1300 : 'pco.edge 5.5 CL',
+    0x1302 : 'pco.edge 4.2 CL',
+    0x1310 : 'pco.edge GL',
+    0x1320 : 'pco.edge USB3',
+    0x1340 : 'pco.edge CLHS',
+    0x1304 : 'pco.edge MT',
+    0x1000 : 'pco.dimax',
+    0x1010 : 'pco.dimax_TV',
+    0x1020 : 'pco.dimax CS',
+    0x1400 : 'pco.flim',
+    0x1500 : 'pco.panda',
+    0x0800 : 'pco.pixelfly usb',
+    0x0100 : 'pco.1200HS',
+    0x0200 : 'pco.1300',
+    0x0220 : 'pco.1600',
+    0x0240 : 'pco.2000',
+    0x0260 : 'pco.4000',
+    0x0830 : 'pco.1400'
 }
 
 PCO_INTERFACE_TYPES = {
-    ctypes.wintypes.WORD(int("0x0001",0)) : 'FireWire',
-    ctypes.wintypes.WORD(int("0x0002",0)) : 'Camera Link',
-    ctypes.wintypes.WORD(int("0x0003",0)) : 'USB 2.0',
-    ctypes.wintypes.WORD(int("0x0004",0)) : 'GigE',
-    ctypes.wintypes.WORD(int("0x0005",0)) : 'Serial Interface',
-    ctypes.wintypes.WORD(int("0x0006",0)) : 'USB 3.0',
-    ctypes.wintypes.WORD(int("0x0007",0)) : 'CLHS'
+    0x0001 : 'FireWire',
+    0x0002 : 'Camera Link',
+    0x0003 : 'USB 2.0',
+    0x0004 : 'GigE',
+    0x0005 : 'Serial Interface',
+    0x0006 : 'USB 3.0',
+    0x0007 : 'CLHS'
 }
 
 # ---------------------------------------------------------------------
@@ -286,7 +289,6 @@ def open_camera():
     cam_num = ctypes.wintypes.WORD()  # unused
     check_status(sc2_cam.PCO_OpenCamera(handle, cam_num))
     return handle
-
 # ---------------------------------------------------------------------
 # 2.1.2 PCO_OpenCameraEx
 # ---------------------------------------------------------------------
@@ -342,6 +344,7 @@ def get_camera_description(handle):
         Struct of camera properties.
     """
     desc = PCO_Description()
+    desc.wSize = ctypes.sizeof(PCO_Description)
     check_status(sc2_cam.PCO_GetCameraDescription(handle, desc))
     return desc
 
@@ -364,6 +367,7 @@ def get_camera_type(handle):
         Struct containing hardware/firmware version, serial number, etc.
     """
     camera_type = PCO_CameraType()
+    camera_type.wSize = ctypes.sizeof(PCO_CameraType)
     check_status(sc2_cam.PCO_GetCameraType(handle, camera_type))
     return camera_type
 
@@ -388,18 +392,18 @@ def get_camera_health_status(handle):
 
     Returns
     -------
-    warn : unsigned long int
+    warn : int
         Warning bit 
-    err : unsigned long int
+    err : int
         Error bit 
-    status : unsigned long int
+    status : int
         Status bit 
     """
     warn = ctypes.wintypes.DWORD()
     err = ctypes.wintypes.DWORD()
     status = ctypes.wintypes.DWORD()
     check_status(sc2_cam.PCO_GetCameraHealthStatus(handle, warn, err, status))
-    return warn, err, status
+    return warn.value, err.value, status.value
 
 # ---------------------------------------------------------------------
 # 2.3.4 PCO_GetTemperature
@@ -418,18 +422,18 @@ def get_temperature(handle):
 
     Returns
     -------
-    ccd_temp : short
+    ccd_temp : int
         Image sensor temp in 1/10 degree i.e. 100 = 10.0 C
-    cam_temp : short
+    cam_temp : int
         Internal camera temp in C
-    pow_temp : short
+    pow_temp : int
         Temp of additional devices (e.g. power supply)
     """
     ccd_temp = ctypes.c_short()
     cam_temp = ctypes.c_short()
     pow_temp = ctypes.c_short()
     check_status(sc2_cam.PCO_GetTemperature(handle, ccd_temp, cam_temp, pow_temp))
-    return ccd_temp, cam_temp, pow_temp
+    return ccd_temp.value, cam_temp.value, pow_temp.value
 
 
 # ---------------------------------------------------------------------
@@ -456,8 +460,8 @@ sc2_cam.PCO_SetImageParameters.argtypes = [HANDLE, ctypes.wintypes.WORD,
                                            ctypes.wintypes.DWORD,
                                            ctypes.c_void_p,
                                            ctypes.c_int]
-PCO_IMAGEPARAMETERS_READ_WHILE_RECORDING = ctypes.wintypes.DWORD(int("0x00000001", 0))
-PCO_IMAGEPARAMETERS_READ_FROM_SEGMENTS = ctypes.wintypes.DWORD(int("0x00000002", 0))
+PCO_IMAGEPARAMETERS_READ_WHILE_RECORDING = 0x00000001
+PCO_IMAGEPARAMETERS_READ_FROM_SEGMENTS = 0x00000002
 def set_image_parameters(handle, lx, ly, image_flag):
     """
     Set image parameters for internal allocated resources before image transfer.
@@ -475,7 +479,10 @@ def set_image_parameters(handle, lx, ly, image_flag):
     """
     param = ctypes.c_void_p(0)
     ilen = ctypes.c_int(0)
-    check_status(sc2_cam.PCO_SetImageParameters(handle, lx, ly, image_flag, param, ilen))
+    check_status(sc2_cam.PCO_SetImageParameters(handle, ctypes.wintypes.WORD(lx), 
+                                                ctypes.wintypes.WORD(ly), 
+                                                ctypes.wintypes.DWORD(image_flag), 
+                                                param, ilen))
 
 # ---------------------------------------------------------------------
 # 2.4.4 PCO_ResetSettingsToDefault
@@ -510,13 +517,13 @@ def get_sizes(handle):
 
     Returns
     -------
-    lx : unsigned short int
+    lx : int
         Image width
-    ly : unsigned short int
+    ly : int
         Image height
-    lx_max : unsigned short int
+    lx_max : int
         Max image width
-    ly_max : unsigned short int
+    ly_max : int
         Max image height
     """
     lx = ctypes.wintypes.WORD()
@@ -524,7 +531,7 @@ def get_sizes(handle):
     lx_max = ctypes.wintypes.WORD()
     ly_max = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetSizes(handle, lx, ly, lx_max, ly_max))
-    return lx, ly, lx_max, ly_max
+    return lx.value, ly.value, lx_max.value, ly_max.value
 
 # ---------------------------------------------------------------------
 # 2.5.6 PCO_GetROI
@@ -545,13 +552,13 @@ def get_roi(handle):
     
     Returns
     -------
-    x0 : unsigned short int
+    x0 : int
         Horizontal (column) start coordinate
-    y0 : unsigned short int
+    y0 : int
         Vertical (row) start coordinate
-    x1 : unsigned short int
+    x1 : int
         Horizontal end coordinate
-    y1 : unsigned short int
+    y1 : int
         Vertical end coordinate
     """
     x0 = ctypes.wintypes.WORD()
@@ -559,7 +566,7 @@ def get_roi(handle):
     y0 = ctypes.wintypes.WORD()
     y1 = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetROI(handle, x0, y0, x1, y1))
-    return x0, x1, y0, y1
+    return x0.value, x1.value, y0.value, y1.value
 
 # ---------------------------------------------------------------------
 # 2.5.7 PCO_SetROI
@@ -577,16 +584,19 @@ def set_roi(handle, x0, y0, x1, y1):
     ----------
     handle : HANDLE
         Unique pco. camera handle (pointer).
-    x0 : unsigned short int
+    x0 : int
         Horizontal (column) start coordinate
-    y0 : unsigned short int
+    y0 : int
         Vertical (row) start coordinate
-    x1 : unsigned short int
+    x1 : int
         Horizontal end coordinate
-    y1 : unsigned short int
+    y1 : int
         Vertical end coordinate
     """
-    check_status(sc2_cam.PCO_SetROI(handle, x0, y0, x1, y1))
+    check_status(sc2_cam.PCO_SetROI(handle, ctypes.wintypes.WORD(x0), 
+                                    ctypes.wintypes.WORD(y0), 
+                                    ctypes.wintypes.WORD(x1), 
+                                    ctypes.wintypes.WORD(y1)))
 
 # ---------------------------------------------------------------------
 # 2.5.8 PCO_GetBinning
@@ -604,15 +614,15 @@ def get_binning(handle):
 
     Returns
     -------
-    bin_horiz : unsigned short int
+    bin_horiz : int
         Horizontal (column) binning in pixels
-    bin_vert : unsigned short int
+    bin_vert : int
         Vertical (row) binning in pixels
     """
     bin_horiz = ctypes.wintypes.WORD()
     bin_vert = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetBinning(handle, bin_horiz, bin_vert))
-    return bin_horiz, bin_vert
+    return bin_horiz.value, bin_vert.value
 
 # ---------------------------------------------------------------------
 # 2.5.9 PCO_SetBinning
@@ -631,12 +641,13 @@ def set_binning(handle, bin_horiz, bin_vert):
     ----------
     handle : HANDLE
         Unique pco. camera handle (pointer).
-    bin_horiz : unsigned short int
+    bin_horiz : int
         Horizontal (column) binning in pixels
-    bin_vert : unsigned short int
+    bin_vert : int
         Vertical (row) binning in pixels
     """
-    check_status(sc2_cam.PCO_SetBinning(handle, bin_horiz, bin_vert))
+    check_status(sc2_cam.PCO_SetBinning(handle, ctypes.wintypes.WORD(bin_horiz), 
+                                        ctypes.wintypes.WORD(bin_vert)))
 
 # ---------------------------------------------------------------------
 # 2.5.10 PCO_GetPixelRate
@@ -653,12 +664,12 @@ def get_pixel_rate(handle):
     
     Returns
     -------
-    pixel_rate : unsigned long int
+    pixel_rate : int
         Pixel rate of the camera in Hz
     """
     pixel_rate = ctypes.wintypes.DWORD()
     check_status(sc2_cam.GetPixelRate(handle, pixel_rate))
-    return pixel_rate
+    return pixel_rate.value
 
 # ---------------------------------------------------------------------
 # 2.5.10 PCO_SetPixelRate
@@ -675,7 +686,7 @@ def set_pixel_rate(handle, pixel_rate):
     pixel_rate : int
         Pixel rate of the camera in Hz
     """
-    check_status(sc2_cam.SetPixelRate(handle, pixel_rate))
+    check_status(sc2_cam.SetPixelRate(handle, ctypes.wintypes.DWORD(pixel_rate)))
 
 # ---------------------------------------------------------------------
 # 2.5.20 PCO_GetCoolingSetpointTemperature
@@ -693,12 +704,12 @@ def get_cooling_setpoint_temperature(handle):
 
     Returns
     -------
-    temp : short
+    temp : int
         Setpoint in degrees C
     """
     temp = ctypes.c_short()
     check_status(sc2_cam.PCO_GetCoolingSetpointTemperature(handle,temp))
-    return temp
+    return temp.value
 
 # ---------------------------------------------------------------------
 # 2.5.21 PCO_SetCoolingSetpointTemperature
@@ -716,7 +727,7 @@ def set_cooling_setpoint_temperature(handle, temp):
         Setpoint in degrees C. Must be in between sMinCoolSetDESC and
         sMaxCoolSetDESC (see output of get_camera_description())
     """
-    check_status(sc2_cam.PCO_SetCoolingSetpointTemperature(handle,temp))
+    check_status(sc2_cam.PCO_SetCoolingSetpointTemperature(handle, ctypes.c_short(temp)))
 # ---------------------------------------------------------------------
 # 2.6.4 PCO_GetDelayExposureTime
 # ---------------------------------------------------------------------
@@ -724,9 +735,9 @@ sc2_cam.PCO_GetDelayExposureTime.argtypes = [HANDLE, ctypes.wintypes.PDWORD,
                                              ctypes.wintypes.PDWORD,
                                              ctypes.wintypes.PWORD,
                                              ctypes.wintypes.PWORD]
-PCO_TIMEBASE_NS = ctypes.wintypes.WORD(int("0x0000", 0))  # nanoseconds
-PCO_TIMEBASE_US = ctypes.wintypes.WORD(int("0x0001", 0))  # microseconds
-PCO_TIMEBASE_MS = ctypes.wintypes.WORD(int("0x0002", 0))  # milliseconds
+PCO_TIMEBASE_NS = 0x0000  # nanoseconds
+PCO_TIMEBASE_US = 0x0001  # microseconds
+PCO_TIMEBASE_MS = 0x0002  # milliseconds
 def get_delay_exposure_time(handle):
     """
     Get delay and exposure times for camera sensor.
@@ -753,7 +764,7 @@ def get_delay_exposure_time(handle):
     timebase_exposure = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetDelayExposureTime(handle, delay, exposure,
                                                   timebase_delay, timebase_exposure))
-    return delay, exposure, timebase_delay, timebase_exposure
+    return delay.value, exposure.value, timebase_delay.value, timebase_exposure.value
 
 # ---------------------------------------------------------------------
 # 2.6.5 PCO_SetDelayExposureTime
@@ -783,8 +794,10 @@ def set_delay_exposure_time(handle, delay, exposure, timebase_delay, timebase_ex
     timebase_exposure : unsigned short int
         Unit for exposure time. One of PCO_TIMEBASE_NS, PCO_TIMEBASE_US, PCO_TIMEBASE_MS.
     """
-    check_status(sc2_cam.PCO_SetDelayExposureTime(handle, delay, exposure,
-                                                  timebase_delay, timebase_exposure))
+    check_status(sc2_cam.PCO_SetDelayExposureTime(handle, ctypes.wintypes.DWORD(delay), 
+                                                  ctypes.wintypes.DWORD(exposure),
+                                                  ctypes.wintypes.DWORD(timebase_delay), 
+                                                  ctypes.wintypes.DWORD(timebase_exposure)))
 
 # ---------------------------------------------------------------------
 # 2.6.26 PCO_GetImageTiming
@@ -813,8 +826,8 @@ def get_image_timing(handle):
 # 2.7.3 PCO_GetRecordingState
 # ---------------------------------------------------------------------
 sc2_cam.PCO_GetRecordingState.argtypes = [HANDLE, ctypes.wintypes.PWORD]
-PCO_CAMERA_STOPPED = ctypes.wintypes.WORD(int("0x0000", 0))
-PCO_CAMERA_RUNNING = ctypes.wintypes.WORD(int("0x0001", 0))
+PCO_CAMERA_STOPPED = 0x0000
+PCO_CAMERA_RUNNING = 0x0001
 def get_recording_state(handle):
     """
     Get the current recording state of the camera.
@@ -826,12 +839,12 @@ def get_recording_state(handle):
 
     Returns
     -------
-    state : unsigned short int
+    state : int
         Recording state, one of PCO_CAMERA_STOPPED (0), PCO_CAMERA_RUNNING (1).
     """
     state = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetRecordingState(handle, state))
-    return state
+    return state.value
 
 # ---------------------------------------------------------------------
 # 2.7.4 PCO_SetRecordingState
@@ -848,14 +861,14 @@ def set_recording_state(handle, state):
     state : int
         Recording state, one of PCO_CAMERA_STOPPED (0), PCO_CAMERA_RUNNING (1).
     """
-    check_status(sc2_cam.PCO_SetRecordingState(handle, state))
+    check_status(sc2_cam.PCO_SetRecordingState(handle, ctypes.wintypes.WORD(state)))
 
 # ---------------------------------------------------------------------
 # 2.7.5 PCO_GetStorageMode
 # ---------------------------------------------------------------------
 sc2_cam.PCO_GetStorageMode.argtypes = [HANDLE, ctypes.wintypes.PWORD]
-PCO_STORAGE_RECORDER = ctypes.wintypes.WORD(int("0x0000", 0))
-PCO_STORAGE_FIFO = ctypes.wintypes.WORD(int("0x0001", 0))
+PCO_STORAGE_RECORDER = 0x0000
+PCO_STORAGE_FIFO = 0x0001
 def get_storage_mode(handle):
     """
     Get camera image storage mode. One of "recorder" or "FIFO buffer".
@@ -867,12 +880,12 @@ def get_storage_mode(handle):
 
     Returns
     -------
-    mode : unsigned short int
+    mode : int
         Camera image storage mode. One of PCO_STORAGE_RECORDER (0) or PCO_STORAGE_FIFO (1).
     """
     mode = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetStorageMode(handle, mode))
-    return mode
+    return mode.value
 
 # ---------------------------------------------------------------------
 # 2.7.6 PCO_SetStorageMode
@@ -889,15 +902,15 @@ def set_storage_mode(handle, mode):
     mode : unsigned short int
         Camera image storage mode. One of PCO_STORAGE_RECORDER (0) or PCO_STORAGE_FIFO (1).
     """
-    check_status(sc2_cam.PCO_SetStorageMode(handle, mode))
+    check_status(sc2_cam.PCO_SetStorageMode(handle, ctypes.wintypes.WORD(mode)))
 
 # ---------------------------------------------------------------------
 # 2.7.9 PCO_GetAcquireMode
 # ---------------------------------------------------------------------
 sc2_cam.PCO_GetAcquireMode.argtypes = [HANDLE, ctypes.wintypes.PWORD]
-PCO_ACQUIRE_AUTO = ctypes.wintypes.WORD(int("0x0000", 0))
-PCO_ACQUIRE_EXTERNAL = ctypes.wintypes.WORD(int("0x0000", 0))
-PCO_ACQUIRE_EXTERNAL_MODULATE = ctypes.wintypes.WORD(int("0x0000", 0))
+PCO_ACQUIRE_AUTO = 0x0000
+PCO_ACQUIRE_EXTERNAL = 0x0000
+PCO_ACQUIRE_EXTERNAL_MODULATE = 0x0000
 def get_acquire_mode(handle):
     """
     Get the current acquisition mode of the camera. One of "auto",
@@ -916,13 +929,13 @@ def get_acquire_mode(handle):
     """
     mode = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetAcquireMode(handle, mode))
-    return mode
+    return mode.value
 
 # ---------------------------------------------------------------------
 # 2.7.10 PCO_SetAcquireMode
 # ---------------------------------------------------------------------
 sc2_cam.PCO_SetAcquireMode.argtypes = [HANDLE, ctypes.wintypes.WORD]
-def set_acquire_mode(handle):
+def set_acquire_mode(handle, mode):
     """
     Set the current acquisition mode of the camera. One of "auto",
     "external" or "external modulate".
@@ -935,9 +948,7 @@ def set_acquire_mode(handle):
         Camera acquisiton mode. One of PCO_ACQUIRE_AUTO (0), PCO_ACQUIRE_EXTERNAL (1), 
         PCO_ACQUIRE_EXTERNAL_MODULATE (2).
     """
-    mode = ctypes.wintypes.WORD()
-    check_status(sc2_cam.PCO_GetAcquireMode(handle, mode))
-    return mode
+    check_status(sc2_cam.PCO_GetAcquireMode(handle, ctypes.wintypes.WORD(mode)))
 
 # ---------------------------------------------------------------------
 # 2.7.14 PCO_GetMetaDataMode
@@ -945,8 +956,8 @@ def set_acquire_mode(handle):
 sc2_cam.PCO_GetMetaDataMode.argtypes = [HANDLE, ctypes.wintypes.PWORD,
                                         ctypes.wintypes.PWORD,
                                         ctypes.wintypes.PWORD]
-PCO_METADATA_OFF = ctypes.wintypes.WORD(int("0x0000", 0))
-PCO_METADATA_ON = ctypes.wintypes.WORD(int("0x0000", 0))
+PCO_METADATA_OFF = 0x0000
+PCO_METADATA_ON = 0x0000
 def get_metadata_mode(handle):
     """
     Get the metadata mode of the camera and information about the size
@@ -970,7 +981,7 @@ def get_metadata_mode(handle):
     size = ctypes.wintypes.WORD()
     version = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetMetaDataMode(handle, mode, size, version))
-    return mode, size, version
+    return mode.value, size.value, version.value
 
 # ---------------------------------------------------------------------
 # 2.7.15 PCO_SetMetaDataMode
@@ -999,15 +1010,16 @@ def set_metadata_mode(handle, mode):
     """
     size = ctypes.wintypes.WORD()
     version = ctypes.wintypes.WORD()
-    check_status(sc2_cam.PCO_SetMetaDataMode(handle, mode, size, version))
-    return size, version
+    check_status(sc2_cam.PCO_SetMetaDataMode(handle, ctypes.wintypes.WORD(mode), 
+                                             size, version))
+    return size.value, version.value
 
 # ---------------------------------------------------------------------
 # 2.9.5 PCO_GetBitAlignment
 # ---------------------------------------------------------------------
 sc2_cam.PCO_GetBitAlignment.argtypes = [HANDLE, ctypes.wintypes.PWORD]
-PCO_ALIGNMENT_MSB = ctypes.wintypes.WORD(int("0x0000", 0))  # align to most significant bit
-PCO_ALIGNMENT_LSB = ctypes.wintypes.WORD(int("0x0001", 0))  # align to least significant bit
+PCO_ALIGNMENT_MSB = 0x0000  # align to most significant bit
+PCO_ALIGNMENT_LSB = 0x0001  # align to least significant bit
 def get_bit_alignment(handle):
     """
     Get the bit alignment of the transferred image data.
@@ -1025,7 +1037,7 @@ def get_bit_alignment(handle):
     """
     alignment = ctypes.wintypes.WORD() 
     check_status(sc2_cam.PCO_GetBitAlignment(handle, alignment))
-    return alignment
+    return alignment.value
 
 # ---------------------------------------------------------------------
 # 2.9.6 PCO_SetBitAlignment
@@ -1043,14 +1055,14 @@ def set_bit_alignment(handle, alignment):
         Bit alignment of the transferred image data. One of PCO_ALIGNMENT_MSB (0)
         or PCO_ALIGNMENT_LSB (1).
     """
-    check_status(sc2_cam.PCO_SetBitAlignment(handle, alignment))
+    check_status(sc2_cam.PCO_SetBitAlignment(handle, ctypes.wintypes.WORD(alignment)))
 
 # ---------------------------------------------------------------------
 # 2.9.7 PCO_GetHotPixelCorrectionMode
 # ---------------------------------------------------------------------
 sc2_cam.PCO_GetHotPixelCorrectionMode.argtypes = [HANDLE, ctypes.wintypes.PWORD]
-PCO_HOTPIXELCORRECTION_OFF = ctypes.wintypes.WORD(int("0x0000", 0)) 
-PCO_HOTPIXELCORRECTION_ON = ctypes.wintypes.WORD(int("0x0001", 0)) 
+PCO_HOTPIXELCORRECTION_OFF = 0x0000
+PCO_HOTPIXELCORRECTION_ON = 0x0001
 def get_hot_pixel_correction_mode(handle):
     """
     Get camera chip hot pixel correction mode. 
@@ -1068,7 +1080,7 @@ def get_hot_pixel_correction_mode(handle):
     """
     mode = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetHotPixelCorrectionMode(handle, mode))
-    return mode
+    return mode.value
 
 # ---------------------------------------------------------------------
 # 2.9.8 PCO_SetHotPixelCorrectionMode
@@ -1086,7 +1098,7 @@ def set_hot_pixel_correction_mode(handle, mode):
         Hot pixel correction mode. One of PCO_HOTPIXELCORRECTION_OFF (0) or 
         PCO_HOTPIXELCORRECTION_ON (1).
     """
-    check_status(sc2_cam.PCO_SetHotPixelCorrectionMode(handle, mode))
+    check_status(sc2_cam.PCO_SetHotPixelCorrectionMode(handle, ctypes.wintypes.WORD(mode)))
 
 # ---------------------------------------------------------------------
 # 2.10.1 PCO_AllocateBuffer
@@ -1128,7 +1140,8 @@ def allocate_buffer(handle, index, size, buffer=None, event=None):
         buffer = ctypes.c_void_p(0)
     if event is None:
         event = ctypes.c_void_p(0)
-    check_status(sc2_cam.PCO_AllocateBuffer(handle, index, size, buffer, event))
+    check_status(sc2_cam.PCO_AllocateBuffer(handle, index, ctypes.wintypes.DWORD(size), 
+                                            buffer, event))
     return index.contents, buffer, event
 
 # ---------------------------------------------------------------------
@@ -1146,7 +1159,7 @@ def free_buffer(handle, index):
     index : int
         Buffer index to free
     """
-    check_status(sc2_cam.PCO_FreeBuffer(handle, index))
+    check_status(sc2_cam.PCO_FreeBuffer(handle, ctypes.c_short(index)))
 
 # ---------------------------------------------------------------------
 # 2.10.3 PCO_GetBufferStatus
@@ -1154,10 +1167,10 @@ def free_buffer(handle, index):
 sc2_cam.PCO_GetBufferStatus.argtypes = [HANDLE, ctypes.c_short,
                                         ctypes.wintypes.PDWORD,
                                         ctypes.wintypes.PDWORD]
-PCO_BUFFER_ALLOCATED = ctypes.wintypes.WORD(int("0x80000000", 0))  # Buffer is allocated
-PCO_BUFFER_CREATED = ctypes.wintypes.WORD(int("0x40000000", 0))    # Buffer event created inside the SDK DLL
-PCO_BUFFER_EXTERNAL = ctypes.wintypes.WORD(int("0x20000000", 0))   # Buffer is allocated externally
-PCO_BUFFER_SET = ctypes.wintypes.WORD(int("0x00008000", 0))        # Buffer event is set
+PCO_BUFFER_ALLOCATED = 0x80000000  # Buffer is allocated
+PCO_BUFFER_CREATED = 0x40000000    # Buffer event created inside the SDK DLL
+PCO_BUFFER_EXTERNAL = 0x20000000   # Buffer is allocated externally
+PCO_BUFFER_SET = 0x00008000        # Buffer event is set
 def get_buffer_status(handle, index):
     """
     Parameters
@@ -1178,8 +1191,9 @@ def get_buffer_status(handle, index):
     """
     status_dll = ctypes.wintypes.DWORD()
     status_drv = ctypes.wintypes.DWORD()
-    check_status(sc2_cam.PCO_GetBufferStatus(handle, index, status_dll, status_drv))
-    return status_dll, status_drv
+    check_status(sc2_cam.PCO_GetBufferStatus(handle, ctypes.c_short(index), 
+                                             status_dll, status_drv))
+    return status_dll.value, status_drv.value
 
 # ---------------------------------------------------------------------
 # 2.10.4 PCO_GetBuffer
@@ -1207,7 +1221,7 @@ def get_buffer(handle, index):
     """
     buffer = ctypes.c_void_p(0)
     event = ctypes.c_void_p(0)
-    check_status(sc2_cam.PCO_GetBuffer(handle, index, buffer, event))
+    check_status(sc2_cam.PCO_GetBuffer(handle, ctypes.c_short(index), buffer, event))
     return buffer, event
 
 # ---------------------------------------------------------------------
@@ -1243,8 +1257,11 @@ def get_image_ex(handle, segment, first_image, buffer_index, lx, ly,
     bits_per_pixel : int
         Bit resolution of the transferred image (16 is the common choice, see pco.sdk manual)
     """
-    check_status(sc2_cam.PCO_GetImageEx(handle, segment, first_image,
-                 first_image, buffer_index, lx, ly, bits_per_pixel))
+    image_index = ctypes.wintypes.DWORD(first_image)
+    check_status(sc2_cam.PCO_GetImageEx(handle, ctypes.wintypes.WORD(segment), image_index,
+                                        image_index, ctypes.c_short(buffer_index), 
+                                        ctypes.wintypes.WORD(lx), ctypes.wintypes.WORD(ly), 
+                                        ctypes.wintypes.WORD(bits_per_pixel)))
 # ---------------------------------------------------------------------
 # 2.11.3 PCO_AddBufferEx
 # ---------------------------------------------------------------------
@@ -1276,8 +1293,11 @@ def add_buffer_ex(handle, first_image, buffer_index, lx, ly,
     bits_per_pixel : int
         Bit resolution of the transferred image (16 is the common choice, see pco.sdk manual)
     """
-    check_status(sc2_cam.PCO_AddBufferEx(handle, first_image, first_image,
-                 buffer_index, lx, ly, bits_per_pixel))
+    image_index = ctypes.wintypes.DWORD(first_image)
+    check_status(sc2_cam.PCO_AddBufferEx(handle, image_index, image_index,
+                                         ctypes.c_short(buffer_index), 
+                                         ctypes.wintypes.WORD(lx), ctypes.wintypes.WORD(ly), 
+                                         ctypes.wintypes.WORD(bits_per_pixel)))
 # ---------------------------------------------------------------------
 # 2.11.6 PCO_CancelImages
 # ---------------------------------------------------------------------
@@ -1317,7 +1337,8 @@ def wait_for_buffer(handle, num_buffers, buffer_list, timeout):
     timeout : int
         Timeout in milliseconds.
     """
-    check_status(sc2_cam.PCO_WaitForBuffer(handle, num_buffers, buffer_list, timeout))
+    check_status(sc2_cam.PCO_WaitForBuffer(handle, ctypes.c_int(num_buffers), 
+                                           buffer_list, ctypes.c_int(timeout)))
 
 # ---------------------------------------------------------------------
 # 2.11.9 PCO_GetMetaData
@@ -1343,7 +1364,8 @@ def get_metadata(handle, index):
     reserved1 = ctypes.wintypes.DWORD()
     reserved2 = ctypes.wintypes.DWORD()
     metadata = PCO_Metadata_Struct()
-    check_status(sc2_cam.PCO_GetMetaData(handle, index, metadata, reserved1, reserved2))
+    check_status(sc2_cam.PCO_GetMetaData(handle, ctypes.c_short(index), metadata, 
+                                         reserved1, reserved2))
     return metadata
 
 # ---------------------------------------------------------------------
@@ -1368,6 +1390,6 @@ def get_error_text(err):
     """
     c_buf_len = 512
     c_buf = ctypes.create_string_buffer(c_buf_len)
-    sc2_cam.PCO_GetErrorText(err, c_buf, c_buf_len)
+    sc2_cam.PCO_GetErrorText(ctypes.wintypes.DWORD(err), c_buf, c_buf_len)
 
     return str(c_buf.value.decode('ascii'))

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -430,7 +430,7 @@ def get_temperature(handle):
     cam_temp = ctypes.c_short()
     pow_temp = ctypes.c_short()
     check_status(sc2_cam.PCO_GetTemperature(handle, ccd_temp, cam_temp, pow_temp))
-    return ccd_temp.value, cam_temp.value, pow_temp.value
+    return (ccd_temp.value/10.0), cam_temp.value, pow_temp.value
 
 
 # ---------------------------------------------------------------------
@@ -1332,6 +1332,7 @@ def add_buffer_ex(handle, first_image, buffer_index, lx, ly,
                                          ctypes.c_short(buffer_index), 
                                          ctypes.wintypes.WORD(lx), ctypes.wintypes.WORD(ly), 
                                          ctypes.wintypes.WORD(bits_per_pixel)))
+
 # ---------------------------------------------------------------------
 # 2.11.6 PCO_CancelImages
 # ---------------------------------------------------------------------

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -345,7 +345,7 @@ def get_camera_description(handle):
     return desc
 
 # ---------------------------------------------------------------------
-# 2.3.3 PCO_GetCameraType
+# 2.3.2 PCO_GetCameraType
 # ---------------------------------------------------------------------
 sc2_cam.PCO_GetCameraType.argtypes = [ctypes.wintypes.HANDLE, ctypes.POINTER(PCO_CameraType)]
 def get_camera_type(handle):
@@ -432,6 +432,32 @@ def get_temperature(handle):
     check_status(sc2_cam.PCO_GetTemperature(handle, ccd_temp, cam_temp, pow_temp))
     return ccd_temp.value, cam_temp.value, pow_temp.value
 
+
+# ---------------------------------------------------------------------
+# 2.3.6 PCO_GetCameraName
+# ---------------------------------------------------------------------
+sc2_cam.PCO_GetCameraName.argtypes = [ctypes.wintypes.HANDLE, ctypes.c_char_p,
+                                      ctypes.wintypes.WORD]
+def get_camera_name(handle):
+    """
+    Get the camera name
+
+    Parameters
+    ----------
+    handle : ctypes.wintypes.HANDLE
+        Unique pco. camera handle (pointer).
+
+    Returns
+    -------
+    string
+        Camera name.
+    """
+    c_buf_len = 40
+    c_buf = ctypes.create_string_buffer(c_buf_len)
+
+    check_status(sc2_cam.PCO_GetCameraName(handle, c_buf, ctypes.wintypes.WORD(c_buf_len)))
+
+    return str(c_buf.value.decode('ascii'))
 
 # ---------------------------------------------------------------------
 # 2.4.1 PCO_ArmCamera
@@ -786,23 +812,23 @@ def set_delay_exposure_time(handle, delay, exposure, timebase_delay, timebase_ex
     ----------
     handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
-    delay : unsigned long int
+    delay : int
         Delay time in units of timebase_delay. In range 
         dwMinDelayDESC .. dwMinDelayStepDESC .. dwMaxDelayDESC
         (see output of get_camera_description()).
-    exposure : unsigned long int
+    exposure : int
         Exposure time in units of timebase_exposure. In range
         dwMinExposDESC ..  dwMinExposStepDESC .. dwMaxExposDESC
         (see output of get_camera_description()).
-    timebase_delay : unsigned short int
+    timebase_delay : int
         Unit for delay time. One of PCO_TIMEBASE_NS, PCO_TIMEBASE_US, PCO_TIMEBASE_MS.
-    timebase_exposure : unsigned short int
+    timebase_exposure : int
         Unit for exposure time. One of PCO_TIMEBASE_NS, PCO_TIMEBASE_US, PCO_TIMEBASE_MS.
     """
     check_status(sc2_cam.PCO_SetDelayExposureTime(handle, ctypes.wintypes.DWORD(delay), 
                                                   ctypes.wintypes.DWORD(exposure),
-                                                  ctypes.wintypes.DWORD(timebase_delay), 
-                                                  ctypes.wintypes.DWORD(timebase_exposure)))
+                                                  ctypes.wintypes.WORD(timebase_delay), 
+                                                  ctypes.wintypes.WORD(timebase_exposure)))
 
 # ---------------------------------------------------------------------
 # 2.6.26 PCO_GetImageTiming
@@ -1142,12 +1168,11 @@ def allocate_buffer(handle, index, size, buffer=None, event=None):
     event : pointer
         Pointer to an event handle
     """
-    index = ctypes.POINTER(ctypes.c_short(index))
     if buffer is None:
         buffer = ctypes.c_void_p(0)
     if event is None:
         event = ctypes.c_void_p(0)
-    check_status(sc2_cam.PCO_AllocateBuffer(handle, index, ctypes.wintypes.DWORD(size), 
+    check_status(sc2_cam.PCO_AllocateBuffer(handle, ctypes.c_short(index), ctypes.wintypes.DWORD(size), 
                                             buffer, event))
     if buffer is None and event is None:
         return index.contents, buffer, event

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -1075,7 +1075,7 @@ def allocate_buffer(handle, index, size):
     buffer = ctypes.c_void_p(0)
     event = ctypes.c_void_p(0)
     check_status(sc2_cam.PCO_AllocateBuffer(handle, index, size, buffer, event))
-    return index, buffer, event
+    return index.contents, buffer, event
 
 # ---------------------------------------------------------------------
 # 2.10.2 PCO_FreeBuffer

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -205,6 +205,7 @@ class PCO_Metadata_Struct(ctypes.Structure):
                 ("bIMAGE_TYPE", ctypes.c_byte),
                 ("wCOLOR_PATTERN", ctypes.wintypes.WORD)]
 
+PCO_NOERROR = ctypes.wintypes.DWORD(int("0x00000000", 0))
 class PCO_Buflist(ctypes.Structure):
     # _pack_ = 1
     _fields_ = [("SBufNr", ctypes.c_short),
@@ -408,8 +409,8 @@ sc2_cam.PCO_SetImageParameters.argtypes = [HANDLE, ctypes.wintypes.WORD,
                                            ctypes.wintypes.DWORD,
                                            ctypes.c_void_p,
                                            ctypes.c_int]
-IMAGEPARAMETERS_READ_WHILE_RECORDING = ctypes.wintypes.DWORD(int("0x00000001", 0))
-IMAGEPARAMETERS_READ_FROM_SEGMENTS = ctypes.wintypes.DWORD(int("0x00000002", 0))
+PCO_IMAGEPARAMETERS_READ_WHILE_RECORDING = ctypes.wintypes.DWORD(int("0x00000001", 0))
+PCO_IMAGEPARAMETERS_READ_FROM_SEGMENTS = ctypes.wintypes.DWORD(int("0x00000002", 0))
 def set_image_parameters(handle, lx, ly, image_flag):
     """
     Set image parameters for internal allocated resources before image transfer.
@@ -423,7 +424,7 @@ def set_image_parameters(handle, lx, ly, image_flag):
     ly : int
         Image height
     image_flag : int
-        IMAGEPARAMETERS_READ_WHILE_RECORDING or IMAGEPARAMETERS_READ_FROM_SEGMENTS
+        PCO_IMAGEPARAMETERS_READ_WHILE_RECORDING or PCO_IMAGEPARAMETERS_READ_FROM_SEGMENTS
     """
     param = ctypes.c_void_p(0)
     ilen = ctypes.c_int(0)
@@ -676,9 +677,9 @@ sc2_cam.PCO_GetDelayExposureTime.argtypes = [HANDLE, ctypes.wintypes.PDWORD,
                                              ctypes.wintypes.PDWORD,
                                              ctypes.wintypes.PWORD,
                                              ctypes.wintypes.PWORD]
-TIMEBASE_NS = ctypes.wintypes.WORD(int("0x0000", 0))  # nanoseconds
-TIMEBASE_US = ctypes.wintypes.WORD(int("0x0001", 0))  # microseconds
-TIMEBASE_MS = ctypes.wintypes.WORD(int("0x0002", 0))  # milliseconds
+PCO_TIMEBASE_NS = ctypes.wintypes.WORD(int("0x0000", 0))  # nanoseconds
+PCO_TIMEBASE_US = ctypes.wintypes.WORD(int("0x0001", 0))  # microseconds
+PCO_TIMEBASE_MS = ctypes.wintypes.WORD(int("0x0002", 0))  # milliseconds
 def get_delay_exposure_time(handle):
     """
     Get delay and exposure times for camera sensor.
@@ -695,9 +696,9 @@ def get_delay_exposure_time(handle):
     exposure : unsigned long int
         Exposure time in units of timebase_exposure
     timebase_delay : unsigned short int
-        Unit for delay time. One of TIMEBASE_NS, TIMEBASE_US, TIMEBASE_MS.
+        Unit for delay time. One of PCO_TIMEBASE_NS, PCO_TIMEBASE_US, PCO_TIMEBASE_MS.
     timebase_exposure : unsigned short int
-        Unit for exposure time. One of TIMEBASE_NS, TIMEBASE_US, TIMEBASE_MS.
+        Unit for exposure time. One of PCO_TIMEBASE_NS, PCO_TIMEBASE_US, PCO_TIMEBASE_MS.
     """
     delay = ctypes.wintypes.DWORD()
     exposure = ctypes.wintypes.DWORD()
@@ -714,7 +715,7 @@ sc2_cam.PCO_SetDelayExposureTime.argtypes = [HANDLE, ctypes.wintypes.DWORD,
                                              ctypes.wintypes.DWORD,
                                              ctypes.wintypes.WORD,
                                              ctypes.wintypes.WORD]
-def get_delay_exposure_time(handle, delay, exposure, timebase_delay, timebase_exposure):
+def set_delay_exposure_time(handle, delay, exposure, timebase_delay, timebase_exposure):
     """
     Set delay and exposure times for camera sensor.
     
@@ -731,9 +732,9 @@ def get_delay_exposure_time(handle, delay, exposure, timebase_delay, timebase_ex
         dwMinExposDESC ..  dwMinExposStepDESC .. dwMaxExposDESC
         (see output of get_camera_description()).
     timebase_delay : unsigned short int
-        Unit for delay time. One of TIMEBASE_NS, TIMEBASE_US, TIMEBASE_MS.
+        Unit for delay time. One of PCO_TIMEBASE_NS, PCO_TIMEBASE_US, PCO_TIMEBASE_MS.
     timebase_exposure : unsigned short int
-        Unit for exposure time. One of TIMEBASE_NS, TIMEBASE_US, TIMEBASE_MS.
+        Unit for exposure time. One of PCO_TIMEBASE_NS, PCO_TIMEBASE_US, PCO_TIMEBASE_MS.
     """
     check_status(sc2_cam.PCO_SetDelayExposureTime(handle, delay, exposure,
                                                   timebase_delay, timebase_exposure))
@@ -765,8 +766,8 @@ def get_image_timing(handle):
 # 2.7.3 PCO_GetRecordingState
 # ---------------------------------------------------------------------
 sc2_cam.PCO_GetRecordingState.argtypes = [HANDLE, ctypes.wintypes.PWORD]
-CAMERA_STOPPED = ctypes.wintypes.WORD(int("0x0000", 0))
-CAMERA_RUNNING = ctypes.wintypes.WORD(int("0x0001", 0))
+PCO_CAMERA_STOPPED = ctypes.wintypes.WORD(int("0x0000", 0))
+PCO_CAMERA_RUNNING = ctypes.wintypes.WORD(int("0x0001", 0))
 def get_recording_state(handle):
     """
     Get the current recording state of the camera.
@@ -779,7 +780,7 @@ def get_recording_state(handle):
     Returns
     -------
     state : unsigned short int
-        Recording state, one of CAMERA_STOPPED (0), CAMERA_RUNNING (1).
+        Recording state, one of PCO_CAMERA_STOPPED (0), PCO_CAMERA_RUNNING (1).
     """
     state = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetRecordingState(handle, state))
@@ -798,7 +799,7 @@ def set_recording_state(handle, state):
     handle : HANDLE
         Unique pco. camera handle (pointer).
     state : int
-        Recording state, one of CAMERA_STOPPED (0), CAMERA_RUNNING (1).
+        Recording state, one of PCO_CAMERA_STOPPED (0), PCO_CAMERA_RUNNING (1).
     """
     check_status(sc2_cam.PCO_SetRecordingState(handle, state))
 
@@ -806,8 +807,8 @@ def set_recording_state(handle, state):
 # 2.7.5 PCO_GetStorageMode
 # ---------------------------------------------------------------------
 sc2_cam.PCO_GetStorageMode.argtypes = [HANDLE, ctypes.wintypes.PWORD]
-STORAGE_RECORDER = ctypes.wintypes.WORD(int("0x0000", 0))
-STORAGE_FIFO = ctypes.wintypes.WORD(int("0x0001", 0))
+PCO_STORAGE_RECORDER = ctypes.wintypes.WORD(int("0x0000", 0))
+PCO_STORAGE_FIFO = ctypes.wintypes.WORD(int("0x0001", 0))
 def get_storage_mode(handle):
     """
     Get camera image storage mode. One of "recorder" or "FIFO buffer".
@@ -820,7 +821,7 @@ def get_storage_mode(handle):
     Returns
     -------
     mode : unsigned short int
-        Camera image storage mode. One of STORAGE_RECORDER (0) or STORAGE_FIFO (1).
+        Camera image storage mode. One of PCO_STORAGE_RECORDER (0) or PCO_STORAGE_FIFO (1).
     """
     mode = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetStorageMode(handle, mode))
@@ -839,7 +840,7 @@ def set_storage_mode(handle, mode):
     handle : HANDLE
         Unique pco. camera handle (pointer).
     mode : unsigned short int
-        Camera image storage mode. One of STORAGE_RECORDER (0) or STORAGE_FIFO (1).
+        Camera image storage mode. One of PCO_STORAGE_RECORDER (0) or PCO_STORAGE_FIFO (1).
     """
     check_status(sc2_cam.PCO_SetStorageMode(handle, mode))
 
@@ -847,9 +848,9 @@ def set_storage_mode(handle, mode):
 # 2.7.9 PCO_GetAcquireMode
 # ---------------------------------------------------------------------
 sc2_cam.PCO_GetAcquireMode.argtypes = [HANDLE, ctypes.wintypes.PWORD]
-ACQUIRE_AUTO = ctypes.wintypes.WORD(int("0x0000", 0))
-ACQUIRE_EXTERNAL = ctypes.wintypes.WORD(int("0x0000", 0))
-ACQUIRE_EXTERNAL_MODULATE = ctypes.wintypes.WORD(int("0x0000", 0))
+PCO_ACQUIRE_AUTO = ctypes.wintypes.WORD(int("0x0000", 0))
+PCO_ACQUIRE_EXTERNAL = ctypes.wintypes.WORD(int("0x0000", 0))
+PCO_ACQUIRE_EXTERNAL_MODULATE = ctypes.wintypes.WORD(int("0x0000", 0))
 def get_acquire_mode(handle):
     """
     Get the current acquisition mode of the camera. One of "auto",
@@ -863,8 +864,8 @@ def get_acquire_mode(handle):
     Returns
     -------
     mode : unsigned short int
-        Camera acquisiton mode. One of ACQUIRE_AUTO (0), ACQUIRE_EXTERNAL (1), 
-        ACQUIRE_EXTERNAL_MODULATE (2).
+        Camera acquisiton mode. One of PCO_ACQUIRE_AUTO (0), PCO_ACQUIRE_EXTERNAL (1), 
+        PCO_ACQUIRE_EXTERNAL_MODULATE (2).
     """
     mode = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetAcquireMode(handle, mode))
@@ -874,7 +875,7 @@ def get_acquire_mode(handle):
 # 2.7.10 PCO_SetAcquireMode
 # ---------------------------------------------------------------------
 sc2_cam.PCO_SetAcquireMode.argtypes = [HANDLE, ctypes.wintypes.WORD]
-def Set_acquire_mode(handle):
+def set_acquire_mode(handle):
     """
     Set the current acquisition mode of the camera. One of "auto",
     "external" or "external modulate".
@@ -884,8 +885,8 @@ def Set_acquire_mode(handle):
     handle : HANDLE
         Unique pco. camera handle (pointer).
     mode : unsigned short int
-        Camera acquisiton mode. One of ACQUIRE_AUTO (0), ACQUIRE_EXTERNAL (1), 
-        ACQUIRE_EXTERNAL_MODULATE (2).
+        Camera acquisiton mode. One of PCO_ACQUIRE_AUTO (0), PCO_ACQUIRE_EXTERNAL (1), 
+        PCO_ACQUIRE_EXTERNAL_MODULATE (2).
     """
     mode = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetAcquireMode(handle, mode))
@@ -897,8 +898,8 @@ def Set_acquire_mode(handle):
 sc2_cam.PCO_GetMetaDataMode.argtypes = [HANDLE, ctypes.wintypes.PWORD,
                                         ctypes.wintypes.PWORD,
                                         ctypes.wintypes.PWORD]
-METADATA_OFF = ctypes.wintypes.WORD(int("0x0000", 0))
-METADATA_ON = ctypes.wintypes.WORD(int("0x0000", 0))
+PCO_METADATA_OFF = ctypes.wintypes.WORD(int("0x0000", 0))
+PCO_METADATA_ON = ctypes.wintypes.WORD(int("0x0000", 0))
 def get_metadata_mode(handle):
     """
     Get the metadata mode of the camera and information about the size
@@ -912,7 +913,7 @@ def get_metadata_mode(handle):
     Returns
     -------
     mode : unsigned short int
-        Metadata mode. One of METADATA_OFF (0) or METADATA_ON (1).
+        Metadata mode. One of PCO_METADATA_OFF (0) or PCO_METADATA_ON (1).
     size : unsigned short int
         Size of the matadata block added to the image.
     version : unsigned short int
@@ -940,7 +941,7 @@ def set_metadata_mode(handle, mode):
     handle : HANDLE
         Unique pco. camera handle (pointer).
     mode : unsigned short int
-        Metadata mode. One of METADATA_OFF (0) or METADATA_ON (1).
+        Metadata mode. One of PCO_METADATA_OFF (0) or PCO_METADATA_ON (1).
     
     Returns
     -------
@@ -958,8 +959,8 @@ def set_metadata_mode(handle, mode):
 # 2.9.5 PCO_GetBitAlignment
 # ---------------------------------------------------------------------
 sc2_cam.PCO_GetBitAlignment.argtypes = [HANDLE, ctypes.wintypes.PWORD]
-ALIGNMENT_MSB = ctypes.wintypes.WORD(int("0x0000", 0))  # align to most significant bit
-ALIGNMENT_LSB = ctypes.wintypes.WORD(int("0x0001", 0))  # align to least significant bit
+PCO_ALIGNMENT_MSB = ctypes.wintypes.WORD(int("0x0000", 0))  # align to most significant bit
+PCO_ALIGNMENT_LSB = ctypes.wintypes.WORD(int("0x0001", 0))  # align to least significant bit
 def get_bit_alignment(handle):
     """
     Get the bit alignment of the transferred image data.
@@ -972,8 +973,8 @@ def get_bit_alignment(handle):
     Returns
     -------
     alignment : unsigned short int
-        Bit alignment of the transferred image data. One of ALIGNMENT_MSB (0)
-        or ALIGNMENT_LSB (1).
+        Bit alignment of the transferred image data. One of PCO_ALIGNMENT_MSB (0)
+        or PCO_ALIGNMENT_LSB (1).
     """
     alignment = ctypes.wintypes.WORD() 
     check_status(sc2_cam.PCO_GetBitAlignment(handle, alignment))
@@ -992,8 +993,8 @@ def set_bit_alignment(handle, alignment):
     handle : HANDLE
         Unique pco. camera handle (pointer).
     alignment : unsigned short int
-        Bit alignment of the transferred image data. One of ALIGNMENT_MSB (0)
-        or ALIGNMENT_LSB (1).
+        Bit alignment of the transferred image data. One of PCO_ALIGNMENT_MSB (0)
+        or PCO_ALIGNMENT_LSB (1).
     """
     check_status(sc2_cam.PCO_SetBitAlignment(handle, alignment))
 
@@ -1001,8 +1002,8 @@ def set_bit_alignment(handle, alignment):
 # 2.9.7 PCO_GetHotPixelCorrectionMode
 # ---------------------------------------------------------------------
 sc2_cam.PCO_GetHotPixelCorrectionMode.argtypes = [HANDLE, ctypes.wintypes.PWORD]
-HOTPIXELCORRECTION_OFF = ctypes.wintypes.WORD(int("0x0000", 0)) 
-HOTPIXELCORRECTION_ON = ctypes.wintypes.WORD(int("0x0001", 0)) 
+PCO_HOTPIXELCORRECTION_OFF = ctypes.wintypes.WORD(int("0x0000", 0)) 
+PCO_HOTPIXELCORRECTION_ON = ctypes.wintypes.WORD(int("0x0001", 0)) 
 def get_hot_pixel_correction_mode(handle):
     """
     Get camera chip hot pixel correction mode. 
@@ -1015,8 +1016,8 @@ def get_hot_pixel_correction_mode(handle):
     Returns
     -------
     mode : unsigned short int
-        Hot pixel correction mode. One of HOTPIXELCORRECTION_OFF (0) or 
-        HOTPIXELCORRECTION_ON (1).
+        Hot pixel correction mode. One of PCO_HOTPIXELCORRECTION_OFF (0) or 
+        PCO_HOTPIXELCORRECTION_ON (1).
     """
     mode = ctypes.wintypes.WORD()
     check_status(sc2_cam.PCO_GetHotPixelCorrectionMode(handle, mode))
@@ -1035,8 +1036,8 @@ def Set_hot_pixel_correction_mode(handle, mode):
     handle : HANDLE
         Unique pco. camera handle (pointer).
     mode : unsigned short int
-        Hot pixel correction mode. One of HOTPIXELCORRECTION_OFF (0) or 
-        HOTPIXELCORRECTION_ON (1).
+        Hot pixel correction mode. One of PCO_HOTPIXELCORRECTION_OFF (0) or 
+        PCO_HOTPIXELCORRECTION_ON (1).
     """
     check_status(sc2_cam.PCO_SetHotPixelCorrectionMode(handle, mode))
 
@@ -1048,7 +1049,7 @@ sc2_cam.PCO_AllocateBuffer.argtypes = [HANDLE, ctypes.POINTER(ctypes.c_short),
                                        ctypes.POINTER(ctypes.wintypes.PWORD),
                                        PHANDLE]
 
-def allocate_buffer(handle, index, size):
+def allocate_buffer(handle, index, size, buffer=None, event=None):
     """
     Allocate a buffer
 
@@ -1061,6 +1062,10 @@ def allocate_buffer(handle, index, size):
         or -1 to create a new buffer.
     size : int
         Buffer size in bytes
+    buffer : double pointer
+        Pointer to a memory block, default None (gets allocated internally)
+    event : pointer
+        Pointer to an event handle, default None (gets allocated internally)
 
     Returns
     -------
@@ -1072,8 +1077,10 @@ def allocate_buffer(handle, index, size):
         Pointer to an event handle
     """
     index = ctypes.POINTER(ctypes.c_short(index))
-    buffer = ctypes.c_void_p(0)
-    event = ctypes.c_void_p(0)
+    if buffer is None:
+        buffer = ctypes.c_void_p(0)
+    if event is None:
+        event = ctypes.c_void_p(0)
     check_status(sc2_cam.PCO_AllocateBuffer(handle, index, size, buffer, event))
     return index.contents, buffer, event
 
@@ -1100,10 +1107,10 @@ def free_buffer(handle, index):
 sc2_cam.PCO_GetBufferStatus.argtypes = [HANDLE, ctypes.c_short,
                                         ctypes.wintypes.PDWORD,
                                         ctypes.wintypes.PDWORD]
-BUFFER_ALLOCATED = ctypes.wintypes.WORD(int("0x80000000", 0))  # Buffer is allocated
-BUFFER_CREATED = ctypes.wintypes.WORD(int("0x40000000", 0))    # Buffer event created inside the SDK DLL
-BUFFER_EXTERNAL = ctypes.wintypes.WORD(int("0x20000000", 0))   # Buffer is allocated externally
-BUFFER_SET = ctypes.wintypes.WORD(int("0x00008000", 0))        # Buffer event is set
+PCO_BUFFER_ALLOCATED = ctypes.wintypes.WORD(int("0x80000000", 0))  # Buffer is allocated
+PCO_BUFFER_CREATED = ctypes.wintypes.WORD(int("0x40000000", 0))    # Buffer event created inside the SDK DLL
+PCO_BUFFER_EXTERNAL = ctypes.wintypes.WORD(int("0x20000000", 0))   # Buffer is allocated externally
+PCO_BUFFER_SET = ctypes.wintypes.WORD(int("0x00008000", 0))        # Buffer event is set
 def get_buffer_status(handle, index):
     """
     Parameters
@@ -1116,8 +1123,8 @@ def get_buffer_status(handle, index):
     Returns
     -------
     status_dll : unsigned long int
-        Status of buffer inside the DLL. One of BUFFER_ALLOCATED, BUFFER_CREATED,
-        BUFFER_EXTERNAL, BUFFER_SET.
+        Status of buffer inside the DLL. One of PCO_BUFFER_ALLOCATED, PCO_BUFFER_CREATED,
+        PCO_BUFFER_EXTERNAL, PCO_BUFFER_SET.
     status_drv : unsigned long int
         Status of the image transfer. One of PCO_NOERROR or see pco.sdk for error
         codes.
@@ -1151,7 +1158,10 @@ def get_buffer(handle, index):
     event: pointer
         Pointer to event handle
     """
-    pass
+    buffer = ctypes.c_void_p(0)
+    event = ctypes.c_void_p(0)
+    check_status(sc2_cam.PCO_GetBuffer(handle, index, buffer, event))
+    return buffer, event
 
 # ---------------------------------------------------------------------
 # 2.11.1 PCO_GetImageEx

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -218,6 +218,37 @@ class PCO_Buflist(ctypes.Structure):
                 ("dwStatusDll", ctypes.wintypes.DWORD),  # BUFFER_ALLOCATED, BUFFER_CREATED, BUFFER_EXTERNAL, BUFFER_SET
                 ("dwStatusDrv", ctypes.wintypes.DWORD)]  # PCO_NOERROR or see pco.sdk for error codes
 
+PCO_CAMERA_TYPES = {
+    ctypes.wintypes.WORD(int("0x1300",0)) : 'pco.edge 5.5 CL',
+    ctypes.wintypes.WORD(int("0x1302",0)) : 'pco.edge 4.2 CL',
+    ctypes.wintypes.WORD(int("0x1310",0)) : 'pco.edge GL',
+    ctypes.wintypes.WORD(int("0x1320",0)) : 'pco.edge USB3',
+    ctypes.wintypes.WORD(int("0x1340",0)) : 'pco.edge CLHS',
+    ctypes.wintypes.WORD(int("0x1304",0)) : 'pco.edge MT',
+    ctypes.wintypes.WORD(int("0x1000",0)) : 'pco.dimax',
+    ctypes.wintypes.WORD(int("0x1010",0)) : 'pco.dimax_TV',
+    ctypes.wintypes.WORD(int("0x1020",0)) : 'pco.dimax CS',
+    ctypes.wintypes.WORD(int("0x1400",0)) : 'pco.flim',
+    ctypes.wintypes.WORD(int("0x1500",0)) : 'pco.panda',
+    ctypes.wintypes.WORD(int("0x0800",0)) : 'pco.pixelfly usb',
+    ctypes.wintypes.WORD(int("0x0100",0)) : 'pco.1200HS',
+    ctypes.wintypes.WORD(int("0x0200",0)) : 'pco.1300',
+    ctypes.wintypes.WORD(int("0x0220",0)) : 'pco.1600',
+    ctypes.wintypes.WORD(int("0x0240",0)) : 'pco.2000',
+    ctypes.wintypes.WORD(int("0x0260",0)) : 'pco.4000',
+    ctypes.wintypes.WORD(int("0x0830",0)) : 'pco.1400'
+}
+
+PCO_INTERFACE_TYPES = {
+    ctypes.wintypes.WORD(int("0x0001",0)) : 'FireWire',
+    ctypes.wintypes.WORD(int("0x0002",0)) : 'Camera Link',
+    ctypes.wintypes.WORD(int("0x0003",0)) : 'USB 2.0',
+    ctypes.wintypes.WORD(int("0x0004",0)) : 'GigE',
+    ctypes.wintypes.WORD(int("0x0005",0)) : 'Serial Interface',
+    ctypes.wintypes.WORD(int("0x0006",0)) : 'USB 3.0',
+    ctypes.wintypes.WORD(int("0x0007",0)) : 'CLHS'
+}
+
 # ---------------------------------------------------------------------
 # Error handling
 # ---------------------------------------------------------------------
@@ -244,6 +275,8 @@ def open_camera():
     to open multiple cameras. Call get_camera_type() to
     figure out which camera was grabbed.
 
+    To open a specific camera, use open_camera_ex().
+
     Returns
     -------
     handle : HANDLE
@@ -253,6 +286,12 @@ def open_camera():
     cam_num = ctypes.wintypes.WORD()  # unused
     check_status(sc2_cam.PCO_OpenCamera(handle, cam_num))
     return handle
+
+# ---------------------------------------------------------------------
+# 2.1.2 PCO_OpenCameraEx
+# ---------------------------------------------------------------------
+def open_camera_ex(**kwargs):
+    raise NotImplementedError("Not implemented, but shouldn't be too hard. Check pco.sdk for details.")
 
 # ---------------------------------------------------------------------
 # 2.1.3 PCO_CloseCamera
@@ -1032,7 +1071,7 @@ def get_hot_pixel_correction_mode(handle):
 # 2.9.8 PCO_SetHotPixelCorrectionMode
 # ---------------------------------------------------------------------
 sc2_cam.PCO_SetHotPixelCorrectionMode.argtypes = [HANDLE, ctypes.wintypes.WORD]
-def Set_hot_pixel_correction_mode(handle, mode):
+def set_hot_pixel_correction_mode(handle, mode):
     """
     Set camera chip hot pixel correction mode. 
 

--- a/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
@@ -1,0 +1,285 @@
+# -*- coding: utf-8 -*-
+
+"""
+Created on Sun May 16 2021
+
+@author: zacsimile
+"""
+
+from PYME.Acquire.Hardware.Camera import Camera
+from PYME.Acquire.Hardware.pco import pco_sdk
+
+import numpy as np
+import logging
+logger = logging.getLogger(__name__)
+
+import ctypes
+
+timebase = {pco_sdk.PCO_TIMEBASE_NS : 1e-9, 
+            pco_sdk.PCO_TIMEBASE_US : 1e-6, 
+            pco_sdk.PCO_TIMEBASE_MS : 1e-3}  # Conversions 
+
+class camReg(object):
+    """
+    Keep track of the number of cameras initialised so we can initialise and
+    finalise the library.
+    """
+    numCameras = -1
+
+    @classmethod
+    def regCamera(cls):
+        if cls.numCameras == -1:
+            pco_sdk.reset_lib()
+
+        cls.numCameras += 1
+
+    @classmethod
+    def unregCamera(cls):
+        cls.numCameras -= 1
+        if cls.numCameras == 0:
+            # There appears to be no pco.sdk uninitialization
+            pass
+
+camReg.regCamera()  # initialize/reset the sdk
+
+class PcoSdkCam(Camera):
+    def __init__(self):
+        Camera.__init__(self)
+        self._initalized = False
+        self.noiseProps = None
+
+    def Init(self):
+        self._handle = pco_sdk.open_camera()
+        camReg.regCamera()
+        self._desc = pco_sdk.get_camera_description(self._handle)
+        self.SetAcquisitionMode(self.MODE_CONTINUOUS)
+        self._cam_type = pco_sdk.get_camera_type(self._handle)
+        self.SetHotPixelCorrectionMode(pco_sdk.PCO_HOTPIXELCORRECTION_OFF)
+        self._integ_time = 0
+        self._delay_time = 0
+        self._electr_temp = 0
+        self._ccd_temp = 0
+        self._buffer_size = 0
+        self._initalized = True
+
+    @property
+    def noise_properties(self):
+        return self.noiseProps
+
+    def ExpReady(self):
+        pass
+
+    def CamReady(self):
+        return self._initalized
+
+    def ExtractColor(self, chSlice, mode):
+        pass
+
+    def GetHeadModel(self):
+        return pco_sdk.PCO_CAMERA_TYPES.get(self._cam_type.wCamType)
+
+    def GetSerialNumber(self):
+        return str(self._cam_type.dwSerialNumber)
+
+    def SetIntegTime(self, time):
+        lb = float(self._desc.dwMinExposDESC)*1e-9
+        ub = float(self._desc.dwMaxExposDESC)*1e-3
+        step = float(self._desc.dwMinExposStepDESC)*1e-9
+
+        # Round to a multiple of time step
+        time = np.floor(time/step)*step
+
+        # Don't let this go out of bounds
+        time = np.clip(time, lb, ub)
+
+        pco_sdk.set_delay_exposure_time(self._handle, self._delay_time*100, time*100, 
+                                        pco_sdk.PCO_TIMEBASE_MS, pco_sdk.PCO_TIMEBASE_MS)
+        _, exposure, _, timebase_exposure = pco_sdk.get_delay_exposure_time(self._handle)
+        self._integ_time = exposure*timebase.get(timebase_exposure)
+
+    def GetIntegTime(self):
+        return self._integ_time
+
+    def GetCycleTime(self):
+        return (self._integ_time + self._delay_time)
+
+    def GetCCDWidth(self):
+        return int(self._desc.wMaxHorzResStdDESC)
+
+    def GetCCDHeight(self):
+        return int(self._desc.wMaxVertResStdDESC)
+
+    def GetPicWidth(self):
+        return self.GetROI()[2] - self.GetROI()[0] + 1
+
+    def GetPicHeight(self):
+        return self.GetROI()[3] - self.GetROI()[1] + 1
+
+    def SetHorizontalBin(self, value):
+        b_max, step_type = self._desc.wMaxBinHorzDESC, self._desc.wBinHorzSteppingDESC
+
+        if step_type == 0:
+            # binary binning, round to powers of two
+            value = 1<<(value-1).bit_length()
+        else:
+            value = int(np.round(value)) # integer
+
+        value = np.clip(value, 1, b_max)
+
+        pco_sdk.set_binning(self._handle, value, self.GetVerticalBin())
+        self._binning_x, _ = pco_sdk.get_binning(self._handle)
+
+    def GetHorizontalBin(self):
+        return self._binning_x
+
+    def SetVerticalBin(self, value):
+        b_max, step_type = self._desc.wMaxBinVertDESC, self._desc.wBinVertSteppingDESC
+
+        if step_type == 0:
+            # binary binning, round to powers of two
+            value = 1<<(value-1).bit_length()
+        else:
+            value = int(np.round(value)) 
+
+        value = np.clip(value, 1, b_max)
+
+        pco_sdk.set_binning(self._handle, self.GetHorizontalBin(), value)
+        _, self._binning_y = pco_sdk.get_binning(self._handle)
+
+    def GetVerticalBin(self):
+        return self._binning_y
+
+    def GetSupportedBinning(self):
+        import itertools
+
+        bx_max, bx_step_type = self._desc.wMaxBinHorzDESC, self._desc.wBinHorzSteppingDESC
+        by_max, by_step_type = self._desc.wMaxBinVertDESC, self._desc.wBinVertSteppingDESC
+
+        if bx_step_type == 0:
+            # binary step type
+            x = [2**j for j in np.arange((bx_max).bit_length())]
+        else:
+            x = [j for j in np.arange(bx_max)]
+
+        if by_step_type == 0:
+            y = [2**j for j in np.arange((by_max).bit_length())]
+        else:
+            y = [j for j in np.arange(by_max)]
+
+        return list(itertools.product(x,y))
+
+    def SetROI(self, x0, y0, x1, y1):
+        # Stepping (n pixels)
+        dx = self._desc.wRoiHorStepsDESC
+        dy = self._desc.wRoiVertStepsDESC
+
+        # Chip size
+        lx_max = self.GetCCDWidth()
+        ly_max = self.GetCCDHeight()
+
+        # Minimum ROI size
+        lx_min = self._desc.wMinSizeHorzDESC
+        ly_min = self._desc.wMinSizeVertDESC
+
+        # Make sure bounds are ordered
+        if x1 < x0:
+            x0, x1 = x1, x0
+        if y1 < y0:
+            y0, y1 = y1, y0
+
+        # Don't let the ROI go out of bounds
+        # See pco.sdk manual chapter 3: IMAGE AREA SELECTION (ROI)
+        x0 = np.clip(x0, 1, lx_max-dx+1)
+        y0 = np.clip(y0, 1, ly_max-dy+1)
+        x1 = np.clip(x1, 1+dx, lx_max)
+        y1 = np.clip(y1, 1+dy, ly_max)
+
+        # Don't let us choose too small an ROI
+        if (x1-x0+1) < lx_min:
+            logger.debug('Selected ROI width is too small, automatically adjusting to {}.'.format(lx_min))
+            guess_pos = x0+lx_min
+            # Deal with boundaries
+            if guess_pos <= lx_max:
+                x1 = guess_pos
+            else:
+                x0 = x1-lx_min-1
+        if (y1-y0+1) < ly_min:
+            logger.debug('Selected ROI height is too small, automatically adjusting to {}.'.format(ly_min))
+            guess_pos = y0+ly_min
+            if guess_pos <= ly_max:
+                y1 = guess_pos
+            else:
+                y0 = y1-ly_min-1
+
+        # Round to a multiple of dx, dy
+        # TODO: Why do I need the 1 correction only on x0, y0???
+        x0 = 1+int(np.floor((x0-1)/dx)*dx)
+        y0 = 1+int(np.floor((y0-1)/dy)*dy)
+        x1 = int(np.floor(x1/dx)*dx)
+        y1 = int(np.floor(y1/dy)*dy)
+
+        pco_sdk.set_roi(self._handle, x0, y0, x1, y1)
+        self._roi = [x0, y0, x1, y1]
+
+        logger.debug('ROI set: x0 %3.1f, y0 %3.1f, w %3.1f, h %3.1f' % (x0, y0, x1-x0+1, y1-y0+1))
+
+    def GetROI(self):
+        return self._roi
+    
+    def GetElectrTemp(self):
+        return self._electr_temp
+
+    def GetCCDTemp(self):
+        return self._ccd_temp
+
+    def GetCCDTempSetPoint(self):
+        return self._ccd_temp_set_point
+
+    def SetCCDTemp(self, temp):
+        lb = self._desc.sMinCoolSetDESC
+        ub = self._desc.sMaxCoolSetDESC
+        temp = np.clip(temp, lb, ub)
+
+        pco_sdk.set_cooling_setpoint_temperature(self._handle, temp)
+        self._ccd_temp_set_point = temp
+        self._get_temps()
+
+    def _get_temps(self):
+        # NOTE: temperature only gets probed when acquisition starts/stops (which can be fairly
+        # irregularly - to the point of not being useful).
+        # TODO - find a way to safely call this while the camera is running
+        # FIXME: should _electr_tmp be power temperature rather than cam temp?
+        self._ccd_temp, self._electr_temp, _ = pco_sdk.get_temperature(self._handle)
+
+    def GetAcquisitionMode(self):
+        return self._mode
+
+    def SetAcquisitionMode(self, mode):
+        if mode in [self.MODE_CONTINUOUS, self.MODE_SINGLE_SHOT]:
+            self._mode = mode
+        else:
+            raise RuntimeError('Mode %d not supported' % mode)
+
+    def StartExposure(self):
+        return 0
+
+    def StopAq(self):
+        pass
+
+    def GetNumImsBuffered(self):
+        pass
+
+    def GetBufferSize(self):
+        return self._buffer_size
+
+    def GetFPS(self):
+        if self.GetCycleTime() == 0:
+            return 0
+        return 1.0/self.GetCycleTime()
+
+    def SetHotPixelCorrectionMode(self, mode):
+        pco_sdk.set_hot_pixel_correction_mode(self._handle, mode)
+
+    def Shutdown(self):
+        pco_sdk.close_camera(self._handle)
+        camReg.unregCamera()

--- a/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
@@ -85,7 +85,6 @@ class PcoSdkCam(Camera):
             self.Shutdown()
             raise pco_sdk.PcoSdkException(f"Camera shutdown with error status {err}.")
 
-        self._bits_per_pixel = 16
         self._integ_time = 0
         self._delay_time = 0
         self._electr_temp = 0
@@ -418,8 +417,6 @@ class PcoSdkCam(Camera):
             self._recording = False
             pco_sdk.set_recording_state(self._handle, pco_sdk.PCO_CAMERA_STOPPED)
             pco_sdk.cancel_images(self._handle)
-            # for i in np.arange(self._n_buffers):
-            #     pco_sdk.free_buffer(self._handle, i)
             while not self._buffers_to_queue.empty():
                 self._buffers_to_queue.get()
             while not self._queued_buffers.empty():
@@ -468,9 +465,6 @@ class PcoSdkCam(Camera):
 
     def SetHotPixelCorrectionMode(self, mode):
         pco_sdk.set_hot_pixel_correction_mode(self._handle, mode)
-
-    def SetBitsPerPixel(self, bits_per_pixel):
-        self._bits_per_pixel = bits_per_pixel
 
     def Shutdown(self):
         self._polling = False

--- a/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
@@ -48,7 +48,7 @@ DEFAULT_N_BUFFERS = 4
 BITS_PER_PIXEL = 16
 
 class PcoSdkCam(Camera):
-    def __init__(self):
+    def __init__(self, camNum, debuglevel='off'):
         Camera.__init__(self)
         self._initalized = False
         self.noiseProps = None
@@ -81,6 +81,8 @@ class PcoSdkCam(Camera):
         self._curr_buf = 0
         self._initalized = True
         self._recording = False
+        self._roi = None
+        self.SetROI(1, 1, self.GetCCDWidth(), self.GetCCDHeight())
 
     @property
     def noise_properties(self):
@@ -148,10 +150,10 @@ class PcoSdkCam(Camera):
         return (self._integ_time + self._delay_time)
 
     def GetCCDWidth(self):
-        return int(self._desc.wMaxHorzResStdDESC)
+        return self._desc.wMaxHorzResStdDESC
 
     def GetCCDHeight(self):
-        return int(self._desc.wMaxVertResStdDESC)
+        return self._desc.wMaxVertResStdDESC
 
     def GetPicWidth(self):
         return self.GetROI()[2] - self.GetROI()[0] + 1
@@ -224,6 +226,9 @@ class PcoSdkCam(Camera):
         # Minimum ROI size
         lx_min = self._desc.wMinSizeHorzDESC
         ly_min = self._desc.wMinSizeVertDESC
+
+        # print(lx_min, ly_min)
+        # print(type(lx_min), type(ly_min))
 
         # Make sure bounds are ordered
         if x1 < x0:

--- a/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
@@ -87,8 +87,8 @@ class PcoSdkCam(Camera):
         self._timeout = 1000  # ms
         self._n_buffered = 0
         self._n_queued = 0
-        self._binning_x = 0
-        self._binning_y = 0
+        self._binning_x = 1
+        self._binning_y = 1
         self._n_timeouts = 0
         self._buffers_to_queue = queue.Queue()
         self._queued_buffers = queue.Queue()

--- a/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
@@ -372,6 +372,9 @@ class PcoSdkCam(Camera):
     def GetBufferSize(self):
         return self._n_buffers
 
+    def SetBufferSize(self, n_buffers):
+        self._n_buffers = n_buffers
+
     def GetFPS(self):
         if self.GetCycleTime() == 0:
             return 0
@@ -380,8 +383,8 @@ class PcoSdkCam(Camera):
     def SetHotPixelCorrectionMode(self, mode):
         pco_sdk.set_hot_pixel_correction_mode(self._handle, mode)
 
-    def SetBitsPerPixel(self, bpp):
-        self._bits_per_pixel = bpp
+    def SetBitsPerPixel(self, bits_per_pixel):
+        self._bits_per_pixel = bits_per_pixel
 
     def Shutdown(self):
         pco_sdk.close_camera(self._handle)

--- a/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
@@ -139,7 +139,7 @@ class PcoSdkCam(Camera):
                 while not self._buffers_to_queue.empty() and (self._n_queued < MAX_QUEUED_BUFFERS):
                     i = self._buffers_to_queue.get()
                     pco_sdk.add_buffer_extern(self._handle, self._buf_event[i], 
-                                              0, 0, self._buf_addr[i], self._bufsize, 
+                                              1, 0, self._buf_addr[i], self._bufsize, 
                                               self._buf_status_addr[i])
                     self._queued_buffers.put(i)
                     self._n_queued += 1

--- a/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
@@ -227,9 +227,6 @@ class PcoSdkCam(Camera):
         lx_min = self._desc.wMinSizeHorzDESC
         ly_min = self._desc.wMinSizeVertDESC
 
-        # print(lx_min, ly_min)
-        # print(type(lx_min), type(ly_min))
-
         # Make sure bounds are ordered
         if x1 < x0:
             x0, x1 = x1, x0
@@ -317,7 +314,7 @@ class PcoSdkCam(Camera):
         self.StopAq()
         self._buf_num = -1*np.ones(self._n_buffers, dtype=ctypes.c_short)
         self._buf_event = np.zeros(self._n_buffers, dtype=pco_sdk.HANDLE)
-        self._buf_addr = np.zeros(self._n_buffers, dtype=ctypes.wintypes.PWORD)
+        self._buf_addr = np.zeros(self._n_buffers, dtype=ctypes.wintypes.WORD)
         self._buf_list = []
         lx, ly = self.GetPicWidth(), self.GetPicHeight()
         bufsize = lx*ly*ctypes.sizeof(ctypes.wintypes.WORD)  # how many words is this image worth?
@@ -338,11 +335,12 @@ class PcoSdkCam(Camera):
         return 0
 
     def StopAq(self):
-        self._recording = False
-        pco_sdk.cancel_images(self._handle)
-        pco_sdk.set_recording_state(self._handle, pco_sdk.PCO_CAMERA_STOPPED)
-        for i in np.arange(self._n_buffers):
-            pco_sdk.free_buffer(self._handle, self._buf_num[i])
+        if self._recording:
+            self._recording = False
+            pco_sdk.cancel_images(self._handle)
+            pco_sdk.set_recording_state(self._handle, pco_sdk.PCO_CAMERA_STOPPED)
+            for i in np.arange(self._n_buffers):
+                pco_sdk.free_buffer(self._handle, self._buf_num[i])
         self._get_temps()
 
     def GetNumImsBuffered(self):

--- a/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
@@ -372,8 +372,8 @@ class PcoSdkCam(Camera):
     def StopAq(self):
         if self._recording:
             self._recording = False
-            pco_sdk.cancel_images(self._handle)
             pco_sdk.set_recording_state(self._handle, pco_sdk.PCO_CAMERA_STOPPED)
+            pco_sdk.cancel_images(self._handle)
             for i in np.arange(self._n_buffers):
                 pco_sdk.free_buffer(self._handle, i)
         self._get_temps()

--- a/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
@@ -101,6 +101,8 @@ class PcoSdkCam(Camera):
         if not self._recording:
             return False
 
+        # FIXME: This works for current use cases, but ExpReady() is supposed to be lightweight and
+        # non-blocking. This may become a problem for faster imaging.
         if self._mode == self.MODE_CONTINUOUS:
             wait_status = k32_dll.WaitForSingleObject(self._buf_event[self._curr_buf], self._timeout)
             if wait_status:


### PR DESCRIPTION
New version of the pco. camera that bypasses the pco.recorder stuff, which seems to not play nice with the Python garbage collector.

This works! I am able to image and it's responsive (potentially full frame rate) and doesn't crash.

However, I decided not to do what we do with the Zyla because pco.sdk makes a big point of saying don't use the camera with threading. As such, we're not buffering exactly as you'd expect. Also, we can only create 16 buffers max. Doesn't seem to be a problem practically, just a lot lower than what I'm used to.

But it works.