### PR TITLE
Fix for #1295

### DIFF
--- a/PYME/DSView/modules/recipes.py
+++ b/PYME/DSView/modules/recipes.py
@@ -44,7 +44,7 @@ class RecipePlugin(recipeGui.PipelineRecipeManager, Plugin):
         Plugin.__init__(self, dsviewer)
 
         if not 'pipeline' in dir(dsviewer):
-            dsviewer.pipeline = pipeline.Pipeline()
+            dsviewer.pipeline = pipeline.Pipeline(execute_on_invalidation=False)
         
         recipeGui.PipelineRecipeManager.__init__(self, dsviewer.pipeline)
         

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -294,13 +294,13 @@ def _processEvents(ds, events, mdh):
     return ev_mappings, eventCharts
 
 class Pipeline:
-    def __init__(self, filename=None, visFr=None):
+    def __init__(self, filename=None, visFr=None, execute_on_invalidation=True):
         self.filter = None
         self.mapping = None
         self.colourFilter = None
         self.events = None
         
-        self.recipe = Recipe(execute_on_invalidation=True)
+        self.recipe = Recipe(execute_on_invalidation=execute_on_invalidation)
         self.recipe.recipe_executed.connect(self.Rebuild)
 
         self.selectedDataSourceKey = None


### PR DESCRIPTION
Fixes #1295. This is the simple fix which leaves some behavioural differences when dealing with point data in PYMEImage (e.g. need to manually run recipe for filter changes to propagate, more details in comments on #1295), but committing as is for expediency