### PR TITLE
Read data type from .dbl header

### DIFF
--- a/PYME/DSView/modules/annotation.py
+++ b/PYME/DSView/modules/annotation.py
@@ -173,7 +173,7 @@ class Annotater(Plugin):
                                       'width' : self.line_width})
             self.do.selection_trace = []
             
-        elif self.do.selectionMode == self.do.SELECTION_LNE:
+        elif self.do.selectionMode == self.do.SELECTION_LINE:
             x0, y0, x1, y1 = self.do.GetSliceSelection()
             self._annotations.append({'type' : 'line', 'points' : [(x0, y0), (x1, y1)],
                                       'labelID' : self.cur_label_index, 'z':self.do.zp,

--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -687,7 +687,7 @@ class ImageStack(object):
         """
         mdfn = self._findAndParseMetadata(filename)
         
-        data = numpy.memmap(filename, dtype='<f4', mode='r', offset=128, shape=(self.mdh['Camera.ROIWidth'],self.mdh['Camera.ROIHeight'],self.mdh['NumImages']), order='F')
+        data = numpy.memmap(filename, dtype=self.mdh['DataType'], mode='r', offset=128, shape=(self.mdh['Camera.ROIWidth'],self.mdh['Camera.ROIHeight'],self.mdh['NumImages']), order='F')
         self.SetData(data)
 
         #from PYME.ParallelTasks.relativeFiles import getRelFilename
@@ -816,6 +816,11 @@ class ImageStack(object):
                     Z, X, Y, T = numpy.fromstring(s, '>u2')
                     s = df.read(16)
                     depth, width, height, elapsed = numpy.fromstring(s, '<f4')
+                    s = df.read(1)
+                    if ord(s) == 1:
+                        self.mdh['DataType'] = '<f4'
+                    else:
+                        self.mdh['DataType'] = '<f8'
                     
                     self.mdh['voxelsize.x'] = width/X
                     self.mdh['voxelsize.y'] = height/Y


### PR DESCRIPTION
Some DBL files are `<f8` instead of `<f4` and they tell you on byte 24 (see https://imspectordocs.readthedocs.io/en/latest/fileformat.html?highlight=dbl#the-dbl-file-format-deprecated).

Also a typo I found a while ago in annotation that I never fixed.