### PR TITLE
Piezo C867 improvements - servo toggling and error messages

### DIFF
--- a/PYME/Acquire/Hardware/Piezos/piezo_c867.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_c867.py
@@ -304,8 +304,10 @@ class piezo_c867T(PiezoBase):
                         logger.debug('Setting stage target pos: %s' % pos)
                         time.sleep(.01)
                     
-                # check to see if we're on target - SERVOCHECK: CS: seems to me this only makes sense when servo is on - check manual
-                # from the manual on 'ONT?' command: "The detection of the on-target state is only possible in closed-loop operation (servo mode ON)"
+                # check to see if we're on target
+                # from the manual on 'ONT?' command:
+                #   "The detection of the on-target state is only possible in closed-loop operation (servo mode ON)"
+                # note that the cleaned up on-target check does not use the 'ONT?' command any more
                 if self.servo:
                     self.onTarget = np.allclose(self.position, self.targetPosition, atol=self.ptol)
                 else: # servo is off

--- a/PYME/Acquire/Hardware/Piezos/piezo_c867.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_c867.py
@@ -29,6 +29,13 @@ from .base_piezo import PiezoBase
 import logging
 logger = logging.getLogger(__name__)
 
+try:
+    import pipython.pidevice.gcserror as gcserr
+except ImportError:
+    _has_gcserr = False
+else:
+    _has_gcserr = True
+
 #C867 controller for PiLine piezo linear motor stages
 #NB units are mm not um as for piezos
 
@@ -237,7 +244,10 @@ class piezo_c867T(PiezoBase):
                 
                 if not self.errCode == 0:
                     #print(('Stage Error: %d' %self.errCode))
-                    logger.error('Stage Error: %d' %self.errCode)
+                    if _has_gcserr:
+                        logger.error('Stage Error: %s' % gcserr.GCSError.translate_error(self.errCode))
+                    else:
+                        logger.error('Stage Error: %d' % self.errCode)
                 
                 #print self.targetPosition, self.stopMove
                 

--- a/PYME/Acquire/Hardware/Piezos/piezo_c867.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_c867.py
@@ -251,7 +251,8 @@ class piezo_c867T(PiezoBase):
                 
                 #print self.targetPosition, self.stopMove
                 
-                if self.stopMove:
+                if self.stopMove: # SERVOCHECK: check if this is ok to process when servo is off!!!
+                    # note that issueing the HLT command sets an error condition, from the manual: "Error code 10 is set."
                     self.ser_port.write(b'HLT\n')
                     time.sleep(.1)
                     self.ser_port.write(b'POS? 1 2\n')
@@ -285,20 +286,26 @@ class piezo_c867T(PiezoBase):
                         logger.debug('Setting stage target pos: %s' % pos)
                         time.sleep(.01)
                     
-                #check to see if we're on target
-                self.ser_port.write(b'ONT?\n')
-                self.ser_port.flushOutput()
-                time.sleep(0.005)
-                res1 = self.ser_port.readline()
-                ont1 = int(res1.split(b'=')[1]) == 1
-                res1 = self.ser_port.readline()
-                ont2 = int(res1.split(b'=')[1]) == 1
+                # check to see if we're on target - SERVOCHECK: CS: seems to me this only makes sense when servo is on - check manual
+                # from the manual on 'ONT?' command: "The detection of the on-target state is only possible in closed-loop operation (servo mode ON)"
+                if self.servo:
+                    self.ser_port.write(b'ONT?\n')
+                    self.ser_port.flushOutput()
+                    time.sleep(0.005)
+                    res1 = self.ser_port.readline()
+                    ont1 = int(res1.split(b'=')[1]) == 1
+                    res1 = self.ser_port.readline()
+                    ont2 = int(res1.split(b'=')[1]) == 1
                 
-                onT = (ont1 and ont2) or (self.servo == False)
-                self.onTarget = onT and self.onTargetLast
-                self.onTargetLast = onT
-                self.onTarget = np.allclose(self.position, self.targetPosition, atol=self.ptol)
+                    onT = (ont1 and ont2)
+                else: # servo is off
+                    onT = False
                     
+                # CS: I dont understand how self.onTargetLast should have worked - from the logic it has no function now
+                self.onTarget = onT and self.onTargetLast
+                self.onTargetLast = onT # note: with the statement below self.onTargetLast has absolutely no effect anymore - intended?
+                self.onTarget = np.allclose(self.position, self.targetPosition, atol=self.ptol)
+                
                 #time.sleep(.1)
                 
             except serial.SerialTimeoutException:
@@ -322,7 +329,17 @@ class piezo_c867T(PiezoBase):
                 
         
     def SetServo(self, state=1):
+        if self.servo and state==0: # we are switching from servo on to off - all moves should be stopped
+            # make sure all moves are stopped
+            # SERVOCHECK: should this be done under the lock or not?
+            self.stopMove()
         self.lock.acquire()
+        if not self.servo and state==1: # we are switching from off to on
+            # make sure no move commands are still in the queue
+            # when we switch back on
+            # this should be achievable by setting target position equal to current position
+            self.lastTargetPosition = self.position.copy()
+            self.targetPosition = self.position.copy()
         try:
             self.ser_port.write(b'SVO 1 %d\n' % state)
             self.ser_port.write(b'SVO 2 %d\n' % state)

--- a/PYME/Acquire/Hardware/Piezos/piezo_c867.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_c867.py
@@ -254,6 +254,7 @@ class piezo_c867T(PiezoBase):
                 if self.stopMove: # SERVOCHECK: check if this is ok to process when servo is off!!!
                     # note that issueing the HLT command sets an error condition, from the manual: "Error code 10 is set."
                     # question: should we check the error status to unset the error code from such a HLT command?
+                    logger.warn('piezo_c867T: stopMove issuing HLT command, expect error 10 to be set')
                     self.ser_port.write(b'HLT\n')
                     time.sleep(.1)
                     self.ser_port.write(b'POS? 1 2\n')


### PR DESCRIPTION
**Is this a bugfix or an enhancement?**
Enhancement to allow servo toggling by the user so that no actuation occurs during imaging. Also uses textual error messages if the user has installed the [`PIPython`](https://pypi.org/project/PIPython/) package.

**Proposed changes:**
The main changes are not user visible to any large degree. Essentially, we have moved the actual servo mode switching into the thread loop and just message into the thread loop using flags, similar to the `stopMove` flag.

Note that the original `SetServo` and thus the `joystick` implementation hung PYME in our tests, prompting us to adopt the  thread loop messaging approach. Also tidied the thread loop to only issue stage commands compatible with the current servo state. Initial testing suggests this now works fine.

We also support proper full text error messages if the [`PIPython`](https://pypi.org/project/PIPython/) has been installed by the user which is available via [PyPI](https://pypi.org). This was very helpful during debugging and testing.

Testing and small tweaks are still ongoing, but I wanted to raise the PR to elicit potential comments and feedback.

**Checklist:**

Ongoing testing with latest PYME git, on Win 10.

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [x] Does this change how users interact with the software? How will these changes be communicated? No user level changes.
- [x] Does this maintain backwards compatibility with old data? Yes.
- [x] Does this change the required dependencies? No, should all work as before.
- [x] Are there any other side effects of the change? Not to our knowledge.
