### PR TITLE
fix remaining str/byte issue - byte encode/decode fix in event viewer

### DIFF
--- a/PYME/DSView/eventLogViewer.py
+++ b/PYME/DSView/eventLogViewer.py
@@ -629,6 +629,13 @@ class eventLogTPanel(wx.Panel):
             cmapping = c[1]
             sourceEv = c[2]
 
+            # this was done above in another chart loop but omitted here
+            # QUESTION: isn't there a better solution to the byte/string handling of event logs
+            # that is more transparent and less error prone than this encode/decode hacking?
+            # we also have the byte literal quotes in the event log viewer this way (which is not necessarily pretty)
+            if not isinstance(sourceEv, bytes):
+                sourceEv = sourceEv.encode()
+
             dc.SetTextForeground(self.lineColours[sourceEv])
 
             dc.DrawText(cname, x4 + chartWidth/2 - dc.GetTextExtent(cname)[0]/2, 0)


### PR DESCRIPTION
Addresses bug in eventLogViewer, see error message further below.

**Is this a bugfix or an enhancement?**

bugfix

**original error message:**

```
/Users/csoe002/Documents/src/PYME-src/pyme-py37/PYME/DSView/eventLogViewer.py:709: wxPyDeprecationWarning: Call to deprecated item EmptyBitmap. Use :class:`wx.Bitmap` instead
  MemBitmap = wx.EmptyBitmap(s.GetWidth(), s.GetHeight())
Traceback (most recent call last):
  File "/Users/csoe002/Documents/src/PYME-src/pyme-py37/PYME/DSView/eventLogViewer.py", line 716, in OnPaint
    self.DoPaint(MemDC);
  File "/Users/csoe002/Documents/src/PYME-src/pyme-py37/PYME/DSView/eventLogViewer.py", line 632, in DoPaint
    dc.SetTextForeground(self.lineColours[sourceEv])
KeyError: 'ShiftMeasure'
```

**Proposed changes:**

As a fix I copied the code from higher up in the `eventLogViewer` module to the 2nd place where the event source type from the charts is being used as a key:

```python
            if not isinstance(sourceEv, bytes):
                sourceEv = sourceEv.encode()
```

While this works it feels like a pretty dirty kludge. It almost certainly is a product of the py2 -> py3 transition but it feels like asking for issues at later times. The stored event names in the HDF files are `byte` type, while the processing in `pipeline._processEvents` mixes use of byte literals and strings. E.g.

```python
            eventCharts.append(('Focus [um]', zm, b'ProtocolFocus'))
```

versus

```python
            eventCharts.append(('X Drift [px]', driftx, 'ShiftMeasure'))
```

This is then used in `eventLogViewer` and means that some entries are `string` types while others are `byte` literals, necessating the code above. Ideally, a more maintainable solution would be nicer, that avoids breakages when code is added/altered. Not sure what the better approach would look like, so looking for suggestions.


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
