### PR TITLE
Fixed size strings when saving to hdf tables

### DIFF
--- a/PYME/recipes/measurement.py
+++ b/PYME/recipes/measurement.py
@@ -869,7 +869,9 @@ class AddMetadataToMeasurements(ModuleBase):
                 v = img.mdh[mdk]
 
             if isinstance(v, str):
-                res[k] = np.array([v]*nEntries, dtype='U%d'%self.string_length)
+                # use bytes/cstring dtype (rather than U) so that 
+                # pytables doesn't bork on us
+                res[k] = np.array([v]*nEntries, dtype='S%d'%self.string_length)
             else:
                 res[k] = np.array([v]*nEntries)
         

--- a/PYME/recipes/measurement.py
+++ b/PYME/recipes/measurement.py
@@ -851,6 +851,7 @@ class AddMetadataToMeasurements(ModuleBase):
     keys = CStr('SampleNotes')
     metadataKeys = CStr('Sample.Notes')
     outputName = Output('annotatedMeasurements')
+    string_length = Int(128, desc='Ammount of storage (characters) to allocate for string values')
     
     def execute(self, namespace):
         res = {}
@@ -866,7 +867,11 @@ class AddMetadataToMeasurements(ModuleBase):
                 v = os.path.split(img.seriesName)[1]
             else:
                 v = img.mdh[mdk]
-            res[k] = np.array([v]*nEntries)
+
+            if isinstance(v, str):
+                res[k] = np.array([v]*nEntries, dtype='U%d'%self.string_length)
+            else:
+                res[k] = np.array([v]*nEntries)
         
         #res = pd.DataFrame(res)
         res = tabular.MappingFilter(res)


### PR DESCRIPTION
Use fixed size strings when saving metadata to table columns so that pytables type inference works when aggregating