### PR TITLE
force listwrap to xyztc array

### DIFF
--- a/PYME/IO/dataExporter.py
+++ b/PYME/IO/dataExporter.py
@@ -77,9 +77,11 @@ class Exporter:
         from PYME.IO.DataSources import BaseDataSource, CropDataSource
         data = dataWrap.Wrap(data) #make sure we can index along a colour dimension
     
-        if data.ndim != 5 or isinstance(data, dataWrap.ListWrapper):
+        if data.ndim != 5:
             # promote to xyztc and force to array datasource
             data = BaseDataSource.XYZTCWrapper.auto_promote(data)
+        elif isinstance(data, dataWrap.ListWrapper):
+            data = BaseDataSource.XYZTCWrapper(data, size_z=data.shape[2], size_t=data.shape[3], size_c=data.shape[4])
         
         cropped = CropDataSource.DataSource(data, xrange=xslice, yrange=yslice, zrange=zslice, trange=tslice)
         

--- a/PYME/IO/dataExporter.py
+++ b/PYME/IO/dataExporter.py
@@ -78,9 +78,10 @@ class Exporter:
         data = dataWrap.Wrap(data) #make sure we can index along a colour dimension
     
         if data.ndim != 5:
-            # promote to xyztc and force to array datasource
+            # promote to xyztc
             data = BaseDataSource.XYZTCWrapper.auto_promote(data)
         elif isinstance(data, dataWrap.ListWrapper):
+            # dimensionality is right, but wrap as array for the crop datasource
             data = BaseDataSource.XYZTCWrapper(data, size_z=data.shape[2], size_t=data.shape[3], size_c=data.shape[4])
         
         cropped = CropDataSource.DataSource(data, xrange=xslice, yrange=yslice, zrange=zslice, trange=tslice)

--- a/PYME/IO/dataExporter.py
+++ b/PYME/IO/dataExporter.py
@@ -73,12 +73,12 @@ class Exporter:
         pass
 
     def _prepare(self, data, xslice, yslice, zslice, tslice):
-        from PYME.IO.dataWrap import Wrap
+        from PYME.IO import dataWrap
         from PYME.IO.DataSources import BaseDataSource, CropDataSource
-        data = Wrap(data) #make sure we can index along a colour dimension
+        data = dataWrap.Wrap(data) #make sure we can index along a colour dimension
     
-        if data.ndim != 5:
-            # promote to xyztc
+        if data.ndim != 5 or isinstance(data, dataWrap.ListWrapper):
+            # promote to xyztc and force to array datasource
             data = BaseDataSource.XYZTCWrapper.auto_promote(data)
         
         cropped = CropDataSource.DataSource(data, xrange=xslice, yrange=yslice, zrange=zslice, trange=tslice)


### PR DESCRIPTION
Addresses issue #1151 . Not clean. @David-Baddeley I haven't been following the change to XYZTC closely enough to know what you want done with listwrapping / recipes.base.Filter outputs, but I'll put my hack-around here for now.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
sloppily force 5d listwrap (e.g. len 2 list wrapping xyz) into xyztc for output






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
