### PR TITLE
Scaling tweaks (alt to #1314)

### DIFF
--- a/PYME/DSView/DisplayOptionsPanel.py
+++ b/PYME/DSView/DisplayOptionsPanel.py
@@ -143,6 +143,7 @@ class OptionsPanel(wx.Panel):
             pan_opt = wx.Panel(fpan_opt, -1)
 
         self.bOptimise = wx.Button(pan_opt, -1, "Stretch", style=wx.BU_EXACTFIT)
+        self.bOptimise.SetToolTip('Rescale image (min->99th percentile). Shift-click for more options')
 
         self.cbScale = wx.Choice(pan_opt, -1, choices=["1:16", "1:8", "1:4", "1:2", "1:1", "2:1", "4:1", "8:1", "16:1"])
         self.cbScale.SetSelection(4)
@@ -261,7 +262,27 @@ class OptionsPanel(wx.Panel):
         #self.SetVirtualSize(-1, _h)
 
     def OnOptimise(self, event):
-        self.do.Optimise()
+        if wx.GetKeyState(wx.WXK_SHIFT):
+            if not hasattr(self, '_optim_minmax_id'):
+                #self._popupid = wx.NewId()
+                self._optim_percentile_id = wx.NewId()
+                self._optim_minmax_id = wx.NewId()
+
+                self.Bind(wx.EVT_MENU, lambda e: self._optimise('percentile'), id=self._optim_percentile_id)
+                self.Bind(wx.EVT_MENU, lambda e: self._optimise('min-max'), id=self._optim_minmax_id)
+
+            menu = wx.Menu()
+            menu.Append(self._optim_percentile_id, 'Percentile (0->99th)')
+            menu.Append(self._optim_minmax_id, 'Min->max')
+
+            self.PopupMenu(menu)
+            menu.Destroy()
+        else:
+            self._optimise()
+
+        
+    def _optimise(self, method='percentile'):
+        self.do.Optimise(method=method)
         self.RefreshHists()
 
     #constants for slice selection

--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -562,7 +562,10 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
                 self.imagepanel.Refresh()
         elif event.GetKeyCode() == 77: #M
             #print 'o'
-            self.do.Optimise()
+            self.do.Optimise(method='min-max')
+        elif event.GetKeyCode() == ord('P'): #M
+            #print 'p'
+            self.do.Optimise(method='percentile')
         elif event.GetKeyCode() == ord('C'):
             if event.GetModifiers() == wx.MOD_CMD:
                 self.CopyImage()

--- a/PYME/DSView/displayOptions.py
+++ b/PYME/DSView/displayOptions.py
@@ -365,6 +365,8 @@ class DisplayOpts(object):
             return d.min(), d.max()
         elif method == 'percentile':
             return d.min(), np.percentile(d, 99.)
+        else:
+            raise NotImplementedError('Scaling method "%s" not understood' % method)
         
     def get_hist_data(self, subsample_threshold=1e4):
         """

--- a/PYME/DSView/displayOptions.py
+++ b/PYME/DSView/displayOptions.py
@@ -366,9 +366,19 @@ class DisplayOpts(object):
         elif method == 'percentile':
             return d.min(), np.percentile(d, 99.)
         
-    def get_hist_data(self):
+    def get_hist_data(self, subsample_threshold=1e4):
         """
         Get data to display in an image histogram. Only returns a subset of the data for large images
+
+        Parameters
+        ----------
+
+        subsample_threshold: int/float, default=10000
+            Number of pixels above which to subsample when calculating histogrammes. The default value of 10,000
+            is enough to give a visually accurate histogram representation whilst ensuring that the time to compute 
+            the histogram (and by extension display latency) remains reasonable. When using get_hist_data for other 
+            purposes (e.g. data scaling) it might be prudent to increase this, especially if wanting to capture minima
+            and maxima on signals which are very sparse.  
         
         Returns
         -------
@@ -423,8 +433,12 @@ class DisplayOpts(object):
             
         return chan_d
 
-    def Optimise(self):
-        bds = [self._optimal_display_range(c) for c in self.get_hist_data()]
+    def Optimise(self, method='percentile'):
+        # Increase the subsample_threshold in Optimise as this will usually be called in response to a mouse click
+        # and Latency can be 1-2s rather than < 100ms for histogram display.
+        #print('do.Optimise()')
+
+        bds = [self._optimal_display_range(c, method=method) for c in self.get_hist_data(subsample_threshold=5e8)]
         
         for i, bd in enumerate(bds):
             low, high = bd

--- a/PYME/DSView/displayOptions.py
+++ b/PYME/DSView/displayOptions.py
@@ -428,8 +428,8 @@ class DisplayOpts(object):
                 else:
                     c = np.abs(c)
                     
-            if c.size > 1e4:
-                c = c[::int(np.floor(c.size/1e4))]
+            if c.size > subsample_threshold:
+                c = c[::int(np.floor(c.size/subsample_threshold))]
             
             chan_d.append(c)
             


### PR DESCRIPTION
Should largely achieve goals of #1314, but reimplemented as easier than rolling back changes which would have lead to unreasonable latency on histogram updates. Now uses all pixels for images < 5Mp when clicking `Stretch`, but still subsamples on histogram calculation. Different scaling methods are accessed by Shift-clicking the `Stretch` button. Have added a tooltip on the button to say what it does and how to access different modes.

Potential TODOs:
- Faster minmax (using c-coded version from PYMEAcquire?
- Improved discoverability for shift-clicking
-  ~~Make keyboard shortcuts consistent between image and histogram viewer (currently hitting 'm' in image viewer does a percentile scale, whereas it's min-max in the histogram viewer)~~