### PR TITLE
fix to calculate checksum on contiguous array

### DIFF
--- a/PYME/localization/FitFactories/ChecksumFR.py
+++ b/PYME/localization/FitFactories/ChecksumFR.py
@@ -54,9 +54,9 @@ class ChecksumFitFactory(FFBase.FitFactory):
         if not isinstance(background, np.ndarray):
             background = np.array(background)
 
-        ch_data = zlib.crc32(data.data)
-        ch_sigma = zlib.crc32(sigma.data)
-        ch_background = zlib.crc32(background.data)
+        ch_data = zlib.crc32(np.ascontiguousarray(data.data))
+        ch_sigma = zlib.crc32(np.ascontiguousarray(sigma.data))
+        ch_background = zlib.crc32(np.ascontiguousarray(background.data))
         
         
         #package results


### PR DESCRIPTION
Addresses issue #1202 .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
make arrays c contiguous before checksumming them






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
