### PR TITLE
change scipy.random to numpy.random calls

### DIFF
--- a/PYME/Acquire/Hardware/Simulator/fakeCam.py
+++ b/PYME/Acquire/Hardware/Simulator/fakeCam.py
@@ -148,10 +148,10 @@ class NoiseMaker:
         if self.approximate_read_noise:
             o = self._read_approx(im.shape)
         else:
-            o = self.ADOffset + (self.ReadoutNoise / self.ElectronsPerCount) * scipy.random.standard_normal(im.shape)
+            o = self.ADOffset + (self.ReadoutNoise / self.ElectronsPerCount) * np.random.standard_normal(im.shape)
         
         if self.shutterOpen:
-            o = o +  (M/(self.ElectronsPerCount*F2))*scipy.random.poisson((self.QE*F2)*(im + self.background))
+            o = o +  (M/(self.ElectronsPerCount*F2))*np.random.poisson((self.QE*F2)*(im + self.background))
 
         return o
         

--- a/PYME/LMVis/visHelpersMin.py
+++ b/PYME/LMVis/visHelpersMin.py
@@ -117,7 +117,7 @@ def rendJitTri(im, x, y, jsig, mcp, imageBounds, pixelSize, n=1):
     for i in range(n):
         #global jParms
         #locals().update(jParms)
-        scipy.random.seed()
+        numpy.random.seed()
 
         Imc = scipy.rand(len(x)) < mcp
         if type(jsig) == numpy.ndarray:

--- a/PYME/LMVis/visHelpersMin.py
+++ b/PYME/LMVis/visHelpersMin.py
@@ -119,11 +119,11 @@ def rendJitTri(im, x, y, jsig, mcp, imageBounds, pixelSize, n=1):
         #locals().update(jParms)
         numpy.random.seed()
 
-        Imc = scipy.rand(len(x)) < mcp
+        Imc = numpy.random.rand(len(x)) < mcp
         if type(jsig) == numpy.ndarray:
             #print jsig.shape, Imc.shape
             jsig = jsig[Imc]
-        T = tri.Triangulation(x[Imc] +  jsig*scipy.randn(Imc.sum()), y[Imc] +  jsig*scipy.randn(Imc.sum()))
+        T = tri.Triangulation(x[Imc] +  jsig*numpy.random.randn(Imc.sum()), y[Imc] +  jsig*numpy.random.randn(Imc.sum()))
 
         #return T
         rendTri(T, imageBounds, pixelSize, im=im)
@@ -167,11 +167,11 @@ else:
         im = numpy.zeros((sizeX, sizeY))
 
         for i in range(n):
-            Imc = scipy.rand(len(x)) < mcp
+            Imc = numpy.random.rand(len(x)) < mcp
             if type(jsig) == numpy.ndarray:
                 #print jsig.shape, Imc.shape
                 jsig = jsig[Imc]
-            T = delaunay.Triangulation(x[Imc] +  jsig*scipy.randn(Imc.sum()), y[Imc] +  jsig*scipy.randn(Imc.sum()))
+            T = delaunay.Triangulation(x[Imc] +  jsig*numpy.random.randn(Imc.sum()), y[Imc] +  jsig*numpy.random.randn(Imc.sum()))
             rendTri(T, imageBounds, pixelSize, im=im)
 
         return im/n
@@ -196,14 +196,14 @@ def rendJitTet(x,y,z,n,jsig, jsigz, mcp, imageBounds, pixelSize, zb,sliceSize=10
     im = numpy.zeros((sizeX, sizeY, sizeZ), order='F')
 
     for i in range(n):
-        Imc = scipy.rand(len(x)) < mcp
+        Imc = numpy.random.rand(len(x)) < mcp
         if type(jsig) == numpy.ndarray:
             print((jsig.shape, Imc.shape))
             jsig = jsig[Imc]
             jsigz = jsigz[Imc]
 
         #gen3DTriangs.renderTetrahedra(im, x[Imc]+ jsig*scipy.randn(Imc.sum()), y[Imc]+ jsig*scipy.randn(Imc.sum()), z[Imc]+ jsigz*scipy.randn(Imc.sum()), scale = [1,1,1], pixelsize=[1,1,1])
-        p = numpy.hstack(((x[Imc]+ jsig*scipy.randn(Imc.sum()))[:, None], (y[Imc]+ jsig*scipy.randn(Imc.sum()))[:, None], (z[Imc]+ jsigz*scipy.randn(Imc.sum()))[:, None]))
+        p = numpy.hstack(((x[Imc]+ jsig*numpy.random.randn(Imc.sum()))[:, None], (y[Imc]+ jsig*numpy.random.randn(Imc.sum()))[:, None], (z[Imc]+ jsigz*numpy.random.randn(Imc.sum()))[:, None]))
         #print p.shape
         RenderTetrahedra(p, im)
 


### PR DESCRIPTION
Addresses issue #1326 

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
change remaining 3 scipy.random calls to numpy.random calls


**Checklist:**
lets tests pass on later scipy versions (e.g. 1.9.3)
note, tested with numpy 1.23.5