### PR TITLE
Fix undersampling, add centre to PYME.simulation.locify.points_from_sdf

### DIFF
--- a/PYME/simulation/locify.py
+++ b/PYME/simulation/locify.py
@@ -83,9 +83,9 @@ def points_from_sdf(sdf, r_max=1, centre=(0,0,0), dx_min=1, p=0.1):
     '''
     dx = 1.2 * r_max
     
-    vx, vy, vz = [v.ravel() for v in 1.2 * np.mgrid[-1:2, -1:2, -1:2]]
+    vx, vy, vz = [v.ravel() for v in np.mgrid[-1:2, -1:2, -1:2]]
     
-    verts = dx * np.vstack([vx, vy, vz])
+    verts = dx * np.vstack([vx, vy, vz]) + np.array(centre)[:,None]
     #print(verts.shape)
     
     c_offs = np.array(


### PR DESCRIPTION
We were undersampling certain parts of the SDF due to an overexpansion of the initial box boundary points. Graphical abstract below. Basically, because dx was less than 1.2x1.2xr_max, we would test corners that are conceivably already outside the object (as in the case of a sphere). Examples below. 

I also made the `centre` argument work, because why not?

![image](https://user-images.githubusercontent.com/1263313/140346232-6edb02c7-49ca-450a-bfd1-161d48eee42e.png)

Previous code:
![image (1)](https://user-images.githubusercontent.com/1263313/140347905-75319716-3487-455d-860c-4a4e59d9e00d.png)

This PR:
![image](https://user-images.githubusercontent.com/1263313/140348368-ffdc28ec-49d3-456f-a7a8-2b6c3edb3ccf.png)


