### PR TITLE
fix colourmap indexing issue in displayPane

### DIFF
--- a/PYME/LMVis/displayPane.py
+++ b/PYME/LMVis/displayPane.py
@@ -61,7 +61,7 @@ class DisplayPane(afp.foldingPane):
         self._pc_clim_change = False
 
         #Colourmap
-        self.cmapnames = list(colormaps.cm.cmapnames)
+        self._cmapnames = list(colormaps.cm.cmapnames)
         
         #print((cmapnames, self.glCanvas.cmap.name))
 
@@ -74,7 +74,7 @@ class DisplayPane(afp.foldingPane):
             #cmapReversed = True
             curCMapName = curCMapName[:-2]
 
-        cmInd = self.cmapnames.index(curCMapName)
+        cmInd = self._cmapnames.index(curCMapName)
 
 
         ##
@@ -102,7 +102,7 @@ class DisplayPane(afp.foldingPane):
         
         hsizer.Add(wx.StaticText(pan, wx.ID_ANY, 'LUT:'), 0, wx.ALL, 2)
 
-        self.cColourmap = wx.Choice(pan, -1, choices=self.cmapnames)
+        self.cColourmap = wx.Choice(pan, -1, choices=self._cmapnames)
         self.cColourmap.SetSelection(cmInd)
 
         hsizer.Add(self.cColourmap, 1,wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
@@ -221,7 +221,7 @@ class DisplayPane(afp.foldingPane):
 
 
     def OnCMapChange(self, event):
-        cmapname = self.cmapnames[self.cColourmap.GetSelection()]
+        cmapname = self._cmapnames[self.cColourmap.GetSelection()]
         #if self.cbCmapReverse.GetValue():
         #    cmapname += '_r'
 

--- a/PYME/LMVis/displayPane.py
+++ b/PYME/LMVis/displayPane.py
@@ -61,7 +61,7 @@ class DisplayPane(afp.foldingPane):
         self._pc_clim_change = False
 
         #Colourmap
-        cmapnames = colormaps.cm.cmapnames
+        self.cmapnames = list(colormaps.cm.cmapnames)
         
         #print((cmapnames, self.glCanvas.cmap.name))
 
@@ -74,7 +74,7 @@ class DisplayPane(afp.foldingPane):
             #cmapReversed = True
             curCMapName = curCMapName[:-2]
 
-        cmInd = cmapnames.index(curCMapName)
+        cmInd = self.cmapnames.index(curCMapName)
 
 
         ##
@@ -102,7 +102,7 @@ class DisplayPane(afp.foldingPane):
         
         hsizer.Add(wx.StaticText(pan, wx.ID_ANY, 'LUT:'), 0, wx.ALL, 2)
 
-        self.cColourmap = wx.Choice(pan, -1, choices=cmapnames)
+        self.cColourmap = wx.Choice(pan, -1, choices=self.cmapnames)
         self.cColourmap.SetSelection(cmInd)
 
         hsizer.Add(self.cColourmap, 1,wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
@@ -221,7 +221,7 @@ class DisplayPane(afp.foldingPane):
 
 
     def OnCMapChange(self, event):
-        cmapname = colormaps.cm.cmapnames[self.cColourmap.GetSelection()]
+        cmapname = self.cmapnames[self.cColourmap.GetSelection()]
         #if self.cbCmapReverse.GetValue():
         #    cmapname += '_r'
 


### PR DESCRIPTION
Addresses issue where the updated colourmap infrastructure breaks the older colourmap selection code in `displayPane`.

**Is this a bugfix or an enhancement?**

Bugfix, we noticed it when running analysis with the latest code, the colourmap panel did not come up properly.

**Proposed changes:**

Adapt display panel code to be compatible with current colourmap infrastructure.

**Checklist:**

- [x ] Tested with latest PYME from git and python 3.7
