### PR TITLE
Remesh speed improvements

### DIFF
--- a/PYME/experimental/_triangle_mesh.pxd
+++ b/PYME/experimental/_triangle_mesh.pxd
@@ -95,8 +95,8 @@ cdef class TriangleMesh(TrianglesBase):
     cdef object fix_boundary
     cdef object _manifold
 
-    cdef object _vertex_normals_valid
-    cdef object _face_normals_valid
+    cdef bint _vertex_normals_valid
+    cdef bint _face_normals_valid
 
     cdef object _H
     cdef object _K

--- a/PYME/experimental/_triangle_mesh.pxd
+++ b/PYME/experimental/_triangle_mesh.pxd
@@ -109,6 +109,8 @@ cdef class TriangleMesh(TrianglesBase):
     cdef _edge_delete(self, np.int32_t)
     cdef _zipper(self, np.int32_t, np.int32_t)
     cpdef int edge_flip(self, np.int32_t, bint live_update=*)
+    cpdef int edge_collapse(self, np.int32_t, bint live_update=*)
+    cpdef int edge_split(self, np.int32_t, bint live_update=*, bint upsample=*)
     
     #cdef int _insert_new_edge(self, int vertex, int prev=-1, int next=-1, int face=-1, int twin=-1
     

--- a/PYME/experimental/_triangle_mesh.pxd
+++ b/PYME/experimental/_triangle_mesh.pxd
@@ -111,6 +111,8 @@ cdef class TriangleMesh(TrianglesBase):
     cpdef int edge_flip(self, np.int32_t, bint live_update=*)
     cpdef int edge_collapse(self, np.int32_t, bint live_update=*)
     cpdef int edge_split(self, np.int32_t, bint live_update=*, bint upsample=*)
+    cpdef int relax(self, float l=*, int n=*)
+    cpdef int regularize(self)
     
     #cdef int _insert_new_edge(self, int vertex, int prev=-1, int next=-1, int face=-1, int twin=-1
     

--- a/PYME/experimental/_triangle_mesh.pxd
+++ b/PYME/experimental/_triangle_mesh.pxd
@@ -95,6 +95,9 @@ cdef class TriangleMesh(TrianglesBase):
     cdef object fix_boundary
     cdef object _manifold
 
+    cdef object _vertex_normals_valid
+    cdef object _face_normals_valid
+
     cdef object _H
     cdef object _K
     cdef public object smooth_curvature

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -1901,7 +1901,7 @@ cdef class TriangleMesh(TrianglesBase):
         if (t2 != -1):
             self._chalfedges[t2].twin = t1
 
-    def regularize(self):
+    cpdef int regularize(self):
         """
         Adjust vertices so they tend toward valence VALENCE 
         (or BOUNDARY_VALENCE for boundaries).
@@ -1959,7 +1959,7 @@ cdef class TriangleMesh(TrianglesBase):
 
     @cython.cdivision(True)
     @cython.boundscheck(False)
-    def relax(self, float l=1, int n=1):
+    cpdef int relax(self, float l=1, int n=1):
         """
         Perform n iterations of Lloyd relaxation on the mesh.
 
@@ -2107,6 +2107,8 @@ cdef class TriangleMesh(TrianglesBase):
             self._vertices['normal'][:] = -1
             self.face_normals
             self.vertex_normals
+
+        return 1
         
     def split_edges(self, float split_threshold):
         cdef int split_count = 0

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -1982,11 +1982,11 @@ cdef class TriangleMesh(TrianglesBase):
         n_vertices = self._vertices.shape[0]
         
         # Get vertex neighbors
-        nn = self._vertices['neighbors']
-        nn_mask = (self._vertices['neighbors'] != -1)
-        #print
-        #nn = nn[nn_mask]
-        vn_idx = self._halfedges['vertex'][nn]
+        # nn = self._vertices['neighbors']
+        # nn_mask = (self._vertices['neighbors'] != -1)
+        # print
+        # nn = nn[nn_mask]
+        # vn_idx = self._halfedges['vertex'][nn]
         
         if self.fix_boundary:
             # Don't move vertices on a boundary

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -470,8 +470,7 @@ cdef class TriangleMesh(TrianglesBase):
         """
         Return the valence of each vertex.
         """
-        if np.all(self._vertices['valence'] == -1):
-            self._vertices['neighbors'][:] = -1
+        if not self._vertex_normals_valid:
             self.vertex_neighbors
         return self._vertices['valence']
 

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -212,10 +212,10 @@ cdef class TriangleMesh(TrianglesBase):
 
         # Populate the normals
         #print('populating face normals')
-        self._face_normals_valid = False
+        self._face_normals_valid = 0
         self.face_normals
         #print('populating vertex normals')
-        self._vertex_normals_valid = False
+        self._vertex_normals_valid = 0
         self.vertex_normals
         #print('done populating normals')
 
@@ -431,7 +431,7 @@ cdef class TriangleMesh(TrianglesBase):
         """
         if not self._face_normals_valid:
             triangle_mesh_utils.c_update_face_normals(list(np.arange(len(self._faces)).astype(np.int32)), self._halfedges, self._vertices, self._faces)
-            self._face_normals_valid = True
+            self._face_normals_valid = 1
         return self._faces['normal'][self._faces['halfedge'] != -1]
 
     @property
@@ -440,7 +440,7 @@ cdef class TriangleMesh(TrianglesBase):
         Return the area of each triangular face.
         """
         if np.all(self._faces['area'] == -1):
-            self._face_normals_valid = False
+            self._face_normals_valid = 0
             self.face_normals
         return self._faces['area']
     
@@ -451,7 +451,7 @@ cdef class TriangleMesh(TrianglesBase):
         """
         if not self._vertex_normals_valid:
             triangle_mesh_utils.c_update_vertex_neighbors(list(np.arange(len(self._vertices)).astype(np.int32)), self._halfedges, self._vertices, self._faces)
-            self._vertex_normals_valid = True
+            self._vertex_normals_valid = 1
 
         return self._vertices['neighbors']
 
@@ -625,9 +625,9 @@ cdef class TriangleMesh(TrianglesBase):
             self._manifold = None
             self._singular_edges = None
             self._singular_vertices = None
-            self._face_normals_valid = False
+            self._face_normals_valid = 0
             self.face_normals
-            self._vertex_normals_valid = False
+            self._vertex_normals_valid = 0
             self.vertex_neighbors
             self._H = None
             self._K = None
@@ -2111,8 +2111,8 @@ cdef class TriangleMesh(TrianglesBase):
             # Now we gotta recalculate the normals
             # self._faces['normal'][:] = -1
             # self._vertices['normal'][:] = -1
-            self._face_normals_valid = False
-            self._vertex_normals_valid = False
+            self._face_normals_valid = 0
+            self._vertex_normals_valid = 0
             self.face_normals
             self.vertex_normals
 
@@ -3113,8 +3113,8 @@ cdef class TriangleMesh(TrianglesBase):
         # Now we gotta recalculate the normals
         # self._faces['normal'][:] = -1
         # self._vertices['normal'][:] = -1
-        self._face_normals_valid = False
-        self._vertex_normals_valid = False
+        self._face_normals_valid = 0
+        self._vertex_normals_valid = 0
         self.face_normals
         self.vertex_normals
 

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -212,8 +212,10 @@ cdef class TriangleMesh(TrianglesBase):
 
         # Populate the normals
         #print('populating face normals')
+        self._face_normals_valid = False
         self.face_normals
         #print('populating vertex normals')
+        self._vertex_normals_valid = False
         self.vertex_normals
         #print('done populating normals')
 
@@ -427,8 +429,9 @@ cdef class TriangleMesh(TrianglesBase):
         """
         Return the normal of each triangular face.
         """
-        if np.all(self._faces['normal'] == -1):
+        if not self._face_normals_valid:
             triangle_mesh_utils.c_update_face_normals(list(np.arange(len(self._faces)).astype(np.int32)), self._halfedges, self._vertices, self._faces)
+            self._face_normals_valid = True
         return self._faces['normal'][self._faces['halfedge'] != -1]
 
     @property
@@ -437,7 +440,7 @@ cdef class TriangleMesh(TrianglesBase):
         Return the area of each triangular face.
         """
         if np.all(self._faces['area'] == -1):
-            self._faces['normal'][:] = -1
+            self._face_normals_valid = False
             self.face_normals
         return self._faces['area']
     
@@ -446,8 +449,9 @@ cdef class TriangleMesh(TrianglesBase):
         """
         Return the up to NEIGHBORSIZE neighbors of each vertex.
         """
-        if np.all(self._vertices['neighbors'] == -1):
+        if not self._vertex_normals_valid:
             triangle_mesh_utils.c_update_vertex_neighbors(list(np.arange(len(self._vertices)).astype(np.int32)), self._halfedges, self._vertices, self._faces)
+            self._vertex_normals_valid = True
 
         return self._vertices['neighbors']
 
@@ -456,9 +460,7 @@ cdef class TriangleMesh(TrianglesBase):
         """
         Return the normal of each vertex.
         """
-        if np.all(self._vertices['normal'] == -1):
-            self._vertices['neighbors'][:] = -1
-            self.vertex_neighbors
+        self.vertex_neighbors
         return self._vertices['normal']
 
     @property
@@ -623,7 +625,9 @@ cdef class TriangleMesh(TrianglesBase):
             self._manifold = None
             self._singular_edges = None
             self._singular_vertices = None
+            self._face_normals_valid = False
             self.face_normals
+            self._vertex_normals_valid = False
             self.vertex_neighbors
             self._H = None
             self._K = None
@@ -2105,8 +2109,10 @@ cdef class TriangleMesh(TrianglesBase):
             #triangle_mesh_utils.c_update_vertex_neighbors(list(np.arange(len(self._vertices)).astype(np.int32)), self._halfedges, self._vertices, self._faces)
 
             # Now we gotta recalculate the normals
-            self._faces['normal'][:] = -1
-            self._vertices['normal'][:] = -1
+            # self._faces['normal'][:] = -1
+            # self._vertices['normal'][:] = -1
+            self._face_normals_valid = False
+            self._vertex_normals_valid = False
             self.face_normals
             self.vertex_normals
 
@@ -3105,8 +3111,10 @@ cdef class TriangleMesh(TrianglesBase):
         self._manifold = None
 
         # Now we gotta recalculate the normals
-        self._faces['normal'][:] = -1
-        self._vertices['normal'][:] = -1
+        # self._faces['normal'][:] = -1
+        # self._vertices['normal'][:] = -1
+        self._face_normals_valid = False
+        self._vertex_normals_valid = False
         self.face_normals
         self.vertex_normals
 

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -1462,7 +1462,8 @@ cdef class TriangleMesh(TrianglesBase):
         cdef bint interior
         cdef np.int32_t v0, v1
         cdef int i
-        cdef np.float32_t x0x, x0y, x0z, x1x, x1y, x1z, n0x, n0y, n0z, n1x, n1y, n1z, ndot, vx, vy, vz
+        cdef np.float32_t x0x, x0y, x0z, x1x, x1y, x1z, n0x, n0y, n0z, n1x, n1y, n1z, ndot
+        cdef np.float32_t[VECTORSIZE] _vertex
 
         if _curr == -1:
             return 0
@@ -1492,9 +1493,9 @@ cdef class TriangleMesh(TrianglesBase):
         # n0 = self._vertices['normal'][curr_edge.vertex, :]
         # n1 = self._vertices['normal'][self._chalfedges[_prev].vertex, :]
         
-        vx = 0.5*(x0x + x1x)
-        vy = 0.5*(x0y + x1y)
-        vz = 0.5*(x0z + x1z)
+        _vertex[0] = 0.5*(x0x + x1x)
+        _vertex[1] = 0.5*(x0y + x1y)
+        _vertex[2] = 0.5*(x0z + x1z)
         if not upsample:
             n0x = self._cvertices[v0].normal0
             n0y = self._cvertices[v0].normal1
@@ -1505,16 +1506,16 @@ cdef class TriangleMesh(TrianglesBase):
 
             ndot = (n1x-n0x)*(x1x-x0x)+(n1y-n0y)*(x1y-x0y)+(n1z-n0z)*(x1z-x0z)
 
-            vx += 0.0625*ndot*(n0x + n1x)
-            vy += 0.0625*ndot*(n0y + n1y)
-            vz += 0.0625*ndot*(n0z + n1z)
+            _vertex[0] += 0.0625*ndot*(n0x + n1x)
+            _vertex[1] += 0.0625*ndot*(n0y + n1y)
+            _vertex[2] += 0.0625*ndot*(n0z + n1z)
 
         #_vertex = 0.5*(x0+x1) + 0.125*(n0-n1)
         #if upsample:
         #    _vertex = 0.5*(x0 + x1)
         #else:
         #    _vertex = 0.5*(x0 + x1) + .125*((n1-n0)*(x1-x0)).sum()*0.5*(n0 + n1)
-        _vertex_idx = self._new_vertex(np.array([vx,vy,vz]))
+        _vertex_idx = self._new_vertex(_vertex)
         #_vertex_idx = self._new_vertex(_vertex)
 
         _twin = curr_edge.twin

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -1910,7 +1910,8 @@ cdef class TriangleMesh(TrianglesBase):
         cdef int i, flip_count, target_valence, r, failed_flip_count
         cdef halfedge_t *curr_edge
         cdef halfedge_t *twin_edge
-        cdef np.int32_t _twin, v1, v2, v3, v4, score_post, score_pre
+        cdef np.int32_t _twin
+        cdef int v1, v2, v3, v4, score_post, score_pre
 
         flip_count = 0
         failed_flip_count = 0
@@ -1945,10 +1946,8 @@ cdef class TriangleMesh(TrianglesBase):
             #score_pre = abs([v1,v2,v3,v4]).sum()
             #score_post = np.abs([v1-1,v2-1,v3+1,v4+1]).sum()
             
-            #score_pre = abs(v1) + abs(v2) + abs(v3) + abs(v4)
-            #score_post = abs(v1-1) + abs(v2-1) + abs(v3+1) + abs(v4+1)
-            score_pre = v1*v1 + v2*v2 + v3*v3 + v4*v4
-            score_post = (v1-1)*(v1-1) + (v2-1)*(v2-1) + (v3+1)*(v3+1) + (v4+1)*(v4+1)
+            score_pre = abs(v1) + abs(v2) + abs(v3) + abs(v4)
+            score_post = abs(v1-1) + abs(v2-1) + abs(v3+1) + abs(v4+1)
 
             if score_post < score_pre:
                 # Flip minimizes deviation of vertex valences from VALENCE (or

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -1908,7 +1908,8 @@ cdef class TriangleMesh(TrianglesBase):
         """
 
         cdef int i, flip_count, target_valence, r, failed_flip_count
-        cdef halfedge_t *curr_edge, *twin_edge
+        cdef halfedge_t *curr_edge
+        cdef halfedge_t *twin_edge
         cdef np.int32_t _twin, v1, v2, v3, v4, score_post, score_pre
 
         flip_count = 0
@@ -1944,8 +1945,10 @@ cdef class TriangleMesh(TrianglesBase):
             #score_pre = abs([v1,v2,v3,v4]).sum()
             #score_post = np.abs([v1-1,v2-1,v3+1,v4+1]).sum()
             
-            score_pre = abs(v1) + abs(v2) + abs(v3) + abs(v4)
-            score_post = abs(v1-1) + abs(v2-1) + abs(v3+1) + abs(v4+1)
+            #score_pre = abs(v1) + abs(v2) + abs(v3) + abs(v4)
+            #score_post = abs(v1-1) + abs(v2-1) + abs(v3+1) + abs(v4+1)
+            score_pre = v1*v1 + v2*v2 + v3*v3 + v4*v4
+            score_post = (v1-1)*(v1-1) + (v2-1)*(v2-1) + (v3+1)*(v3+1) + (v4+1)*(v4+1)
 
             if score_post < score_pre:
                 # Flip minimizes deviation of vertex valences from VALENCE (or

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -907,7 +907,7 @@ cdef class TriangleMesh(TrianglesBase):
         
         return 1
     
-    def edge_collapse(self, np.int32_t _curr, bint live_update=1):
+    cpdef int edge_collapse(self, np.int32_t _curr, bint live_update=1):
         """
         A.k.a. delete two triangles. Remove an edge, defined by halfedge _curr,
         and its associated triangles, while keeping mesh connectivity.
@@ -1439,7 +1439,7 @@ cdef class TriangleMesh(TrianglesBase):
 
         return idx
 
-    def edge_split(self, np.int32_t _curr, bint live_update=1, bint upsample=0):
+    cpdef int edge_split(self, np.int32_t _curr, bint live_update=1, bint upsample=0):
         """
         Split triangles evenly along an edge specified by halfedge index _curr.
 

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -429,9 +429,8 @@ cdef class TriangleMesh(TrianglesBase):
         """
         Return the normal of each triangular face.
         """
-        cdef int size = self._faces.shape[0]
         if not self._face_normals_valid:
-            triangle_mesh_utils.c_update_all_face_normals(size, self._halfedges, self._vertices, self._faces)
+            triangle_mesh_utils.c_update_all_face_normals(self._faces.shape[0], self._halfedges, self._vertices, self._faces)
             self._face_normals_valid = 1
         return self._faces['normal'][self._faces['halfedge'] != -1]
 
@@ -450,9 +449,8 @@ cdef class TriangleMesh(TrianglesBase):
         """
         Return the up to NEIGHBORSIZE neighbors of each vertex.
         """
-        cdef int size = self._vertices.shape[0]
         if not self._vertex_normals_valid:
-            triangle_mesh_utils.c_update_all_vertex_neighbors(size, self._halfedges, self._vertices, self._faces)
+            triangle_mesh_utils.c_update_all_vertex_neighbors(self._vertices.shape[0], self._halfedges, self._vertices, self._faces)
             self._vertex_normals_valid = 1
 
         return self._vertices['neighbors']

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -429,8 +429,9 @@ cdef class TriangleMesh(TrianglesBase):
         """
         Return the normal of each triangular face.
         """
+        cdef int size = self._faces.shape[0]
         if not self._face_normals_valid:
-            triangle_mesh_utils.c_update_face_normals(list(np.arange(len(self._faces)).astype(np.int32)), self._halfedges, self._vertices, self._faces)
+            triangle_mesh_utils.c_update_all_face_normals(size, self._halfedges, self._vertices, self._faces)
             self._face_normals_valid = 1
         return self._faces['normal'][self._faces['halfedge'] != -1]
 
@@ -449,8 +450,9 @@ cdef class TriangleMesh(TrianglesBase):
         """
         Return the up to NEIGHBORSIZE neighbors of each vertex.
         """
+        cdef int size = self._vertices.shape[0]
         if not self._vertex_normals_valid:
-            triangle_mesh_utils.c_update_vertex_neighbors(list(np.arange(len(self._vertices)).astype(np.int32)), self._halfedges, self._vertices, self._faces)
+            triangle_mesh_utils.c_update_all_vertex_neighbors(size, self._halfedges, self._vertices, self._faces)
             self._vertex_normals_valid = 1
 
         return self._vertices['neighbors']

--- a/PYME/experimental/triangle_mesh_utils.c
+++ b/PYME/experimental/triangle_mesh_utils.c
@@ -264,7 +264,7 @@ static PyObject *update_vertex_neighbors(PyObject *self, PyObject *args)
 static PyObject *update_all_vertex_neighbors(PyObject *self, PyObject *args)
 {
     PyObject *halfedges=0, *vertices=0, *faces=0;
-    int32_t j, n_idxs;
+    int j, n_idxs;
     halfedge_t *p_halfedges;
     vertex_t *p_vertices;
     face_t *p_faces;
@@ -419,7 +419,7 @@ static PyObject *update_face_normals(PyObject *self, PyObject *args)
 static PyObject *update_all_face_normals(PyObject *self, PyObject *args)
 {
     PyObject *halfedges=0, *vertices=0, *faces=0;
-    int32_t j, n_idxs;
+    int j, n_idxs;
     halfedge_t *p_halfedges;
     face_t *p_faces;
     vertex_t *p_vertices;

--- a/PYME/experimental/triangle_mesh_utils.c
+++ b/PYME/experimental/triangle_mesh_utils.c
@@ -294,6 +294,7 @@ static PyObject *update_all_vertex_neighbors(PyObject *self, PyObject *args)
 
     for (j = 0; j < n_idxs; ++j)
     {
+        if (p_vertices[j].halfedge == -1) continue;
         update_single_vertex_neighbours(j, p_halfedges, p_vertices, p_faces);
     }
 
@@ -448,6 +449,7 @@ static PyObject *update_all_face_normals(PyObject *self, PyObject *args)
 
     for (j = 0; j < n_idxs; ++j)
     {
+        if (p_faces[j].halfedge == -1) continue;
         update_face_normal(j, p_halfedges, p_vertices, p_faces);
     }
 

--- a/PYME/experimental/triangle_mesh_utils.c
+++ b/PYME/experimental/triangle_mesh_utils.c
@@ -261,6 +261,46 @@ static PyObject *update_vertex_neighbors(PyObject *self, PyObject *args)
     return Py_None;
 }
 
+static PyObject *update_all_vertex_neighbors(PyObject *self, PyObject *args)
+{
+    PyObject *halfedges=0, *vertices=0, *faces=0;
+    int32_t j, n_idxs;
+    halfedge_t *p_halfedges;
+    vertex_t *p_vertices;
+    face_t *p_faces;
+
+    n_idxs = 0;
+
+    if (!PyArg_ParseTuple(args, "iOOO", &n_idxs, &halfedges, &vertices, &faces)) return NULL;
+    if (!PyArray_Check(halfedges) || !PyArray_ISCONTIGUOUS(halfedges))
+    {
+        PyErr_Format(PyExc_RuntimeError, "Expecting a contiguous numpy array for the edge data.");
+        return NULL;
+    }
+    if (!PyArray_Check(vertices) || !PyArray_ISCONTIGUOUS(vertices)) 
+    {
+        PyErr_Format(PyExc_RuntimeError, "Expecting a contiguous numpy array for the vertex data.");
+        return NULL;
+    }
+    if (!PyArray_Check(faces) || !PyArray_ISCONTIGUOUS(faces)) 
+    {
+        PyErr_Format(PyExc_RuntimeError, "Expecting a contiguous numpy array for the face data.");
+        return NULL;
+    } 
+
+    p_vertices = (vertex_t*)PyArray_GETPTR1(vertices, 0);
+    p_halfedges = (halfedge_t*)PyArray_GETPTR1(halfedges, 0);
+    p_faces = (face_t*)PyArray_GETPTR1(faces, 0);
+
+    for (j = 0; j < n_idxs; ++j)
+    {
+        update_single_vertex_neighbours(j, p_halfedges, p_vertices, p_faces);
+    }
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
 
 static void update_face_normal(int f_idx, halfedge_t *halfedges, void *vertices_, void *faces_)
 {
@@ -325,6 +365,7 @@ static void _update_face_normals(int32_t *f_idxs, halfedge_t *halfedges, vertex_
         update_face_normal(f_idx, halfedges, vertices, faces);
     }
 }
+
 static PyObject *update_face_normals(PyObject *self, PyObject *args)
 {
     PyObject *f_idxs=0, *halfedges=0, *vertices=0, *faces=0;
@@ -374,9 +415,51 @@ static PyObject *update_face_normals(PyObject *self, PyObject *args)
     return Py_None;
 }
 
+static PyObject *update_all_face_normals(PyObject *self, PyObject *args)
+{
+    PyObject *halfedges=0, *vertices=0, *faces=0;
+    int32_t j, n_idxs;
+    halfedge_t *p_halfedges;
+    face_t *p_faces;
+    vertex_t *p_vertices;
+
+    n_idxs = 0;
+
+    if (!PyArg_ParseTuple(args, "iOOO", &n_idxs, &halfedges, &vertices, &faces)) return NULL;
+    if (!PyArray_Check(halfedges) || !PyArray_ISCONTIGUOUS(halfedges))
+    {
+        PyErr_Format(PyExc_RuntimeError, "Expecting a contiguous numpy array for the edge data.");
+        return NULL;
+    }
+    if (!PyArray_Check(vertices) || !PyArray_ISCONTIGUOUS(vertices)) 
+    {
+        PyErr_Format(PyExc_RuntimeError, "Expecting a contiguous numpy array for the vertex data.");
+        return NULL;
+    }
+    if (!PyArray_Check(faces) || !PyArray_ISCONTIGUOUS(faces)) 
+    {
+        PyErr_Format(PyExc_RuntimeError, "Expecting a contiguous numpy array for the face data.");
+        return NULL;
+    } 
+
+    p_vertices = (vertex_t*)PyArray_GETPTR1(vertices, 0);
+    p_halfedges = (halfedge_t*)PyArray_GETPTR1(halfedges, 0);
+    p_faces = (face_t*)PyArray_GETPTR1(faces, 0);
+
+    for (j = 0; j < n_idxs; ++j)
+    {
+        update_face_normal(j, p_halfedges, p_vertices, p_faces);
+    }
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
 static PyMethodDef triangle_mesh_utils_methods[] = {
     {"c_update_vertex_neighbors", update_vertex_neighbors, METH_VARARGS},
     {"c_update_face_normals", update_face_normals, METH_VARARGS},
+    {"c_update_all_vertex_neighbors", update_all_vertex_neighbors, METH_VARARGS},
+    {"c_update_all_face_normals", update_all_face_normals, METH_VARARGS},
     {NULL, NULL, 0}  /* Sentinel */
 };
 

--- a/PYME/experimental/triangle_mesh_utils.h
+++ b/PYME/experimental/triangle_mesh_utils.h
@@ -87,7 +87,9 @@ void cross(const float *a, const float *b, float *n);
 void difference(const float *a, const float *b, float *d);
 
 static PyObject *update_vertex_neighbors(PyObject *self, PyObject *args);
+static PyObject *update_all_vertex_neighbors(PyObject *self, PyObject *args);
 static PyObject *update_face_normals(PyObject *self, PyObject *args);
+static PyObject *update_all_face_normals(PyObject *self, PyObject *args);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Some minor improvements to remesh.

Current stats on `test_er_data.hdf`

```
        1620971 function calls (1606453 primitive calls) in 5.470 seconds

   Ordered by: internal time
   List reduced from 1311 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    20053    0.847    0.000    0.890    0.000 _triangle_mesh.pyx:910(edge_collapse)
    17561    0.559    0.000    0.952    0.000 _triangle_mesh.pyx:1364(edge_split)
3381/2432    0.477    0.000    0.661    0.000 dual_marching_cubes.py:673(vert_proc)
        5    0.446    0.089    0.499    0.100 _triangle_mesh.pyx:1851(relax)
    15623    0.403    0.000    0.419    0.000 {method 'fix_empty_nodes' of 'PYME.experimental._octree.Octree' objects}
    53447    0.276    0.000    0.276    0.000 {method 'reduce' of 'numpy.ufunc' objects}
       41    0.262    0.006    0.319    0.008 _triangle_mesh.pyx:1793(regularize)
    32208    0.145    0.000    0.422    0.000 dual_marching_cubes.py:140(subdivided)
      976    0.134    0.000    0.134    0.000 weakiddict.py:26(_remover)
    17561    0.126    0.000    0.136    0.000 _triangle_mesh.pyx:1328(_new_vertex)
    40820    0.114    0.000    0.114    0.000 {built-in method numpy.array}
     4986    0.111    0.000    0.527    0.000 dual_marching_cubes.py:175(<listcomp>)
        1    0.100    0.100    0.103    0.103 _triangle_mesh.pyx:524(_initialize_halfedges)
   105366    0.065    0.000    0.098    0.000 _triangle_mesh.pyx:1252(_insert_new_edge)
68879/68252    0.053    0.000    0.517    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
    32481    0.052    0.000    0.207    0.000 fromnumeric.py:70(_wrapreduction)
       10    0.051    0.005    0.155    0.016 {built-in method Update}
    19060    0.042    0.000    0.042    0.000 _triangle_mesh.pyx:1517(edge_flip)
       21    0.041    0.002    0.041    0.002 {method 'sort' of 'numpy.ndarray' objects}
   158049    0.037    0.000    0.043    0.000 _triangle_mesh.pyx:1167(_get_insertion_slot)
```

and new stats, with this PR...

```

         1628103 function calls (1613595 primitive calls) in 3.755 seconds

   Ordered by: internal time
   List reduced from 1312 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
3381/2432    0.466    0.000    0.644    0.000 dual_marching_cubes.py:673(vert_proc)
    15623    0.360    0.000    0.375    0.000 {method 'fix_empty_nodes' of 'PYME.experimental._octree.Octree' objects}
       40    0.228    0.006    0.271    0.007 _triangle_mesh.pyx:1904(regularize)
       51    0.203    0.004    0.206    0.004 _triangle_mesh.pyx:445(__get__)
       51    0.202    0.004    0.205    0.004 _triangle_mesh.pyx:426(__get__)
    36021    0.165    0.000    0.165    0.000 {method 'reduce' of 'numpy.ufunc' objects}
    32208    0.142    0.000    0.414    0.000 dual_marching_cubes.py:140(subdivided)
    40810    0.110    0.000    0.110    0.000 {built-in method numpy.array}
    18109    0.109    0.000    0.339    0.000 _triangle_mesh.pyx:1442(edge_split)
      976    0.107    0.000    0.107    0.000 weakiddict.py:26(_remover)
     4986    0.105    0.000    0.479    0.000 dual_marching_cubes.py:175(<listcomp>)
        1    0.101    0.101    0.105    0.105 _triangle_mesh.pyx:524(_initialize_halfedges)
    20670    0.101    0.000    0.140    0.000 _triangle_mesh.pyx:910(edge_collapse)
    18109    0.096    0.000    0.104    0.000 _triangle_mesh.pyx:1406(_new_vertex)
   108654    0.059    0.000    0.088    0.000 _triangle_mesh.pyx:1330(_insert_new_edge)
        5    0.055    0.011    0.487    0.097 _triangle_mesh.pyx:1962(relax)
    32616    0.052    0.000    0.206    0.000 fromnumeric.py:70(_wrapreduction)
68974/68357    0.048    0.000    0.490    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
       10    0.038    0.004    0.118    0.012 {built-in method Update}
   162981    0.031    0.000    0.038    0.000 _triangle_mesh.pyx:1245(_get_insertion_slot)
```