### PR TITLE
add pixel size for dh5view -t generated image

### DIFF
--- a/PYME/DSView/dsviewer.py
+++ b/PYME/DSView/dsviewer.py
@@ -442,6 +442,7 @@ class MyApp(wx.App):
             if options.test:
                 # import pylab
                 im = ImageStack(np.random.randn(100,100))
+                im.pixelSize = 100
             elif options.test3d:
                 # import numpy as np
                 from scipy import ndimage


### PR DESCRIPTION
Addresses issue #1273.

**Is this a bugfix or an enhancement?**
bugfix

**Proposed changes:**
provide a voxel size

**Checklist:**

- tested with python 3.8 and conda-forge build on mac ARM64