### PR TITLE
Pymeacquire logging tweaks

### DIFF
--- a/PYME/Acquire/PYMEAcquire.py
+++ b/PYME/Acquire/PYMEAcquire.py
@@ -66,6 +66,9 @@ def setup_logging(default_level=logging.DEBUG):
     else:
         logging.basicConfig(level=default_level)
 
+    # we want to somehow supress the level of matplotlib messages below debug level
+    logging.getLogger('matplotlib').setLevel(logging.WARN)
+
 
 class BoaApp(wx.App):
     def __init__(self, options, *args):

--- a/PYME/Acquire/PYMEAcquire.py
+++ b/PYME/Acquire/PYMEAcquire.py
@@ -67,7 +67,7 @@ def setup_logging(default_level=logging.DEBUG):
         logging.basicConfig(level=default_level)
 
     # we want to somehow supress the level of matplotlib messages below debug level
-    logging.getLogger('matplotlib').setLevel(logging.WARN)
+    logging.getLogger('matplotlib').setLevel(logging.ERROR) #clobber unhelpful matplotlib debug messages
 
 
 class BoaApp(wx.App):


### PR DESCRIPTION
Addresses issue #1204 (partially, i.e. only for `PYMEAcquire` and `matplotlib` noise).

**Is this a bugfix or an enhancement?**
more enhancement

**Proposed changes:**
Tell the `matplotlib` loggers to stay at higher logging level (here chosen `logging.ERROR`).

**Checklist:**

- [x] Tested on python 3.7 and latest git
