### PR TITLE
create a new metadatahandler for h5 data every ImageStack load 

### DIFF
--- a/PYME/Analysis/MetaData.py
+++ b/PYME/Analysis/MetaData.py
@@ -48,6 +48,8 @@ from PYME.IO.MetaDataHandler import NestedClassMDHandler, HDFMDHandler
 ##FIXME - THIS SHOULD ALL BE EXTRACTED FROM LOG FILES OR THE LIKE
 #TIRFDefault = MetaData(VoxelSize(0.07, 0.07, 0.2), CCDMetaDataIXonDefault())
 
+# NOTE - if using these metadatahandlers as defaults be sure to
+# copy into a new metadatahandler rather than using them directly
 TIRFDefault = NestedClassMDHandler()
 
 #voxelsize

--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -552,7 +552,7 @@ class ImageStack(object):
         self.SetData(BGSDataSource.DataSource(self.dataSource)) #this will get replaced with a wrapped version
 
         #try: #should be true the whole time
-        self.mdh = MetaData.TIRFDefault
+        self.mdh = MetaDataHandler.NestedClassMDHandler(MetaData.TIRFDefault)
         self.mdh.copyEntriesFrom(self.dataSource.getMetadata())
         #except:
         #    self.mdh = MetaData.TIRFDefault
@@ -582,7 +582,7 @@ class ImageStack(object):
         self.SetData(BGSDataSource.DataSource(self.dataSource)) #this will get replaced with a wrapped version
 
         #try: #should be true the whole time
-        self.mdh = MetaData.TIRFDefault
+        self.mdh = MetaDataHandler.NestedClassMDHandler(MetaData.TIRFDefault)
         self.mdh.copyEntriesFrom(self.dataSource.getMetadata())
 
         #attempt to estimate any missing parameters from the data itself        

--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -502,7 +502,7 @@ class ImageStack(object):
         #background subtraction in the GUI the same way as in the analysis
         self.SetData(BGSDataSource.DataSource(self.dataSource)) #this will get replaced with a wrapped version
 
-        self.mdh = MetaData.TIRFDefault
+        self.mdh = MetaDataHandler.NestedClassMDHandler(MetaData.TIRFDefault)
 
         if self.dataSource.mdh is not None: #should be true the whole time    
             self.mdh.copyEntriesFrom(self.dataSource.mdh)


### PR DESCRIPTION
Addresses issue #1213 .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- don't re-use the same metadatahandler instance when loading h5 files






**Checklist:**
```
(pyme) C:\Users\aesb>ipython
Python 3.7.11 (default, Jul 27 2021, 09:42:29) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.27.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from PYME.IO.image import ImageStack

In [2]: from os import path

In [3]: base_path = "censored"

In [4]: im1 = ImageStack(filename=path.join(base_path, '25_3_series_I.h5'))
filename ==censored\25_3_series_I.h5
censored\25_3_series_I.h5r

In [5]: im1.mdh['Camera.ElectronsPerCount']
Out[5]: 10.0

In [6]: im2 = ImageStack(filename=path.join(base_path, '25_3_series_I_scmos.h5'))
filename == censored\25_3_series_I_scmos.h5
censored\25_3_series_I_scmos.h5r

In [7]: im2.mdh['Camera.ElectronsPerCount']
Out[7]: 0.23

In [8]: im1.mdh['Camera.ElectronsPerCount']
Out[8]: 10.0
```
