### PR TITLE
Native compilation on apple M1

### DIFF
--- a/PYME/Acquire/Hardware/Simulator/setup.py
+++ b/PYME/Acquire/Hardware/Simulator/setup.py
@@ -40,7 +40,7 @@ def configuration(parent_package = '', top_path = None):
     ext = Extension(name='.'.join([parent_package, 'Simulator', 'illuminate']),
                     sources=[os.path.join(os.path.dirname(__file__),'illuminate.pyx')],
                     include_dirs=get_numpy_include_dirs(),
-                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math', '-march=native', '-mtune=native'],
+                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math'], #'-march=native', '-mtune=native'],
                     extra_link_args=linkArgs)
 
     config = Configuration('Simulator', parent_package, top_path, ext_modules=cythonize([ext]))

--- a/PYME/Analysis/points/DeClump/setup.py
+++ b/PYME/Analysis/points/DeClump/setup.py
@@ -35,7 +35,7 @@ def configuration(parent_package = '', top_path = None):
     config.add_extension('deClump',
         sources=['deClump.c'],
         include_dirs = [get_numpy_include_dirs()],
-	extra_compile_args = ['-O3', '-fno-exceptions', '-march=native', '-mtune=native'],
+	extra_compile_args = ['-O3', '-fno-exceptions'], # '-march=native', '-mtune=native'],
         extra_link_args=linkArgs)
 
     return config

--- a/PYME/Analysis/points/DistHist/setup.py
+++ b/PYME/Analysis/points/DistHist/setup.py
@@ -35,7 +35,7 @@ def configuration(parent_package = '', top_path = None):
     config.add_extension('distHist',
         sources=['distHist.c'],
         include_dirs = [get_numpy_include_dirs()],
-	extra_compile_args = ['-O3', '-fno-exceptions', '-march=native', '-mtune=native'],
+	extra_compile_args = ['-O3', '-fno-exceptions', ],#'-march=native', '-mtune=native'],
         extra_link_args=linkArgs)
 
     return config

--- a/PYME/Analysis/points/arcfit/setup.py
+++ b/PYME/Analysis/points/arcfit/setup.py
@@ -32,7 +32,7 @@ def configuration(parent_package = '', top_path = None):
     config.add_extension('arcmf',
         sources=['arcmf.c'],
         include_dirs = [get_numpy_include_dirs()],
-	extra_compile_args = ['-O3', '-fno-exceptions', '-ffast-math', '-march=native', '-mtune=native'],
+	extra_compile_args = ['-O3', '-fno-exceptions', '-ffast-math'],# '-march=native', '-mtune=native'],
         extra_link_args=[])#'-static-libgcc'])
 
     return config

--- a/PYME/Analysis/points/astigmatism/setup.py
+++ b/PYME/Analysis/points/astigmatism/setup.py
@@ -35,7 +35,7 @@ def configuration(parent_package = '', top_path = None):
     config.add_extension('astiglookup',
         sources=['astiglookup.c'],
         include_dirs = [get_numpy_include_dirs()],
-	extra_compile_args = ['-O3', '-fno-exceptions', '-march=native', '-mtune=native'],
+	extra_compile_args = ['-O3', '-fno-exceptions', ],#,'-march=native', '-mtune=native'],
         extra_link_args=linkArgs)
 
     return config

--- a/PYME/Analysis/points/traveling_salesperson/setup.py
+++ b/PYME/Analysis/points/traveling_salesperson/setup.py
@@ -27,7 +27,7 @@ def configuration(parent_package='', top_path=None):
     ext = Extension(name='.'.join([parent_package, 'traveling_salesperson', 'two_opt_utils']),
                     sources=[os.path.join(cur_dir, 'two_opt_utils.pyx')],
                     include_dirs= get_numpy_include_dirs() + extra_include_dirs,
-                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math', '-march=native', '-mtune=native'],
+                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math'],#, '-march=native', '-mtune=native'],
                     extra_link_args=link_args)
 
     config = Configuration('traveling_salesperson', parent_package, top_path, ext_modules=cythonize([ext]))

--- a/PYME/IO/countdir/setup.py
+++ b/PYME/IO/countdir/setup.py
@@ -39,7 +39,7 @@ def configuration(parent_package = '', top_path = None):
       config.add_extension('countdir',
           sources=['countdir.c'],
           include_dirs = [get_numpy_include_dirs()],
-  	      extra_compile_args = ['-O3', '-fno-exceptions', '-ffast-math', '-march=native', '-mtune=native'],
+  	      extra_compile_args = ['-O3', '-fno-exceptions', '-ffast-math'],# '-march=native', '-mtune=native'],
           extra_link_args=linkArgs)
 
     return config

--- a/PYME/IO/setup.py
+++ b/PYME/IO/setup.py
@@ -36,7 +36,7 @@ def configuration(parent_package='',top_path=None):
     ext = Extension(name='.'.join([parent_package, 'IO', 'buffer_helpers']),
                     sources=[os.path.join(os.path.dirname(__file__), 'buffer_helpers.pyx')],
                     include_dirs=get_numpy_include_dirs(),
-                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math', '-march=native', '-mtune=native'],
+                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math'],# '-march=native', '-mtune=native'],
                     extra_link_args=linkArgs)
     config = Configuration('IO',parent_package,top_path, ext_modules=cythonize([ext]))
     config.add_subpackage('FileUtils')

--- a/PYME/experimental/setup.py
+++ b/PYME/experimental/setup.py
@@ -52,19 +52,19 @@ def configuration(parent_package='', top_path=None):
     ext = Extension(name='.'.join([parent_package, 'experimental', '_octree']),
                     sources=[os.path.join(cur_dir, '_octree.pyx')],
                     include_dirs= get_numpy_include_dirs() + extra_include_dirs,
-                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math', '-march=native', '-mtune=native'],
+                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math'],# '-march=native', '-mtune=native'],
                     extra_link_args=linkArgs)
 
     ext2 = Extension(name='.'.join([parent_package, 'experimental', '_treap']),
                     sources=[os.path.join(cur_dir, '_treap.pyx')],
                     include_dirs= get_numpy_include_dirs() + extra_include_dirs,
-                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math', '-march=native', '-mtune=native'],
+                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math'],# '-march=native', '-mtune=native'],
                     extra_link_args=linkArgs)
 
     ext3 = Extension(name='.'.join([parent_package, 'experimental', '_triangle_mesh']),
                     sources=[os.path.join(cur_dir, '_triangle_mesh.pyx')],
                     include_dirs= get_numpy_include_dirs() + extra_include_dirs,
-                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math', '-march=native', '-mtune=native'],
+                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math'],# '-march=native', '-mtune=native'],
                     extra_link_args=linkArgs)
     
     config = Configuration('experimental', parent_package, top_path, ext_modules=cythonize([ext, ext2, ext3]))
@@ -72,7 +72,7 @@ def configuration(parent_package='', top_path=None):
     config.add_extension(name='triangle_mesh_utils',
                     sources='triangle_mesh_utils.c',
                     include_dirs= get_numpy_include_dirs() + extra_include_dirs,
-                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math', '-march=native', '-mtune=native'],
+                    extra_compile_args=['-O3', '-fno-exceptions', '-ffast-math'],# '-march=native', '-mtune=native'],
                     extra_link_args=linkArgs)
     
     # config = Configuration('pymecompress', parent_package, top_path)

--- a/PYME/localization/cInterp/setup.py
+++ b/PYME/localization/cInterp/setup.py
@@ -35,7 +35,7 @@ def configuration(parent_package = '', top_path = None):
     config.add_extension('cInterp',
         sources=['cInterp.c'],
         include_dirs = [get_numpy_include_dirs()],
-	extra_compile_args = ['-O3', '-fno-exceptions', '-ffast-math', '-march=native', '-mtune=native'],
+	extra_compile_args = ['-O3', '-fno-exceptions', '-ffast-math'],# '-march=native', '-mtune=native'],
         extra_link_args=linkArgs)
 
     return config

--- a/PYME/localization/cModels/setup.py
+++ b/PYME/localization/cModels/setup.py
@@ -38,7 +38,7 @@ def configuration(parent_package = '', top_path = None):
     config.add_extension('gauss_app',
         sources=['gauss_ap.c'],
         include_dirs = [get_numpy_include_dirs()],
-	extra_compile_args = ['-O3', '-fno-exceptions', '-ffast-math', '-march=native', '-mtune=native'],
+	extra_compile_args = ['-O3', '-fno-exceptions', '-ffast-math', ],#'-march=native', '-mtune=native'],
         extra_link_args=linkArgs)
 
     return config

--- a/PYME/util/mProfile/colorize_db_t.py
+++ b/PYME/util/mProfile/colorize_db_t.py
@@ -33,6 +33,10 @@ import cgi, string, sys
 from io import StringIO
 import keyword, token, tokenize
 
+try:
+    from cgi import escape
+except ImportError:
+    from html import escape
 
 #############################################################################
 ### Python Source Parser (does Highlighting)
@@ -234,7 +238,7 @@ class Parser:
 
         # send text
         self.out.write('<span class="%s">' % (css_class,))
-        self.out.write(cgi.escape(toktext))
+        self.out.write(escape(toktext))
         self.out.write('</span>')
 
         if toktype == tokenize.COMMENT and toktext[-1] == '\n':

--- a/PYME/util/mProfile/mProfile.py
+++ b/PYME/util/mProfile/mProfile.py
@@ -79,6 +79,7 @@ lStore = threading.local()
 #lStore.tPrev = {}
 #lStore.lPrev = mydictn()
 
+global filenames, files, linecounts
 filenames = []
 files = {}
 linecounts = {}


### PR DESCRIPTION
Clang does not understand -march=native, -mtune=native on arm64 architectures. 

**TODOs** 

- do this in a way that does not cause a performance regression on intel x64 chips
- refactor compiler flags to a common point?
- make use of the numpy dispatch infrastructure so we truely generate portable, optimsised, code rather than relying on our build machine being older than most users machines???