### PR TITLE
point set generation: fix dialog and change filesource format, allow saving coordinates to file

### DIFF
--- a/PYME/LMVis/Extras/pointSetGeneration.py
+++ b/PYME/LMVis/Extras/pointSetGeneration.py
@@ -126,6 +126,7 @@ There should be no need to modify this from the default and it is accordingly no
             visFr.AddMenuItem('Extras>Synthetic Data', "Configure", self.OnConfigure)
             visFr.AddMenuItem('Extras>Synthetic Data', 'Generate fluorophore positions and events', self.OnGenPoints)
             visFr.AddMenuItem('Extras>Synthetic Data', 'Generate events', self.OnGenEvents)
+            visFr.AddMenuItem('Extras>Synthetic Data', 'Save fluorophore positions', self.OnSavePoints)
 
 
 
@@ -137,6 +138,27 @@ There should be no need to modify this from the default and it is accordingly no
         self.xp, self.yp, self.zp = self.source.getPoints()
         self.OnGenEvents(None)
 
+
+    def OnSavePoints(self, event):
+        import wx
+        try:
+            x = self.xp
+        except AttributeError:
+            wx.MessageBox('No points! Generate fluorophore positions first', 'Warning', style=wx.OK)
+            return
+
+        # using a pandas based CSV IO here, there may be preferences for a more direct implementation
+        # I (CS) like it for the high-level interface
+        import pandas as pd
+        df = pd.DataFrame({'x': self.xp,
+                           'y': self.yp,
+                           'z': self.zp})
+        filename = wx.FileSelector("Save coordinates as",
+                                   wildcard='Comma separated values (*.csv)|*.csv',
+                                   flags=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT)
+        df.to_csv(filename,index=False)
+
+        
     def OnGenEvents(self, event):
         from PYME.simulation import locify
         #from PYME.Acquire.Hardware.Simulator import wormlike2

--- a/PYME/simulation/pointsets.py
+++ b/PYME/simulation/pointsets.py
@@ -30,15 +30,19 @@ class WormlikeSource(PointSource):
         mdh['GeneratedPoints.Source.PersistLength'] = self.persistLength
         
 class FileSource(PointSource):
-    file = File(filter=['*.csv'],exists=True)
+    file = File(filter=['*.npy', '*.csv'],exists=True)
     
     #name = Str('Points File')
     
     def getPoints(self):
-        # switched to csv based storage format
-        import pandas as pd
-        df = pd.read_csv(self.file)
-        return (df['x'].values,df['y'].values,df['z'].values)
+        if self.file.endswith('.csv'):
+            # csv based storage format
+            import pandas as pd
+            df = pd.read_csv(self.file)
+            return (df['x'].values,df['y'].values,df['z'].values)
+        else:
+            import numpy as np
+            return np.load(self.file)
 
     def genMetaData(self, mdh):
         mdh['GeneratedPoints.Source.Type'] = 'File'

--- a/PYME/simulation/pointsets.py
+++ b/PYME/simulation/pointsets.py
@@ -30,13 +30,15 @@ class WormlikeSource(PointSource):
         mdh['GeneratedPoints.Source.PersistLength'] = self.persistLength
         
 class FileSource(PointSource):
-    file = File()
+    file = File(filter=['*.csv'],exists=True)
     
     #name = Str('Points File')
     
     def getPoints(self):
-        import numpy as np
-        return np.load(self.file)
+        # switched to csv based storage format
+        import pandas as pd
+        df = pd.read_csv(self.file)
+        return (df['x'].values,df['y'].values,df['z'].values)
 
     def genMetaData(self, mdh):
         mdh['GeneratedPoints.Source.Type'] = 'File'


### PR DESCRIPTION
Addresses issue #1089.

**Is this a bugfix or an enhancement?**

bugfix + saving coordinates enhancement

**Proposed changes:**

- change filesource format to csv; numpy load/save formats are difficult to preview and generate using third party software while very easy with csv
- change traits `File` options to default to `File>Open` type dialog
- add `Extras>Synthetic Data>Save fluorophore positions` functionality to save generated positions in `FileSource` readable format

**Remaining issue with file dialog**

With the `exists=True` flag the file selection remains red and the ok button can't be selected in my wx version **just the first time around**, like so

<img width="410" alt="Screenshot 2021-07-16 at 16 50 09" src="https://user-images.githubusercontent.com/3750860/125974963-bc439c3e-fbb3-4428-8a35-07ced734fe03.png">

This is then worked around by pressing `Cancel` and then when you configure `Source` again everything is fine, as below and you can select what you like.

<img width="407" alt="Screenshot 2021-07-16 at 16 50 26" src="https://user-images.githubusercontent.com/3750860/125976586-1bdaf088-eabd-4ee6-bd88-24b6bd4a9d70.png">

Possibly there is another flag that makes this behave right away or this is an actual bug. But I don't feel comfortable enough with traits to come up with a better solution, e.g. a custom editor etc, was happy enough that I managed to google the flags which were hard enough to find any docs on.

**Checklist:**

- [x ] Tested with numpy=1.14
- [x ] Tested on python 3.7
- [x] Tested with wx=4.x [if UI code]
- [x ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

**Discussion**

Happy to discuss, bottom line is we need a fix/improvement for the `FileSource` for our use cases. Saving fluorophore positions is high on our list of needed features, so ideally we can incorporate that too. The file format(s) can clearly be dicussed, CSV seems like a good compromise that is flexible. This does not have to use the pandas interface if that were an issue.