### PR TITLE
use camera_noise in ueye, falling back on current base properties

### DIFF
--- a/PYME/Acquire/Hardware/ueye.py
+++ b/PYME/Acquire/Hardware/ueye.py
@@ -61,7 +61,7 @@ BaseProps = {
     },
     'UI327x' : {  # calibrated by AESB 2022/04 on S/N 4103211322 running in 12 bit mode, 100 ms integration time.
         'ElectronsPerCount': 2.706,  # fitted from Var [ADU^2] vs Mean [ADU] plot (1/slope)
-        'ReadNoise' : 8.96, # median of 100 ms varmap from gen_sCMOS_maps.py is 80.33986 e-^2. ReadNoise is sigma, i.e. sqrt(80.34)
+        'ReadNoise' : 2.425, # median of 100 ms varmap from gen_sCMOS_maps.py is 5.883 e-^2. ReadNoise is sigma, i.e. sqrt of that
         'ADOffset' : 7.67,  # median of 100 ms dark map from gen_sCMOS_maps.py
     },
     'default' : { # fairly arbitrary values

--- a/PYME/Acquire/Hardware/ueye.py
+++ b/PYME/Acquire/Hardware/ueye.py
@@ -59,6 +59,11 @@ BaseProps = {
         'ReadNoise' : 6.0,
         'ADOffset' : 10
     },
+    'UI327x' : {  # calibrated by AESB 2022/04 on S/N 4103211322 running in 12 bit mode, 100 ms integration time.
+        'ElectronsPerCount': 2.706,  # fitted from Var [ADU^2] vs Mean [ADU] plot (1/slope)
+        'ReadNoise' : 8.96, # median of 100 ms varmap from gen_sCMOS_maps.py is 80.33986 e-^2. ReadNoise is sigma, i.e. sqrt(80.34)
+        'ADOffset' : 7.67,  # median of 100 ms dark map from gen_sCMOS_maps.py
+    },
     'default' : { # fairly arbitrary values
         'ElectronsPerCount'  : 10,
         'ReadNoise' : 20,

--- a/PYME/Acquire/Hardware/ueye.py
+++ b/PYME/Acquire/Hardware/ueye.py
@@ -469,10 +469,14 @@ class UEyeCamera(Camera):
     
     @property
     def noise_properties(self):
-        return {'ElectronsPerCount': self.baseProps['ElectronsPerCount']/self.GetGainFactor(),
-                'ReadNoise': self.baseProps['ReadNoise'],
-                'ADOffset': self.baseProps['ADOffset'],
-                'SaturationThreshold': 2 ** self.nbits  - 1}
+        try:  # try and get noise properties following the current convention
+            return super().noise_properties
+        except RuntimeError:  # fall back loudly on "base properties"
+            logger.exception('Noise properties not set up for this camera, falling back on values which are likely wrong')
+            return {'ElectronsPerCount': self.baseProps['ElectronsPerCount']/self.GetGainFactor(),
+                    'ReadNoise': self.baseProps['ReadNoise'],
+                    'ADOffset': self.baseProps['ADOffset'],
+                    'SaturationThreshold': 2 ** self.nbits  - 1}
 
     
     # @property

--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -193,7 +193,7 @@ class CameraInfoManager(object):
 
     def getVarianceMap(self, md):
         """Returns the pixel variance map specified in the supplied metadata, from cache if possible.
-        The variance map should be in units of *photoelectrons*."""
+        The variance map should be in units of *photoelectrons^2*."""
         varMapName = md.getOrDefault('Camera.VarianceMapID', None)
 
         mp = self._getMap(md, varMapName)


### PR DESCRIPTION
Addresses issue default of 10 e-/ADU being wrong for my camera.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- note the variance maps are in e-^2 in `remFitBuf.CameraInfoManager.getVarianceMap`
- add a 327x camera calibration to the ueye base props dict.
- switch `UEyeCamera.noise_properties` to default to standard base-class `Camera.noise_properties` yaml lookup by serial number and fall-back on baseprops dict loudly

Don't want to interrupt anyone using an IDS camera for e.g. a focus lock who doesn't care, so figured best not to hard-switch to the current convention.

**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
