### PR TITLE
Prevent mesh collapse on remesh

### DIFF
--- a/PYME/experimental/_triangle_mesh.pxd
+++ b/PYME/experimental/_triangle_mesh.pxd
@@ -99,9 +99,9 @@ cdef class TriangleMesh(TrianglesBase):
     cdef object _K
     cdef public object smooth_curvature
 
-    cdef _set_chalfedges(self, halfedge_t[:])
-    cdef _set_cfaces(self, face_d[:])
-    cdef _set_cvertices(self, vertex_d[:])
+    cdef _set_chalfedges(self, np.ndarray)#halfedge_t[:])
+    cdef _set_cfaces(self, np.ndarray)#face_d[:])
+    cdef _set_cvertices(self, np.ndarray)#vertex_d[:])
     cdef bint _check_neighbour_twins(self, int)
     cdef bint _check_collapse_fast(self, int, int)
     cdef bint _check_collapse_slow(self, int, int)
@@ -109,3 +109,8 @@ cdef class TriangleMesh(TrianglesBase):
     cdef _edge_delete(self, np.int32_t)
     cdef _zipper(self, np.int32_t, np.int32_t)
     cpdef int edge_flip(self, np.int32_t, bint live_update=*)
+    
+    #cdef int _insert_new_edge(self, int vertex, int prev=-1, int next=-1, int face=-1, int twin=-1
+    
+    cdef int _new_face(self, int)
+    #cdef int _new_vertex(self, np.ndarray, int)


### PR DESCRIPTION
@zacsimile - Seems to prevent the skeletonization problems we had on remeshing.

Works by making the target edge length adapt to the local curvature at that edge.  Currently uses the dot product between the vertex normals at either end of the edge to derive the weighting.

```latex
target_edge_length_i = dot(halfedge_i.vertex.normal, halfedge_i.twin.vertex.normal)*target_edge_length 
```

This functions to reduce the edge length / make the mesh finer where the normals between the vertices at either end of an edge are not aligned (i.e. we are in an area of high curvature). Probably best considered a work in progress for now because of the performance regression.

### TODOs:

- optimise for performance (this is definitely a performance regression as currently implemented)
- finalise the scaling factor (this is the first thing I attempted, but might be a bit conservative - we might, e.g., want to raise the dot product to some power to amplify the effect)
- alternatively, introduce curvature as an independent metric for division rather than scaling the edge length - e.g. divide whenever the dot product is < a desired angle.
