### PR TITLE
Mesh bbox, collapse and sdf tweak

### DIFF
--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -492,6 +492,19 @@ cdef class TriangleMesh(TrianglesBase):
 
         return self._manifold
 
+    @property
+    def bbox(self):
+        """
+        Mesh bounding box. xl, yl, zl, xu, yu, zu
+        """
+        cdef float xl, xu, yl, yu, zl, zu
+        v = self._vertices['position'][self._vertices['halfedge'] != -1]
+        xl, xu = np.min(v[:,0]), np.max(v[:,0])
+        yl, yu = np.min(v[:,1]), np.max(v[:,1])
+        zl, zu = np.min(v[:,2]), np.max(v[:,2])
+
+        return xl, yl, zl, xu, yu, zu
+
     def keys(self):
         return list(self.vertex_properties) + list(self.extra_vertex_data.keys())
 
@@ -1035,15 +1048,16 @@ cdef class TriangleMesh(TrianglesBase):
             #dead_list = self._halfedges['vertex'][dead_nn[dead_mask]]
         else:
             # grab the set of halfedges pointing to dead_vertices
+            
             dead_count = 0
             for i in range(self._halfedges.shape[0]):
                 if self._chalfedges[i].vertex == _dead_vertex:
                     dead_vertices[dead_count] = i
                     dead_count += 1
                     if dead_count > 5*NEIGHBORSIZE:
-                        print('WARNING: Way too many dead vertices!')
-                        break
-            
+                        print(f'WARNING: Way too many dead vertices: {dead_count}! Politely declining to collapse.')
+                        return 0
+
             # loop over all live vertices and check for twins in dead_vertices,
             # as we do in fast_collapse
             twin_count = 0
@@ -1062,7 +1076,7 @@ cdef class TriangleMesh(TrianglesBase):
                                 twin_count += 1
                     if twin_count > 2:
                         break
-            
+
             # no more than two vertices shared by the neighbors of dead and live vertex
             if twin_count != 2:
                 return 0
@@ -1495,7 +1509,7 @@ cdef class TriangleMesh(TrianglesBase):
         # x1 = self._vertices['position'][self._chalfedges[_prev].vertex, :]
         # n0 = self._vertices['normal'][curr_edge.vertex, :]
         # n1 = self._vertices['normal'][self._chalfedges[_prev].vertex, :]
-        
+
         _vertex[0] = 0.5*(x0x + x1x)
         _vertex[1] = 0.5*(x0y + x1y)
         _vertex[2] = 0.5*(x0z + x1z)

--- a/PYME/experimental/isosurface.py
+++ b/PYME/experimental/isosurface.py
@@ -91,11 +91,13 @@ def sdf_min(sdf, smooth=True, k=0.1):
     if smooth:
         # Exponentially smoothed minimum
         # https://iquilezles.org/www/articles/smin/smin.htm
-        return -np.log2(np.exp2(-k*sdf).sum(1))/k
+        val = -np.log2(np.nansum(np.exp2(-k*sdf), axis=1))/k
+        val[np.isnan(val)] = 0  # log2 of 0 or a negative number, shouldn't happen
+        return val
     else:
         return np.min(sdf, axis=1)
 
-def distance_to_mesh(points, surf):
+def distance_to_mesh(points, surf, smooth=True, smooth_k=0.1):
     """
     Calculate the distance to a mesh from points in a tabular dataset 
 
@@ -105,6 +107,10 @@ def distance_to_mesh(points, surf):
             3D point cloud to fit (nm).
         surf : PYME.experimental._triangle_mesh
             Isosurface
+        smooth : bool
+            Smooth distance to mesh?
+        smooth_k : float
+            Smoothing constant, by default 0.1 = smoothed by 1/10 nm
     """
 
     import scipy.spatial
@@ -125,4 +131,4 @@ def distance_to_mesh(points, surf):
 
     # the negative reverses the norpa sign flip
     # trick 2 from https://iquilezles.org/www/articles/interiordistance/interiordistance.htm
-    return -sdf_min(triangle_sdf(points, v), smooth=True)
+    return -sdf_min(triangle_sdf(points, v), smooth=smooth, k=smooth_k)


### PR DESCRIPTION
- Add a bbox property to `_triangle_mesh`
- Change break to return 0 to decline collapse on high valence vertices without throwing an abort trap
- Make sure we don't return nan values when smoothing the distance to the mesh
- Convert volume calculation to accept a component as an argument and add a surface area calculation, also by component