### PR TITLE
update fitpoints docstring to include some unit information

### DIFF
--- a/PYME/recipes/measurement.py
+++ b/PYME/recipes/measurement.py
@@ -178,8 +178,29 @@ class DetectPoints2D(ModuleBase):
 
 @register_module('FitPoints')
 class FitPoints(ModuleBase):
-    """ Apply one of the fit modules from PYME.localization.FitFactories to each of the points in the provided
-    in inputPositions
+    """ 
+    Apply one of the fit modules from PYME.localization.FitFactories to each of
+    the points in the provided in inputPositions. 
+
+    Parameters
+    ----------
+    inputImage: PYME.IO.image.ImageStack
+        FitPoints does not do unit conversions normally done during localization
+        analysis in PYME (where we convert from raw analog-digital units [ADU]
+        to photoelectrons [e-]). Intensity units output in fit results from this
+        module will therefore be different unless you take care to convert the
+        units of inputImage first.
+    inputPositions: PYME.IO.tabular
+        positions to fit in units of nanometers, if inputImage has voxelsize
+        metadata, otherwise units of pixels. Note these units will propogate
+        into position related fit result parameters
+    outputName: PYME.IO.tabular
+        see selected fit module datatype for fit result and fit error parameters
+    
+    Notes
+    -----
+    Pay attention to units when using this module! 
+
     """
     inputImage = Input('input')
     inputPositions = Input('objPositions')

--- a/PYME/recipes/measurement.py
+++ b/PYME/recipes/measurement.py
@@ -185,21 +185,15 @@ class FitPoints(ModuleBase):
     Parameters
     ----------
     inputImage: PYME.IO.image.ImageStack
-        FitPoints does not do unit conversions normally done during localization
-        analysis in PYME (where we convert from raw analog-digital units [ADU]
-        to photoelectrons [e-]). Intensity units output in fit results from this
-        module will therefore be different unless you take care to convert the
-        units of inputImage first.
+        FitPoints does not do the camera correction normally done during 
+        localization analysis in PYME. To accomplish this using recipe modules,
+        run your ImageStack through `processing.FlatfieldAndDarkCorrect` first.
     inputPositions: PYME.IO.tabular
         positions to fit in units of nanometers, if inputImage has voxelsize
         metadata, otherwise units of pixels. Note these units will propogate
         into position related fit result parameters
     outputName: PYME.IO.tabular
         see selected fit module datatype for fit result and fit error parameters
-    
-    Notes
-    -----
-    Pay attention to units when using this module! 
 
     """
     inputImage = Input('input')

--- a/PYME/recipes/measurement.py
+++ b/PYME/recipes/measurement.py
@@ -189,9 +189,8 @@ class FitPoints(ModuleBase):
         localization analysis in PYME. To accomplish this using recipe modules,
         run your ImageStack through `processing.FlatfieldAndDarkCorrect` first.
     inputPositions: PYME.IO.tabular
-        positions to fit in units of nanometers, if inputImage has voxelsize
-        metadata, otherwise units of pixels. Note these units will propogate
-        into position related fit result parameters
+        positions to fit in units of nanometers. If inputImage is missing voxelsize
+        metadata, a pixel size of 1 nm is assumed.
     outputName: PYME.IO.tabular
         see selected fit module datatype for fit result and fit error parameters
 


### PR DESCRIPTION
Addresses issue try and communicate what's going on with units in this module to someone who might not have read the code.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- note that intensity units are not touched by this module (despite throwing in camera noise metadata)
- note that position units might be in nanometers or might be in pixels depending on the weather (but really whether your input ImageStack has voxelsize metadata)






**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
