### PR TITLE
Make points_from_sdf "single-pixel thick"

### DIFF
--- a/PYME/simulation/locify.py
+++ b/PYME/simulation/locify.py
@@ -118,7 +118,7 @@ def points_from_sdf(sdf, r_max=1, centre=(0,0,0), dx_min=1, p=0.1):
     corners = [verts + dx * c_offs[i][:, None] for i in range(8)]
     corner_dists = [sdf(c) for c in corners]
     
-    contains_points = (np.abs(np.sum([np.sign(c) for c in corner_dists], axis=0)) < 8) | (sdf(verts) < dx)
+    contains_points = (np.abs(np.sum([np.sign(c) for c in corner_dists], axis=0)) < 8) & (sdf(verts) < dx)
     verts = verts[:, contains_points]
     
     #print(verts.shape)


### PR DESCRIPTION
We're accepting too many points. Here's a cross-section of a tube from the current version:

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/1263313/159741413-669a40af-1e28-4d95-ba23-9905d4eda59b.png">

And updated with this PR:

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/1263313/159741142-6ff981cf-4ceb-4121-b11b-117dcbd3a09e.png">

