### PR TITLE
meshing tweaks

### DIFF
--- a/PYME/LMVis/layers/mesh.py
+++ b/PYME/LMVis/layers/mesh.py
@@ -206,6 +206,7 @@ class TriangleRenderLayer(EngineLayer):
     def _get_cdata(self):
         try:
             cdata = self.datasource[self.vertexColour]
+            cdata = cdata[self.datasource._vertices['halfedge']!= -1]
         except (KeyError, TypeError):
             cdata = np.array([0, 1])
 

--- a/PYME/LMVis/layers/quiver.py
+++ b/PYME/LMVis/layers/quiver.py
@@ -187,9 +187,10 @@ class QuiverRenderLayer(EngineLayer):
         #t = ds.vertices[ds.faces]
         #n = ds.vertex_normals[ds.faces]
         
-        x, y, z = ds.vertices.reshape(-1, 3).T
+        valid = ds._vertices['halfedge'] != -1
+        x, y, z = ds.vertices.reshape(-1, 3)[valid, :].T
 
-        vec_data = getattr(ds, self.vector_property).reshape(-1, 3).T
+        vec_data = getattr(ds, self.vector_property).reshape(-1, 3)[valid,:].T
         xv, yv, zv = vec_data
         
         #if self.normal_mode == 'Per vertex':

--- a/PYME/recipes/surface_fitting.py
+++ b/PYME/recipes/surface_fitting.py
@@ -140,8 +140,8 @@ class DualMarchingCubes(ModuleBase):
     
     smooth_curvature = Bool(True)  # TODO: This is actually a mesh property, so it can be toggled outside of the recipe.
     repair = Bool(False)
-    remesh = Bool(False)
-    cull_inner_surfaces = Bool(False)
+    remesh = Bool(True)
+    cull_inner_surfaces = Bool(True)
     
     def execute(self, namespace):
         #from PYME.experimental import dual_marching_cubes_v2 as dual_marching_cubes

--- a/PYME/ui/histLimits.py
+++ b/PYME/ui/histLimits.py
@@ -44,11 +44,18 @@ class HistLimitPanel(wx.Panel):
         
         dSort = np.argsort(self.data)
         
-        self.upper_pctile = float(self.data[dSort[int(len(self.data)*.99)]])
-        self.lower_pctile = float(self.data[dSort[int(len(self.data)*.01)]])
+        if len(self.data) == 0:
+            # special case - we have no data
+            self.upper_pctile = 1
+            self.lower_pctile = 0
+            self.dmin, self.dmax = 0,1
+        else:
+        
+            self.upper_pctile = float(self.data[dSort[int(len(self.data)*.99)]])
+            self.lower_pctile = float(self.data[dSort[int(len(self.data)*.01)]])
 
-        self.dmin = self.data[dSort[0]]
-        self.dmax = self.data[dSort[-1]]
+            self.dmin = self.data[dSort[0]]
+            self.dmax = self.data[dSort[-1]]
 
         self.limit_lower = float(limit_lower)
         self.limit_upper = float(limit_upper)


### PR DESCRIPTION
A few meshing and mesh display / PYMEVis robustness tweaks. Addresses a couple of annoying glitches when data is missing, and with quiver display. Also changes remesh so that collapse_edges() does not shrink the mesh as much. Does this by interpolating along the surface for the position of the merged vertex rather than just doing a linear interpolation. This PR simply copies the split_edges interpolation to collapse_edges. TODO - check the maths here - there is a slightly odd constant scaler in here which suggests that this interpolation logic is perhaps a low-angle approximation. We might not actually want the small angle approx in practive.