### PR TITLE
hardware support for micro photon devices picosecond delayer

### DIFF
--- a/PYME/Acquire/Hardware/mpd_picosecond_delayer.py
+++ b/PYME/Acquire/Hardware/mpd_picosecond_delayer.py
@@ -43,9 +43,9 @@ class PicosecondDelayer(object):
     cached values, while GetXXXX calls will query the board over serial.
 
     Echo mode means the board replies back the command it received, the string
-    terminator '#' and then its response. Turning off echo mode while their
-    labview software communicates with the board is problematic because it can
-    interupt communication.
+    terminator '#' and then its response (and anoher #). Somewhat nebulous 
+    message in manual that turning off echo mode can interupt communication 
+    with he board.
 
     Local mode means most settings (delay, pulse width, trigger level, divider,
     edge, or I/O) cannot be set over serial and must be set using the front

--- a/PYME/Acquire/Hardware/mpd_picosecond_delayer.py
+++ b/PYME/Acquire/Hardware/mpd_picosecond_delayer.py
@@ -1,0 +1,278 @@
+
+## Microphoton devices picosecond delay module
+
+import serial
+import time
+import threading
+
+
+mpd_psd_errors = {
+    1 : 'Command not recognized',
+    2 : 'Picosecond Delayer in local mode; cannot set parameters',
+    3 : 'Frequency divider value too high (>999); parameter is not set',
+    4 : 'Frequency divider value too low (<1); parameter is not set',
+    5 : 'Trigger level is higher than maximum 2 V; parameter is not set',
+    6 : 'Trigger level is lower than minimum -2 V; parameter is not set',
+    7 : 'Delay value is higher than the maximum delay; parameter is not set',
+    8 : 'Delay value is less than 0 ps; parameter is not set',
+    9 : 'Pulse width value too high (>250 ns); parameter is not set',
+    10: 'Pulse width value too low (<1 ns); parameter is not set'
+}
+
+def check_success(resp):
+    if b'ERR' in resp:
+        err_no = int((resp.split(b'ERR')[-1]).decode())
+        try:
+            raise RuntimeError(mpd_psd_errors[err_no])
+        except KeyError:
+            raise RuntimeError('Unknown error code; %d' % err_no)
+    return resp
+
+
+class PicosecondDelayer(object):
+    """
+    Microphoton devices picosecond delay module. This implementation uses
+    serial commands without context managers due to issues experienced with
+    an arduino previously 
+    (see https://github.com/python-microscopy/python-microscopy/issues/1194)
+
+    However, that would potentially be a cleaner option than opening the port
+    and leaving it open continually.
+
+    Most properties are implemented as properties with getters returning 
+    cached values, while GetXXXX calls will query the board over serial.
+
+    Echo mode means the board replies back the command it received, the string
+    terminator '#' and then its response. Turning off echo mode while their
+    labview software communicates with the board is problematic because it can
+    interupt communication.
+
+    Local mode means most settings (delay, pulse width, trigger level, divider,
+    edge, or I/O) cannot be set over serial and must be set using the front
+    panel of the box.
+    """
+    def __init__(self, port='COM4'):
+        self.lock = threading.Lock()
+        self.ser = serial.Serial(port=port, baudrate=115200, 
+                                 bytesize=serial.EIGHTBITS,
+                                 parity=PARITY_NONE, stopbits=STOPBITS_ONE,
+                                 rtscts=False, timeout=.1, writeTimeout=2)
+        
+        self._delay = self.GetDelay()
+        self._pulse_width = self.GetPulseWidth()
+        self._trigger_level = self.GetTriggerLevel()
+        self._divide_by = self.GetFrequencyDivider()
+        self._edge = self.GetEdge()
+        self._enabled = self.GetIO()
+        self._echo_mode = self.GetEchoMode()
+        self._temperature = self.GetTemperature()
+        self._max_delay = self.GetMaxDelay()
+
+        # there is no way to query high-speed mode without setting it.
+        self._high_speed_mode = False  # start us off in normal mode
+        
+    
+    @property
+    def temperature(self):
+        """
+        Returns
+        -------
+        temp: float
+            Temperature in units of Celsius. Should stabilize to about 55 C
+        """
+        return self._temperature
+    
+    @property
+    def delay(self):
+        return self._delay
+    
+    @delay.setter
+    def delay(self, delay):
+        """
+        Parameters
+        ----------
+        delay: int
+            delay setpoint in units of picoseconds. Delay can be varied in 10 ps
+            steps from 0 to MAX-DELAY. MAX-DELAY is slightly nuanced, but
+            something like 50 nanoseconds.
+        """
+        with self.lock:
+            self.ser.write(b'SD%d\n' % delay)
+            self._delay = int(str(self.ser.readline()))
+    
+    @property
+    def pulse_width(self):
+        return self._pulse_width
+    
+    @pulse_width.setter
+    def pulse_width(self, pulse_width):
+        """
+        Parameters
+        ----------
+        pulse_width: int
+            pulse width duration in nanoseconds. Possible values are
+            non-linearly distributed from 1 ns to 250 ns, and will be rounded to
+            on the unit.
+        """
+        with self.lock:
+            self.ser.write(b'SP%d\n' % pulse_width)
+            self._pulse_width = int(str(self.ser.readline()))
+    
+    @property
+    def trigger_level(self):
+        return self._trigger_level
+    
+    @property.setter
+    def trigger_level(self, trigger_level):
+        """
+        Parameters
+        ----------
+        trigger_level: int
+            threshold voltage in mV to trigger an output pulse. Can be set in
+            10 mV steps from -2 V to + 2 V. Level is rounded to the nearest
+            10 mV on unit.
+        """
+        with self.lock:
+            self.ser.write(b'SH%d\n' % trigger_level)
+            self._trigger_level = int(str(self.ser.readline()))
+    
+    @property
+    def frequency_divider(self):
+        return self._divide_by
+    
+    @frequency_divider.setter
+    def frequency_divider(self, divide_by):
+        """
+        Parameters
+        ----------
+        divide_by: int
+            frequency divider factor. Possible values are integers from 1 to
+            999.
+        """
+        with self.lock:
+            self.ser.write(b'SV%d\n' % divide_by)
+            self._divide_by = int(str(self.ser.readline()))
+    
+    @property
+    def edge(self):
+        return self._edge
+    
+    @edge.setter
+    def edge(self, rising):
+        """
+        Parameters
+        ----------
+        rising: bool
+            significant edge for trigger input. False: falling edge, True:
+            rising edge.
+        """
+        with self.lock:
+            self.ser.write(b'SE%d\n' % rising)
+            self._divide_by = bool(str(self.ser.readline()))
+
+    @property
+    def io(self, io):
+        return self._enabled
+
+    @io.setter
+    def io(self, io):
+        """
+        Parameters
+        ----------
+        io: bool
+            enable (True) or disable (False) output signal
+        """
+        with self.lock:
+            self.ser.write(b'EO%d\n' % io)
+            self._enabled = bool(str(self.ser.readline()))
+    
+    def Enable(self):
+        self.io(True)
+    
+    def Disable(self):
+        self.io(False)
+    
+    @property
+    def echo_mode(self):
+        return self._echo_mode
+    
+    @echo_mode.setter
+    def echo_mode(self, echo_mode):
+        """
+        Parameters
+        ----------
+        echo_mode: bool
+            enable (True) or disable (False) echo mode
+        """
+        if not echo_mode:
+            raise RuntimeError('Echo mode should never be turned off over serial')
+        with self.lock:
+            self.ser.write(b'EM%d\n' % io)
+            self._echo_mode = bool(str(self.ser.readline()))
+    
+    @property
+    def high_speed_mode(self):
+        return self._high_speed_mode
+    
+    @high_speed_mode.setter
+    def high_speed_mode(self, high_speed):
+        """
+        high-speed mode stops refreshing the display on the unit in order to the
+        achieve fastest set-delay update rate.
+
+        Parameters
+        ----------
+        high_speed: bool
+            enable (True) or disable (False) high-speed mode, 
+        """
+        with self.lock:
+            self.ser.write(b'HS%d\n' % io)
+            self._high_speed_mode = bool(str(self.ser.readline()))
+    
+    def GetTemperature(self):
+        with self.lock:
+            self.ser.write(b'RT#\n' % io)
+            self._temperature = float(str(self.ser.readline()))
+        return self._temperature
+    
+    def GetDelay(self):
+        with self.lock:
+            self.ser.write(b'RD#\n' % io)
+            self._delay = int(str(self.ser.readline()))
+        return self._delay
+    
+    def GetPulseWidth(self):
+        with self.lock:
+            self.ser.write(b'RP#\n')
+            self._pulse_width = int(str(self.ser.readline()))
+        return self._pulse_width
+    
+    def GetTriggerLevel(self):
+        with self.lock:
+            self.ser.write(b'RH#\n')
+            self._trigger_level = int(str(self.ser.readline()))
+        return self._trigger_level
+    
+    def GetEdge(self):
+        with self.lock:
+            self.ser.write(b'RE#\n')
+            self._edge = bool(str(self.ser.readline()))
+        return self._edge
+    
+    def GetIO(self):
+        with self.lock:
+            self.ser.write(b'RO#\n')
+            self._io = bool(str(self.ser.readline()))
+        return self._io
+    
+    def GetFrequencyDivider(self):
+        with self.lock:
+            self.ser.write(b'RO#\n')
+            self._divide_by = int(str(self.ser.readline()))
+        return self._divide_by
+    
+    def GetMaxDelay(self):
+        with self.lock:
+            self.ser.write(b'RMD#\n')
+            self._max_delay = int(str(self.ser.readline()))
+        return self._max_delay

--- a/PYME/Acquire/microscope.py
+++ b/PYME/Acquire/microscope.py
@@ -268,7 +268,7 @@ class StateManager(object):
         
         key : string
             The hardware key - e.g. "Positioning.x", or "Lasers.405.Power". This
-            will also be how the hardware state is recorder in the metadata.
+            will also be how the hardware state is recorded in the metadata.
         getFcn : function
             The function to call to get the value of the parameter. Should take
             one parameter which is the value to get

--- a/PYME/Acquire/ui/mpd_picosecond_delay_panel.py
+++ b/PYME/Acquire/ui/mpd_picosecond_delay_panel.py
@@ -1,0 +1,69 @@
+import wx
+
+class DelayPanel(wx.Panel):
+    """
+    Simple slider panel showing/controling the delay of the MPD picosecond 
+    delay module. See PYME.Acquire.Hardware.mpd_picosecond_delayer.
+
+    Example setup in init script:
+    @init_gui('pulse phase control')
+    def pulse_phase_controls(MainFrame, scope):
+        from PYME.Acquire.ui import mpd_picosecond_delay_panel
+        delay_panel = mpd_picosecond_delay_panel.DelayPanel(MainFrame, scope.mpd, scope)
+        MainFrame.camPanels.append((delay_panel, 'Phase Delay', False, False))
+        MainFrame.time1.WantNotification.append(delay_panel.update)
+    """
+    def __init__(self, parent, delayer, scope):
+        self.delayer = delayer
+        self.scope = scope
+        self.sliding = False
+
+        wx.Panel.__init__(self, parent)
+        vsizer=wx.BoxSizer(wx.VERTICAL)
+
+        delay = wx.StaticBoxSizer(wx.StaticBox(self, -1, u'Delay (ps)'), wx.VERTICAL)
+        
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.l = wx.StaticText(self, -1, '%d' % self.delayer.delay)
+        hsizer.Add(self.l, 0, wx.ALL, 2)
+        self.sl = wx.Slider(self, -1, self.delayer.delay, 0, self.delayer.GetMaxDelay(), size=wx.Size(150,-1),style=wx.SL_HORIZONTAL | wx.SL_HORIZONTAL | wx.SL_AUTOTICKS )
+        self.sl.SetTickFreq(25000)
+        self.Bind(wx.EVT_SCROLL,self.on_slide)
+        hsizer.Add(self.sl, 1, wx.ALL|wx.EXPAND, 2)
+        delay.Add(hsizer, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+
+        
+
+        vsizer.Add(delay, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.cb_highspeed = wx.CheckBox(self, wx.ID_ANY, 'High-Speed mode (no GUI update)')
+        self.cb_highspeed.SetValue(self.delayer.high_speed_mode)
+        self.cb_highspeed.Bind(wx.EVT_CHECKBOX, self.on_cb_highspeed)
+
+        vsizer.Add(hsizer, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+
+        self.SetSizer(vsizer)
+
+        
+
+    def on_slide(self, event):
+        self.sliding = True
+        try: 
+            sl = event.GetEventObject()
+            self.delayer.delay = sl.GetValue()
+            self.l.SetLabel('%d' % self.delayer.delay)
+        finally:
+            self.sliding = False
+    
+    def on_cb_highspeed(self, wx_event):
+        self.delayer.high_speed_mode = self.cb_highspeed.GetValue()
+
+    def update(self):
+        # only update if we aren't sliding and if we aren't running
+        # the delayer in high speed mode (where it doesn't even update
+        # the front panel for the sake of speed)
+        if (not self.sliding) and (not self.delayer.high_speed_mode):
+            delay = self.delayer.GetDelay()
+            self.sl.SetValue(delay)
+            self.l.SetLabel('%d' % delay)

--- a/docs/supported_hardware.rst
+++ b/docs/supported_hardware.rst
@@ -42,6 +42,7 @@ Miscellaneous
 * Nikon TE2000 stand
 * Nikon Ti stand
 * 3D Connexion "Space Navigator" 3D mouse
+* Micro Photon Devices Picosecond Delayer
 
 .. note::
 


### PR DESCRIPTION
**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- add a [picosecond delayer](http://www.micro-photon-devices.com/Products/Instrumentation/Picosend-Delayer) [distributed by picoquant](https://www.picoquant.com/products/category/accessories/psd-mod-picosecond-delayer) useful for synchronizing pulsed diode lasers
- add a GUI panel to control/visualize the delay set-point
- fix trivial typo in a microscopy.py docstring
- add the picosecond delayer to the list of supported hardware under miscellaneous. 

Note: will likely follow up at some point with a class to support the [Picoquant Taiko](https://www.picoquant.com/products/category/picosecond-pulsed-driver/taiko-pdl-m1) pulsed/cw driver.


**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
