### PR TITLE
Enable HDF in __aggregate_h5r

### DIFF
--- a/PYME/cluster/HTTPDataServer.py
+++ b/PYME/cluster/HTTPDataServer.py
@@ -313,8 +313,16 @@ class PYMEHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         # filename, tablename = path.split('.h5r')
         # filename += '.h5r'
 
-        filename, tablename = self.path.lstrip('/')[len('__aggregate_h5r'):].split('.h5r')
-        filename = self.translate_path(filename + '.h5r')
+        # filename, tablename = self.path.lstrip('/')[len('__aggregate_h5r'):].split('.h5r')
+        # filename = self.translate_path(filename + '.h5r')
+
+        filename = self.path.lstrip('/')[len('__aggregate_h5r'):]
+        if '.h5r' in filename:
+            filename, tablename = filename.split('.h5r')
+            filename = self.translate_path(filename  + '.h5r')
+        else:
+            filename, tablename = filename.split('.hdf')
+            filename = self.translate_path(filename  + '.hdf')
 
         data = self._get_data()
 


### PR DESCRIPTION
Addendum to 5c50d52f84741f78d771edb8d664317195cb5062 to enable use of `hdf` file extension in `__aggregate_h5r`.