### PR TITLE
Add metadata to Octree and TriangleMesh and associated recipes

### DIFF
--- a/PYME/experimental/_octree.pyx
+++ b/PYME/experimental/_octree.pyx
@@ -2,6 +2,8 @@ cimport numpy as np
 import numpy as np
 cimport cython
 
+from PYME.IO.MetaDataHandler import DictMDHandler
+
 #size to initialize the storage to
 INITIAL_NODES = 1000
 NODE_DTYPE = [('depth', 'i4'), ('n_children', 'i4'), ('children', '8i4'),('parent', 'i4'), ('nPoints', 'i4'), ('centre', '3f4'), ('centroid', '3f4'),('point_idx', 'i4')]
@@ -132,11 +134,20 @@ cdef class Octree:
         
         self._octant_sign = np.array([[2*(n&1) - 1, (n&2) -1, (n&4)/2 -1] for n in range(8)])
         
+        self._mdh = None
         
         #precalculate scaling factors for locating the centre of the next box down.
         for n in range(50):
             self._scale[n] = 1.0/(2.0**(n + 1))
             
+    @property
+    def mdh(self):
+        self._mdh = DictMDHandler()
+        self._mdh['Octree.BoundingBox'] = self._bounds
+        self._mdh['Octree.MaxDepth'] = self._maxdepth
+        self._mdh['Octree.SamplesPerNode'] = self._samples_per_node
+
+        return self._mdh
         
     def truncate_at_n_points(self, n_points=5):
         out = Octree(self._bounds, self._maxdepth, samples_per_node=n_points)

--- a/PYME/experimental/_octree.pyx
+++ b/PYME/experimental/_octree.pyx
@@ -103,6 +103,7 @@ cdef class Octree:
     cdef node_d * _cnodes
     cdef object _octant_offsets
     cdef object _octant_sign
+    cdef public object mdh
     
     cdef np.float32_t[50] _scale
     
@@ -134,20 +135,14 @@ cdef class Octree:
         
         self._octant_sign = np.array([[2*(n&1) - 1, (n&2) -1, (n&4)/2 -1] for n in range(8)])
         
-        self._mdh = None
+        self.mdh = DictMDHandler()
+        self.mdh['Octree.BoundingBox'] = self._bounds
+        self.mdh['Octree.MaxDepth'] = self._maxdepth
+        self.mdh['Octree.SamplesPerNode'] = self._samples_per_node
         
         #precalculate scaling factors for locating the centre of the next box down.
         for n in range(50):
             self._scale[n] = 1.0/(2.0**(n + 1))
-            
-    @property
-    def mdh(self):
-        self._mdh = DictMDHandler()
-        self._mdh['Octree.BoundingBox'] = self._bounds
-        self._mdh['Octree.MaxDepth'] = self._maxdepth
-        self._mdh['Octree.SamplesPerNode'] = self._samples_per_node
-
-        return self._mdh
         
     def truncate_at_n_points(self, n_points=5):
         out = Octree(self._bounds, self._maxdepth, samples_per_node=n_points)

--- a/PYME/experimental/_triangle_mesh.pxd
+++ b/PYME/experimental/_triangle_mesh.pxd
@@ -108,6 +108,8 @@ cdef class TriangleMesh(TrianglesBase):
     cdef object _K
     cdef public object smooth_curvature
 
+    cdef public object mdh
+
     cdef _set_chalfedges(self, np.ndarray)#halfedge_t[:])
     cdef _set_cfaces(self, np.ndarray)#face_d[:])
     cdef _set_cvertices(self, np.ndarray)#vertex_d[:])

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -9,6 +9,7 @@ from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 import copy
 
 from PYME.experimental import triangle_mesh_utils
+from PYME.IO.MetaDataHandler import DictMDHandler
 
 DEF MAX_VERTEX_COUNT = 2**31
 
@@ -255,6 +256,8 @@ cdef class TriangleMesh(TrianglesBase):
 
         self._components_valid = 0
 
+        self._mdh = None
+
         # Set fix_boundary, etc.
         for key, value in kwargs.items():
             setattr(self, key, value)
@@ -327,6 +330,15 @@ cdef class TriangleMesh(TrianglesBase):
 
         print('Data munged to vertices, faces')
         return cls(vertices, faces, **kwargs)
+
+    @property
+    def mdh(self):
+        self._mdh = DictMDHandler()
+        self._mdh['TriangleMesh.Manifold'] = self.manifold
+        self._mdh['TriangleMesh.BoundingBox'] = self.bbox
+        self._mdh['TriangleMesh.SmoothCurvature'] = self.smooth_curvature
+
+        return self._mdh
 
     @property
     def x(self):

--- a/PYME/experimental/_triangle_mesh.pyx
+++ b/PYME/experimental/_triangle_mesh.pyx
@@ -256,8 +256,12 @@ cdef class TriangleMesh(TrianglesBase):
 
         self._components_valid = 0
 
-        self._mdh = None
-
+        # Set up metadata
+        self.mdh = DictMDHandler()
+        self.mdh['TriangleMesh.Manifold'] = self.manifold
+        self.mdh['TriangleMesh.BoundingBox'] = self.bbox
+        self.mdh['TriangleMesh.SmoothCurvature'] = self.smooth_curvature
+        
         # Set fix_boundary, etc.
         for key, value in kwargs.items():
             setattr(self, key, value)
@@ -330,15 +334,6 @@ cdef class TriangleMesh(TrianglesBase):
 
         print('Data munged to vertices, faces')
         return cls(vertices, faces, **kwargs)
-
-    @property
-    def mdh(self):
-        self._mdh = DictMDHandler()
-        self._mdh['TriangleMesh.Manifold'] = self.manifold
-        self._mdh['TriangleMesh.BoundingBox'] = self.bbox
-        self._mdh['TriangleMesh.SmoothCurvature'] = self.smooth_curvature
-
-        return self._mdh
 
     @property
     def x(self):

--- a/PYME/recipes/pointcloud.py
+++ b/PYME/recipes/pointcloud.py
@@ -27,6 +27,8 @@ class Octree(ModuleBase):
 
         ot = gen_octree_from_points(inp, min_pixel_size=self.minimum_pixel_size, max_depth=self.max_depth, samples_per_node=self.samples_per_node)
         
+        ot.mdh['Octree.MinimumPixelSize'] = self.minimum_pixel_size
+
         namespace[self.output_octree] = ot
         
         

--- a/PYME/recipes/surface_fitting.py
+++ b/PYME/recipes/surface_fitting.py
@@ -168,6 +168,12 @@ class DualMarchingCubes(ModuleBase):
         if self.cull_inner_surfaces:
             surf.remove_inner_surfaces()
 
+        surf.mdh['DualMarchingCubes.ThresholdDensity'] = self.threshold_density
+        surf.mdh['DualMarchingCubes.NPointsMin'] = self.n_points_min
+        surf.mdh['DualMarchingCubes.Repair'] = self.repair
+        surf.mdh['DualMarchingCubes.Remesh'] = self.remesh
+        surf.mdh['DualMarchingCubes.CullInnerSurfaces'] = self.cull_inner_surfaces
+
         namespace[self.output] = surf
 
 @register_module('Isosurface')


### PR DESCRIPTION
Metadata handlers for `Octree` and `TriangleMesh` allow us to add recipe metadata as well.