### PR TITLE
Convert channel display to concertina when `DisplayOptionsPanel` in a vertical layout

### DIFF
--- a/PYME/DSView/DisplayOptionsPanel.py
+++ b/PYME/DSView/DisplayOptionsPanel.py
@@ -26,6 +26,7 @@ import wx.lib.agw.aui as aui
 # import pylab
 import wx.lib.scrolledpanel as scrolled
 import PYME.ui.manualFoldPanel as afp
+import PYME.ui.layerFoldPanel as lfp
 
 from matplotlib import cm
 
@@ -86,9 +87,10 @@ class OptionsPanel(scrolled.ScrolledPanel):
                 ssizer = wx.StaticBoxSizer(wx.StaticBox(self, -1, self.do.names[i]), wx.VERTICAL)
                 p = self
             else:
-                item = afp.foldingPane(chan_pan, -1, caption=self.do.names[i], pinned=True)
+                item = lfp.ChannelFoldingPane(chan_pan, id=-1, display_opts = self.do, chan=i, caption=self.do.names[i], folded=False, pinned=False)
                 pane = wx.Panel(item, -1)
-                ssizer = wx.StaticBoxSizer(wx.StaticBox(pane, -1), wx.VERTICAL)
+                #ssizer = wx.StaticBoxSizer(wx.StaticBox(pane, -1), wx.VERTICAL)
+                ssizer = wx.BoxSizer(wx.VERTICAL)
                 p = pane
 
             id = wx.NewId()
@@ -112,12 +114,13 @@ class OptionsPanel(scrolled.ScrolledPanel):
             cCmap.Bind(wx.EVT_CHOICE, self.OnCMapChanged)
             hsizer2.Add(cCmap, 1, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
             
-            id = wx.NewId()
-            self.shIds.append(id)            
-            cbShow = wx.CheckBox(p, id)
-            cbShow.SetValue(self.do.show[i])
-            cbShow.Bind(wx.EVT_CHECKBOX, self.OnShowChanged)
-            hsizer2.Add(cbShow, 0,wx.ALL|wx.ALIGN_CENTER_VERTICAL,2)
+            if horizOrientation:
+                id = wx.NewId()
+                self.shIds.append(id)            
+                cbShow = wx.CheckBox(p, id)
+                cbShow.SetValue(self.do.show[i])
+                cbShow.Bind(wx.EVT_CHECKBOX, self.OnShowChanged)
+                hsizer2.Add(cbShow, 0,wx.ALL|wx.ALIGN_CENTER_VERTICAL,2)
             
             ssizer.Add(hsizer2, 0, wx.ALL|wx.EXPAND, 0)
 
@@ -129,28 +132,37 @@ class OptionsPanel(scrolled.ScrolledPanel):
                 item.AddNewElement(pane)
                 chan_pan.AddPane(item)
 
-        if not horizOrientation:
-            vsizer.Add(chan_pan, 0, wx.ALL|wx.EXPAND, 5)
+        if horizOrientation:
+            pan_opt = wx.Panel(self, -1)
+        else:
+            fpan_opt = afp.foldingPane(chan_pan, -1, style=wx.BORDER_NONE)
+            pan_opt = wx.Panel(fpan_opt, -1)
 
-        self.bOptimise = wx.Button(self, -1, "Stretch", style=wx.BU_EXACTFIT)
+        self.bOptimise = wx.Button(pan_opt, -1, "Stretch", style=wx.BU_EXACTFIT)
 
-        self.cbScale = wx.Choice(self, -1, choices=["1:16", "1:8", "1:4", "1:2", "1:1", "2:1", "4:1", "8:1", "16:1"])
+        self.cbScale = wx.Choice(pan_opt, -1, choices=["1:16", "1:8", "1:4", "1:2", "1:1", "2:1", "4:1", "8:1", "16:1"])
         self.cbScale.SetSelection(4)
         self.scale_11 = 4
 
         if horizOrientation:
             vsizer.Add(hsizer, 0, wx.ALL, 0)
+            
             hsizer = wx.BoxSizer(wx.HORIZONTAL)
             hsizer.Add(self.bOptimise, 0, wx.ALL|wx.ALIGN_CENTER, 5)
             hsizer.Add(self.cbScale, 0, wx.ALL|wx.ALIGN_CENTER, 5)
-            vsizer.Add(hsizer, 0, wx.ALL|wx.ALIGN_CENTER, 0)
+            
+            pan_opt.SetSizerAndFit(hsizer)
+
+            vsizer.Add(pan_opt, 0, wx.ALL|wx.ALIGN_CENTER, 0)
+
         else:
-            vsizer.Add(self.bOptimise, 0, wx.LEFT|wx.RIGHT|wx.TOP|wx.EXPAND, 5)
+            pvsizer = wx.BoxSizer(wx.VERTICAL)
+            pvsizer.Add(self.bOptimise, 0, wx.LEFT|wx.RIGHT|wx.TOP|wx.EXPAND, 5)
 
             hsizer = wx.BoxSizer(wx.HORIZONTAL)
 
             #ssizer = wx.StaticBoxSizer(wx.StaticBox(self, -1, 'Slice'), wx.VERTICAL)
-            self.cbSlice = wx.Choice(self, -1, choices=["X-Y", "X-Z", "Y-Z"])
+            self.cbSlice = wx.Choice(pan_opt, -1, choices=["X-Y", "X-Z", "Y-Z"])
             self.cbSlice.SetSelection(0)
             hsizer.Add(self.cbSlice, 1, wx.ALL|wx.EXPAND, 5)
 
@@ -159,9 +171,15 @@ class OptionsPanel(scrolled.ScrolledPanel):
             #ssizer = wx.StaticBoxSizer(wx.StaticBox(self, -1, 'Scale'), wx.VERTICAL)
             hsizer.Add(self.cbScale, 1, wx.ALL|wx.EXPAND, 5)
 
-            vsizer.Add(hsizer, 0, wx.ALL|wx.EXPAND, 0)
-
+            pvsizer.Add(hsizer, 0, wx.ALL|wx.EXPAND, 0)
             self.cbSlice.Bind(wx.EVT_CHOICE, self.OnSliceChanged)
+
+            pan_opt.SetSizerAndFit(pvsizer)
+            #pan_opt.sizer.Fit(pan_opt)
+            fpan_opt.AddNewElement(pan_opt, foldable=False)
+            chan_pan.AddPane(fpan_opt)
+
+            vsizer.Add(chan_pan, 1, wx.ALL|wx.EXPAND, 5)
 
         
         #self.cbSlice.Bind(wx.EVT_CHOICE, self.OnSliceChanged)
@@ -222,7 +240,7 @@ class OptionsPanel(scrolled.ScrolledPanel):
 
             vsizer.Add(ssizer, 0, wx.ALL|wx.EXPAND, 5)
 
-        self.SetSizer(vsizer)
+        self.SetSizerAndFit(vsizer)
         #self.SetupScrolling(scroll_x=False)
         
         self.do.WantChangeNotification.append(self.OnDoChange)

--- a/PYME/DSView/displayOptions.py
+++ b/PYME/DSView/displayOptions.py
@@ -271,7 +271,7 @@ class DisplayOpts(object):
                 self.cmaps = []
                 self.show = []
 
-                cms = [cm.r, cm.g, cm.b]
+                cms = [cm.r, cm.g, cm.b, cm.c, cm.m, cm.y]
 
                 for i in range(nchans):
                     self.Chans.append(i)

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -206,7 +206,7 @@ class VisGUICore(object):
 
         self.recipeView = RecipeDisplayPanel(item)
         self.recipeView.SetRecipe(self.pipeline.recipe)
-        item.AddNewElement(self.recipeView, priority=20)
+        item.AddNewElement(self.recipeView, priority=20, foldable=False)
 
         pnl.AddPane(item, 20)
         

--- a/PYME/ui/manualFoldPanel.py
+++ b/PYME/ui/manualFoldPanel.py
@@ -693,36 +693,37 @@ class foldPanel(wx.Panel):
                 p.Fold()
         
         self.sizer.Layout()
-        self.SetMinSize(self.sizer.GetMinSize())
+        self.SetMinSize((-1, self.sizer.GetMinSize()[1]))
 
         #expand all panes
-        for p in self.panes:
-            #if p.foldable:
-            p.Unfold()
+        #for p in self.panes:
+        #    #if p.foldable:
+        #    p.Unfold()
 
-        self.sizer.Layout()
+        #self.sizer.Layout()
         
         
-        self.SetMaxSize((-1, self.sizer.GetMinSize()[1]))  
+        #self.SetMaxSize((-1, self.sizer.GetMinSize()[1]))  
 
         #restore inital state
         for p, s in zip(self.panes, _state):
             if not p.folded == s:
                 p.Fold(s)
 
-        self._in_fold1 = False  
+        self._in_fold1 = False
+        self.sizer.Layout()  
         
     def fold1(self, pan=None):
         #print('fold1')
         self._in_fold1 = True
         self.Layout()
-        print(self.GetSize(), self.GetBestSize(), self.GetMinSize(), self.GetMaxSize())
+        #print(self.GetSize(), self.GetBestSize(), self.GetMinSize(), self.GetMaxSize())
         
         if self._one_pane_active and not (pan is None):
             self._collapse_all_other_frames(pan)
         else:
             if (self.GetBestSize()[1] > self.GetSize()[1]):
-                print('collaping old panes')
+                #print('collaping old panes')
                 self._collapse_old_frames(pan)
         
         

--- a/PYME/ui/manualFoldPanel.py
+++ b/PYME/ui/manualFoldPanel.py
@@ -491,7 +491,10 @@ class foldingPane(wx.Panel):
                         element.foldedWindow.Show()
 
             self.folded = True
-            self.stCaption.Refresh()
+            try:
+                self.stCaption.Refresh()
+            except AttributeError:
+                pass
             self.Layout()
             wx.PostEvent(self, PanelFoldCommandEvent(self.GetId()))
             self.fold1()
@@ -513,7 +516,10 @@ class foldingPane(wx.Panel):
                         element.foldedWindow.Hide()
 
             self.folded = False
-            self.stCaption.Refresh()
+            try:
+                self.stCaption.Refresh()
+            except AttributeError:
+                pass
             self.Layout()
             self.fold1()
             wx.PostEvent(self, PanelFoldCommandEvent(self.GetId()))
@@ -659,6 +665,8 @@ class foldPanel(wx.Panel):
         for pane, priority in zip(self.panes, self.priorities):
             self.sizer.Add(pane, priority, self.sizerflags, self.padding)
 
+        self._calc_min_max_sizes()
+
         if self._stretch_sizer:
             self.sizer.AddStretchSpacer()
 
@@ -671,17 +679,50 @@ class foldPanel(wx.Panel):
         self.panes = []
 
         self.RegenSizer()
+
+    def _calc_min_max_sizes(self):
+        #remember current states
+        _state = [p.folded for p in self.panes]
+
+        #prevent fold1 logic from running
+        self._in_fold1 = True
+
+        #fold all panes
+        for p in self.panes:
+            if p.foldable:
+                p.Fold()
+        
+        self.sizer.Layout()
+        self.SetMinSize(self.sizer.GetMinSize())
+
+        #expand all panes
+        for p in self.panes:
+            #if p.foldable:
+            p.Unfold()
+
+        self.sizer.Layout()
+        
+        
+        self.SetMaxSize((-1, self.sizer.GetMinSize()[1]))  
+
+        #restore inital state
+        for p, s in zip(self.panes, _state):
+            if not p.folded == s:
+                p.Fold(s)
+
+        self._in_fold1 = False  
         
     def fold1(self, pan=None):
         #print('fold1')
         self._in_fold1 = True
         self.Layout()
-        #print(self.GetSize()[1], self.GetBestSize()[1])
+        print(self.GetSize(), self.GetBestSize(), self.GetMinSize(), self.GetMaxSize())
         
         if self._one_pane_active and not (pan is None):
             self._collapse_all_other_frames(pan)
         else:
             if (self.GetBestSize()[1] > self.GetSize()[1]):
+                print('collaping old panes')
                 self._collapse_old_frames(pan)
         
         
@@ -713,7 +754,7 @@ class foldPanel(wx.Panel):
         self.Refresh()
         
     def OnResize(self, event):
-        if not self._in_fold1:
+        if (not self._in_fold1) and self.IsShownOnScreen():
             self.fold1()
 
     


### PR DESCRIPTION
Addresses issue #1054.

**Is this a bugfix or an enhancement?**
Enhancement

**Proposed changes:**
- Display channels as concertina of foldable panels when `DisplayOptionsPanel` has a vertical layout

