### PR TITLE
Fix mask display (recent numpy)

### DIFF
--- a/PYME/DSView/displayOptions.py
+++ b/PYME/DSView/displayOptions.py
@@ -351,6 +351,10 @@ class DisplayOpts(object):
         """ Estimate a suitable starting display range
         """
         
+        if d.dtype == 'bool':
+            # special case for boolean masks ...
+            return 0,1
+
         #discard NaNa
         d = d[np.isnan(d) == 0].ravel()
         


### PR DESCRIPTION
Recent numpy versions have got more picky about promoting boolean datatypes, so percentile was failing. Add a special case for booleans.