### PR TITLE
fix ueye type issue c_uint which trips up JSON dump in cluster IO

### DIFF
--- a/PYME/Acquire/Hardware/ueye.py
+++ b/PYME/Acquire/Hardware/ueye.py
@@ -91,7 +91,7 @@ class UEyeCamera(Camera):
         sensor_info = ueye.SENSORINFO()
         self.check_success(ueye.is_GetSensorInfo(self.h, sensor_info))
         
-        self._chip_size = (sensor_info.nMaxWidth, sensor_info.nMaxHeight)
+        self._chip_size = (int(sensor_info.nMaxWidth), int(sensor_info.nMaxHeight)) # convert from c_uint, otherwise trips up JSON dumps
         self.sensor_type = sensor_info.strSensorName.decode().split('x')[0] + 'x'
 
         # work out the camera base parameters for this sensortype


### PR DESCRIPTION
**Is this a bugfix or an enhancement?**
Bugfix. Original bug meant `c_uint`s from IDS wrappers made it into metadata without conversion. This caused error in JSON dump during cluster IO, see below.
**Proposed changes:**
Explicitly convert these `c_uint`s to `int`. Note sure if it would be preferable to make metadata IO more lenient. My feeling was it was best to convert these `c_uints`.

**Bug encountered**
```
Traceback (most recent call last):
  File "c:\python-support-files\pyme-py37\PYME\IO\MetaDataHandler.py", line 509, in default
    return obj.to_JSON()
AttributeError: 'c_uint' object has no attribute 'to_JSON'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "c:\python-support-files\pyme-py37\PYME\Acquire\ui\HDFSpoolFrame.py", line 475, in OnBStartSpoolButton
    self.spoolController.start_spooling(fn)
  File "c:\python-support-files\pyme-py37\PYME\Acquire\SpoolController.py", line 521, in start_spooling
    self.spooler.StartSpool()
  File "c:\python-support-files\pyme-py37\PYME\IO\HTTPSpooler_v2.py", line 107, in StartSpool
    self._backend.initialise()
  File "c:\python-support-files\pyme-py37\PYME\IO\acquisition_backends.py", line 166, in initialise
    self._streamer.put(self._series_location + '/metadata.json', self.mdh.to_JSON().encode())
  File "c:\python-support-files\pyme-py37\PYME\IO\MetaDataHandler.py", line 515, in to_JSON
    return json.dumps(d, indent=2, sort_keys=True, cls=CustomEncoder)
  File "c:\python-support-files\envs\pyme-shared\lib\json\__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "c:\python-support-files\envs\pyme-shared\lib\json\encoder.py", line 201, in encode
    chunks = list(chunks)
  File "c:\python-support-files\envs\pyme-shared\lib\json\encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "c:\python-support-files\envs\pyme-shared\lib\json\encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "c:\python-support-files\envs\pyme-shared\lib\json\encoder.py", line 438, in _iterencode
    o = _default(o)
  File "c:\python-support-files\pyme-py37\PYME\IO\MetaDataHandler.py", line 511, in default
    return json.JSONEncoder.default(self, obj)
  File "c:\python-support-files\envs\pyme-shared\lib\json\encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type c_uint is not JSON serializable
```



**Checklist:**
Tested on current production system with IDS cam. With PR writes frame series via clusterIO fine.