### PR TITLE
Cast to int in dc.DrawLine (scalebar)

### DIFF
--- a/PYME/Acquire/microscope.py
+++ b/PYME/Acquire/microscope.py
@@ -457,8 +457,8 @@ class microscope(object):
             elif self.cam.__class__.__name__ == 'FakeCamera':
                 # read voxel size from directly from our simulated camera
                 logger.info('Reading voxel size directly from simulated camera')
-                vx_um = (self.cam.XVals[1] - self.cam.XVals[0]) / 1.0e3
-                vy_um = (self.cam.YVals[1] - self.cam.YVals[0]) / 1.0e3
+                vx_um = float(self.cam.XVals[1] - self.cam.XVals[0]) / 1.0e3
+                vy_um = float(self.cam.YVals[1] - self.cam.YVals[0]) / 1.0e3
                 return vx_um * self.cam.GetHorizontalBin(), vy_um * self.cam.GetVerticalBin()
                     
 

--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -339,7 +339,7 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
             dc.SetPen(pGreen)
             sX, sY = view.imagepanel.Size
             
-            sbLen = self.scaleBarLength*view.scale/view.voxelsize[0]
+            sbLen = int(self.scaleBarLength*view.scale/view.voxelsize[0])
             
             y1 = 20
             x1 = 20 + sbLen


### PR DESCRIPTION
fixes #1044\n doesn't address why voxelsize is a np.float64 rather than a straight float, but this shouldn't matter. More robust with cast in any case