### PR TITLE
Mesh vertex deletion

### DIFF
--- a/PYME/DSView/modules/annotation.py
+++ b/PYME/DSView/modules/annotation.py
@@ -502,7 +502,7 @@ class Annotater(Plugin):
         from PYME.IO.image import ImageStack
         from PYME.DSView import ViewIm3D
         # import pylab
-        import matplotlib.cm
+        from PYME.misc.colormaps import cm
         #sp = self.image.data.shape[:3]
         #if len(sp)
         lab2 = self.cf.classify(self.dsviewer.image.data[:, :, self.do.zp, 0].squeeze())#, self.image.labels[:,:,self.do.zp])
@@ -526,7 +526,7 @@ class Annotater(Plugin):
         #set scaling to (0,10)
         for i in range(im.data.shape[3]):
             self.dv.do.Gains[i] = .1
-            self.dv.do.cmaps[i] = matplotlib.cm.labeled
+            self.dv.do.cmaps[i] = cm.labeled
     
         self.dv.Refresh()
         self.dv.Update()


### PR DESCRIPTION
@zacsimile 

First steps in a candidate for resolving topological issues (e.g. necks between otherwise separate mesh components) when deforming meshes. Takes a topoisomerase like approach:

- find unlikely / high energy vertices. e.g. `np.argwhere(m._E > 30)`
- delete them and all incident faces
- let `.repair()` patch the resulting hole

Seems to avoid singularities if (and only if):
- you only delete one vertex at a time, followed by a repair

There's also a patch for an annotation regression along for the ride on the PR