### PR TITLE
Name layer by mesh filename if loaded

### DIFF
--- a/PYME/LMVis/Extras/extra_layers.py
+++ b/PYME/LMVis/Extras/extra_layers.py
@@ -1,5 +1,6 @@
 import numpy as np
 import wx
+import os
 
 
 
@@ -103,13 +104,15 @@ def open_surface(visFr):
                                    wildcard='STL mesh (*.stl)|*.stl|PLY mesh (*.ply)|*.ply')
     #print filename
     if not filename == '':
-        surf_count = 0
-        surf_name = 'surf%d' % surf_count
-        while surf_name in visFr.pipeline.dataSources.keys():
-            surf_count += 1
-            surf_name = 'surf%d' % surf_count
+        # surf_count = 0
+        # surf_name = 'surf%d' % surf_count
+        # while surf_name in visFr.pipeline.dataSources.keys():
+        #     surf_count += 1
+        #     surf_name = 'surf%d' % surf_count
+        tail = os.path.split(filename)[-1]
+        surf_name = tail.split('.')[0]
 
-        ext = filename.split('.')[-1]
+        ext = tail.split('.')[-1]
         if ext == 'stl':
             visFr.pipeline.dataSources[surf_name] = triangle_mesh.TriangleMesh.from_stl(filename)
         elif ext == 'ply':

--- a/PYME/LMVis/Extras/extra_layers.py
+++ b/PYME/LMVis/Extras/extra_layers.py
@@ -104,13 +104,12 @@ def open_surface(visFr):
                                    wildcard='STL mesh (*.stl)|*.stl|PLY mesh (*.ply)|*.ply')
     #print filename
     if not filename == '':
-        # surf_count = 0
-        # surf_name = 'surf%d' % surf_count
-        # while surf_name in visFr.pipeline.dataSources.keys():
-        #     surf_count += 1
-        #     surf_name = 'surf%d' % surf_count
         tail = os.path.split(filename)[-1]
-        surf_name = tail.split('.')[0]
+        base_name = tail.split('.')[0]
+        surf_name, surf_count = base_name, 0
+        while surf_name in visFr.pipeline.dataSources.keys():
+            surf_count += 1
+            surf_name = '%s%d' % (base_name, surf_count)
 
         ext = tail.split('.')[-1]
         if ext == 'stl':


### PR DESCRIPTION
Loaded meshes now display the filename in the layer, rather than just `surf0`, `surf1`, etc. Helpful for loading & comparing meshes.