### PR TITLE
Unified selection and annotation

### DIFF
--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -535,7 +535,7 @@ class PYMEMainFrame(AUIFrame):
         logging.debug('Stopping frame wrangler to set ROI')
         self.scope.frameWrangler.stop()
         
-        #print (self.scope.vp.selection_begin_x, self.scope.vp.selection_begin_y, self.scope.vp.selection_end_x, self.scope.vp.selection_end_y)
+        #print (self.scope.vp.selection.start.x, self.scope.vp.selection.start.y, self.scope.vp.selection.finish.x, self.scope.vp.selection.finish.y)
 
         if 'validROIS' in dir(self.scope.cam) and self.scope.cam.ROIsAreFixed():
             #special case for cameras with restricted ROIs - eg Neo
@@ -608,7 +608,7 @@ class PYMEMainFrame(AUIFrame):
     def SetCentredRoi(self, event=None, halfwidth=5):
         self.scope.frameWrangler.stop()
 
-        #print (self.scope.vp.selection_begin_x, self.scope.vp.selection_begin_y, self.scope.vp.selection_end_x, self.scope.vp.selection_end_y)
+        #print (self.scope.vp.selection.start.x, self.scope.vp.selection.start.y, self.scope.vp.selection.finish.x, self.scope.vp.selection.finish.y)
 
         w = self.scope.cam.GetCCDWidth()
         h = self.scope.cam.GetCCDHeight()

--- a/PYME/DSView/DisplayOptionsPanel.py
+++ b/PYME/DSView/DisplayOptionsPanel.py
@@ -41,6 +41,7 @@ from PYME import resources
 import numpy as np
 #from matplotlib import cm
 from PYME.ui import histLimits
+from PYME.ui import selection
 from .displayOptions import DisplayOpts #, fast_grey, labeled
 
 import os
@@ -406,7 +407,7 @@ class OptionsPanel(wx.Panel):
 
     def OnSelectObject(self, event):
         self.do.leftButtonAction = DisplayOpts.ACTION_SELECT_OBJECT
-        self.do.selectionMode = DisplayOpts.SELECTION_RECTANGLE
+        self.do.selection.mode = selection.SELECTION_RECTANGLE
         self.do.showSelection = False
 
         #self.Refresh()
@@ -414,7 +415,7 @@ class OptionsPanel(wx.Panel):
     
     def OnSelectCrosshairs(self, event):
         self.do.leftButtonAction = DisplayOpts.ACTION_POSITION
-        self.do.selectionMode = DisplayOpts.SELECTION_RECTANGLE
+        self.do.selection.mode = selection.SELECTION_RECTANGLE
         self.do.showSelection = False
 
         #self.Refresh()
@@ -422,7 +423,7 @@ class OptionsPanel(wx.Panel):
 
     def OnSelectRectangle(self, event):
         self.do.leftButtonAction = DisplayOpts.ACTION_SELECTION
-        self.do.selectionMode = DisplayOpts.SELECTION_RECTANGLE
+        self.do.selection.mode = selection.SELECTION_RECTANGLE
         self.do.showSelection = True
 
         #self.Refresh()
@@ -430,7 +431,7 @@ class OptionsPanel(wx.Panel):
 
     def OnSelectLine(self, event):
         self.do.leftButtonAction = DisplayOpts.ACTION_SELECTION
-        self.do.selectionMode = DisplayOpts.SELECTION_LINE
+        self.do.selection.mode = selection.SELECTION_LINE
         self.do.showSelection = True
 
         #self.Refresh()
@@ -438,7 +439,7 @@ class OptionsPanel(wx.Panel):
         
     def OnSelectSquiggle(self, event):
         self.do.leftButtonAction = DisplayOpts.ACTION_SELECTION
-        self.do.selectionMode = DisplayOpts.SELECTION_SQUIGGLE
+        self.do.selection.mode = selection.SELECTION_SQUIGGLE
         self.do.showSelection = True
 
         #self.Refresh()
@@ -460,10 +461,10 @@ class OptionsPanel(wx.Panel):
 
     def OnLineThickness(self, event):
         print('foo')
-        dlg = wx.TextEntryDialog(self, 'Line Thickness', 'Set width of line selection', '%d' % self.do.selectionWidth)
+        dlg = wx.TextEntryDialog(self, 'Line Thickness', 'Set width of line selection', '%d' % self.do.selection.width)
 
         if dlg.ShowModal() == wx.ID_OK:
-            self.do.selectionWidth = int(dlg.GetValue())
+            self.do.selection.width = int(dlg.GetValue())
 
         dlg.Destroy()
 

--- a/PYME/DSView/displayOptions.py
+++ b/PYME/DSView/displayOptions.py
@@ -60,7 +60,7 @@ class DisplayOpts(object):
     SLICE_XY, SLICE_XZ, SLICE_YZ = range(3)
 
     ACTION_POSITION, ACTION_SELECTION, ACTION_SELECT_OBJECT = range(3)
-    SELECTION_RECTANGLE, SELECTION_LINE, SELECTION_SQUIGGLE = range(3)
+    #SELECTION_RECTANGLE, SELECTION_LINE, SELECTION_SQUIGGLE = range(3)
 
     def __init__(self, datasource, xp=0, yp=0, zp=0, aspect=1):
         self.WantChangeNotification = []# MyWeakSet() #[]
@@ -99,9 +99,9 @@ class DisplayOpts(object):
         self.scale = 0
 
         self.leftButtonAction = self.ACTION_POSITION
-        self.selectionMode = self.SELECTION_RECTANGLE
+        self.selection.mode = selection.SELECTION_RECTANGLE
 
-        self.selectionWidth = 1
+        #self.selection.width = 1
 
         self.showSelection=False
 
@@ -186,56 +186,56 @@ class DisplayOpts(object):
         return [(self.Offs[chanNum] + 0.5/self.Gains[chanNum]) for chanNum in range(len(self.Offs))]
 
     def ResetSelection(self):
-        self.selection_begin_x = 0
-        self.selection_begin_y = 0
-        self.selection_begin_z = 0
+        self.selection.start = (0, 0, 0)
 
-        self.selection_end_x = self.ds.shape[0] - 1
-        self.selection_end_y = self.ds.shape[1] - 1
-        self.selection_end_z = self.ds.shape[2] - 1
+        self.selection.finish.x = self.ds.shape[0] - 1
+        self.selection.finish.y = self.ds.shape[1] - 1
+        self.selection.finish.z = self.ds.shape[2] - 1
         
-        self.selection_trace = []
+        self.selection.trace = []
 
     def SetSelection(self, begin, end):
-        (b_x, b_y, b_z) = begin
-        (e_x, e_y, e_z) = end
-        self.selection_begin_x = b_x
-        self.selection_begin_y = b_y
-        self.selection_begin_z = b_z
+        self.selection.start = begin
+        self.selection.finish = end
+        # (b_x, b_y, b_z) = begin
+        # (e_x, e_y, e_z) = end
+        # self.selection.start.x = b_x
+        # self.selection.start.y = b_y
+        # self.selection.start.z = b_z
 
-        self.selection_end_x = e_x
-        self.selection_end_y = e_y
-        self.selection_end_z = e_z
+        # self.selection.finish.x = e_x
+        # self.selection.finish.y = e_y
+        # self.selection.finish.z = e_z
         
-    @property
-    def selection(self):
-        return self.selection_begin_x, self.selection_end_x, self.selection_begin_y, self.selection_end_y, self.selection_begin_z, self.selection_end_z
+    #@property
+    #def selection(self):
+    #    return self.selection.start.x, self.selection.finish.x, self.selection.start.y, self.selection.finish.y, self.selection.start.z, self.selection.finish.z
     
     @property
     def sorted_selection(self):
-        return sorted([self.selection_begin_x, self.selection_end_x]) + \
-               sorted([self.selection_begin_y, self.selection_end_y]) + \
-               sorted([self.selection_begin_z, self.selection_end_z])
+        return sorted([self.selection.start.x, self.selection.finish.x]) + \
+               sorted([self.selection.start.y, self.selection.finish.y]) + \
+               sorted([self.selection.start.z, self.selection.finish.z])
         
     def EndSelection(self):
         self.on_selection_end.send(self)
 
     def GetSliceSelection(self):
         if(self.slice == self.SLICE_XY):
-            lx = self.selection_begin_x
-            ly = self.selection_begin_y
-            hx = self.selection_end_x
-            hy = self.selection_end_y
+            lx = self.selection.start.x
+            ly = self.selection.start.y
+            hx = self.selection.finish.x
+            hy = self.selection.finish.y
         elif(self.slice == self.SLICE_XZ):
-            lx = self.selection_begin_x
-            ly = self.selection_begin_z
-            hx = self.selection_end_x
-            hy = self.selection_end_z
+            lx = self.selection.start.x
+            ly = self.selection.start.z
+            hx = self.selection.finish.x
+            hy = self.selection.finish.z
         elif(self.slice == self.SLICE_YZ):
-            lx = self.selection_begin_y
-            ly = self.selection_begin_z
-            hx = self.selection_end_y
-            hy = self.selection_end_z
+            lx = self.selection.start.y
+            ly = self.selection.start.z
+            hx = self.selection.finish.y
+            hy = self.selection.finish.z
 
         return lx, ly, hx, hy
 

--- a/PYME/DSView/displayOptions.py
+++ b/PYME/DSView/displayOptions.py
@@ -28,6 +28,7 @@ import numpy as np
 
 from PYME.contrib import dispatch
 from PYME.IO import dataWrap
+from PYME.ui import selection
 
 import logging
 logger = logging.getLogger(__name__)
@@ -86,6 +87,8 @@ class DisplayOpts(object):
         
         self.inOnChange = False
         self.syncedWith = []
+
+        self.selection = selection.Selection(units=selection.UNITS_PIXELS)
 
         self.SetDataStack(datasource)
         self.SetAspect(aspect)

--- a/PYME/DSView/dsviewer.py
+++ b/PYME/DSView/dsviewer.py
@@ -331,10 +331,10 @@ class DSViewFrame(AUIFrame):
     def OnExport(self, event=None):
         from PYME.ui import crop_dialog
         from PYME.IO.DataSources.CropDataSource import crop_image
-        bx = min(self.do.selection_begin_x, self.do.selection_end_x)
-        ex = max(self.do.selection_begin_x, self.do.selection_end_x)
-        by = min(self.do.selection_begin_y, self.do.selection_end_y)
-        ey = max(self.do.selection_begin_y, self.do.selection_end_y)
+        bx = min(self.do.selection.start.x, self.do.selection.finish.x)
+        ex = max(self.do.selection.start.x, self.do.selection.finish.x)
+        by = min(self.do.selection.start.y, self.do.selection.finish.y)
+        ey = max(self.do.selection.start.y, self.do.selection.finish.y)
         
         roi = [[bx, ex + 1],[by, ey + 1],
                [0, self.image.data_xyztc.shape[2]],

--- a/PYME/DSView/dsviewer.py
+++ b/PYME/DSView/dsviewer.py
@@ -275,6 +275,10 @@ class DSViewFrame(AUIFrame):
             #if 'view' in dir(self):
             #    self.view.Refresh()
             statusText = 'z: (%d/%d)    x: %d    y: %d    t:(%d/%d)' % (self.do.zp, self.do.nz, self.do.xp, self.do.yp, self.do.tp, self.do.nt)
+            
+            #intensity at current cursor
+            statusText += '    I: (%s)' % ', '.join(['%3.3f' % self.do.ds[self.do.zp, self.do.xp, self.do.yp, self.do.tp, c] for c in range(self.do.ds.shape[4])]) 
+            
             #grab status from modules which supply it
             for sCallback in self.statusHooks:
                 statusText += '\t' + sCallback() #'Frames Analysed: %d    Events detected: %d' % (self.vp.do.zp, self.vp.do.ds.shape[2], self.vp.do.xp, self.vp.do.yp, self.LMAnalyser.numAnalysed, self.LMAnalyser.numEvents)

--- a/PYME/DSView/modules/annotation.py
+++ b/PYME/DSView/modules/annotation.py
@@ -6,6 +6,8 @@ import matplotlib.pyplot as plt
 import wx
 import wx.lib.agw.aui as aui
 
+from PYME.ui import selection
+
 from ._base import Plugin
 
 class _Snake_Settings(HasTraits):
@@ -163,8 +165,8 @@ class Annotater(Plugin):
         
     
     def add_curved_line(self, event=None):
-        if self.do.selectionMode == self.do.SELECTION_SQUIGGLE:
-            l = self.do.selection_trace
+        if self.do.selection.mode == selection.SELECTION_SQUIGGLE:
+            l = self.do.selection.trace
             if len(l) < 1:
                 print('Line must have at least 1 point')
                 return
@@ -174,9 +176,9 @@ class Annotater(Plugin):
             self._annotations.append({'type' : 'curve', 'points' : l,
                                       'labelID' : self.cur_label_index, 'z' : self.do.zp,
                                       'width' : self.line_width})
-            self.do.selection_trace = []
+            self.do.selection.trace = []
             
-        elif self.do.selectionMode == self.do.SELECTION_LINE:
+        elif self.do.selection.mode == selection.SELECTION_LINE:
             x0, y0, x1, y1 = self.do.GetSliceSelection()
             self._annotations.append({'type' : 'line', 'points' : [(x0, y0), (x1, y1)],
                                       'labelID' : self.cur_label_index, 'z':self.do.zp,
@@ -186,17 +188,17 @@ class Annotater(Plugin):
         self.dsviewer.Update()
 
     def add_filled_polygon(self, event=None):
-        if self.do.selectionMode == self.do.SELECTION_SQUIGGLE:
-            l = self.do.selection_trace
+        if self.do.selection.mode == selection.SELECTION_SQUIGGLE:
+            l = self.do.selection.trace
             if isinstance(l, np.ndarray):
                 l = l.tolist()
             self._annotations.append({'type': 'polygon', 'points': l,
                                       'labelID': self.cur_label_index, 'z': self.do.zp,
                                       'width': 1
                                       })
-            self.do.selection_trace = []
+            self.do.selection.trace = []
     
-        elif self.do.selectionMode == self.do.SELECTION_RECTANGLE:
+        elif self.do.selection.mode == selection.SELECTION_RECTANGLE:
             x0, y0, x1, y1 = self.do.GetSliceSelection()
             # TODO - make this a polygon instead?
             self._annotations.append({'type': 'rectangle', 'points': [(x0, y0), (x1, y1)],
@@ -231,7 +233,7 @@ class Annotater(Plugin):
             
     def snake_refine_trace(self, event=None, sender=None, **kwargs):
         print('Refining selection')
-        if self.lock_mode == 'None' or not self.do.selectionMode == self.do.SELECTION_SQUIGGLE:
+        if self.lock_mode == 'None' or not self.do.selection.mode == selection.SELECTION_SQUIGGLE:
             return
         else:
             try:
@@ -240,9 +242,9 @@ class Annotater(Plugin):
                 
                 im = ndimage.gaussian_filter(self.do.ds[:,:,self.do.zp].squeeze(), float(self._snake_settings.prefilter_sigma)).T
                 
-                pts = np.array(self.do.selection_trace)
+                pts = np.array(self.do.selection.trace)
                 
-                self.do.selection_trace = active_contour(im, pts,
+                self.do.selection.trace = active_contour(im, pts,
                                                          alpha=self._snake_settings.length_weight,
                                                          beta=self._snake_settings.smoothness,
                                                          w_line=self._snake_settings.line_weight,

--- a/PYME/DSView/modules/cropping.py
+++ b/PYME/DSView/modules/cropping.py
@@ -21,6 +21,7 @@
 ##################
 import wx
 from ._base import Plugin
+from PYME.ui import selection
 
 class Cropper(Plugin):
     def __init__(self, dsviewer):
@@ -36,7 +37,7 @@ class Cropper(Plugin):
         
         from PYME.DSView import ViewIm3D
 
-        if not (self.do.selectionMode == self.do.SELECTION_RECTANGLE):
+        if not (self.do.selection.mode == selection.SELECTION_RECTANGLE):
             wx.MessageBox('Cropping only supported for rectangular selections\n For non-rectangular masking see the `annotation` module', 'Error', wx.OK|wx.ICON_ERROR)
             return
 
@@ -81,7 +82,7 @@ class Cropper(Plugin):
             #print sigmas
             #print self.images[0].img.shape
 
-        x0, x1, y0, y1 = [self.do.selection_begin_x, self.do.selection_end_x, self.do.selection_begin_y, self.do.selection_end_y]
+        x0, x1, y0, y1 = [self.do.selection.start.x, self.do.selection.finish.x, self.do.selection.start.y, self.do.selection.finish.y]
         
         dx = x1 - x0
         dy = y1 - y0

--- a/PYME/DSView/modules/filtering.py
+++ b/PYME/DSView/modules/filtering.py
@@ -186,7 +186,7 @@ class Filterer(Plugin):
             #print sigmas
             #print self.images[0].img.shape
 
-        #roi = [[self.do.selection_begin_x, self.do.selection_end_x + 1],[self.do.selection_begin_y, self.do.selection_end_y +1], [0, self.image.data.shape[2]]]
+        #roi = [[self.do.selection.start.x, self.do.selection.finish.x + 1],[self.do.selection.start.y, self.do.selection.finish.y +1], [0, self.image.data.shape[2]]]
 
         #filt_ims = [np.atleast_3d(self.image.data[:,:,:,chanNum].squeeze() > self.dsviewer.do.Offs[chanNum]) for chanNum in range(self.image.data.shape[3])]
 

--- a/PYME/DSView/modules/profilePlotting.py
+++ b/PYME/DSView/modules/profilePlotting.py
@@ -27,6 +27,7 @@ import wx
 import matplotlib.pyplot as plt
 from scipy import ndimage
 import numpy as np
+from PYME.ui import selection
 
 from PYME.DSView.dsviewer import ViewIm3D, ImageStack
 
@@ -44,7 +45,7 @@ class ProfilePlotter(Plugin):
         
     
     def OnProfile(self, event=None):
-        if (self.do.selectionMode == self.do.SELECTION_SQUIGGLE):
+        if (self.do.selection.mode == selection.SELECTION_SQUIGGLE):
             self.OnPlotWavyProfile(event)
         else:
             self.OnPlotProfile(event)
@@ -54,7 +55,7 @@ class ProfilePlotter(Plugin):
         
         lx, ly, hx, hy = self.do.GetSliceSelection()
     
-        w = int(self.do.selectionWidth)
+        w = int(self.do.selection.width)
     
         try:
             names = self.image.mdh.getEntry('ChannelNames')
@@ -111,7 +112,7 @@ class ProfilePlotter(Plugin):
     def _OnPlotProfile(self, event=None):
         lx, ly, hx, hy = self.do.GetSliceSelection()
 
-        w = int(np.floor(0.5*self.do.selectionWidth))
+        w = int(np.floor(0.5*self.do.selection.width))
 
         try:
             names = self.image.mdh.getEntry('ChannelNames')
@@ -294,9 +295,9 @@ class ProfilePlotter(Plugin):
 
     def OnPlotWavyProfile(self, event=None):
         #lx, ly, hx, hy = self.do.GetSliceSelection()
-        pts = np.array(self.do.selection_trace)
+        pts = np.array(self.do.selection.trace)
 
-        w = int(np.floor(0.5 * self.do.selectionWidth))
+        w = int(np.floor(0.5 * self.do.selection.width))
 
         try:
             names = self.image.mdh.getEntry('ChannelNames')

--- a/PYME/LMVis/Extras/__init__.py
+++ b/PYME/LMVis/Extras/__init__.py
@@ -26,6 +26,7 @@ import glob
 import os
 
 from PYME import config
+from PYME.DSView.modules import _load_mod
 
 import logging
 
@@ -34,17 +35,20 @@ logger = logging.getLogger(__name__)
 mods = list(set([os.path.splitext(os.path.split(p)[-1])[0] for p in glob.glob(__path__[0] + '/[a-zA-Z]*.py') + glob.glob(__path__[0] + '/[a-zA-Z]*.pyc')]))
 mods.sort()
 
+
 def InitPlugins(visFr):
     for mn in mods:
         #print mods
         logger.debug('Initializing %s plugin' % mn)
         m = __import__('PYME.LMVis.Extras.' + mn, fromlist=['PYME', 'LMVis', 'Extras'])
-        m.Plug(visFr)
+        #m.Plug(visFr)
+        _load_mod(m, mn, visFr)
 
     for mn in config.get_plugins('visgui'):
         try:
             m = __import__(mn, fromlist=mn.split('.')[:-1])
-            m.Plug(visFr)
+            #m.Plug(visFr)
+            _load_mod(m, mn, visFr)
         except Exception as e:
             #import traceback
             #traceback.print_exc()

--- a/PYME/LMVis/Extras/annotation.py
+++ b/PYME/LMVis/Extras/annotation.py
@@ -1,0 +1,38 @@
+from PYME.DSView.modules import annotation as ann
+from PYME.LMVis.layers.OverlayLayer import OverlayLayer
+
+class AnnotationOverlayLayer(OverlayLayer):
+
+    """
+    This OverlayLayer creates the lines of a box.
+    The dimensions of the box are determined by the selection_settings
+    """
+    def __init__(self, annotator, **kwargs):
+        super(AnnotationOverlayLayer, self).__init__([0, 0], **kwargs)
+        self._annotator = annotator
+
+    def render(self, gl_canvas):
+        """
+
+        Parameters
+        ----------
+        gl_canvas
+            zc is used to set the z value of the Overlay
+        Returns
+        -------
+
+        """
+        if not self.visible:
+            return
+        
+        self._clear_shader_clipping(gl_canvas)
+        with self.get_shader_program(gl_canvas):
+            self._annotator.render(gl_canvas)
+
+class Annotator(ann.AnnotateBase):
+    def __init__(self, vis_fr):
+        ann.AnnotateBase.__init__(self, vis_fr, vis_fr.glCanvas.selectionSettings, minimize=True)
+        vis_fr.glCanvas.overlays.append(AnnotationOverlayLayer(self))
+
+def Plug(vis_fr):
+    return Annotator(vis_fr)

--- a/PYME/LMVis/gl_render3D_shaders.py
+++ b/PYME/LMVis/gl_render3D_shaders.py
@@ -789,6 +789,8 @@ class LMGLShaderCanvas(GLCanvas):
 
             self.selectionSettings.start = (xp, yp, None)
             self.selectionSettings.finish = (xp, yp, None)
+            self.selectionSettings.trace.clear()
+            self.selectionSettings.trace.append((xp, yp))
 
         event.Skip()
 
@@ -799,6 +801,7 @@ class LMGLShaderCanvas(GLCanvas):
             xp, yp = self._ScreenCoordinatesToNm(event.GetX(), event.GetY())
 
             self.selectionSettings.finish = (xp, yp, None)
+            self.selectionSettings.trace.append((xp, yp))
             self.selectionDragging = False
 
             self.Refresh()
@@ -832,6 +835,7 @@ class LMGLShaderCanvas(GLCanvas):
         if self.selectionDragging:
             sx, sy = self._ScreenCoordinatesToNm(x, y)
             self.selectionSettings.finish = (sx, sy, None)
+            self.selectionSettings.trace.append((sx, sy))
             self.Refresh()
             event.Skip()
 

--- a/PYME/LMVis/gl_render3D_shaders.py
+++ b/PYME/LMVis/gl_render3D_shaders.py
@@ -74,12 +74,11 @@ name = 'ball_glut'
 
 from . import views
 from PYME.contrib import dispatch
+from PYME.ui import selection
 
-
-class SelectionSettings(object):
+class SelectionSettings(selection.Selection):
     def __init__(self):
-        self.start = (0, 0)
-        self.finish = (0, 0)
+        selection.Selection.__init__(self)
         self.colour = [1, 1, 0]
         self.show = False
 
@@ -788,8 +787,8 @@ class LMGLShaderCanvas(GLCanvas):
             self.selectionDragging = True
             self.selectionSettings.show = True
 
-            self.selectionSettings.start = (xp, yp)
-            self.selectionSettings.finish = (xp, yp)
+            self.selectionSettings.start = (xp, yp, None)
+            self.selectionSettings.finish = (xp, yp, None)
 
         event.Skip()
 
@@ -799,7 +798,7 @@ class LMGLShaderCanvas(GLCanvas):
         if self.selectionDragging:
             xp, yp = self._ScreenCoordinatesToNm(event.GetX(), event.GetY())
 
-            self.selectionSettings.finish = (xp, yp)
+            self.selectionSettings.finish = (xp, yp, None)
             self.selectionDragging = False
 
             self.Refresh()
@@ -831,7 +830,8 @@ class LMGLShaderCanvas(GLCanvas):
         y = event.GetY()
 
         if self.selectionDragging:
-            self.selectionSettings.finish = self._ScreenCoordinatesToNm(x, y)
+            sx, sy = self._ScreenCoordinatesToNm(x, y)
+            self.selectionSettings.finish = (sx, sy, None)
             self.Refresh()
             event.Skip()
 

--- a/PYME/LMVis/imageView.py
+++ b/PYME/LMVis/imageView.py
@@ -33,6 +33,7 @@ import scipy.misc
 #import subprocess
 
 from PYME.ui import wx_compat
+from PYME.ui import selection
 
 #from PYME.Analysis import thresholding
 
@@ -153,22 +154,22 @@ class ImageViewPanel(wx.Panel):
             hx, hy = self._PixelToScreenCoordinates(hx, hy)
 
 
-            if self.do.selectionMode == DisplayOpts.SELECTION_RECTANGLE:
+            if self.do.selection.mode == selection.SELECTION_RECTANGLE:
                 dc.DrawRectangle(lx,ly, (hx-lx),(hy-ly))
                 
-            elif self.do.selectionMode == DisplayOpts.SELECTION_SQUIGGLE:
-                if len(self.do.selection_trace) > 2:
-                    x, y = numpy.array(self.do.selection_trace).T
+            elif self.do.selection.mode == selection.SELECTION_SQUIGGLE:
+                if len(self.do.selection.trace) > 2:
+                    x, y = numpy.array(self.do.selection.trace).T
                     pts = numpy.vstack(self._PixelToScreenCoordinates(x, y)).T
                     print((pts.shape))
                     dc.DrawSpline(pts)
-            elif self.do.selectionWidth == 1:
+            elif self.do.selection.width == 1:
                 dc.DrawLine(lx,ly, hx,hy)
             else:
                 dx = hx - lx
                 dy = hy - ly
 
-                w = self.do.selectionWidth*sc
+                w = self.do.selection.width*sc
 
                 if dx == 0 and dy == 0: #special case - profile is orthogonal to current plane
                     d_x = 0.5*w
@@ -296,11 +297,11 @@ class ImageViewPanel(wx.Panel):
 
         xp, yp = self._ScreenToPixelCoordinates(event.GetX(), event.GetY())
         
-        self.do.selection_begin_x = int(xp)
-        self.do.selection_begin_y = int(yp)
+        self.do.selection.start.x = int(xp)
+        self.do.selection.start.y = int(yp)
         
-        self.do.selection_trace = []
-        self.do.selection_trace.append((xp, yp))
+        self.do.selection.trace = []
+        self.do.selection.trace.append((xp, yp))
 
     def OnMotion(self, event):
         if event.Dragging() and self.selecting:
@@ -323,24 +324,24 @@ class ImageViewPanel(wx.Panel):
         xp, yp = self._ScreenToPixelCoordinates(event.GetX(), event.GetY())
 
         if not event.ShiftDown():
-            self.do.selection_end_x = int(xp)
-            self.do.selection_end_y = int(yp)
+            self.do.selection.finish.x = int(xp)
+            self.do.selection.finish.y = int(yp)
             
         else: #lock
-            self.do.selection_end_x = int(xp)
-            self.do.selection_end_y = int(yp)
+            self.do.selection.finish.x = int(xp)
+            self.do.selection.finish.y = int(yp)
 
-            dx = abs(self.do.selection_end_x - self.do.selection_begin_x)
-            dy = abs(self.do.selection_end_y - self.do.selection_begin_y)
+            dx = abs(self.do.selection.finish.x - self.do.selection.start.x)
+            dy = abs(self.do.selection.finish.y - self.do.selection.start.y)
 
             if dx > 1.5*dy: #horizontal
-                self.do.selection_end_y = self.do.selection_begin_y
+                self.do.selection.finish.y = self.do.selection.start.y
             elif dy > 1.5*dx: #vertical
-                self.do.selection_end_x = self.do.selection_begin_x
+                self.do.selection.finish.x = self.do.selection.start.x
             else: #diagonal
-                self.do.selection_end_y = self.do.selection_begin_y + dx*numpy.sign(self.do.selection_end_y - self.do.selection_begin_y)
+                self.do.selection.finish.y = self.do.selection.start.y + dx*numpy.sign(self.do.selection.finish.y - self.do.selection.start.y)
                 
-        self.do.selection_trace.append((xp, yp))
+        self.do.selection.trace.append((xp, yp))
 
         self.Refresh()
         self.Update()

--- a/PYME/LMVis/imageView2.py
+++ b/PYME/LMVis/imageView2.py
@@ -25,6 +25,7 @@ import numpy
 
 import wx
 from PYME.ui import wx_compat
+from PYME.ui import selection
 
 # import scipy.misc
 import scipy.ndimage
@@ -83,22 +84,22 @@ class ImageViewPanel(wx.Panel):
             hx, hy = self._PixelToScreenCoordinates(hx, hy)
 
 
-            if self.do.selectionMode == DisplayOpts.SELECTION_RECTANGLE:
+            if self.do.selection.mode == selection.SELECTION_RECTANGLE:
                 dc.DrawRectangle(lx,ly, (hx-lx),(hy-ly))
                 
-            elif self.do.selectionMode == DisplayOpts.SELECTION_SQUIGGLE:
-                if len(self.do.selection_trace) > 2:
-                    x, y = numpy.array(self.do.selection_trace).T
+            elif self.do.selection.mode == selection.SELECTION_SQUIGGLE:
+                if len(self.do.selection.trace) > 2:
+                    x, y = numpy.array(self.do.selection.trace).T
                     pts = numpy.vstack(self._PixelToScreenCoordinates(x, y)).T
                     print((pts.shape))
                     dc.DrawSpline(pts)
-            elif self.do.selectionWidth == 1:
+            elif self.do.selection.width == 1:
                 dc.DrawLine(lx,ly, hx,hy)
             else:
                 dx = hx - lx
                 dy = hy - ly
 
-                w = self.do.selectionWidth*sc
+                w = self.do.selection.width*sc
 
                 if dx == 0 and dy == 0: #special case - profile is orthogonal to current plane
                     d_x = 0.5*w
@@ -221,11 +222,11 @@ class ImageViewPanel(wx.Panel):
 
         xp, yp = self._ScreenToPixelCoordinates(event.GetX(), event.GetY())
         
-        self.do.selection_begin_x = int(xp)
-        self.do.selection_begin_y = int(yp)
+        self.do.selection.start.x = int(xp)
+        self.do.selection.start.y = int(yp)
         
-        self.do.selection_trace = []
-        self.do.selection_trace.append((xp, yp))
+        self.do.selection.trace = []
+        self.do.selection.trace.append((xp, yp))
 
     def OnMotion(self, event):
         if event.Dragging() and self.selecting:
@@ -246,24 +247,24 @@ class ImageViewPanel(wx.Panel):
         xp, yp = self._ScreenToPixelCoordinates(event.GetX(), event.GetY())
 
         if not event.ShiftDown():
-            self.do.selection_end_x = int(xp)
-            self.do.selection_end_y = int(yp)
+            self.do.selection.finish.x = int(xp)
+            self.do.selection.finish.y = int(yp)
             
         else: #lock
-            self.do.selection_end_x = int(xp)
-            self.do.selection_end_y = int(yp)
+            self.do.selection.finish.x = int(xp)
+            self.do.selection.finish.y = int(yp)
 
-            dx = abs(self.do.selection_end_x - self.do.selection_begin_x)
-            dy = abs(self.do.selection_end_y - self.do.selection_begin_y)
+            dx = abs(self.do.selection.finish.x - self.do.selection.start.x)
+            dy = abs(self.do.selection.finish.y - self.do.selection.start.y)
 
             if dx > 1.5*dy: #horizontal
-                self.do.selection_end_y = self.do.selection_begin_y
+                self.do.selection.finish.y = self.do.selection.start.y
             elif dy > 1.5*dx: #vertical
-                self.do.selection_end_x = self.do.selection_begin_x
+                self.do.selection.finish.x = self.do.selection.start.x
             else: #diagonal
-                self.do.selection_end_y = self.do.selection_begin_y + dx*numpy.sign(self.do.selection_end_y - self.do.selection_begin_y)
+                self.do.selection.finish.y = self.do.selection.start.y + dx*numpy.sign(self.do.selection.finish.y - self.do.selection.start.y)
                 
-        self.do.selection_trace.append((xp, yp))
+        self.do.selection.trace.append((xp, yp))
 
         self.Refresh()
         self.Update()

--- a/PYME/LMVis/layers/SelectionOverlayLayer.py
+++ b/PYME/LMVis/layers/SelectionOverlayLayer.py
@@ -20,7 +20,8 @@
 #
 from PYME.LMVis.layers.OverlayLayer import OverlayLayer
 from OpenGL.GL import *
-
+from PYME.ui import selection
+import numpy as np
 
 class SelectionOverlayLayer(OverlayLayer):
 
@@ -50,15 +51,51 @@ class SelectionOverlayLayer(OverlayLayer):
         with self.get_shader_program(gl_canvas):
             if self._selection_settings.show:
                 glDisable(GL_LIGHTING)
-                x0, y0, _ = self._selection_settings.start
-                x1, y1, _ = self._selection_settings.finish
+                if self._selection_settings.mode == selection.SELECTION_RECTANGLE: 
+                    x0, y0, _ = self._selection_settings.start
+                    x1, y1, _ = self._selection_settings.finish
 
-                zc = gl_canvas.view.translation[2]
+                    zc = gl_canvas.view.translation[2]
 
-                glColor3fv(self._selection_settings.colour)
-                glBegin(GL_LINE_LOOP)
-                glVertex3f(x0, y0, zc)
-                glVertex3f(x1, y0, zc)
-                glVertex3f(x1, y1, zc)
-                glVertex3f(x0, y1, zc)
-                glEnd()
+                    glLineWidth(1)
+                    glColor3fv(self._selection_settings.colour)
+                    glBegin(GL_LINE_LOOP)
+                    glVertex3f(x0, y0, zc)
+                    glVertex3f(x1, y0, zc)
+                    glVertex3f(x1, y1, zc)
+                    glVertex3f(x0, y1, zc)
+                    glEnd()
+
+                elif self._selection_settings.mode == selection.SELECTION_LINE:
+                    x0, y0, _ = self._selection_settings.start
+                    x1, y1, _ = self._selection_settings.finish
+
+                    zc = gl_canvas.view.translation[2]
+
+                    glLineWidth(self._selection_settings.width)
+                    glColor3fv(self._selection_settings.colour)
+                    glBegin(GL_LINES)
+                    glVertex3f(x0, y0, zc)
+                    glVertex3f(x1, y1, zc)
+                    glEnd()
+
+                elif self._selection_settings.mode == selection.SELECTION_SQUIGGLE:
+                    x, y = np.array(self._selection_settings.trace).T
+                    z = np.ones_like(x)*gl_canvas.view.translation[2]
+
+                    vertices = np.vstack((x.ravel(), y.ravel(), z.ravel()))
+                    vertices = vertices.T.ravel().reshape(len(x.ravel()), 3)
+                    normals = -0.69 * np.ones(vertices.shape)
+                    c = np.ones(len(x))[:,None]*np.hstack([self._selection_settings.colour, 1.0])[None,:]
+                    
+                    glDisable(GL_LIGHTING)
+                    glPolygonMode(GL_FRONT_AND_BACK, GL_LINE)
+                    glDisable(GL_DEPTH_TEST)
+                    glLineWidth(self._selection_settings.width)
+                    #glColor3fv(self._selection_settings.colour)
+
+                    glVertexPointerf(vertices)
+                    glNormalPointerf(normals)
+                    glColorPointerf(c)
+                    glDrawArrays(GL_LINE_STRIP, 0, len(x))
+

--- a/PYME/LMVis/layers/SelectionOverlayLayer.py
+++ b/PYME/LMVis/layers/SelectionOverlayLayer.py
@@ -50,8 +50,8 @@ class SelectionOverlayLayer(OverlayLayer):
         with self.get_shader_program(gl_canvas):
             if self._selection_settings.show:
                 glDisable(GL_LIGHTING)
-                x0, y0 = self._selection_settings.start
-                x1, y1 = self._selection_settings.finish
+                x0, y0, _ = self._selection_settings.start
+                x1, y1, _ = self._selection_settings.finish
 
                 zc = gl_canvas.view.translation[2]
 

--- a/PYME/LMVis/layers/SelectionOverlayLayer.py
+++ b/PYME/LMVis/layers/SelectionOverlayLayer.py
@@ -80,6 +80,9 @@ class SelectionOverlayLayer(OverlayLayer):
                     glEnd()
 
                 elif self._selection_settings.mode == selection.SELECTION_SQUIGGLE:
+                    if len(self._selection_settings.trace) == 0:
+                        return
+                        
                     x, y = np.array(self._selection_settings.trace).T
                     z = np.ones_like(x)*gl_canvas.view.translation[2]
 

--- a/PYME/recipes/measurement.py
+++ b/PYME/recipes/measurement.py
@@ -869,7 +869,9 @@ class AddMetadataToMeasurements(ModuleBase):
                 v = img.mdh[mdk]
 
             if isinstance(v, str):
-                res[k] = np.array([v]*nEntries, dtype='U%d'%self.string_length)
+                # use bytes/cstring dtype (rather than U) so that 
+                # pytables doesn't bork on us
+                res[k] = np.array([v]*nEntries, dtype='S%d'%self.string_length)
             else:
                 res[k] = np.array([v]*nEntries)
         

--- a/PYME/recipes/measurement.py
+++ b/PYME/recipes/measurement.py
@@ -851,6 +851,7 @@ class AddMetadataToMeasurements(ModuleBase):
     keys = CStr('SampleNotes')
     metadataKeys = CStr('Sample.Notes')
     outputName = Output('annotatedMeasurements')
+    string_length = Int(128, desc='Ammount of storage (characters) to allocate for string values')
     
     def execute(self, namespace):
         res = {}
@@ -866,7 +867,11 @@ class AddMetadataToMeasurements(ModuleBase):
                 v = os.path.split(img.seriesName)[1]
             else:
                 v = img.mdh[mdk]
-            res[k] = np.array([v]*nEntries)
+
+            if isinstance(v, str):
+                res[k] = np.array([v]*nEntries, dtype='U%d'%self.string_length)
+            else:
+                res[k] = np.array([v]*nEntries)
         
         #res = pd.DataFrame(res)
         res = tabular.MappingFilter(res)

--- a/PYME/ui/filterPane.py
+++ b/PYME/ui/filterPane.py
@@ -319,8 +319,8 @@ class FilterPane(afp.foldingPane):
                 x1, y1 = self.visFr.glCanvas.selectionFinish
             except AttributeError:
                 #new glcanvas
-                x0, y0 = self.visFr.glCanvas.selectionSettings.start
-                x1, y1 = self.visFr.glCanvas.selectionSettings.finish
+                x0, y0, _ = self.visFr.glCanvas.selectionSettings.start
+                x1, y1, _ = self.visFr.glCanvas.selectionSettings.finish
 
             if not 'x' in self.filterKeys.keys():
                 indx = self.pFilter.lFiltKeys.InsertItem(UI_MAXSIZE, 'x')

--- a/PYME/ui/selection.py
+++ b/PYME/ui/selection.py
@@ -1,0 +1,71 @@
+"""
+Common selection settings interface for PYMEVis/PYMEImage
+
+"""
+import logging
+logger = logging.getLogger(__name__)
+
+class Point(list):
+    def __init__(self, x, y, z=None):
+        list.__init__(self, [x,y,z])
+
+    @property
+    def x(self):
+        return self[0]
+
+    @x.setter
+    def x(self, value):
+        self[0] = value
+
+    @property
+    def y(self):
+        return self[1]
+
+    @y.setter
+    def y(self, value):
+        self[1] = value
+
+    @property
+    def z(self):
+        return self[2]
+
+    @z.setter
+    def z(self, value):
+        self[2] = value
+
+SELECTION_RECTANGLE, SELECTION_LINE, SELECTION_SQUIGGLE = range(3)
+UNITS_NM, UNITS_PIXELS = range(2)
+
+class Selection(object):
+    def __init__(self, units=UNITS_NM):
+        self._start = Point(0, 0, 0)
+        self._finish = Point(0, 0, 0)
+
+        self.width = 1
+        self.trace = [] # path taken whilst making the selection
+
+        self.mode = SELECTION_RECTANGLE
+
+        if units == UNITS_PIXELS:
+            logger.warning('Using units=UNITS_PIXELS')
+            
+        self.units = units
+
+        #self.colour = [1, 1, 0]
+        #self.show = False
+
+    @property
+    def start(self):
+        return self._start
+
+    @start.setter
+    def start(self, value):
+        self._start = Point(*value) 
+
+    @property
+    def finish(self):
+        return self._finish
+
+    @finish.setter
+    def finish(self, value):
+        self._finish = Point(*value) 


### PR DESCRIPTION
Still very much work in process, but preliminary steps to moving PYMEVis and PYMEImage to a unified selection (and annotation) mechanism. Motivated by a need to perform annotation on pointclouds, but also goes some way to addressing #252 and #226 (and potentially a more recent request for non-rectangular roi selection in PYMEVis which eludes me).