### PR TITLE
Pass at parallelizing DMC

### DIFF
--- a/PYME/experimental/dual_marching_cubes.py
+++ b/PYME/experimental/dual_marching_cubes.py
@@ -10,7 +10,7 @@ import multiprocessing
 
 class DualMarchingCubes(ModifiedMarchingCubes):
     
-    def __init__(self, isolevel=0, parallel=True):
+    def __init__(self, isolevel=0, parallel=False):
         super(DualMarchingCubes, self).__init__(isolevel)
         self._ot = None
         self._parallel = parallel
@@ -43,11 +43,12 @@ class DualMarchingCubes(ModifiedMarchingCubes):
         
         if self._parallel:
             self._pool = multiprocessing.Pool(multiprocessing.cpu_count())
-        self.node_proc(self._ot._nodes[0])  # Create the dual grid
-        self._pool.apply_async(time.sleep, (10,))
-        if self._parallel:
+            ret = self._pool.apply_async(self.node_proc, (self._ot._nodes[0],))
+            ret.get()
             self._pool.close()
             self._pool.join()
+        else:
+            self.node_proc(self._ot._nodes[0])  # Create the dual grid
 
         # Make vertices/values np arrays
         self.vertices = np.vstack(self.vertices).astype('float64')


### PR DESCRIPTION
Profiling revealed that the `face_proc_` and `edge_proc_` functions are the biggest bottle neck in mesh generation. There's no reason they cannot be run in parallel at each level of recursion, since they do not depend on one another and the resulting `self.vertices` is an unsorted set of cubes to march. Presumably pushing a bunch of `apply_async` calls to a multiprocessing pool should take care of this, but it seems to not work. Removing the `apply_async` calls from `node_proc` works better, but it's still missing quite a few cubes. It's unclear to me why this is the case. Pushing this as a draft to see if any of the other devs have ideas.