### PR TITLE
remove deprecated has_key with in operator

### DIFF
--- a/PYME/contrib/TextCtrlAutoComplete.py
+++ b/PYME/contrib/TextCtrlAutoComplete.py
@@ -73,7 +73,7 @@ class TextCtrlAutoComplete (wx.TextCtrl, listmix.ColumnSorterMixin ):
         by calling setChoices.
         """
 
-        if therest.has_key('style'):
+        if 'style' in therest:
             therest['style']=wx.TE_PROCESS_ENTER | therest['style']
         else:
             therest['style']=wx.TE_PROCESS_ENTER

--- a/PYME/util/mProfile/p.py
+++ b/PYME/util/mProfile/p.py
@@ -35,7 +35,7 @@ class mydictn(dict):
         dict.__init__(self, *args)
 
     def __getitem__(self,key):
-        if self.has_key(key):
+        if key in self:
             return dict.__getitem__(self, key)
         else:
             return None
@@ -52,7 +52,7 @@ class mydict(dict):
         dict.__init__(self, *args)
 
     def __getitem__(self,key):
-        if self.has_key(key):
+        if key in self:
             return dict.__getitem__(self, key)
         else:
             return 0


### PR DESCRIPTION
**Enhancement**

**Proposed changes:**
Remove deprecated `has_key` function and use `in` operator instead.

**Checklist:**

- [ ] Tested with numpy=1.14
- [ ] Tested on python 2.7 and 3.6
- [ ] Tested with wx=3.x and wx=4.x [if UI code]
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)? No
- [ ] Does this change how users interact with the software? How will these changes be communicated? NA
- [*] Does this maintain backwards compatibility with old data? Yes
- [*] Does this change the required dependencies? No
- [*] Are there any other side effects of the change? No
