### PR TITLE
colormap refactor

### DIFF
--- a/PYME/DSView/DisplayOptionsPanel.py
+++ b/PYME/DSView/DisplayOptionsPanel.py
@@ -28,18 +28,20 @@ import wx.lib.scrolledpanel as scrolled
 import PYME.ui.manualFoldPanel as afp
 import PYME.ui.layerFoldPanel as lfp
 
-from matplotlib import cm
+#from matplotlib import cm
+from PYME.misc.colormaps import cm
 
 from PYME import resources
 
-try:
-    from PYME.misc import extraCMaps
-except:
-    pass
+# try:
+#     from PYME.misc import extraCMaps
+# except:
+#     pass
+
 import numpy as np
 #from matplotlib import cm
 from PYME.ui import histLimits
-from .displayOptions import DisplayOpts, fast_grey, labeled
+from .displayOptions import DisplayOpts #, fast_grey, labeled
 
 import os
 dirname = os.path.dirname(__file__)
@@ -68,8 +70,8 @@ class OptionsPanel(wx.Panel):
         self.hcs = []
         self.shIds = []
 
-        cmapnames = list(cm.cmapnames) + ['fastGrey', 'labeled']# + [n + '_r' for n in pylab.cm.cmapnames]
-        cmapnames.sort()
+        cmapnames = list(cm.graded_cmaps)  #+ ['fastGrey', 'labeled']# + [n + '_r' for n in pylab.cm.cmapnames]
+        #cmapnames.sort()
         ##do = parent.do
 
         dispSize = (120, 80)
@@ -286,13 +288,7 @@ class OptionsPanel(wx.Panel):
         ind = self.cIds.index(event.GetId())
 
         cmn = event.GetString()
-        if cmn == 'fastGrey':
-            self.do.SetCMap(ind, fast_grey)
-
-        elif cmn == 'labeled':
-            self.do.SetCMap(ind, labeled)
-        else:
-            self.do.SetCMap(ind, cm.__getattribute__(cmn))
+        self.do.SetCMap(ind, cm[cmn])
             
     def OnComplexChanged(self, event):
         #print event.GetId()

--- a/PYME/DSView/displayOptions.py
+++ b/PYME/DSView/displayOptions.py
@@ -21,7 +21,8 @@
 #
 ##################
 
-from matplotlib import cm
+#from matplotlib import cm
+from PYME.misc.colormaps import cm
 import numpy as np
 #import tables
 

--- a/PYME/DSView/modules/LMDisplay.py
+++ b/PYME/DSView/modules/LMDisplay.py
@@ -22,7 +22,7 @@ from PYME.DSView import fitInfo
 from PYME.DSView import overlays
 import wx.lib.agw.aui as aui
 
-from PYME.misc import extraCMaps
+#from PYME.misc import extraCMaps
 
 
 from PYME.LMVis import pipeline

--- a/PYME/DSView/modules/vis3D.py
+++ b/PYME/DSView/modules/vis3D.py
@@ -164,6 +164,7 @@ class Visualiser(Plugin):
         from PYME.experimental import isosurface
         from PYME.LMVis import gl_render3D_shaders as glrender
         from PYME.LMVis.layers.mesh import TriangleRenderLayer
+        from PYME.misc.colormaps import cm
 
         glcanvas = new_mesh_viewer()#glrender.showGLFrame()
         glcanvas.layer_data={}
@@ -173,7 +174,7 @@ class Visualiser(Plugin):
             T = isosurface.isosurface(self.image.data[:,:,:,i].astype('f'), isolevel=isolevel, voxel_size=self.image.voxelsize, origin=self.image.origin)
             glcanvas.layer_data[self.image.names[i]] = T
             layer = TriangleRenderLayer(glcanvas.layer_data, dsname=self.image.names[i], method='shaded', context=glcanvas.gl_context,
-                                        cmap=['C', 'M', 'Y', 'R', 'G', 'B'][i % 6],
+                                        cmap=cm.solid_cmaps[i % len(cm.solid_cmaps)],
                                         #normal_mode='Per face', #use face normals rather than vertex normals, as there is currently a bug in computation of vertex normals
                                         )
             glcanvas.add_layer(layer)

--- a/PYME/DSView/modules/visgui.py
+++ b/PYME/DSView/modules/visgui.py
@@ -22,7 +22,8 @@
 
 from PYME.LMVis.imageView2 import ImageViewPanel, ColourImageViewPanel
 # import pylab
-import matplotlib.cm
+#import matplotlib.cm
+from PYME.misc.colormaps import cm
 import numpy
 import wx
 import os
@@ -127,7 +128,7 @@ class GLImageView(LMGLShaderCanvas):
 def Plug(dsviewer):
     dsviewer.vgextras = visGuiExtras(dsviewer)
 
-    cmaps = [matplotlib.cm.r, matplotlib.cm.g, matplotlib.cm.b]
+    cmaps = [cm.r, cm.g, cm.b]
 
     if not 'ivps' in dir(dsviewer):
         dsviewer.ivps = []

--- a/PYME/LMVis/Extras/extra_layers.py
+++ b/PYME/LMVis/Extras/extra_layers.py
@@ -77,6 +77,7 @@ def gen_octree_from_points(visFr):
 def gen_isosurface(visFr):
     from PYME.LMVis.layers.mesh import TriangleRenderLayer
     from PYME.recipes.surface_fitting import DualMarchingCubes
+    from PYME.misc.colormaps import cm
     
     oc_name = gen_octree_from_points(visFr)
     surf_name, surf_count = visFr.pipeline.new_ds_name('surf', return_count=True)
@@ -88,7 +89,7 @@ def gen_isosurface(visFr):
         recipe.add_modules_and_execute([dmc,])
 
         print('Isosurface generated, adding layer')
-        layer = TriangleRenderLayer(visFr.pipeline, dsname=surf_name, method='shaded', cmap = ['C', 'M', 'Y', 'R', 'G', 'B'][surf_count % 6])
+        layer = TriangleRenderLayer(visFr.pipeline, dsname=surf_name, method='shaded', cmap = cm.solid_cmaps[surf_count % len(cm.solid_cmaps)])
         visFr.add_layer(layer)
         dmc._invalidate_parent = True
         print('Isosurface layer added')
@@ -286,6 +287,7 @@ def add_tesselation_layer(visFr):
 def gen_isosurface_from_tesselation(visFr):
     from PYME.LMVis.layers.mesh import TriangleRenderLayer
     from PYME.recipes.surface_fitting import DelaunayMarchingTetrahedra
+    from PYME.misc.colormaps import cm
 
     if 'delaunay0' not in visFr.pipeline.dataSources.keys():
         del_name = add_tesselation(visFr)
@@ -306,7 +308,7 @@ def gen_isosurface_from_tesselation(visFr):
         recipe.add_modules_and_execute([mt,])
 
         print('Isosurface generated, adding layer')
-        layer = TriangleRenderLayer(visFr.pipeline, dsname=surf_name, method='shaded', cmap = ['C', 'M', 'Y', 'R', 'G', 'B'][surf_count % 6])
+        layer = TriangleRenderLayer(visFr.pipeline, dsname=surf_name, method='shaded', cmap = cm.solid_cmaps[surf_count % len(cm.solid_cmaps)])
         visFr.add_layer(layer)
         mt._invalidate_parent = True
         print('Isosurface layer added')

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -43,7 +43,7 @@ matplotlib.use('wxagg')
 # import pylab
 
 from PYME import config
-from PYME.misc import extraCMaps
+#from PYME.misc import extraCMaps
 from PYME.IO.FileUtils import nameUtils
 
 #import os

--- a/PYME/LMVis/displayPane.py
+++ b/PYME/LMVis/displayPane.py
@@ -27,7 +27,7 @@ import wx.lib.newevent
 #import PYME.ui.autoFoldPanel as afp
 import PYME.ui.manualFoldPanel as afp
 # import pylab
-import matplotlib.cm
+from PYME.misc import colormaps
 import numpy as np
 
 from PYME.ui import histLimits
@@ -61,7 +61,7 @@ class DisplayPane(afp.foldingPane):
         self._pc_clim_change = False
 
         #Colourmap
-        cmapnames = matplotlib.cm.cmapnames
+        cmapnames = colormaps.cm.cmapnames
         
         #print((cmapnames, self.glCanvas.cmap.name))
 
@@ -221,11 +221,11 @@ class DisplayPane(afp.foldingPane):
 
 
     def OnCMapChange(self, event):
-        cmapname = matplotlib.cm.cmapnames[self.cColourmap.GetSelection()]
+        cmapname = colormaps.cm.cmapnames[self.cColourmap.GetSelection()]
         #if self.cbCmapReverse.GetValue():
         #    cmapname += '_r'
 
-        self.glCanvas.setCMap(matplotlib.cm.__dict__[cmapname])
+        self.glCanvas.setCMap(colormaps.cm[cmapname])
         #self.visFr.OnGLViewChanged()
         evt = DisplayInvalidEvent(self.GetId())
         self.ProcessEvent(evt)

--- a/PYME/LMVis/gl_render3D.py
+++ b/PYME/LMVis/gl_render3D.py
@@ -24,7 +24,8 @@
 import numpy
 import numpy as np
 # import pylab
-import matplotlib.cm
+#import matplotlib.cm
+from PYME.misc.colormaps import cm
 import wx
 import wx.glcanvas
 from OpenGL import GLUT
@@ -268,7 +269,7 @@ class LMGLCanvas(GLCanvas):
         self.nVertices = 0
         self.IScale = [1.0, 1.0, 1.0]
         self.zeroPt = [0, 1.0/3, 2.0/3]
-        self.cmap = matplotlib.cm.hsv
+        self.cmap = cm.hsv
         self.clim = [0,1]
         self.alim = [0,1]
 

--- a/PYME/LMVis/gl_render3D_shaders.py
+++ b/PYME/LMVis/gl_render3D_shaders.py
@@ -985,9 +985,9 @@ class LegacyGLCanvas(LMGLShaderCanvas):
     def __init__(self, *args, **kwargs):
         LMGLShaderCanvas.__init__(self, *args, **kwargs)
         
-        import matplotlib.cm
+        from PYME.misc.colormaps import cm
 
-        self.cmap = matplotlib.cm.gist_rainbow
+        self.cmap = cm.gist_rainbow
         self.clim = [0, 1]
         self.alim = [0, 1]
 

--- a/PYME/LMVis/layers/image_layer.py
+++ b/PYME/LMVis/layers/image_layer.py
@@ -6,7 +6,7 @@ from PYME.LMVis.shader_programs.TesselShaderProgram import TesselShaderProgram
 
 from PYME.recipes.traits import CStr, Float, Enum, ListFloat, List, Int, observe
 # from pylab import cm
-from matplotlib import cm
+from PYME.misc.colormaps import cm
 import numpy as np
 from PYME.contrib import dispatch
 
@@ -264,7 +264,7 @@ class ImageRenderLayer(EngineLayer):
         #else:
         
         clim = self.clim
-        cmap = getattr(cm, self.cmap)
+        cmap = cm[self.cmap]
             
         alpha = float(self.alpha)
         

--- a/PYME/LMVis/layers/mesh.py
+++ b/PYME/LMVis/layers/mesh.py
@@ -6,7 +6,7 @@ from PYME.LMVis.shader_programs.TesselShaderProgram import TesselShaderProgram
 
 from PYME.recipes.traits import CStr, Float, Enum, ListFloat, List, Bool
 # from pylab import cm
-from matplotlib import cm
+from PYME.misc.colormaps import cm
 import numpy as np
 from PYME.contrib import dispatch
 
@@ -270,7 +270,7 @@ class TriangleRenderLayer(EngineLayer):
             c = ds[self.vertexColour][ds.faces].ravel()
             clim = self.clim
 
-        cmap = getattr(cm, self.cmap)
+        cmap = cm[self.cmap]
         alpha = float(self.alpha)
 
         # Do we have coordinates? Concatenate into vertices.

--- a/PYME/LMVis/layers/octree.py
+++ b/PYME/LMVis/layers/octree.py
@@ -5,7 +5,7 @@ from PYME.experimental._octree import Octree
 
 from PYME.recipes.traits import CStr, Float, Enum, ListFloat, List, Int
 # from pylab import cm
-from matplotlib import cm
+from PYME.misc.colormaps import cm
 import numpy as np
 
 
@@ -135,7 +135,7 @@ class OctreeRenderLayer(TriangleRenderLayer):
             alpha = np.repeat(alpha.ravel(), 3)
             print('Octree scaled alpha range: %g, %g' % (alpha.min(), alpha.max()))
 
-            cmap = getattr(cm, self.cmap)
+            cmap = cm[self.cmap]
 
             # Do we have coordinates? Concatenate into vertices.
             if x is not None and y is not None and z is not None:

--- a/PYME/LMVis/layers/pointcloud.py
+++ b/PYME/LMVis/layers/pointcloud.py
@@ -5,7 +5,7 @@ from PYME.LMVis.shader_programs.GouraudShaderProgram import GouraudShaderProgram
 
 from PYME.recipes.traits import CStr, Float, Enum, ListFloat, List, Bool
 # from pylab import cm
-from matplotlib import cm
+from PYME.misc.colormaps import cm
 import numpy as np
 from PYME.contrib import dispatch
 
@@ -215,9 +215,9 @@ class PointCloudRenderLayer(EngineLayer):
             
         if self.xn_key in ds.keys():
             xn, yn, zn = ds[self.xn_key], ds[self.yn_key], ds[self.zn_key]
-            self.update_data(x, y, z, c, cmap=getattr(cm, self.cmap), clim=self.clim, alpha=self.alpha, xn=xn, yn=yn, zn=zn)
+            self.update_data(x, y, z, c, cmap=cm[self.cmap], clim=self.clim, alpha=self.alpha, xn=xn, yn=yn, zn=zn)
         else:
-            self.update_data(x, y, z, c, cmap=getattr(cm, self.cmap), clim=self.clim, alpha=self.alpha)
+            self.update_data(x, y, z, c, cmap=cm[self.cmap], clim=self.clim, alpha=self.alpha)
     
     
     def update_data(self, x=None, y=None, z=None, colors=None, cmap=None, clim=None, alpha=1.0, xn=None, yn=None, zn=None):
@@ -294,11 +294,13 @@ class PointCloudRenderLayer(EngineLayer):
     def default_view(self):
         from traitsui.api import View, Item, Group, InstanceEditor, EnumEditor, TextEditor
         from PYME.ui.custom_traits_editors import HistLimitsEditor, CBEditor
+
+        vis_when = 'cmap not in %s' % cm.solid_cmaps
     
         return View([Group([Item('dsname', label='Data', editor=EnumEditor(name='_datasource_choices')), ]),
                      Item('method'),
-                     Item('vertexColour', editor=EnumEditor(name='_datasource_keys'), label='Colour', visible_when='cmap not in ["R", "G", "B", "C", "M","Y", "K"]'),
-                     Group([Item('clim', editor=HistLimitsEditor(data=self._get_cdata, update_signal=self.on_update), show_label=False), ], visible_when='cmap not in ["R", "G", "B", "C", "M","Y", "K"]'),
+                     Item('vertexColour', editor=EnumEditor(name='_datasource_keys'), label='Colour', visible_when=vis_when),
+                     Group([Item('clim', editor=HistLimitsEditor(data=self._get_cdata, update_signal=self.on_update), show_label=False), ], visible_when=vis_when),
                      Group(Item('cmap', label='LUT'),
                            Item('alpha', visible_when="method in ['pointsprites', 'transparent_points']", editor=TextEditor(auto_set=False, enter_set=True, evaluate=float)),
                            Item('point_size', label=u'Point\u00A0size', editor=TextEditor(auto_set=False, enter_set=True, evaluate=float)))])

--- a/PYME/LMVis/layers/tracks.py
+++ b/PYME/LMVis/layers/tracks.py
@@ -8,7 +8,7 @@ from PYME.LMVis.shader_programs.DefaultShaderProgram import DefaultShaderProgram
 
 from PYME.recipes.traits import CStr, Float, Enum, ListFloat, List
 # from pylab import cm
-from matplotlib import cm
+from PYME.misc.colormaps import cm
 import numpy as np
 from PYME.contrib import dispatch
 
@@ -233,7 +233,7 @@ class TrackRenderLayer(EngineLayer):
         self._bbox = np.array([x.min(), y.min(), z.min(), x.max(), y.max(), z.max()])
         
         clim = self.clim
-        cmap = getattr(cm, self.cmap)
+        cmap = cm[self.cmap]
         
         if clim is not None:
             cs_ = ((c - clim[0]) / (clim[1] - clim[0]))
@@ -273,13 +273,15 @@ class TrackRenderLayer(EngineLayer):
     def default_view(self):
         from traitsui.api import View, Item, Group, InstanceEditor, EnumEditor, TextEditor
         from PYME.ui.custom_traits_editors import HistLimitsEditor, CBEditor
+
+        vis_when = 'cmap not in %s' % cm.solid_cmaps
         
         return View([Group([Item('dsname', label='Data', editor=EnumEditor(name='_datasource_choices')), ]),
                      Item('method'),
                      Item('vertexColour', editor=EnumEditor(name='_datasource_keys'), label='Colour',
-                          visible_when='cmap not in ["R", "G", "B", "C", "M","Y", "K"]'),
+                          visible_when=vis_when),
                      Group([Item('clim', editor=HistLimitsEditor(data=self._get_cdata, update_signal=self.on_update),
-                                 show_label=False), ], visible_when='cmap not in ["R", "G", "B", "C", "M","Y", "K"]'),
+                                 show_label=False), ], visible_when=vis_when),
                      Group(Item('cmap', label='LUT'),
                            Item('alpha', editor=TextEditor(auto_set=False, enter_set=True, evaluate=float)),
                            Item('line_width')

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -21,7 +21,7 @@ from PYME.LMVis import gl_render3D as gl_render
 # import pylab
 
 from PYME.LMVis.gl_render3D_shaders import LMGLShaderCanvas
-from PYME.misc import extraCMaps
+#from PYME.misc import extraCMaps
 from PYME.IO.FileUtils import nameUtils
 
 import os
@@ -659,6 +659,7 @@ class VisGUICore(object):
         self.dsviewer.AddMenuItem('Points>' + menuName, *args, **kwargs)
         
     def _create_base_layer(self):
+        from PYME.misc.colormaps import cm
         if self.glCanvas._is_initialized and self._new_layers and len(self.layers) == 0:
             #add a new layer
             l = self.add_pointcloud_layer(method='points')
@@ -671,7 +672,7 @@ class VisGUICore(object):
         if len(colour_chans) > 1:
             #add a layer for each colour channel
             for i, c in enumerate(sorted(colour_chans)):
-                self.add_pointcloud_layer(ds_name=('output.' + c), cmap=['C', 'M', 'Y', 'R', 'G', 'B'][i%6], visible=False)
+                self.add_pointcloud_layer(ds_name=('output.' + c), cmap=cm.solid_cmaps[i % len(cm.solid_cmaps)], visible=False)
                 
     def _populate_open_args(self, filename):
         args = {}

--- a/PYME/misc/colormaps.py
+++ b/PYME/misc/colormaps.py
@@ -1,0 +1,188 @@
+#!/usr/bin/python
+
+###############
+# extraCMaps.py
+#
+# Copyright David Baddeley, 2012
+# d.baddeley@auckland.ac.nz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+################
+import matplotlib.colors as colors
+from matplotlib import cm as mp_cm
+from collections import OrderedDict
+
+#import matplotlib as mpl
+# import pylab
+import numpy as np
+
+class CMapDict(OrderedDict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.solid_cmaps = []
+
+    def __getattr__(self, key):
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError('No attribute %s' % key)
+
+    def register_cmap(self, name, solid=False):
+        """A decorator"""
+
+        def _reg_cmap(func):
+            func.name = name
+            self[name] = func
+
+            if solid:
+                self.solid_cmaps.append(name)
+
+            return func
+    
+        return _reg_cmap
+
+    @property
+    def cmapnames(self):
+        return self.keys()
+
+    @property
+    def graded_cmaps(self):
+        return [k for k in self.keys() if not k in self.solid_cmaps]
+
+    
+
+try:
+    # try version 3.5 way first ....
+    from matplotlib import colormaps
+    _cmd = dict(colormaps)
+except ImportError:
+    # older matplotlib - note this generates a deprecation warning on 3.4.2 as it does not appear to have matplotlib.colormaps
+    # but still does not want you to access the colourmap dictionary (cmap_d) directly.
+    if 'cmap_d' in dir(mp_cm):
+        _cmd = mp_cm.cmap_d
+    elif 'cmapnames' in dir(mp_cm):
+        _cmd = {k: mp_cm.__dict__[k] for k in mp_cm.cmapnames}
+    else:
+        _cmd = {k: mp_cm.__dict__[k] for k in mp_cm._cmapnames}
+
+cm = CMapDict(_cmd)
+
+_r = {'red':((0.,0.,0.), (1.,1.,1.)), 'green':((0.,0,0), (1.,0.,0.)), 'blue':((0.,0.,0.), (1.,0.,0.))}
+_g = {'green':((0.,0.,0.), (1.,1.,1.)), 'red':((0.,0,0), (1.,0.,0.)), 'blue':((0.,0.,0.), (1.,0.,0.))}
+_b = {'blue':((0.,0.,0.), (1.,1.,1.)), 'green':((0.,0,0), (1.,0.,0.)), 'red':((0.,0.,0.), (1.,0.,0.))}
+
+_c = {'blue':((0.,0.,0.), (1.,1.,1.)), 'green':((0.,0,0), (1.,1.,1.)), 'red':((0.,0.,0.), (1.,0.,0.))}
+_m = {'blue':((0.,0.,0.), (1.,1.,1.)), 'red':((0.,0,0), (1.,1.,1.)), 'green':((0.,0.,0.), (1.,0.,0.))}
+_y = {'red':((0.,0.,0.), (1.,1.,1.)), 'green':((0.,0,0), (1.,1.,1.)), 'blue':((0.,0.,0.), (1.,0.,0.))}
+
+_hsv_part = {'red':   ((0., 1., 1.),(0.25, 1.000000, 1.000000),
+                       (0.5, 0, 0),
+                       (1, 0.000000, 0.000000)),
+             'green': ((0., 0., 0.),(0.25, 1, 1),
+                       (.75, 1.000000, 1.000000),
+                       (1.0, 0.2, 0.2)),
+             'blue':  ((0., 0., 0.),(0.5, 0.000000, 0.000000),
+                       (0.75, 1, 1),
+                       (1.0, 1, 1))}
+
+ndat = {'r':_r, 'g':_g, 'b':_b, 'c':_c, 'm':_m, 'y':_y, 'hsp': _hsv_part}
+
+cm.update({cmapname: colors.LinearSegmentedColormap(cmapname, ndat[cmapname], mp_cm.LUTSIZE) for cmapname in ndat.keys()})
+
+#solid colour colormaps for VisGUI multichannel and isosurface display
+@cm.register_cmap('SoildRed', solid=True)
+def Red(data):
+    z = np.ones_like(data)
+    return np.stack([z, 0*z, 0*z, z], -1)
+
+@cm.register_cmap('SolidGreen', solid=True)
+def Green(data):
+    z = np.ones_like(data)
+    return np.stack([0*z, z, 0*z, z], -1)
+
+@cm.register_cmap('SolidBlue', solid=True)
+def Blue(data):
+    z = np.ones_like(data)
+    return np.stack([0*z, 0*z, z, z], -1)
+
+@cm.register_cmap('SolidCyan', solid=True)
+def Cyan(data):
+    z = np.ones_like(data)
+    return np.stack([0*z, z, z, z], -1)
+
+@cm.register_cmap('SolidMagenta', solid=True)
+def Magenta(data):
+    z = np.ones_like(data)
+    return np.stack([z, 0*z, z, z], -1)
+
+@cm.register_cmap('SolidYellow', solid=True)
+def Yellow(data):
+    z = np.ones_like(data)
+    return np.stack([z, z, 0*z, z], -1)
+
+@cm.register_cmap('labeled')
+def labeled(data):
+    return (data > 0).reshape(list(data.shape) +  [1])*cm.gist_rainbow(data % 1)
+
+# @cm.register_cmap('flow_gray')
+# def flow_gray(data):
+#     v = ((data > 0)*(data < 1)).reshape(list(data.shape) +  [1])*cm.gray(data)
+#     v += (data == 0).reshape(list(data.shape) + [1]) * np.array([0, 1., 0, 0]).reshape(list(np.ones(data.ndim) + [3]))
+#     v += (data == 1).reshape(list(data.shape) + [1]) * np.array([1., 0, 1., 0]).reshape(list(np.ones(data.ndim) + [3]))
+#     return v
+
+# @cm.register_cmap('fast_grey')
+# def fast_grey(data):
+#     return data[:,:,None]*np.ones((1,1,4))
+
+def grey_overflow(underflowcol = 'magenta', overflowcol = 'lime', percentage=5, greystart=0.1):
+    if percentage < 1:
+        percentage = 1
+    if percentage > 15:
+        percentage = 15
+
+    ucolrgb = colors.hex2color(colors.cnames[underflowcol])
+    ocolrgb = colors.hex2color(colors.cnames[overflowcol])
+    p = 0.01 * percentage
+
+    def r(rgb):
+        return rgb[0]
+
+    def g(rgb):
+        return rgb[1]
+
+    def b(rgb):
+        return rgb[2]
+    
+    grey_data = {'red':   [(0, r(ucolrgb), r(ucolrgb)),
+                          (p, r(ucolrgb), greystart),
+                          (1.0-p, 1.0, r(ocolrgb)),
+                          (1.0, r(ocolrgb), r(ocolrgb))],
+                'green': [(0, g(ucolrgb), g(ucolrgb)),
+                          (p, g(ucolrgb), greystart),
+                          (1.0-p, 1.0, g(ocolrgb)),
+                          (1.0, g(ocolrgb), g(ocolrgb))],
+                'blue':  [(0, b(ucolrgb), b(ucolrgb)),
+                          (p, b(ucolrgb), greystart),
+                          (1.0-p, 1.0, b(ocolrgb)),
+                          (1.0, b(ocolrgb), b(ocolrgb))]}
+
+    cm_grey2 = colors.LinearSegmentedColormap('grey_overflow', grey_data)
+    return cm_grey2
+
+cm['grey_overflow'] = grey_overflow(percentage=2.5,greystart=0.125)
+
+#cm.cmapnames.sort()

--- a/PYME/ui/layerFoldPanel.py
+++ b/PYME/ui/layerFoldPanel.py
@@ -53,11 +53,11 @@ class LUTBitmap(manualFoldPanel.CaptionButton):
     def _active_bitmap(self):
         import numpy as np
         # from pylab import cm
-        from matplotlib import cm
+        from PYME.misc.colormaps import cm
         x = np.linspace(0, 1, 30)
 
         if isinstance(self._layer.cmap, str):
-            img = (255*getattr(cm, self._layer.cmap)(np.ones(10)[:, None]*x[None, :]))[:,:,:3].astype('uint8')
+            img = (255*cm[self._layer.cmap](np.ones(10)[:, None]*x[None, :]))[:,:,:3].astype('uint8')
         else:
             # assume an actual colourmap instance - TODO make the check explicit on a colormap base class??
             img = (255*self._layer.cmap(np.ones(10)[:, None]*x[None, :]))[:,:,:3].astype('uint8')


### PR DESCRIPTION
initial progress on #700 and addressing pending matplotlib deprecations. Refactors our colormap access so that we no longer need to monkey-patch matplotlib.cm. Also brings colormap list into one place where we can start to try and make the ordering more logical.