### PR TITLE
Large .csv support

### DIFF
--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -573,9 +573,27 @@ class TextfileSource(TabularBase):
         #self.res = np.loadtxt(filename, dtype={'names' : columnnames,  # TODO: evaluate why these are cast as floats
         #                                       'formats' :  ['f4' for i in range(len(columnnames))]}, delimiter = delimiter, skiprows=skiprows)
 
-        print('invalid_raise:', invalid_raise)
+        from PYME import config
+        
+        #print('invalid_raise:', invalid_raise)
 
-        self.res = np.genfromtxt(filename,
+        if config.get('TextFileSource-use_pandas',False):
+            print('Opening %s using pandas (set TextFileSource-use_pandas: False in config.yaml to use legacy np.genfromtxt instead)')
+            import pandas as pd
+            self.res = pd.read_csv(filename,
+                comment=comments,
+                delimiter=delimiter,
+                skiprows=skiprows,
+                skipfooter=skip_footer,
+                names=columnnames,
+                dtype='f4',
+                skipinitialspace=True,
+                on_bad_lines='error' if invalid_raise else 'warn,'
+                ).to_records(index=False)
+
+        else:
+            print('Opening %s using np.genfromtxt (set TextFileSource-use_pandas: True in config.yaml to use pandas instead)')
+            self.res = np.genfromtxt(filename,
                              comments=comments,
                              delimiter=delimiter,
                              skip_header=skiprows,

--- a/PYME/ui/custom_traits_editors.py
+++ b/PYME/ui/custom_traits_editors.py
@@ -479,7 +479,7 @@ class _HistLimitsEditor (Editor):
         """
         import traceback
         print('hl update')
-        #print traceback.print_stack()
+        #print(traceback.print_stack())
         if self.value:
             self.control.SetData(self.factory.data(), *self.value)
             self.control.SetValue(self.value)

--- a/PYME/ui/histLimits.py
+++ b/PYME/ui/histLimits.py
@@ -31,8 +31,10 @@ import os
 LimitChangeEvent, EVT_LIMIT_CHANGE = wx.lib.newevent.NewCommandEvent()
 
 class HistLimitPanel(wx.Panel):
-    def __init__(self, parent, id, data, limit_lower, limit_upper, log=False, size =(200, 100), pos=(0,0), threshMode= False):
-        wx.Panel.__init__(self, parent, id, size=size, pos=pos, style=wx.BORDER_SUNKEN)
+    def __init__(self, parent, wx_id, data, limit_lower, limit_upper, log=False, size =(200, 100), pos=(0,0), threshMode= False):
+        wx.Panel.__init__(self, parent, wx_id, size=size, pos=pos, style=wx.BORDER_SUNKEN)
+
+        self._data_id = id(data)
 
         self.data = data.ravel()
         self.data = self.data[np.isfinite(self.data)]
@@ -93,6 +95,11 @@ class HistLimitPanel(wx.Panel):
         self.ProcessEvent(evt)
 
     def SetData(self, data, lower, upper):
+        if (id(data) == self._data_id) and (self.limit_lower == lower) and (self.limit_upper == upper):
+            # called with the data and limits we already have, no need to do anything
+            # this prevents histogram recalculation if we just, e.g., change the LUT
+            return
+
         self.data = np.array(data).ravel()
         self.data = self.data[np.isfinite(self.data)]
 

--- a/PYME/ui/histLimits.py
+++ b/PYME/ui/histLimits.py
@@ -100,6 +100,7 @@ class HistLimitPanel(wx.Panel):
             # this prevents histogram recalculation if we just, e.g., change the LUT
             return
 
+        self._data_id = id(data)
         self.data = np.array(data).ravel()
         self.data = self.data[np.isfinite(self.data)]
 


### PR DESCRIPTION
Add support for using pandas in TextFileSource (and a couple of ui responsiveness tweaks)

This results in **much** better loading performance (both speed and memory usage), and is likely required for large (> ~1M localisations) .csv formatted datasets.

Partial solution to #1293

pandas usage should eventually become the default due to the substantial performance improvement even on more modestly sized datasets, but with this PR is still hiding behind a PYME.config option until we have a chance to check against the many different .csv "flavours" some of which proved quite temperamental in the past. (see @csoeller s work on csv flavours - #1128),

To enable pandas based loading, add the following line to `~/.PYME/config.yaml`:

```yaml
TextFileSource-use_pandas: True
```   
