### PR TITLE
GUI panel for manually logging an acquisition event

### DIFF
--- a/PYME/Acquire/ui/manual_event_panel.py
+++ b/PYME/Acquire/ui/manual_event_panel.py
@@ -1,0 +1,48 @@
+
+import wx
+
+class ManualEventPanel(wx.Panel):
+    def __init__(self, parent):
+        """
+        Panel to allow manually logging an acquisition event in PYMEAcquire.
+
+        Parameters
+        ----------
+        parent : wx parent, i.e. MainFrame in your init script
+
+        example usage:
+            @init_gui('events')
+            def events(MainFrame, scope):
+                from PYME.Acquire.ui.manual_event_panel import ManualEventPanel
+                event_panel = ManualEventPanel(MainFrame)
+                MainFrame.camPanels.append((event_panel, 'manual event panel', False))
+        """
+        wx.Panel.__init__(self, parent)
+
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, 'Name:'), 0, wx.ALL, 2)
+        self.name = wx.TextCtrl(self, -1, value='')
+        hsizer.Add(self.name, 1, wx.EXPAND)
+        vsizer.Add(hsizer, 1, wx.EXPAND)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, 'Description:'), 0, wx.ALL, 2)
+        self.description = wx.TextCtrl(self, -1, value='')
+        hsizer.Add(self.description, 1, wx.EXPAND)
+        vsizer.Add(hsizer, 1, wx.EXPAND)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.log_button = wx.Button(self, -1, 'Log Event')
+        hsizer.Add(self.log_button, 0, wx.ALL, 2)
+        self.log_button.Bind(wx.EVT_BUTTON, self.OnLog)
+        vsizer.Add(hsizer, 1, wx.EXPAND)
+
+        self.SetSizerAndFit(vsizer)
+
+    def OnLog(self, wx_event=None):
+        """    
+        """
+        from PYME.Acquire import eventLog
+        eventLog.logEvent(self.name.GetValue(), self.description.GetValue())


### PR DESCRIPTION
Addresses issue I am waiting for a piece of equipment, and in the meantime I am flipping a physical switch instead of sending a serial command, however I still need a rough time point for these switch-throws (writing frame number does not cut it when imaging with two unsynchronized cameras, at high frame rates). Clicking my mouse and throwing the switch at "the same" time works for now.

**Is this a bugfix or an enhancement?**
kind of a cludge, but maybe someone finds it useful (e.g. 'lost immersion oil')
**Proposed changes:**
- gui panel to allow an acquisition event to be logged manually

![image](https://user-images.githubusercontent.com/31105780/163892368-85f2eb17-3298-4be1-95bb-4e4676098795.png)

![image](https://user-images.githubusercontent.com/31105780/163892396-d966bdf0-808a-40ec-98f0-daa32481b6de.png)





**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
