### PR TITLE
set scalebar size in PYMEAcquire

### DIFF
--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -190,9 +190,10 @@ class PYMEMainFrame(AUIFrame):
             if 'vp' in dir(self):
                     self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
             else:
-                self.vp = arrayViewPanel.ArrayViewPanel(self, self.scope.frameWrangler.currentFrame)
-                self.vp.crosshairs = False
-                self.vp.showScaleBar = False
+                vs_x_um, vs_y_um = self.scope.GetPixelSize()
+                vs = MetaDataHandler.VoxelSize(1000 * vs_x_um, 1000* vs_y_um, z=1)
+                self.vp = arrayViewPanel.ArrayViewPanel(self, self.scope.frameWrangler.currentFrame,
+                                                        voxelsize=vs)
                 self.vp.do.leftButtonAction = self.vp.do.ACTION_SELECTION
                 self.vp.do.showSelection = True
                 self.vp.CenteringHandlers.append(self.scope.PanCamera)

--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -52,6 +52,12 @@ def getLUT(cmap):
             
 class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
     def __init__(self, parent, dstack = None, aspect=1, do = None, voxelsize=[1,1,1]):
+        """
+        Parameters
+        ----------
+        voxelsize : tuple-like, PYME.IO.MetaDataHandler.VoxelSize
+            x, y, z voxelsize in units of nanometers
+        """
         
         if (dstack is None and do is None):
             dstack = scipy.zeros((10,10))


### PR DESCRIPTION
Addresses issue: after #1149 (which in general I'm really appreciating) the array view overlays are now drawn in PYMEAcquire (they would have to be toggled off by something like `MainFrame.vp.overlays[0].visible = False`). I actually like this, and would eventually enjoy seeing an overlay option panel (or really just a scalebar toggle added to the current 'display') but the voxelsize never gets set, so the scalebar is currently drawn at 2000 pixels = 1 um. 

**Is this a bugfix or an enhancement?**
temporary bugfix I guess
**Proposed changes:**
- grab pixelsize from the scope and set the view panel voxelsize with it






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
