### PR TITLE
int + str fix for sliding window background estimation module

### DIFF
--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -6,7 +6,7 @@ Created on Mon May 25 17:15:01 2015
 """
 
 from .base import ModuleBase, register_module, Filter
-from PYME.recipes.traits import Input, Output, Float, Enum, CStr, Bool, Int, List, FileOrURI, ListInt
+from PYME.recipes.traits import Input, Output, Float, Enum, CStr, Bool, Int, List, FileOrURI, CInt
 
 #try:
 #    from traitsui.api import View, Item, Group
@@ -1942,7 +1942,7 @@ class BackgroundSubtractionMovingAverage(ModuleBase):
     """
 
     input_name = Input('input')
-    window = ListInt([-32, 0, 1])
+    window = List(type=CInt, value=[-32, 0, 1])
     output_name = Output('background_subtracted')
 
     percentile = 0

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -6,7 +6,7 @@ Created on Mon May 25 17:15:01 2015
 """
 
 from .base import ModuleBase, register_module, Filter
-from PYME.recipes.traits import Input, Output, Float, Enum, CStr, Bool, Int, List, FileOrURI
+from PYME.recipes.traits import Input, Output, Float, Enum, CStr, Bool, Int, List, FileOrURI, ListInt
 
 #try:
 #    from traitsui.api import View, Item, Group
@@ -1942,7 +1942,7 @@ class BackgroundSubtractionMovingAverage(ModuleBase):
     """
 
     input_name = Input('input')
-    window = List([-32, 0, 1])
+    window = ListInt([-32, 0, 1])
     output_name = Output('background_subtracted')
 
     percentile = 0


### PR DESCRIPTION
Addresses issue cannot add int + str, which sometimes happens after configuring the recipe module in PYMEImage recipes tab (windows 10, wx 4.0.4)

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
-hard type window as listint






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
