### PR TITLE
Allow self.f and data to be different sizes

### DIFF
--- a/PYME/Deconv/dec.py
+++ b/PYME/Deconv/dec.py
@@ -136,13 +136,13 @@ class ICTMDeconvolution(object):
 
         #guess a starting estimate for the object
         self.f = self.startGuess(data).ravel()
-        self.res = 0*self.f
 
         self.fs = self.f.reshape(self.shape)
 
         #make things 1 dimensional
         #self.f = self.f.ravel()
         data = data.ravel()
+        self.res = 0*data
         
         if not np.isscalar(weights):
             weights = weights / weights.mean()


### PR DESCRIPTION
`self.res` must but the same size as `data` because of line 173, `self.res[:] = (weights*(data - self.Afunc(self.f)))`. However, `self.f` can be of a different size if A is non-square. In this case, `startGuess()` will have a different size than res. In all A-is-square cases, this change keeps the behaviour the same as before.