### PR TITLE
ListWrapper - add missing tuple conversion

### DIFF
--- a/PYME/IO/dataWrap.py
+++ b/PYME/IO/dataWrap.py
@@ -45,7 +45,7 @@ class ListWrapper(BaseDataSource):
 
     @property
     def shape(self):
-        return self._shape
+        return tuple(self._shape)
 
     @property
     def ndim(self):


### PR DESCRIPTION
Addresses issue #1086.

**Is this a bugfix or an enhancement?**
Bugfix.

**Proposed changes:**
Just add missing tuple conversion in shape property.






**Checklist:**

- [ x] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [x ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]
