### PR TITLE
ueye 4.96 driver updates, bugfixes, and output trigger options

### DIFF
--- a/PYME/Acquire/Hardware/ueye.py
+++ b/PYME/Acquire/Hardware/ueye.py
@@ -148,8 +148,7 @@ class UEyeCamera(Camera):
             
             self._buffers.append((buffer_id, data))
 
-        # IDS currently only supports nMode = 0
-        self.check_success(ueye.is_InitImageQueue(self.h, 0))
+        self.check_success(ueye.is_ImageQueue(self.h, ueye.IS_IMAGE_QUEUE_CMD_INIT, None, ctypes.c_int(0)))
         
         self.transfer_buffer = np.zeros([self.GetPicHeight(), self.GetPicWidth()], bufferdtype)
         
@@ -165,7 +164,7 @@ class UEyeCamera(Camera):
         
     def DestroyBuffers(self):
         self._poll = False
-        self.check_success(ueye.is_ExitImageQueue(self.h))
+        self.check_success(ueye.is_ImageQueue(self.h, ueye.IS_IMAGE_QUEUE_CMD_EXIT, None, ctypes.c_int(0)))
         self.check_success(ueye.is_ClearSequence(self.h))
         
         while len(self._buffers) > 0:
@@ -219,15 +218,17 @@ class UEyeCamera(Camera):
         self.DestroyBuffers()
     
     def _poll_buffer(self):
-        data = ueye.c_mem_p()
-        buffer_id = ueye.int()
+        waitbuffer = ueye.IMAGEQUEUEWAITBUFFER(timeout=ueye.uint(1000))
         
         try:
-            self.check_success(ueye.is_WaitForNextImage(self.h, 1000, data,
-                                                        buffer_id))
+            self.check_success(ueye.is_ImageQueue(self.h, ueye.IS_IMAGE_QUEUE_CMD_WAIT, waitbuffer, ctypes.sizeof(waitbuffer)))
+            # IMAGE_QUEUE_CMD_WAIT should have filled nMemId and pcMem, if not this will throw null pointer ValueError
+            data = waitbuffer.ppcMem.contents
+            buffer_id = waitbuffer.pnMemId.contents
             self.check_success(ueye.is_CopyImageMem(self.h, data, buffer_id, 
                                                     self.transfer_buffer.ctypes.data_as(ctypes.POINTER(ctypes.c_uint8))))
-        except RuntimeError:
+        except RuntimeError as e:
+            logger.error(e)
             try:
                 self.check_success(ueye.is_UnlockSeqBuf(self.h, ueye.IS_IGNORE_PARAMETER, data))
             except:

--- a/PYME/Acquire/Hardware/ueye.py
+++ b/PYME/Acquire/Hardware/ueye.py
@@ -369,7 +369,7 @@ class UEyeCamera(Camera):
         -------
         float
             The exposure time in s
-        
+
         See Also
         --------
         SetIntegTime
@@ -430,7 +430,7 @@ class UEyeCamera(Camera):
             Right x-coordinate, (excluded from ROI)
         y2 : int
             Bottom y-coordinate, (excluded from ROI)
-        
+
         Returns
         -------
         None
@@ -469,7 +469,7 @@ class UEyeCamera(Camera):
         -------
         
             The ROI, [x1, y1, x2, y2] in the numpy convention used by SetROI
-        
+
         """
         aoi = ueye.IS_RECT()
         self.check_success(ueye.is_AOI(self.h, ueye.IS_AOI_IMAGE_GET_AOI, aoi,
@@ -499,7 +499,7 @@ class UEyeCamera(Camera):
             Number of images that can be stored in the buffer.
         """
         if self._poll:
-        return len(self._buffers)
+            return len(self._buffers)
         else:
             # if we aren't polling, spoof infinitely large buffer so we don't
             # flag a buffer overflow while we e.g. rebuild the buffers. This


### PR DESCRIPTION
Addresses issue #1179 .

**Is this a bugfix or an enhancement?**
bugfix, but not there yet
**Proposed changes:**
-use new uEye ImageQueue methods


@David-Baddeley & @csoeller  - I think I should be instantiating an imagequeuewaitbuffer and passing it (by reference*) as shon below, however, the pointers that get instantiated do not seem to ever be filled and I just get Null pointer access violations. IDS doc shows (void*)&waitBuffer, but this appears to be handled by pyueye. Any ideas for what I'm doing wrong are appreciated!

If I include a `IS_IMAGE_QUEUE_CMD_GET_PENDING` call (and don't hard-throw the valueerror by checking contents on the pointers explicitly) it usually returns zero unless I do something to gum things up for a minute (change integration time or something). I haven't checked if in these non-zero cases the pointers get set.



**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
