### PR TITLE
dcam tweaks for Fusion

### DIFF
--- a/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
@@ -422,8 +422,8 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
 class Fusion(HamamatsuORCA):
     """
     Orca Fusion is functionally the same as the Flash, however uses multiple gain modes.
-    TODO - check whether Flash fails nicely on READOUT SPEED property so we can catch/return 'fixed'
-    and not introduce an extra class
+    TODO - check Flash return/fail on READOUT SPEED property so we can catch/return 'fixed'
+    and not necessarily introduce an extra class
     """
     _gain_modes = {
         1:'Ultra-quiet',

--- a/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
@@ -150,7 +150,14 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
         #OFF =1 , ON = 2
 
         onoff = 2.0 if on else 1.0
-        self.setCamPropValue('SENSOR COOLER', onoff)
+        try:
+            self.setCamPropValue('SENSOR COOLER', onoff)
+        except DCAMException as e:
+            # api v20.10.641, BT FUSION does not have SENSOR COOLER property
+            # don't worry about it if cooling is already on 
+            status = self.getCamPropValue('SENSOR COOLER STATUS')
+            if status != onoff:
+                raise e
 
         
     def GetAcquisitionMode(self):

--- a/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
@@ -419,6 +419,22 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
             #                "dcamwait_close")
         HamamatsuDCAM.Shutdown(self)
 
+class Fusion(HamamatsuORCA):
+    """
+    Orca Fusion is functionally the same as the Flash, however uses multiple gain modes.
+    TODO - check whether Flash fails nicely on READOUT SPEED property so we can catch/return 'fixed'
+    and not introduce an extra class
+    """
+    _gain_modes = {
+        1:'Ultra-quiet',
+        2:'Standard',
+        3:'Fast'
+    }
+
+    @property
+    def _gain_mode(self):
+        return self._gain_modes[int(self.getCamPropValue('READOUT SPEED'))]
+
 
 class MultiviewOrca(MultiviewCameraMixin, HamamatsuORCA):
     def __init__(self, camNum, multiview_info):

--- a/docs/supported_hardware.rst
+++ b/docs/supported_hardware.rst
@@ -3,7 +3,7 @@ Cameras / Detectors
 ===================
 * Andor IXon
 * Andor SDK3 Cameras (tested on Zyla and Neo)
-* Hamamatsu DCAM cameras (tested on Orca Flash)
+* Hamamatsu DCAM cameras (tested on Orca Flash and Fusion BT)
 * PCO Cameras (tested on pco.edge 4.2 LT)
 * Thorlabs DCC1240 (maybe also DCC3240)
 * IDS uEye industrial cameras (UI306x, UI327x, UI324x, probably others. Thorlabs-branded IDS)


### PR DESCRIPTION
Addresses issue hard-throw if property isn't present, even if sensor status reports cooling is enabled.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**



- handle dcam sensors without SENSOR COOLER propety
- add Fusion class to handle gain modes for camera noise_properties

TODO:
at some point write a control panel to match

**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
