### PR TITLE
Saner workaround for #1292

### DIFF
--- a/PYME/LMVis/renderers.py
+++ b/PYME/LMVis/renderers.py
@@ -268,6 +268,10 @@ class ColourRenderer(CurrentRenderer):
         mdh['Origin.z'] = oz + imb.z0
 
         colours = settings['colours']
+        if ((len(colours) == 1) and (colours[0] == 'all')):
+            # for recipe usage, if provided with 'all', replace colour list with a list of all available channels
+            colours = self.colourFilter.getColourChans()
+
         oldC = self.colourFilter.currentColour
 
         ims = []

--- a/PYME/recipes/localisations.py
+++ b/PYME/recipes/localisations.py
@@ -1,5 +1,5 @@
 from .base import register_module, ModuleBase, Filter
-from .traits import Input, Output, Float, Enum, CStr, Bool, Int, List, DictStrStr, DictStrFloat, DictStrList, ListFloat, ListStr
+from .traits import Input, Output, Float, Enum, CStr, Str, Bool, Int, List, DictStrStr, DictStrFloat, DictStrList, ListFloat, ListStr
 
 import numpy as np
 from PYME.IO import tabular
@@ -59,13 +59,13 @@ class DensityMapping(ModuleBase):
     jitterScaleZ = Float(1.0)
     MCProbability = Float(1.0)
     numSamples = Int(10)
-    colours = ListStr(['none',])
+    colours = List(Str, ['all',])
     zBoundsMode = Enum(['manual', 'min-max'])
-    zBounds = ListFloat([-500, 500])
+    zBounds = List(Float, [-500, 500])
     zSliceThickness = Float(50.0)
     softRender = Bool(True)
     xyBoundsMode = Enum(['estimate', 'inherit', 'metadata', 'manual'])
-    manualXYBounds = ListFloat([0,0,5e3, 5e3])
+    manualXYBounds = List(Float, [0,0,5e3, 5e3])
     
 
     def execute(self, namespace):
@@ -106,10 +106,10 @@ class DensityMapping(ModuleBase):
         namespace[self.outputImage] = out
         
     def _view_items(self, params=None):
-        from traitsui.api import Group, Item
+        from traitsui.api import Group, Item, CSVListEditor
         return [Item('renderingModule'),
                     Item('pixelSize'),
-                    #Item('colours', style='text'),#editor=CSVListEditor()),
+                    Item('colours', style='text',editor=CSVListEditor(auto_set=False, enter_set=True)),
                     #Item('softRender'),
                     Group(
                         Item('jitterVariable'),
@@ -122,11 +122,11 @@ class DensityMapping(ModuleBase):
                     Group(
                         Item('zSliceThickness'),
                         Item('zBoundsMode'),
-                        #Item('zBounds', visible_when='zBoundsMode=="manual"'),
+                        Item('zBounds', visible_when='zBoundsMode=="manual"',editor=CSVListEditor(auto_set=False, enter_set=True)),
                         label='3D', visible_when='"3D" in renderingModule'),
                     Group(
                         Item('xyBoundsMode'),
-                        #Item('manualXYBounds', visible_when='xyBoundsMode=="manual"'),
+                        Item('manualXYBounds', visible_when='xyBoundsMode=="manual"',editor=CSVListEditor(auto_set=False, enter_set=True)),
                         label='Output Image Size',
                     ),
                 ]

--- a/docs/cluster/clusterFilesystem.rst
+++ b/docs/cluster/clusterFilesystem.rst
@@ -170,9 +170,9 @@ a given directory on their host, it is possible to access the cluster data from 
 programming languages using standard HTTP requests. When accessing the data in this way,
 determining what files are in a given directory (the union of the directory listings of
 all the individual servers), and conversely which server to query for a particular file
-must be performed by the end user, as is any caching of this directory information. Files 
-may be added to the cluster using an HTTP `PUT` to one of the servers (deciding which is 
-again on the implementer). The HTTP servers which make up the cluster can be discovered
+must be performed by the implementation. Files 
+may be added to the cluster using an HTTP `PUT` to one of the servers (load distribution - ie 
+deciding which server to put to - is left to the implementer). The HTTP servers which make up the cluster can be discovered
 using the mDNS protocol and querying/browsing for the `_pyme-http._tcp.local.` service type.
 
 The following is a brief outline of accessing the cluster using command
@@ -243,10 +243,12 @@ line tools (note - you'll need to use an mDNS library and programatic HTTP fetch
     # ensure that data is approximately evenly distributed across nodes 
     >> curl -T /path/to/file.png http://0.0.0.0:55003/somefolder/newfile.png
 
-The above is mainly shown to reinforce the fact that the protocol is just HTTP.
+The command line example above is certainly not the easiest way to implement a client. It is 
+mainly shown to reinforce the fact that the protocol is just HTTP and is language agnostic.
 In practice, you would probably want to reimplement clusterIO in your language of
-choice. If performance is important, this reimplementation should includes
-caching on directory lookups and local pass-though/bypass.
+choice. If performance is important, this reimplementation should include
+caching on directory lookups and a "bypass" mechanism to access data stored on the local node
+without making a HTTP request.
 
 
 Read-only access using UnionFS


### PR DESCRIPTION
Fixes #1292, adds saner default for DensityMapping on multicolour datasets