### PR TITLE
fix new_output_name helper method of class Recipe

### DIFF
--- a/PYME/recipes/recipe.py
+++ b/PYME/recipes/recipe.py
@@ -36,7 +36,7 @@ class Recipe(HasTraits):
         self.namespace.clear()
     
     def new_output_name(self, stub):
-        count = len([k.startswith(stub) for k in self.namespace.keys()])
+        count = len([k for k in self.namespace.keys() if k.startswith(stub)])
         
         if count == 0:
             return stub


### PR DESCRIPTION
Addresses issue where method `new_output_name` of class `Recipe` implementation needed a small fix.

**Is this a bugfix or an enhancement?**
bugfix

**Proposed changes:**
Just a tweak in the list comprehension to get the original intent across.

**Checklist:**

- [x] Tested with latest PYME from github at time of writing
