### PR TITLE
Make check_name work for mac and windows

### DIFF
--- a/PYME/IO/unifiedIO.py
+++ b/PYME/IO/unifiedIO.py
@@ -12,7 +12,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-alpha_regex = re.compile(r'^[\w/\.\-]+$')
+alpha_regex = re.compile(r'^[\w/(\\)\.\-]+$')
 
 def check_name(name):
     """
@@ -29,7 +29,7 @@ def check_name(name):
         True if filename/url is fully compatible
 
     """
-    return bool(alpha_regex.match(name))
+    return bool(alpha_regex.match(name.split(':')[-1]))
     #return name == fix_name(name)
 
 def check_uri(name):


### PR DESCRIPTION
Addresses issue #1098.

**Is this a bugfix or an enhancement?**
Yes

**Proposed changes:**
- Adjust regex to work for \\ as well as /
- Eliminate `C:\` and the like from `check_name` on Windows, similar to how we remove `PYME-CLUSTER://` from `check_uri`

Tested on Mac OS Catalina and Win 10.