### PR TITLE
PYMEImage histogram bounds: use all pixels to calculate, add choice-box for method

### DIFF
--- a/PYME/DSView/DisplayOptionsPanel.py
+++ b/PYME/DSView/DisplayOptionsPanel.py
@@ -144,6 +144,11 @@ class OptionsPanel(wx.Panel):
 
         self.bOptimise = wx.Button(pan_opt, -1, "Stretch", style=wx.BU_EXACTFIT)
 
+        self.cb_stretch_method = wx.Choice(pan_opt, -1, choices=["min-99th", "min-max"])
+        self._stretch_settings = ['percentile', 'min-max']  # translate to displayOptions terms
+        self.cb_stretch_method.SetSelection(0)
+        self.cb_stretch_method.Bind(wx.EVT_CHOICE, self.OnStretchMethodChanged)
+
         self.cbScale = wx.Choice(pan_opt, -1, choices=["1:16", "1:8", "1:4", "1:2", "1:1", "2:1", "4:1", "8:1", "16:1"])
         self.cbScale.SetSelection(4)
         self.scale_11 = 4
@@ -153,6 +158,7 @@ class OptionsPanel(wx.Panel):
             
             hsizer = wx.BoxSizer(wx.HORIZONTAL)
             hsizer.Add(self.bOptimise, 0, wx.ALL|wx.ALIGN_CENTER, 5)
+            hsizer.Add(self.cb_stretch_method, 0, wx.ALL|wx.EXPAND, 5)
             hsizer.Add(self.cbScale, 0, wx.ALL|wx.ALIGN_CENTER, 5)
             
             pan_opt.SetSizerAndFit(hsizer)
@@ -161,7 +167,10 @@ class OptionsPanel(wx.Panel):
 
         else:
             pvsizer = wx.BoxSizer(wx.VERTICAL)
-            pvsizer.Add(self.bOptimise, 0, wx.LEFT|wx.RIGHT|wx.TOP|wx.EXPAND, 5)
+            hsizer = wx.BoxSizer(wx.HORIZONTAL)
+            hsizer.Add(self.cb_stretch_method, 0, wx.ALL|wx.EXPAND, 5)
+            hsizer.Add(self.bOptimise, 0, wx.ALL|wx.EXPAND, 5)
+            pvsizer.Add(hsizer, 0, wx.ALL|wx.EXPAND, 0)
 
             hsizer = wx.BoxSizer(wx.HORIZONTAL)
 
@@ -259,9 +268,15 @@ class OptionsPanel(wx.Panel):
         #def OnSize(self, evt):
         #_w, _h = self.GetVirtualSize()
         #self.SetVirtualSize(-1, _h)
+    
+    def OnStretchMethodChanged(self, wx_event):
+        """
+        Call optimize with the new stretch setting
+        """
+        self.OnOptimise(wx_event)
 
     def OnOptimise(self, event):
-        self.do.Optimise()
+        self.do.Optimise(bounds_method=self._stretch_settings[self.cb_stretch_method.GetSelection()])
         self.RefreshHists()
 
     #constants for slice selection

--- a/PYME/DSView/displayOptions.py
+++ b/PYME/DSView/displayOptions.py
@@ -416,15 +416,12 @@ class DisplayOpts(object):
                 else:
                     c = np.abs(c)
                     
-            if c.size > 1e4:
-                c = c[::int(np.floor(c.size/1e4))]
-            
             chan_d.append(c)
             
         return chan_d
 
-    def Optimise(self):
-        bds = [self._optimal_display_range(c) for c in self.get_hist_data()]
+    def Optimise(self, bounds_method='percentile'):
+        bds = [self._optimal_display_range(c, bounds_method) for c in self.get_hist_data()]
         
         for i, bd in enumerate(bds):
             low, high = bd


### PR DESCRIPTION
Addresses issue @d-perez-1 appreciates PYMEAcquire histogram tweaks #1270 / #1271 but then opens data in PYMEImage and is frustrated again. Speed should be even less of an issue here, when the data is already acquired.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- use all pixels to calculate histogram bounds (currently using a subset if we have 256 x 256 or larger image)
- allow users to see what 'stretch' button does, and to toggle mode with a choice box

![image](https://user-images.githubusercontent.com/31105780/203136568-f4204770-bf4c-4399-b99c-2cec1c5e1c7d.png)

![image](https://user-images.githubusercontent.com/31105780/203136617-ce573c7a-742d-4e65-9cf3-6b6c47df1344.png)






**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [x] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
