### PR TITLE
change events 'Time' field dtype from time to float

### DIFF
--- a/PYME/IO/FileUtils/RawToHdf5.py
+++ b/PYME/IO/FileUtils/RawToHdf5.py
@@ -28,13 +28,8 @@ import tables
 import os
 import sys
 import numpy
-
+from PYME.IO.events import SpoolEvent
 from PYME.Analysis import MetaData
-
-class SpoolEvent(tables.IsDescription):
-   EventName = tables.StringCol(32)
-   Time = tables.Time64Col()
-   EventDescr = tables.StringCol(256)
 
 
 def convertFile(pathToData, outFile, frameSize = [256,256], pixelsize=None, complib='zlib', complevel=9):

--- a/PYME/IO/FileUtils/TiffSeqToHdf5.py
+++ b/PYME/IO/FileUtils/TiffSeqToHdf5.py
@@ -29,13 +29,8 @@ import os
 import sys
 
 from PIL import Image
-
+from PYME.IO.events import SpoolEvent
 from numpy import array
-
-class SpoolEvent(tables.IsDescription):
-   EventName = tables.StringCol(32)
-   Time = tables.Time64Col()
-   EventDescr = tables.StringCol(256)
 
 
 

--- a/PYME/IO/FileUtils/h5ExFrames.py
+++ b/PYME/IO/FileUtils/h5ExFrames.py
@@ -29,11 +29,7 @@ import sys
 
 from PYME.IO import MetaDataHandler
 from PYME.IO.DataSources import HDFDataSource
-
-class SpoolEvent(tables.IsDescription):
-   EventName = tables.StringCol(32)
-   Time = tables.Time64Col()
-   EventDescr = tables.StringCol(256)
+from PYME.IO.events import SpoolEvent
 
 def extractFrames(dataSource, metadata, origName, outFile, start, end, subsamp=1, complib='zlib', complevel=5):
     

--- a/PYME/IO/FileUtils/h5rFormatDef.py
+++ b/PYME/IO/FileUtils/h5rFormatDef.py
@@ -41,10 +41,7 @@ if __name__ == '__main__':
    #acquisition such as changes to laser power or focus stepping. I have a feeeling
    #that VisGUI complains if this isn't there, but you can safely leave the table
    #empty.
-   class SpoolEvent(tables.IsDescription):
-      EventName = tables.StringCol(32)
-      Time = tables.Time64Col()
-      EventDescr = tables.StringCol(256)
+   from PYME.IO.events import SpoolEvent
       
    resultsEvents = h5ResultsFile.create_table(h5ResultsFile.root, 'Events', SpoolEvent,filters=tables.Filters(complevel=5, shuffle=True))
 

--- a/PYME/IO/dataExporter.py
+++ b/PYME/IO/dataExporter.py
@@ -35,11 +35,7 @@ except ImportError:
 import os
 from PYME.IO.FileUtils import saveTiffStack
 from PYME.IO import MetaDataHandler
-
-class SpoolEvent(tables.IsDescription):
-   EventName = tables.StringCol(32)
-   Time = tables.Time64Col()
-   EventDescr = tables.StringCol(256)
+from PYME.IO.events import SpoolEvent
 
 #formats = ['PYME HDF - .h5',
 #            'TIFF (stack if 3D) - .tif',

--- a/PYME/IO/events.py
+++ b/PYME/IO/events.py
@@ -9,7 +9,7 @@ EVENTS_DTYPE = np.dtype([('EventDescr', 'S256'), ('EventName', 'S32'), ('Time', 
 class SpoolEvent(tables.IsDescription):
     """Pytables description for Events table in spooled dataset"""
     EventName = tables.StringCol(32)
-    Time = tables.Time64Col()
+    Time = tables.Float64Col()
     EventDescr = tables.StringCol(256)
 
 

--- a/PYME/ParallelTasks/HDFTaskQueue.py
+++ b/PYME/ParallelTasks/HDFTaskQueue.py
@@ -24,7 +24,7 @@
 import tables
 from taskQueue import *
 from PYME.localization.remFitBuf import fitTask
-
+from PYME.IO.events import SpoolEvent
 from PYME.Analysis import MetaData
 from PYME.IO import MetaDataHandler
 
@@ -225,12 +225,6 @@ class rwlock2(object):
         self.wlock = self.rlock
 
 tablesLock = rwlock2()
-
-
-class SpoolEvent(tables.IsDescription):
-   EventName = tables.StringCol(32)
-   Time = tables.Time64Col()
-   EventDescr = tables.StringCol(256)
 
 
 # class HDFResultsTaskQueue_(TaskQueue):


### PR DESCRIPTION
Addresses issue #1263 .

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- change Time field dtype in SpoolEvent from Time64Col to Float64Col
- import events.SpoolEvent where we need it rather than redefining it each time


Appears to work fine with PYMEAcquire simulator and PYMEImage, though I haven't done anything too intense with it
```
>>> image.events
array([(b'0', b'StartAq', 1.65834111e+09)],
      dtype=[('EventDescr', 'S256'), ('EventName', 'S32'), ('Time', '<f8')])
>>> image.events[0]['Time']
1658341107.9741135
```


