### PR TITLE
electrons/second datasource and ADU to e/s recipe module

### DIFF
--- a/PYME/IO/DataSources/ElectronsPerSecondDataSource.py
+++ b/PYME/IO/DataSources/ElectronsPerSecondDataSource.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
 
 ##################
-# HDFDataSource.py
+# ElectronsPerSecondDataSource.py
 #
-# Copyright David Baddeley, 2009
+# Copyright Andrew Barentine, David Baddeley, 2022
 # d.baddeley@auckland.ac.nz
 #
 # This program is free software: you can redistribute it and/or modify
@@ -31,9 +31,21 @@ class DataSource(FlatFieldDataSource):
         Create a datasource which wraps a series in units of ADU and returns frames in units of
         photoelectrons per second (e/s). parentSource should not be camera map corrected (dark-
         or flatfield-corrected).
+
+        WARNING
+        #######
+
+        A lot of PYME assumes that image units are in ADUs. This means that it would be easy to end up doing this correction
+        in downstream modules as well as here and ending up with erroneous data as a result. Safe usage of this module in
+        complex workflows will require building enhanced unit awareness into other parts of PYME. 
+        
+        This is discussed in more detail in 
+        PYME.recipes.processing.RawADUToElectronsPerCount
         
         """
-        if mdh.getOrDefault('Units', 'ADU') == 'e/s':  # TODO - rather than hard throw just don't further correct the parentSource
+        if mdh.getOrDefault('Units', 'ADU') == 'e/s':
+            # FIXME - the name of this key might change (maybe Units.Intensity or similar)  
+            # TODO - rather than hard throw just don't further correct the parentSource
             raise RuntimeError('units are already e/s')
         
         FlatFieldDataSource.__init__(self, parentSource, mdh, flatfield, dark)

--- a/PYME/IO/DataSources/ElectronsPerSecondDataSource.py
+++ b/PYME/IO/DataSources/ElectronsPerSecondDataSource.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+
+##################
+# HDFDataSource.py
+#
+# Copyright David Baddeley, 2009
+# d.baddeley@auckland.ac.nz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##################
+
+from PYME.IO.DataSources.FlatFieldDataSource import DataSource as FlatFieldDataSource
+
+
+class DataSource(FlatFieldDataSource):
+    moduleName = 'ElectronsPerSecondDataSource'
+    def __init__(self, parentSource, mdh, flatfield=None, dark=None):
+        """
+        Create a datasource which wraps a series in units of ADU and returns frames in units of
+        photoelectrons per second (e/s). parentSource should not be camera map corrected (dark-
+        or flatfield-corrected).
+        
+        """
+        if mdh.getOrDefault('Units', 'ADU') == 'e/s':  # TODO - rather than hard throw just don't further correct the parentSource
+            raise RuntimeError('units are already e/s')
+        
+        FlatFieldDataSource.__init__(self, parentSource, mdh, flatfield, dark)
+        
+        self._adu_to_epers = self.mdh['Camera.ElectronsPerCount'] / self.mdh['Camera.TrueEMGain'] / self.mdh['Camera.IntegrationTime']
+
+    def getSlice(self, ind):
+        # flatfield getSlice will subtract the dark map and flatfield. 
+        return FlatFieldDataSource.getSlice(self, ind) * self._adu_to_epers  # corrected ADU to photoelectrons/second

--- a/PYME/IO/DataSources/ElectronsPerSecondDataSource.py
+++ b/PYME/IO/DataSources/ElectronsPerSecondDataSource.py
@@ -43,7 +43,7 @@ class DataSource(FlatFieldDataSource):
         PYME.recipes.processing.RawADUToElectronsPerCount
         
         """
-        if mdh.getOrDefault('Units', 'ADU') == 'e/s':
+        if mdh.getOrDefault('Units.Intensity', 'ADU') == 'e/s':
             # FIXME - the name of this key might change (maybe Units.Intensity or similar)  
             # TODO - rather than hard throw just don't further correct the parentSource
             raise RuntimeError('units are already e/s')
@@ -51,6 +51,10 @@ class DataSource(FlatFieldDataSource):
         FlatFieldDataSource.__init__(self, parentSource, mdh, flatfield, dark)
         
         self._adu_to_epers = self.mdh['Camera.ElectronsPerCount'] / self.mdh['Camera.TrueEMGain'] / self.mdh['Camera.IntegrationTime']
+
+        # set a units property on the datasource
+        # this might not end up getting used, but is a nice failsafe for situations where we don't propagate metadata
+        self.units='e/s'
 
     def getSlice(self, ind):
         # flatfield getSlice will subtract the dark map and flatfield. 

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -2194,6 +2194,29 @@ class RawADUToElectronsPerSecond(ModuleBase):
     output_name : Output
         PYME.IO.ImageStack in units of photoelectrons/second
 
+    Warnings
+    --------
+
+    A lot of PYME assumes that image units are in ADUs. This means that it would be easy to end up doing this correction
+    in downstream modules as well as here and ending up with erroneous data as a result. Safe usage of this module in
+    complex workflows will require building enhanced unit awareness into other parts of PYME which is not currently present.
+
+    At this point there is not much certainty about how unit awareness should be done, and it is likely to change signficantly from
+    the first attempt here:
+
+    - Should units be a property of the metadata, or of the datasource itself?
+    - If in the metadata, an acquisition have multiple different units (intensity, position, time) 
+    - This means that the `Units` metadata key is probably not appropriate and we should use something more specific
+
+    In practice this means:
+
+    - this should be viewed as experimental
+    - there is no garuantee that the Units metadata entry will be the same in future versions of PYME
+    - in this case, I (DB) am not prepared to maintain backwards compatibility, as I think it would make things un-neccesarily messy
+    - before building extensive pipelines that depend on Units metadata, or saving large numbers of files calibrated in e/s please
+      force the issue (through, e.g an issue on github and a discussion) so we can finalise what unit support is going to look like
+      and what metadata should be used).
+
     """
     input_name = Input('raw_adu')
     output_name = Output('electrons_per_s')
@@ -2207,6 +2230,10 @@ class RawADUToElectronsPerSecond(ModuleBase):
         epers_ds = ElectronsPerSecondDataSource.DataSource(series_adu.data, series_adu.mdh)
         series_epers = ImageStack(data=epers_ds, events=series_adu.events, mdh=DictMDHandler(series_adu.mdh))
         series_epers.mdh['Parent'] = series_adu.filename
+        
+        # TODO - potentially change the name of this metadata key as we also have spatial and temporal units and 
+        # we share the metadata definition across image and point datatypes
+        # `Units.Intensity` might be a better option here. 
         series_epers.mdh['Units'] = 'e/s'
         
         # TODO - do we need to fudge/break the remaining metadata entries?

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -2202,17 +2202,9 @@ class RawADUToElectronsPerSecond(ModuleBase):
     complex workflows will require building enhanced unit awareness into other parts of PYME which is not currently present.
 
     At this point there is not much certainty about how unit awareness should be done, and it is likely to change signficantly from
-    the first attempt here:
-
-    - Should units be a property of the metadata, or of the datasource itself?
-    - If in the metadata, an acquisition have multiple different units (intensity, position, time) 
-    - This means that the `Units` metadata key is probably not appropriate and we should use something more specific
-
-    In practice this means:
+    the first attempt here. In practice this means:
 
     - this should be viewed as experimental
-    - there is no garuantee that the Units metadata entry will be the same in future versions of PYME
-    - in this case, I (DB) am not prepared to maintain backwards compatibility, as I think it would make things un-neccesarily messy
     - before building extensive pipelines that depend on Units metadata, or saving large numbers of files calibrated in e/s please
       force the issue (through, e.g an issue on github and a discussion) so we can finalise what unit support is going to look like
       and what metadata should be used).
@@ -2231,14 +2223,14 @@ class RawADUToElectronsPerSecond(ModuleBase):
         series_epers = ImageStack(data=epers_ds, events=series_adu.events, mdh=DictMDHandler(series_adu.mdh))
         series_epers.mdh['Parent'] = series_adu.filename
         
-        # TODO - potentially change the name of this metadata key as we also have spatial and temporal units and 
-        # we share the metadata definition across image and point datatypes
-        # `Units.Intensity` might be a better option here. 
-        series_epers.mdh['Units'] = 'e/s'
+        series_epers.mdh['Units.Intensity'] = 'e/s'
         
-        # TODO - do we need to fudge/break the remaining metadata entries?
-        # im.mdh['Camera.ElectronsPerCount'] = 1.0
-        # im.mdh['Camera.TrueEMGain'] = 1.0
-        # im.mdh['Camera.ADOffset'] = 0
+        # Fudge metadata 
+        # This should make metadata calibration more or less work where needed (at least until we have more comprehensive units support)
+        # note that in order for us to be able to get to electrons (not e/s) for noise models, we need to fudge either the gain or electrons
+        # per count with the integration time.
+        im.mdh['Camera.ElectronsPerCount'] = 1.0*series_adu.mdh['Camera.IntegrationTime']
+        im.mdh['Camera.TrueEMGain'] = 1.0
+        im.mdh['Camera.ADOffset'] = 0
 
         namespace[self.output_name] = series_epers


### PR DESCRIPTION
Addresses issue #1207 .

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- thinly wrap FlatFieldDataSource in a new datasource to additionally convert to electrons/second
- add a recipe module interface for this new datasource

Thanks for the conversation in #1207 @David-Baddeley and @csoeller. I think electrons/second is sort of the holy as far as Poisson is concerned, and being what I need at the moment I just wrote that, but it would be simple to add an option to choose whether we output was just photoelectrons instead of electrons/second. It just starts to get bigger, and maybe uglier unless some real time is spent on it (I'm sure we can all envision a 'units' datasource snowballing a bit).

Still some metadata questions - thanks @csoeller for pointing these out in your mapTools.


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [x] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
