### PR TITLE
Remove scalebar in acquire

### DIFF
--- a/PYME/Acquire/Hardware/splitter.py
+++ b/PYME/Acquire/Hardware/splitter.py
@@ -473,7 +473,7 @@ class UnMixPanel(wx.Panel):
 #
 #        sizer.Add(pan, 0, 0, 0)
 
-        self.vp = ArrayViewPanel(self, self.ds)
+        self.vp = ArrayViewPanel(self, self.ds, initial_overlays=[])
         sizer.Add(self.vp, 1,wx.EXPAND,0)
         #self.SetAutoLayout(1)
         self.SetSizer(sizer)

--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -190,7 +190,7 @@ class PYMEMainFrame(AUIFrame):
             if 'vp' in dir(self):
                     self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
             else:
-                self.vp = arrayViewPanel.ArrayViewPanel(self, self.scope.frameWrangler.currentFrame)
+                self.vp = arrayViewPanel.ArrayViewPanel(self, self.scope.frameWrangler.currentFrame, initial_overlays=[])
                 self.vp.crosshairs = False
                 self.vp.showScaleBar = False
                 self.vp.do.leftButtonAction = self.vp.do.ACTION_SELECTION

--- a/PYME/DSView/modules/arrayView.py
+++ b/PYME/DSView/modules/arrayView.py
@@ -30,7 +30,7 @@ def save_as_png(view):
         view.GrabPNG(filename)
 
 def Plug(dsviewer):
-    dsviewer.view = ArrayViewPanel(dsviewer, do=dsviewer.do, voxelsize=dsviewer.image.voxelsize)
+    dsviewer.view = ArrayViewPanel(dsviewer, do=dsviewer.do, voxelsize=lambda : getattr(dsviewer.image, 'voxelsize_nm'))
     dsviewer.updateHooks.append(dsviewer.view.Redraw)
     dsviewer.AddPage(dsviewer.view, True, 'Data')
 


### PR DESCRIPTION
Replaces and closes #1183. Allows overlays to be specified on view panel creation, allows dynamic voxelsize (helpful if we do want scaled overlays in future)