### PR TITLE
Wx deprecation fixes

### DIFF
--- a/PYME/Acquire/Hardware/uc480/ucCamControlFrame.py
+++ b/PYME/Acquire/Hardware/uc480/ucCamControlFrame.py
@@ -42,7 +42,7 @@ class ucCamPanel(wx.Panel):
         hsizer.Add(self.l, 0, wx.ALL, 2)
         self.sl = wx.Slider(self, -1, 100.0*self.cam.GetGain()/100, 0, 100, size=wx.Size(150,-1),style=wx.SL_HORIZONTAL | wx.SL_HORIZONTAL | wx.SL_AUTOTICKS )
         self.sl.SetTickFreq(10)
-        wx.EVT_SCROLL(self,self.onSlide)
+        self.Bind(wx.EVT_SCROLL,self.onSlide)
         hsizer.Add(self.sl, 1, wx.ALL|wx.EXPAND, 2)
         ucGain.Add(hsizer, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
 

--- a/PYME/Acquire/ui/splashScreen.py
+++ b/PYME/Acquire/ui/splashScreen.py
@@ -28,6 +28,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from PYME import resources
+from PYME.ui import wx_compat
 
 class SplashPanel(wx.Panel):
     def __init__(self, parent, scope, size=(-1,-1)):
@@ -121,7 +122,7 @@ class SplashPanel(wx.Panel):
         #self.PrepareDC(DC)
 
         s = self.GetVirtualSize()
-        MemBitmap = wx.EmptyBitmap(s.GetWidth(), s.GetHeight())
+        MemBitmap = wx_compat.EmptyBitmap(s.GetWidth(), s.GetHeight())
         #del DC
         MemDC = wx.MemoryDC()
         OldBitmap = MemDC.SelectObject(MemBitmap)

--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -454,7 +454,7 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
             xs = min(s.GetWidth(), xs)
             ys = min(s.GetHeight(), ys)
 
-        MemBitmap = wx.EmptyBitmap(xs, ys)
+        MemBitmap = wx_compat.EmptyBitmap(xs, ys)
         MemDC = wx.MemoryDC()
         OldBitmap = MemDC.SelectObject(MemBitmap)
 

--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -34,6 +34,7 @@ import scipy
 # import pylab
 import matplotlib.cm
 
+from PYME.ui import wx_compat
 
 LUTCache = {}
 
@@ -429,7 +430,7 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
             sc2 = sc*step
 
         
-        im2 = wx.BitmapFromImage(im)
+        im2 = wx_compat.BitmapFromImage(im)
         dc.DrawBitmap(im2,-sc2/2,-sc2/2)
         
         self._draw_selection(self, dc) 
@@ -944,7 +945,7 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
             #print('seg.shape, ima.shape:', seg.shape, ima.shape)
             self._map_colour(seg, gain, offset, cmap, ima)
 #        
-        img = wx.ImageFromData(ima.shape[1], ima.shape[0], ima.ravel())
+        img = wx_compat.ImageFromData(ima.shape[1], ima.shape[0], ima.ravel())
         img.Rescale(img.GetWidth()*sc2,img.GetHeight()*sc2*self.aspect)
         self._oldIm = img
         self._oldImSig = sig

--- a/PYME/DSView/eventLogViewer.py
+++ b/PYME/DSView/eventLogViewer.py
@@ -25,6 +25,9 @@ import wx
 import numpy as np
 import time
 import six
+
+from PYME.ui import wx_compat
+
 # import pylab
 from matplotlib import cm
 from PYME.Analysis.piecewiseMapping import times_to_frames, frames_to_times
@@ -709,7 +712,7 @@ class eventLogTPanel(wx.Panel):
         #self.PrepareDC(DC)
 
         s = self.GetVirtualSize()
-        MemBitmap = wx.EmptyBitmap(s.GetWidth(), s.GetHeight())
+        MemBitmap = wx_compat.EmptyBitmap(s.GetWidth(), s.GetHeight())
         #del DC
         MemDC = wx.MemoryDC()
         OldBitmap = MemDC.SelectObject(MemBitmap)

--- a/PYME/DSView/eventLogViewer.py
+++ b/PYME/DSView/eventLogViewer.py
@@ -301,7 +301,7 @@ class eventLogPanel(wx.Panel):
         #self.PrepareDC(DC)
 
         s = self.GetVirtualSize()
-        MemBitmap = wx.EmptyBitmap(s.GetWidth(), s.GetHeight())
+        MemBitmap = wx_compat.EmptyBitmap(s.GetWidth(), s.GetHeight())
         #del DC
         MemDC = wx.MemoryDC()
         OldBitmap = MemDC.SelectObject(MemBitmap)

--- a/PYME/DSView/scrolledImagePanel.py
+++ b/PYME/DSView/scrolledImagePanel.py
@@ -23,6 +23,8 @@
 
 import wx
 
+from PYME.ui import wx_compat
+
 class ImagePanel(wx.Panel):
     def __init__(self, parent, renderer, *args, **kwargs):
         wx.Panel.__init__(self, parent, *args, **kwargs)
@@ -49,7 +51,7 @@ class ImagePanel(wx.Panel):
         #self.PrepareDC(DC)
         
         s = self.GetClientSize()
-        MemBitmap = wx.EmptyBitmap(s.GetWidth(), s.GetHeight())
+        MemBitmap = wx_compat.EmptyBitmap(s.GetWidth(), s.GetHeight())
         MemDC = wx.MemoryDC()
         OldBitmap = MemDC.SelectObject(MemBitmap)
         try:

--- a/PYME/DSView/splashScreen.py
+++ b/PYME/DSView/splashScreen.py
@@ -26,6 +26,7 @@ import time
 import os
 
 from PYME import resources
+from PYME.ui import wx_compat
 
 class SplashPanel(wx.Panel):
     def __init__(self, parent, scope, size=(-1,-1)):
@@ -114,7 +115,7 @@ class SplashPanel(wx.Panel):
         #self.PrepareDC(DC)
 
         s = self.GetVirtualSize()
-        MemBitmap = wx.EmptyBitmap(s.GetWidth(), s.GetHeight())
+        MemBitmap = wx_compat.EmptyBitmap(s.GetWidth(), s.GetHeight())
         #del DC
         MemDC = wx.MemoryDC()
         OldBitmap = MemDC.SelectObject(MemBitmap)

--- a/PYME/LMVis/imageView.py
+++ b/PYME/LMVis/imageView.py
@@ -32,6 +32,8 @@ import wx
 import scipy.misc
 #import subprocess
 
+from PYME.ui import wx_compat
+
 #from PYME.Analysis import thresholding
 
 #from PYME.DSView.myviewpanel_numarray import MyViewPanel
@@ -195,7 +197,7 @@ class ImageViewPanel(wx.Panel):
         #self.PrepareDC(DC)
         
         s = self.GetVirtualSize()
-        MemBitmap = wx.EmptyBitmap(s.GetWidth(), s.GetHeight())
+        MemBitmap = wx_compat.EmptyBitmap(s.GetWidth(), s.GetHeight())
         #del DC
         MemDC = wx.MemoryDC()
         OldBitmap = MemDC.SelectObject(MemBitmap)

--- a/PYME/LMVis/imageView.py
+++ b/PYME/LMVis/imageView.py
@@ -120,14 +120,14 @@ class ImageViewPanel(wx.Panel):
 
         im = (255*self.do.cmaps[self.chan](im)[:,:,:3]).astype('b')
             
-        imw =  wx.ImageFromData(im.shape[1], im.shape[0], im.ravel())
+        imw =  wx_compat.ImageFromData(im.shape[1], im.shape[0], im.ravel())
                                          
         imw.Rescale(imw.GetWidth()*sc,imw.GetHeight()*sc)
         self.curIm = imw
 
         dc.Clear()
         
-        dc.DrawBitmap(wx.BitmapFromImage(imw),(-self.centreX + x0 + width/2)/pixelsize,(self.centreY - y1 + height/2)/pixelsize)
+        dc.DrawBitmap(wx_compat.BitmapFromImage(imw),(-self.centreX + x0 + width/2)/pixelsize,(self.centreY - y1 + height/2)/pixelsize)
 
     def DrawOverlays(self,dc):
         sc = self.image.pixelSize/self.glCanvas.pixelsize
@@ -435,7 +435,7 @@ class ColourImageViewPanel(ImageViewPanel):
         im_ = numpy.minimum(im_, 255).astype('b')
         #print im_.shape
 
-        imw =  wx.ImageFromData(im_.shape[1], im_.shape[0], im_.ravel())
+        imw =  wx_compat.ImageFromData(im_.shape[1], im_.shape[0], im_.ravel())
         #print imw.GetWidth()
 
         #imw.Rescale(imw.GetWidth()*sc,imw.GetHeight()*sc)
@@ -444,8 +444,8 @@ class ColourImageViewPanel(ImageViewPanel):
 
         dc.Clear()
 
-        #dc.DrawBitmap(wx.BitmapFromImage(imw),(-self.centreX + x0 + width/2)/pixelsize,(self.centreY - y1 + height/2)/pixelsize)
-        dc.DrawBitmap(wx.BitmapFromImage(imw), 0,0)
+        #dc.DrawBitmap(wx_compat.BitmapFromImage(imw),(-self.centreX + x0 + width/2)/pixelsize,(self.centreY - y1 + height/2)/pixelsize)
+        dc.DrawBitmap(wx_compat.BitmapFromImage(imw), 0,0)
 
         #print self.glCanvas.centreCross
 

--- a/PYME/LMVis/imageView2.py
+++ b/PYME/LMVis/imageView2.py
@@ -24,6 +24,8 @@
 import numpy
 
 import wx
+from PYME.ui import wx_compat
+
 # import scipy.misc
 import scipy.ndimage
 
@@ -127,7 +129,7 @@ class ImageViewPanel(wx.Panel):
         #self.PrepareDC(DC)
         
         s = self.GetVirtualSize()
-        MemBitmap = wx.EmptyBitmap(s.GetWidth(), s.GetHeight())
+        MemBitmap = wx_compat.EmptyBitmap(s.GetWidth(), s.GetHeight())
         #del DC
         MemDC = wx.MemoryDC()
         OldBitmap = MemDC.SelectObject(MemBitmap)

--- a/PYME/LMVis/imageView2.py
+++ b/PYME/LMVis/imageView2.py
@@ -321,12 +321,12 @@ class ImageViewPanel(wx.Panel):
     
         im = self._map_image(im, self.chan)
     
-        imw = wx.ImageFromData(im.shape[1], im.shape[0], im.ravel())
+        imw = wx_compat.ImageFromData(im.shape[1], im.shape[0], im.ravel())
         imw.Rescale(imw.GetWidth() * sc, imw.GetHeight() * sc)
         self.curIm = imw
     
         dc.Clear()
-        dc.DrawBitmap(wx.BitmapFromImage(imw), (-self.centreX + x0 + width / 2) / pixelsize,
+        dc.DrawBitmap(wx_compat.BitmapFromImage(imw), (-self.centreX + x0 + width / 2) / pixelsize,
                       (-self.centreY + y0 + height / 2) / pixelsize)
 
 
@@ -361,11 +361,11 @@ class ColourImageViewPanel(ImageViewPanel):
 
         im_ = numpy.minimum(im_, 255).astype('b')
 
-        imw =  wx.ImageFromData(im_.shape[1], im_.shape[0], im_.ravel())
+        imw =  wx_compat.ImageFromData(im_.shape[1], im_.shape[0], im_.ravel())
         self.curIm = imw
 
         dc.Clear()
-        dc.DrawBitmap(wx.BitmapFromImage(imw), 0,0)
+        dc.DrawBitmap(wx_compat.BitmapFromImage(imw), 0,0)
         
         
         

--- a/PYME/LMVis/view_clipping_pane.py
+++ b/PYME/LMVis/view_clipping_pane.py
@@ -9,6 +9,7 @@ import wx.lib.newevent
 #import PYME.ui.autoFoldPanel as afp
 import PYME.ui.manualFoldPanel as afp
 import numpy as np
+from PYME.ui import wx_compat
 
 LimitChangeEvent, EVT_LIMIT_CHANGE = wx.lib.newevent.NewCommandEvent()
 
@@ -204,7 +205,7 @@ class ClippingPanel(wx.Panel):
         #self.PrepareDC(DC)
     
         s = self.GetVirtualSize()
-        MemBitmap = wx.EmptyBitmap(s.GetWidth(), s.GetHeight())
+        MemBitmap = wx_compat.EmptyBitmap(s.GetWidth(), s.GetHeight())
         #del DC
         MemDC = wx.MemoryDC()
         OldBitmap = MemDC.SelectObject(MemBitmap)

--- a/PYME/contrib/listctrlMixins.py
+++ b/PYME/contrib/listctrlMixins.py
@@ -34,6 +34,7 @@
 import locale
 import wx
 from six.moves import xrange
+from PYME.ui import wx_compat
 
 #python 3 compatibility
 cmp = lambda x, y: (x > y) - (x < y)
@@ -750,7 +751,7 @@ class CheckListCtrlMixin(object):
         is used to determine the checkboxes state (see wx.CONTROL_*)
 
         """
-        bmp = wx.EmptyBitmap(*size)
+        bmp = wx_compat.EmptyBitmap(*size)
         dc = wx.MemoryDC(bmp)
         dc.Clear()
         wx.RendererNative.Get().DrawCheckBox(self, dc,

--- a/PYME/misc/fbpIcons.py
+++ b/PYME/misc/fbpIcons.py
@@ -25,6 +25,8 @@ __author__="david"
 __date__ ="$15/02/2009 00:02:07$"
 
 import wx
+from PYME.ui import wx_compat
+
 
 def GetCollapsedIconData():
     return \
@@ -48,7 +50,7 @@ zzW\xcff&\xb8,\x89\xa8@Q\xd6\xaaf\xdfRm,\xee\xb1BDxr#\xae\xf5|\xddo\xd6\xe2H\
 \x00\x00\x00IEND\xaeB`\x82'
 
 def GetCollapsedIconBitmap():
-    return wx.BitmapFromImage(GetCollapsedIconImage())
+    return wx_compat.BitmapFromImage(GetCollapsedIconImage())
 
 def GetCollapsedIconImage():
     from io import BytesIO
@@ -80,7 +82,7 @@ b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x10\x00\x00\x00\x10\x08\x06\
 `\x82'
 
 def GetExpandedIconBitmap():
-    return wx.BitmapFromImage(GetExpandedIconImage())
+    return wx_compat.BitmapFromImage(GetExpandedIconImage())
 
 def GetExpandedIconImage():
     from io import BytesIO

--- a/PYME/ui/fastGraph.py
+++ b/PYME/ui/fastGraph.py
@@ -23,6 +23,7 @@
 
 import wx
 import wx.lib.newevent
+from PYME.ui import wx_compat
 
 import sys,math
 import numpy
@@ -205,7 +206,7 @@ class FastGraphPanel(wx.Panel):
         #self.PrepareDC(DC)
 
         s = self.GetVirtualSize()
-        MemBitmap = wx.EmptyBitmap(s.GetWidth(), s.GetHeight())
+        MemBitmap = wx_compat.EmptyBitmap(s.GetWidth(), s.GetHeight())
         #del DC
         MemDC = wx.MemoryDC()
         OldBitmap = MemDC.SelectObject(MemBitmap)

--- a/PYME/ui/wx_compat.py
+++ b/PYME/ui/wx_compat.py
@@ -1,0 +1,43 @@
+import wx
+
+def CheckWxPhoenix():
+    if 'phoenix' in wx.version():
+        return True
+    return False
+
+wxPythonPhoenix = CheckWxPhoenix()
+
+# currently for initial testing simply forcing to 4.x
+# could replace with test that figures out if newer or older wx present
+# wxPythonPhoenix = True
+
+def BitmapFromImage(image, depth=-1):
+    if wxPythonPhoenix:
+        return wx.Bitmap(img=image, depth=depth)
+    else:
+        return wx.BitmapFromImage(image, depth=depth)
+
+
+def ImageFromBitmap(bitmap):
+    if wxPythonPhoenix:
+        return bitmap.ConvertToImage()
+    else:
+        return wx.ImageFromBitmap(bitmap)
+
+def ImageFromData(width,height,data):
+    if wxPythonPhoenix:
+        return wx.Image(width,height,data)
+    else:
+        return wx.ImageFromData(width,height,data)
+    
+def EmptyBitmap(width, height, depth=-1):
+    if wxPythonPhoenix:
+        return wx.Bitmap(width=width, height=height, depth=depth)
+    else:
+        return wx.EmptyBitmap(width=width, height=height, depth=depth)
+
+def EmptyImage(width, height, clear=True):
+    if wxPythonPhoenix:
+        return wx.Image(width=width, height=height, clear=clear)
+    else:
+        return wx.EmptyImage(width=width, height=height, clear=clear)


### PR DESCRIPTION
Addresses issue #1198.

**Is this a bugfix or an enhancement?**
bugfix for a bug waiting to happen (which is what deprecation warnings eventually morph into).

**Proposed changes:**
Replace all deprecated `EmptyBitmap` and similar calls so that newer interfaces are used.

**State of this PR:**
This is submitted basically as a proof-of-principle. Primary goal is to elicit some feedback and agree on the best way to solve the issue.

Things that may still need doing:

1. agree if we need a backwards compatible solution or not.
2. if backwards compatibility is a thing the compatibility layer adopted here seems like an ok approach. The naming and placement of such a module can obviously be adjusted (currently `PYME.ui.wx_compat`).
3. not all occurences of the deprecated statements have been exhaustively changed. So far I did the ones that came up in my tests but presumably we should go through the whole dist.
4. probably more but first of all hoping to kick off a brief discussion.

For completeness, the approach used here I came across in [OSGeo/grass](https://github.com/OSGeo/grass) which itself is GPL2 (I think).

**Checklist:**

This has been tested on a production system with `wx` 4.x.
