### PR TITLE
nodeserver start order

### DIFF
--- a/PYME/cluster/PYMERuleNodeServer.py
+++ b/PYME/cluster/PYMERuleNodeServer.py
@@ -58,8 +58,8 @@ def main():
         externalAddr = '127.0.0.1' #bind to localhost
     
     #TODO - move this into the nodeserver proper so that the ruleserver doesn't need to be up before we start
-    print(distribution.getDistributorInfo(ns).values())
-    distributors = [u.lstrip('http://').rstrip('/') for u in distribution.getDistributorInfo(ns).values()]
+    #print(distribution.getDistributorInfo(ns).values())
+    #distributors = [u.lstrip('http://').rstrip('/') for u in distribution.getDistributorInfo(ns).values()]
     
     #set up nodeserver logging
     cluster_root = conf.get('dataserver-root')
@@ -97,7 +97,7 @@ def main():
         nodeserverLog = logger
 
 
-    proc = rulenodeserver.ServerThread(distributors[0], serverPort, externalAddr=externalAddr, profile=False)
+    proc = rulenodeserver.ServerThread(ns, serverPort, externalAddr=externalAddr, profile=False)
     proc.start()
         
     # TODO - do we need this advertisement

--- a/PYME/cluster/rulenodeserver.py
+++ b/PYME/cluster/rulenodeserver.py
@@ -18,6 +18,8 @@ import os
 
 from PYME.util import webframework
 
+from PYME.cluster import distribution
+
 import ujson as json
 
 WORKER_GET_TIMEOUT = config.get('nodeserver-worker-get-timeout', 60)
@@ -132,12 +134,19 @@ class Rater(object):
         
 
 class NodeServer(object):
-    def __init__(self, distributor, ip_address, port, nodeID=computerName.GetComputerName()):
+    def __init__(self, distributor_or_ns, ip_address, port, nodeID=computerName.GetComputerName()):
         self._tasks = Queue.Queue()
         self._handins = Queue.Queue()
 
         self.nodeID = nodeID
-        self.distributor_url = distributor
+
+        if isinstance(distributor_or_ns, str):
+            self._distributor_url = distributor_or_ns
+        else:
+            # got a nameserver instance - use that instead
+            self._ns = distributor_or_ns
+            self._distributor_url = None
+
         self.ip_address = ip_address
         self.port = port
 
@@ -168,6 +177,21 @@ class NodeServer(object):
         self.taskThread = threading.Thread(target=self._poll_tasks)
         self.taskThread.start()
 
+    @property
+    def distributor_url(self):
+        if self._distributor_url is None:
+            # try and find a distributor
+            #distributors = [u.lstrip('http://').rstrip('/') for u in distribution.getDistributorInfo(self._ns).values()]
+            distributors = list(distribution.getDistributorInfo(self._ns).values())
+            print(distributors)
+
+            if len(distributors) == 0:
+                logger.debug('No distributor found')
+                return None
+            else:
+                self._distributor_url = distributors[0]
+                
+        return self._distributor_url
 
 
     @property
@@ -341,14 +365,16 @@ class NodeServer(object):
 
     def _poll(self):
         while self._do_poll:
-            #self._announce()
-            self._do_handins()
-            #self._update_tasks()
+            if self._distributor_url is not None:
+                #self._announce()
+                self._do_handins()
+                #self._update_tasks()
             time.sleep(.5)
 
     def _poll_tasks(self):
         while self._do_poll:
-            self._update_tasks()
+            if self._distributor_url is not None:
+                self._update_tasks()
             time.sleep(1.0)
 
 
@@ -404,9 +430,9 @@ class WFNodeServer(webframework.APIHTTPServer, NodeServer):
 
 
 class ServerThread(threading.Thread):
-    def __init__(self, distributor, port, externalAddr=None, profile=False):
+    def __init__(self, distributor_or_ns, port, externalAddr=None, profile=False):
         self.port = int(port)
-        self.distributor = distributor
+        #self.distributor = distributor
         self._profile = profile
         
         if externalAddr is None:
@@ -414,7 +440,10 @@ class ServerThread(threading.Thread):
             externalAddr = socket.gethostbyname(socket.gethostname())
             
         self.externalAddr = externalAddr
-        self.nodeserver = WFNodeServer('http://' + self.distributor + '/', port=self.port, ip_address=self.externalAddr)
+
+        if isinstance(distributor_or_ns, str):
+            distributor_or_ns = 'http://' + distributor_or_ns + '/'
+        self.nodeserver = WFNodeServer(distributor_or_ns, port=self.port, ip_address=self.externalAddr)
         
         threading.Thread.__init__(self)
     


### PR DESCRIPTION
make it so that the nodeserver can start before the ruleserver is up and running (with the ultimate goal of making launch order less critical and running components as services rather than manually)