### PR TITLE
Cluster localization fixes (issue 1098)

### DIFF
--- a/PYME/Acquire/Hardware/Simulator/simui_wx.py
+++ b/PYME/Acquire/Hardware/Simulator/simui_wx.py
@@ -423,7 +423,7 @@ class dSimControl(afp.foldPanel):
     
     def __init__(self, parent, sim_controller):
         afp.foldPanel.__init__(self, parent, -1)
-        self.sim_controller = sim_controller # type: .simcontrol.SimController
+        self.sim_controller = sim_controller # type: PYME.Acquire.Hardware.Simulator.simcontrol.SimController
         
         self._init_ctrls(parent)
         

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -328,19 +328,25 @@ class AnalysisController(object):
             return self.pushImagesDS(image)
 
     def pushImagesCluster(self, image):
-        from PYME.cluster import HTTPRulePusher
+        from PYME.cluster import rules #HTTPRulePusher
 
         resultsFilename = _verifyClusterResultsFilename(genClusterResultFileName(image.filename))
         logging.debug('Results file: ' + resultsFilename)
 
 
         self.resultsMdh = MetaDataHandler.NestedClassMDHandler(self.analysisMDH)
-        self.resultsMdh['DataFileID'] = fileID.genDataSourceID(image.dataSource)
+        if self.resultsMdh.get('DataFileID', None) is None:
+            self.resultsMdh['DataFileID'] = fileID.genDataSourceID(image.dataSource)
 
-        self.pusher = HTTPRulePusher.HTTPRulePusher(dataSourceID=image.filename,
-                                                    metadata=self.resultsMdh, resultsFilename=resultsFilename)
+        #self.pusher = HTTPRulePusher.HTTPRulePusher(dataSourceID=image.filename,
+        #                                            metadata=self.resultsMdh, resultsFilename=resultsFilename, startAt=self.analysisMDH.get('Analysis.StartAt', 10))
 
-        self.queueName = self.pusher.queueID
+        rule = rules.LocalisationRule(seriesName=image.filename, analysisMetadata=self.resultsMdh, resultsFilename=resultsFilename, startAt=self.analysisMDH.get('Analysis.StartAt', 10))
+        rule.push()
+
+        self.pusher = rule #for compatibility - TODO refactor??
+
+        self.queueName = rule._ruleID #self.pusher.queueID
         self.results_filename = resultsFilename
 
         debugPrint('Queue created')

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -780,7 +780,7 @@ class LMAnalyser2(Plugin):
             #newResults = pickle.loads(requests.get(self.analysisController.pusher.resultsURI.replace('__aggregate_h5r/', '') + '/FitResults?from=%d' % len(self.fitResults)).content)
             
             # load from server as .npy
-            cont = requests.get(self.analysisController.pusher.resultsURI.replace('__aggregate_h5r/', '') + '/FitResults.npy?from=%d' % len(self.fitResults)).content
+            cont = requests.get(self.analysisController.pusher.worker_resultsURI.replace('__aggregate_h5r/', '') + '/FitResults.npy?from=%d' % len(self.fitResults)).content
             newResults = np.load(BytesIO(cont))
             
             self._add_new_results(newResults)

--- a/PYME/IO/unifiedIO.py
+++ b/PYME/IO/unifiedIO.py
@@ -65,6 +65,16 @@ def assert_uri_ok(name):
     except AssertionError:
         raise AssertionError('Name "%s" is invalid. Names must only include alphanumeric characters and underscore' % name)
 
+def assert_uri_name_ok(name):
+    """
+    combination of assert_name_ok and assert_uri_ok - runs assert_uri_ok if we have a URI, assert_name_ok if we have a name
+    """
+
+    if is_cluster_uri(name):
+        assert_uri_ok(name)
+    else:
+        assert_name_ok(name)
+
 def fix_name(name):
     """
     Cleans filename / url for use with, e.g. clusterIO, by replacing spaces with underscores and removing all

--- a/PYME/cluster/HTTPRulePusher.py
+++ b/PYME/cluster/HTTPRulePusher.py
@@ -185,7 +185,10 @@ class HTTPRulePusher(object):
         #set up results file:
         logging.debug('resultsURI: ' + self.resultsURI)
         clusterResults.fileResults(self.resultsURI + '/MetaData', metadata)
-        clusterResults.fileResults(self.resultsURI + '/Events', self.ds.getEvents())
+        evts = self.ds.getEvents()
+        if evts:
+            # only push events if we have them (supresses an error message when trying to parse and save null events on server)
+            clusterResults.fileResults(self.resultsURI + '/Events', self.ds.getEvents())
 
         # set up metadata file which is used for deciding how to launch the analysis
         clusterIO.put_file(resultsMDFilename, self.mdh.to_JSON().encode(), serverfilter=serverfilter)

--- a/PYME/cluster/PYMERuleNodeServer.py
+++ b/PYME/cluster/PYMERuleNodeServer.py
@@ -47,10 +47,11 @@ def main():
     args = op.parse_args()
 
     serverPort = args.port
-    externalAddr = socket.gethostbyname(socket.gethostname())
+    #externalAddr = socket.gethostbyname(socket.gethostname())
     
     if args.advertisements == 'zeroconf':
         ns = pyme_zeroconf.getNS('_pyme-taskdist')
+        externalAddr = socket.gethostbyname(socket.gethostname())
     else:
         #assume local
         ns = sqlite_ns.getNS('_pyme-taskdist')

--- a/PYME/cluster/rulenodeserver.py
+++ b/PYME/cluster/rulenodeserver.py
@@ -414,12 +414,11 @@ class ServerThread(threading.Thread):
             externalAddr = socket.gethostbyname(socket.gethostname())
             
         self.externalAddr = externalAddr
+        self.nodeserver = WFNodeServer('http://' + self.distributor + '/', port=self.port, ip_address=self.externalAddr)
         
         threading.Thread.__init__(self)
     
     def run(self):
-        self.nodeserver = WFNodeServer('http://' + self.distributor + '/', port=self.port, ip_address=self.externalAddr)
-
         try:
             logger.info('Starting nodeserver on %s:%d' % (self.externalAddr, self.port))
             self.nodeserver.serve_forever()

--- a/PYME/cluster/rules.py
+++ b/PYME/cluster/rules.py
@@ -479,7 +479,7 @@ class LocalisationRule(Rule):
         from PYME.IO.FileUtils.nameUtils import genClusterResultFileName
         from PYME.IO import unifiedIO
     
-        unifiedIO.assert_uri_ok(seriesName)
+        unifiedIO.assert_uri_name_ok(seriesName)
     
         if resultsFilename is None:
             resultsFilename = genClusterResultFileName(seriesName)
@@ -489,7 +489,10 @@ class LocalisationRule(Rule):
     
         resultsMdh = MetaDataHandler.NestedClassMDHandler()
         # NB - anything passed in analysis MDH will wipe out corresponding entries in the series metadata
-        resultsMdh.update(json.loads(unifiedIO.read(seriesName + '/metadata.json')))
+        try:
+            resultsMdh.update(json.loads(unifiedIO.read(seriesName + '/metadata.json')))
+        except IOError:
+            logger.exception('Raw file metadata (%s) not found, continuing with analysis metadata alone. Can probably be ignored for .tiff analysis' % (seriesName + '/metadata.json') )
         resultsMdh.update(analysisMetadata)
     
         resultsMdh['EstimatedLaserOnFrameNo'] = resultsMdh.getOrDefault('EstimatedLaserOnFrameNo',


### PR DESCRIPTION
Fixes #1098, fixes #990, closes #786 

3 for the price of one!

We were silently ignoring `startAt` when doing cluster (and cluster of one) based analyses. This fixes that, and at the same time  shifts everything to the rule classes in `cluster.rules` so we don't need to maintain two lots of code for pushing (meaning that we can finally close #786).

Whilst testing (newer OSX version with slower network IO :( ) , I also ran into #990, so this includes a fix for that as well (which turned out to be surprisingly simple - just moving the socket opening into the constructor).

At present, the fix only extends to getting the analysis to run, display in PYMEImage is still broken. Will see if I can hit that before merging. If not, the output file is still created and correct, and can be opened in PYMEVis.