### PR TITLE
SaturationThreshold property for camera base class

### DIFF
--- a/PYME/Acquire/Hardware/Camera.py
+++ b/PYME/Acquire/Hardware/Camera.py
@@ -713,12 +713,12 @@ class Camera(object):
         'ElectronsPerCount' : AD conversion factor - how many electrons per ADU
         'NoiseFactor' : excess (multiplicative) noise factor 1.44 for EMCCD, 1 for standard CCD/sCMOS. See
             doi: 10.1109/TED.2003.813462
+        'SaturationThreshold' : the full well capacity (in ADU)  
 
         and optionally
 
         'ADOffset' : the dark level (in ADU)
         'DefaultEMGain' : a sensible EM gain setting to use for localization recording
-        'SaturationThreshold' : the full well capacity (in ADU)  
 
 
         These are sourced from config files, referenced by camera serial number and gain mode. 
@@ -818,6 +818,16 @@ class Camera(object):
             mdh.setEntry('Camera.ROIOriginY', y1)
             mdh.setEntry('Camera.ROIWidth', x2 - x1)
             mdh.setEntry('Camera.ROIHeight', y2 - y1)
+    
+    @property
+    def SaturationThreshold(self):
+        """
+        Returns
+        -------
+        int
+            the full well capacity (in ADU), typically 2^bitdepth - 1
+        """
+        return self.noise_properties['SaturationThreshold']
             
 
     def Shutdown(self):

--- a/PYME/Acquire/Hardware/camera_noise.py
+++ b/PYME/Acquire/Hardware/camera_noise.py
@@ -51,6 +51,16 @@ The yaml files should encode a dictionary in the following form:
                 NGainStages: 0
                 ReadNoise: 1.65
                 SaturationThreshold: 65535
+    
+    # A UEye entry:
+    '4103211322':
+        noise_properties:
+            12-bit:
+                ADOffset: 100
+                ElectronsPerCount: 2.706
+                ReadNoise: 2.425
+                ADOffset: 7.67
+                SaturationThreshold: 4095
 
 This dictionary is indexed by camera serial number. Each camera entry is itself a dictionary, and must have a dictionary called `noise_properties` as one entry.
 The `noise_properties` dictionary contains a set of dictionaries of readout characteristics for each gain mode of the camera (the keys here will typically vary between

--- a/PYME/Acquire/Hardware/camera_noise.py
+++ b/PYME/Acquire/Hardware/camera_noise.py
@@ -56,7 +56,6 @@ The yaml files should encode a dictionary in the following form:
     '4103211322':
         noise_properties:
             12-bit:
-                ADOffset: 100
                 ElectronsPerCount: 2.706
                 ReadNoise: 2.425
                 ADOffset: 7.67

--- a/PYME/Acquire/Hardware/ueye.py
+++ b/PYME/Acquire/Hardware/ueye.py
@@ -477,6 +477,10 @@ class UEyeCamera(Camera):
                     'ReadNoise': self.baseProps['ReadNoise'],
                     'ADOffset': self.baseProps['ADOffset'],
                     'SaturationThreshold': 2 ** self.nbits  - 1}
+    
+    @property
+    def _gain_mode(self):
+        return '%d-bit' % self.nbits
 
     
     # @property


### PR DESCRIPTION
Addresses issue only fakeCam.py and specCam.py having SaturationThreshold attributes, now required for #1271

**Proposed changes:**
- give all cameras a SaturationThreshold attribute which leans on the camera noise property unless SaturationThreshold as an attribute is overwritten during init (as in fakeCam)
- add ueye gain_mode to alias the bitdepth for noise_properties key access (@csoeller  - look OK?)







**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
