### PR TITLE
onTarget tolerance adjustment in piezo init

### DIFF
--- a/PYME/Acquire/Hardware/Piezos/piezo_e816.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_e816.py
@@ -180,7 +180,7 @@ class piezo_e816(PiezoBase):
 
 import numpy as np
 class piezo_e816T(PiezoBase):
-    def __init__(self, portname='COM1', maxtravel=12.00, Osen=None, hasTrigger=False):
+    def __init__(self, portname='COM1', maxtravel=12.00, Osen=None, hasTrigger=False, targetTolerance=0.002):
         self.max_travel = maxtravel
         #self.waveData = None
         #self.numWavePoints = 0
@@ -205,6 +205,7 @@ class piezo_e816T(PiezoBase):
         self.servo = True
         self.errCode = 0
         self.onTarget = False
+        self.targetTolerance = targetTolerance
 
         #self.lastPos = self.GetPos()
 
@@ -263,7 +264,7 @@ class piezo_e816T(PiezoBase):
                     # print('p')
                     logging.debug('Moving piezo to target: %f' % (pos[0],))
 
-                if np.allclose(self.position, self.targetPosition, atol=.002):
+                if np.allclose(self.position, self.targetPosition, atol=self.targetTolerance):
                     self.onTarget = True
 
                 # check to see if we're on target

--- a/PYME/Acquire/Hardware/pco/pco_edge_42_lt.py
+++ b/PYME/Acquire/Hardware/pco/pco_edge_42_lt.py
@@ -27,3 +27,8 @@ class PcoEdge42LT(pco_sdk_cam.PcoSdkCam):
     def Init(self):
         pco_sdk_cam.PcoSdkCam.Init(self)
         self.noiseProps = noiseProperties[self.GetSerialNumber()]
+
+    def GenStartMetadata(self, mdh):
+        pco_sdk_cam.PcoSdkCam.GenStartMetadata(self, mdh)
+        if self.active:
+            mdh.setEntry('Camera.ADOffset', self.noiseProps['ADOffset'])


### PR DESCRIPTION
Make it possible to change the `onTarget` tolerance on piezo initialization. Needed for my less precise piezo.

Might be worth thinking about refactoring the piezo hardware code. I think this, along with many other parameters, belongs in the `BasePizeo` class, but perhaps I am wrong.