### PR TITLE
stop spool in test_cluster_spooling

### DIFF
--- a/PYME/IO/testClusterSpooling.py
+++ b/PYME/IO/testClusterSpooling.py
@@ -111,7 +111,8 @@ class TestSpooler:
             startTime = time.time()
     
             self._spoolData(nFrames, interval)
-    
+
+            self.spooler.StopSpool()
             #wait until we've sent everything
             #this is a bit of a hack
             time.sleep(.1)
@@ -126,7 +127,6 @@ class TestSpooler:
             print('%3.0f frames per second' % (nFrames/duration))
             print('Avg throughput: %3.0f MB/s' % (nFrames*self.testData.nbytes/(1e6*duration)))
     
-            self.spooler.StopSpool()
         finally:
             self.spooler.cleanup()
 


### PR DESCRIPTION
Addresses issue #1328 

**Is this a bugfix or an enhancement?**
bugfix

**Proposed changes:**
move stopspool call to be in front of finished check as new spooler only gets marked as finished in the `finalise` call in `stopspool`


This fixes the test on my machine. @David-Baddeley would be interested to hear if this also lets it run on Azure.