### PR TITLE
fix needed to make Export cropped work again

### DIFF
--- a/PYME/DSView/dsviewer.py
+++ b/PYME/DSView/dsviewer.py
@@ -333,11 +333,13 @@ class DSViewFrame(AUIFrame):
         by = min(self.do.selection_begin_y, self.do.selection_end_y)
         ey = max(self.do.selection_begin_y, self.do.selection_end_y)
         
-        roi = [[bx, ex + 1],[by, ey + 1], [0, self.image.data.shape[2]]]
+        roi = [[bx, ex + 1],[by, ey + 1],
+               [0, self.image.data_xyztc.shape[2]],
+               [0, self.image.data_xyztc.shape[3]]]
         
         dlg = crop_dialog.ExportDialog(self, roi)
         try:
-            succ = dlg.ShowModel()
+            succ = dlg.ShowModal()
             if (succ == wx.ID_OK):
                 img = crop_image(self.image, xrange=dlg.GetXSlice(), yrange=dlg.GetYSlice(), zrange=dlg.GetZSlice(), trange=dlg.GetTSlice())
                 img.Save()


### PR DESCRIPTION
Addresses issue where `File>Export  Cropped` was incompatible with recent cropping and data x,y,z,t changes.

**Is this a bugfix or an enhancement?**
bugfix

**Proposed changes:**
The patch seem to fix things as needed but please check for any further work needed.

**Error message:**

```
Error whilst running File>&Export Cropped
==============================================
python-microscopy=21.09.23.post0.dev[git]
python=3.7.11, platform=win32
numpy=1.19.2, wx=4.0.4 msw (phoenix) wxWidgets 3.0.5

Traceback
=========
Traceback (most recent call last):
  File "c:\python-support-files\pyme-py37\PYME\ui\progress.py", line 153, in func
    return fcn(*args, **kwargs)
  File "c:\python-support-files\pyme-py37\PYME\DSView\dsviewer.py", line 338, in OnExport
    dlg = crop_dialog.ExportDialog(self, roi)
  File "c:\python-support-files\pyme-py37\PYME\ui\crop_dialog.py", line 36, in __init__
    self.tTStart = wx.TextCtrl(self, -1, '%d' % roi[3][0])
IndexError: list index out of range
```


**Checklist:**

- [x] Tested with latest guthub PYME
