### PR TITLE
Hc single shot

### DIFF
--- a/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
@@ -76,7 +76,7 @@ DCAMPROP_TRIGGERSOURCE_EXTERNAL = 2
 DCAMPROP_TRIGGERSOURCE_SOFTWARE = 3
 
 DCAMCAP_START_SEQUENCE = ctypes.c_int32(int("-1",0))
-
+#DCAMCAP_START_SNAP = ctypes.c_int32(int("0",0))
 
 class DCAMZeroBufferedException(Exception):
     pass
@@ -122,6 +122,7 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
             self.setDefectCorrectMode(False)
             self.enable_cooling(True)
             self._mode = self.MODE_CONTINUOUS
+            #self._mode = self.MODE_SINGLE_SHOT
             self.initialized = True
             logger.debug('Hamamatsu Orca initialized')
 
@@ -161,12 +162,12 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
 
         
     def GetAcquisitionMode(self):
-        #FIXME - actually support both continuous and single shot modes
+        # Support both continuous and single shot modes
         #return self.MODE_CONTINUOUS
         return self._mode
 
     def SetAcquisitionMode(self, mode):
-        if mode in [self.MODE_CONTINUOUS, self.MODE_SOFTWARE_TRIGGER]:
+        if mode in [self.MODE_CONTINUOUS, self.MODE_SOFTWARE_TRIGGER, self.MODE_SINGLE_SHOT]:
             self._mode = mode
         else:
             raise RuntimeError('Mode %d not supported' % mode)
@@ -192,20 +193,29 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
 
         if self._mode == self.MODE_SOFTWARE_TRIGGER:
             self.setCamPropValue('TRIGGER SOURCE', DCAMPROP_TRIGGERSOURCE_SOFTWARE)
-        else:
-            #continuous mode, internal trigger
-            self.setCamPropValue('TRIGGER SOURCE', DCAMPROP_TRIGGERSOURCE_INTERNAL)
+            self.checkStatus(dcam.dcamcap_start(self.handle,
+                                            DCAMCAP_START_SEQUENCE),
+                         "dcamcap_start")
 
+        elif self._mode == self.MODE_CONTINUOUS:
+            # Continuous mode, internal trigger
+            self.setCamPropValue('TRIGGER SOURCE', DCAMPROP_TRIGGERSOURCE_INTERNAL)
+            self.checkStatus(dcam.dcamcap_start(self.handle,
+                                            DCAMCAP_START_SEQUENCE),
+                         "dcamcap_start")
+
+        elif self._mode == self.MODE_SINGLE_SHOT:
+            # Single shot mode, software trigger with firetrigger
+            self.setCamPropValue('TRIGGER SOURCE', DCAMPROP_TRIGGERSOURCE_SOFTWARE)
+            self.checkStatus(dcam.dcamcap_start(self.handle,
+                                            DCAMCAP_START_SEQUENCE),
+                         "dcamcap_start")
+            self.FireSoftwareTrigger()
 
         eventLog.logEvent('StartAq', '')
 
         # Start the capture
         #print str(self.getCamPropValue('SENSOR MODE'))
-        #TODO - this is probably where we would need to deal with continuous vs single shot modes.
-        self.checkStatus(dcam.dcamcap_start(self.handle,
-                                            DCAMCAP_START_SEQUENCE),
-                         "dcamcap_start")
-
         self._aq_active = True
         return 0
 

--- a/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
@@ -205,7 +205,8 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
                          "dcamcap_start")
 
         elif self._mode == self.MODE_SINGLE_SHOT:
-            # Single shot mode, software trigger with firetrigger
+            # Spoofed single shot mode, using the software trigger
+            # NOTE: this should no longer be needed when we add software trigger support to z-stepping etc ...
             self.setCamPropValue('TRIGGER SOURCE', DCAMPROP_TRIGGERSOURCE_SOFTWARE)
             self.checkStatus(dcam.dcamcap_start(self.handle,
                                             DCAMCAP_START_SEQUENCE),

--- a/PYME/Acquire/Hardware/HamamatsuDCAM/Hamamatsu_control_panel.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/Hamamatsu_control_panel.py
@@ -1,0 +1,54 @@
+import wx
+
+# Mostly copied from PYME.Acquire.Hardware.pco.pco_sdk_cam_control_panel
+class ModeControl(wx.Panel):
+    def __init__(self, parent, cam):
+        wx.Panel.__init__(self, parent)
+        self.scope = parent.scope
+        self.parent = parent
+        self.cam = cam
+        self.options = ["Single shot", "Continuous", "Software trigger", "Hardware trigger"]
+        
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, "Mode : "), 1, wx.ALL, 2)
+        
+        self.choice = wx.Choice(self, -1, size = [100,-1], choices=self.options)
+        self.choice.Bind(wx.EVT_CHOICE, self.on_change)
+        hsizer.Add(self.choice, 0, wx.ALL, 2)
+        
+        self.update()
+        
+        self.SetSizerAndFit(hsizer)
+        
+    def on_change(self, event=None):
+        self.scope.frameWrangler.stop()
+        self.cam.SetAcquisitionMode(int(self.choice.GetSelection()))
+        self.scope.frameWrangler.start()
+        self.parent.update()
+        
+    def update(self):
+        self.choice.SetSelection(self.cam.GetAcquisitionMode())
+
+class HamamatsuControl(wx.Panel):
+    def __init__(self, parent, cam, scope):
+        wx.Panel.__init__(self, parent)
+        
+        self.cam = cam
+        self.scope = scope
+        
+        self.ctrls = [ModeControl(self, cam)]
+        
+        self._init_ctrls()
+
+    def _init_ctrls(self):
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+
+        for c in self.ctrls:
+            vsizer.Add(c, 0, wx.EXPAND|wx.ALL, 2)
+        
+        self.SetSizerAndFit(vsizer)
+        
+    def update(self):
+        for c in self.ctrls:
+            c.update()
+            


### PR DESCRIPTION
Addresses issue # .

**This is an enhancement**

**Proposed changes:**
1. Now we can swtich between imaging modes in GUI for Hamamatsu
2. Single shot mode is added to HamamatsuORCA







**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
