### PR TITLE
Get rid of vertical alignment in vertical sizer in voxelSizeDialog

### DIFF
--- a/PYME/Acquire/ui/voxelSizeDialog.py
+++ b/PYME/Acquire/ui/voxelSizeDialog.py
@@ -83,7 +83,7 @@ class VoxelSizeDialog(wx.Dialog):
 
         btSizer.Realize()
 
-        sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALL, 5)
 
         self.SetSizer(sizer1)
         sizer1.Fit(self)


### PR DESCRIPTION
Another wx4.1 fix.

```
 Error whilst running Camera>Set pixel size
==============================================
python-microscopy=21.03.10
python=3.8.8, platform=win32
numpy=1.20.3, wx=4.1.1 msw (phoenix) wxWidgets 3.1.5

Traceback
=========
Traceback (most recent call last):
  File "c:\users\scope_baby\code\python-microscopy\PYME\ui\progress.py", line 121, in func
    return fcn(*args, **kwargs)
  File "c:\users\scope_baby\code\python-microscopy\PYME\Acquire\acquiremainframe.py", line 530, in OnMCamSetPixelSize
    dlg = voxelSizeDialog.VoxelSizeDialog(self, self.scope)
  File "c:\users\scope_baby\code\python-microscopy\PYME\Acquire\ui\voxelSizeDialog.py", line 86, in __init__
    sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
wx._core.wxAssertionError: C++ assertion "!(flags & wxALIGN_CENTRE_VERTICAL)" failed at ..\..\src\common\sizer.cpp(2147) in wxBoxSizer::DoInsert(): Vertical alignment flags are ignored in vertical sizers
```