### PR TITLE
Recipe .run() refactoring

### DIFF
--- a/PYME/IO/DataSources/ArrayDataSource.py
+++ b/PYME/IO/DataSources/ArrayDataSource.py
@@ -177,10 +177,15 @@ class XYZTCArrayDataSource(BaseDataSource): #permit indexing with more dimension
         # zarr/dask support
         if hasattr(data, 'chuncks'):
             self.chunks =  np.ones(5, 'i')
+            self.chunksize = np.ones(5, 'i')
             for j, ax in enumerate('XYZTC'):
                 ix = self._dim_to_idx[ax]
                 if ix < self.data.ndim:
                     self.chunks[j] = self.data.chunks[ix]
+                    self.chunksize[j] = self.data.chunksize[ix]
+
+        self.chunks = tuple(self.chunks)
+        self.chunksize = tuple(self.chunksize)    
 
         self._transpose = self._dim_to_idx['Y'] < self._dim_to_idx['X']
         
@@ -196,7 +201,7 @@ class XYZTCArrayDataSource(BaseDataSource): #permit indexing with more dimension
     
     @property
     def shape(self):
-        return self._shape
+        return tuple(self._shape)
     
     @property
     def dtype(self):

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -255,7 +255,7 @@ class ModuleBase(HasStrictTraits):
         """
         from PYME.IO import MetaDataHandler
         inputs = {k: namespace[v] for k, v in self._input_traits.items()}
-        
+
         ret = self.run(**inputs)
 
         # convert output to a dictionary if needed
@@ -360,15 +360,17 @@ class ModuleBase(HasStrictTraits):
         -------
         set of input names
         """
-        return {v for k, v in self.trait_get().items() if (k.startswith('input') or isinstance(k, Input)) and not v == ''}
+        #return {v for k, v in self.trait_get().items() if (k.startswith('input') or isinstance(k, Input)) and not v == ''}
+        return set(self._input_traits.values())
 
     @property
-    def _input_traits(self):
-        return {k:v for k, v in self.trait_get().items() if (k.startswith('input') or isinstance(k, Input)) and not v == ''}
+    def _input_traits(self): 
+        return {k:getattr(self,k) for k, v in self.traits().items() if (k.startswith('input') or isinstance(v.trait_type, Input)) and not getattr(self, k) == ''}
 
     @property
     def _output_traits(self):
-        return {k:v for k, v in self.trait_get().items() if (k.startswith('output') or isinstance(k, Output)) and not v ==''}
+        #return {k:v for k, v in self.trait_get().items() if (k.startswith('output') or isinstance(k, Output)) and not v ==''}
+        return {k:getattr(self,k) for k, v in self.traits().items() if (k.startswith('output') or isinstance(v.trait_type, Output)) and not getattr(self, k) == ''}
     
     @property
     def outputs(self):

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -275,6 +275,7 @@ class ModuleBase(HasStrictTraits):
                 v.mdh = MetaDataHandler.DictMDHandler()
 
             v.mdh.mergeEntriesFrom(mdhin) #merge, to allow e.g. voxel size overrides due to downsampling
+            print(v.mdh, mdh)
             v.mdh.copyEntriesFrom(mdh) # copy / overwrite with module processing parameters
 
         namespace.update(out)
@@ -943,7 +944,7 @@ class JoinChannels(ModuleBase):
         chans = [] 
         channel_names = []      
 
-        for i, c in enumerate[inputChan0, inputChan1, inputChan2, inputChan3]:
+        for i, c in enumerate([inputChan0, inputChan1, inputChan2, inputChan3]):
             if c:
                 chans.append(np.atleast_3d(c.data_xyztc[:,:,:,:,0])) #FIXME .... so as not to drag everything into memory if not needed
                 channel_names.append(getattr(self, 'inputChan%d' %i))

--- a/PYME/recipes/filters.py
+++ b/PYME/recipes/filters.py
@@ -44,7 +44,7 @@ class GaussianFilter(Filter):
         return ndimage.gaussian_filter(data, self.sigmas[:len(data.shape)])
     
     def completeMetadata(self, im):
-        im.mdh['Processing.GaussianFilter'] = self.sigmas
+        im.mdh['Processing.GaussianFilter.Sigmas'] = self.sigmas
 
 @register_module('MedianFilter')         
 class MedianFilter(Filter):
@@ -80,7 +80,7 @@ class MedianFilter(Filter):
         return ndimage.median_filter(data, self.sigmas[:len(data.shape)])
     
     def completeMetadata(self, im):
-        im.mdh['Processing.MedianFilter'] = self.sigmas
+        im.mdh['Processing.MedianFilter.Sigmas'] = self.sigmas
 
 
 @register_module('MaxFilter')
@@ -117,7 +117,7 @@ class MaxFilter(Filter):
         return ndimage.maximum_filter(data, self.sigmas[:len(data.shape)])
 
     def completeMetadata(self, im):
-        im.mdh['Processing.MaxFilter'] = self.sigmas
+        im.mdh['Processing.MaxFilter.Sigmas'] = self.sigmas
 
 @register_module('MinFilter')
 class MinFilter(Filter):
@@ -153,7 +153,7 @@ class MinFilter(Filter):
         return ndimage.minimum_filter(data, self.sigmas[:len(data.shape)])
 
     def completeMetadata(self, im):
-        im.mdh['Processing.MinFilter'] = self.sigmas
+        im.mdh['Processing.MinFilter.Sigmas'] = self.sigmas
         
 @register_module('DespeckleFilter')         
 class DespeckleFilter(Filter):
@@ -205,7 +205,7 @@ class DespeckleFilter(Filter):
         return ndimage.generic_filter(data, self._filt, self.sigmas[:len(data.shape)])
     
     def completeMetadata(self, im):
-        im.mdh['Processing.DespeckleFilter'] = self.sigmas
+        im.mdh['Processing.DespeckleFilter.Sigmas'] = self.sigmas
 
 @register_module('MeanFilter') 
 class MeanFilter(Filter):
@@ -241,7 +241,7 @@ class MeanFilter(Filter):
         return ndimage.uniform_filter(data, self.sigmas[:len(data.shape)])
     
     def completeMetadata(self, im):
-        im.mdh['Processing.MeanFilter'] = self.sigmas
+        im.mdh['Processing.MeanFilter.Sigmas'] = self.sigmas
 
 @register_module('Zoom')         
 class Zoom(Filter):
@@ -267,7 +267,7 @@ class Zoom(Filter):
         return ndimage.zoom(data, self.zoom)
     
     def completeMetadata(self, im):
-        im.mdh['Processing.Zoom'] = self.zoom
+        #im.mdh['Processing.Zoom'] = self.zoom
         im.mdh['voxelsize.x'] = im.mdh['voxelsize.x']/self.zoom
         im.mdh['voxelsize.y'] = im.mdh['voxelsize.y']/self.zoom
         
@@ -301,7 +301,7 @@ class Subsample(Filter):
             return data[::self.step, ::self.step, ::self.step,]
     
     def completeMetadata(self, im):
-        im.mdh['Processing.SubsampleStep'] = self.step
+        #im.mdh['Processing.SubsampleStep'] = self.step
         im.mdh['voxelsize.x'] = im.mdh['voxelsize.x']*self.step
         im.mdh['voxelsize.y'] = im.mdh['voxelsize.y']*self.step
         
@@ -380,7 +380,7 @@ class DoGFilter(Filter):
         return ndimage.gaussian_filter(data, self.sigmas[:len(data.shape)]) - ndimage.gaussian_filter(data, self.sigma2s[:len(data.shape)])
     
     def completeMetadata(self, im):
-        im.mdh['Processing.GaussianFilter'] = self.sigmas
+        im.mdh['Processing.GaussianFilter.Sigmas'] = self.sigmas
 
 
 

--- a/PYME/recipes/filters.py
+++ b/PYME/recipes/filters.py
@@ -262,6 +262,8 @@ class Zoom(Filter):
     dimensionality = Enum('XY', 'XYZ', desc='Which image dimensions should the filter be applied to?')
     
     zoom = Float(1.0)
+
+    _block_safe = False # TODO - make a block safe version of this!
     
     def apply_filter(self, data, voxelsize):
         return ndimage.zoom(data, self.zoom)
@@ -293,6 +295,8 @@ class Subsample(Filter):
     dimensionality = Enum('XY', 'XYZ', desc='Which image dimensions should the filter be applied to?')
     
     step = Int(2)
+
+    _block_safe = False
     
     def apply_filter(self, data, voxelsize):
         if data.ndim == 2:

--- a/PYME/recipes/localisations.py
+++ b/PYME/recipes/localisations.py
@@ -15,15 +15,18 @@ class ExtractTableChannel(ModuleBase):
     channel = CStr('everything')
     outputName = Output('filtered')
 
-    def execute(self, namespace):
-        inp = namespace[self.inputName]
+    # def execute(self, namespace):
+    #     inp = namespace[self.inputName]
 
-        map = tabular.ColourFilter(inp, currentColour=self.channel)
+    #     map = tabular.ColourFilter(inp, currentColour=self.channel)
 
-        if 'mdh' in dir(inp):
-            map.mdh = inp.mdh
+    #     if 'mdh' in dir(inp):
+    #         map.mdh = inp.mdh
 
-        namespace[self.outputName] = map
+    #     namespace[self.outputName] = map
+
+    def run(self, inputName):
+        return tabular.ColourFilter(inputName, currentColour=self.channel)
 
     @property
     def _colour_choices(self):
@@ -68,9 +71,46 @@ class DensityMapping(ModuleBase):
     manualXYBounds = List(Float, [0,0,5e3, 5e3])
     
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.IO.image import ImageBounds
+    #     inp = namespace[self.inputLocalizations]
+    #     if not isinstance(inp, tabular.ColourFilter):
+    #         cf = tabular.ColourFilter(inp, None)
+            
+    #         print('Created colour filter with chans: %s' % cf.getColourChans())
+    #         cf.mdh = inp.mdh
+    #     else:
+    #         cf = inp
+            
+    #     #default to taking min and max localizations as image bounds
+    #     imb = ImageBounds.estimateFromSource(inp)
+        
+    #     if self.zBoundsMode == 'min-max':
+    #         self.zBounds[0], self.zBounds[1] = float(imb.z0), float(imb.z1)
+        
+    #     if (self.xyBoundsMode == 'inherit') and not (getattr(inp, 'imageBounds', None) is None):
+    #         imb = inp.imageBounds
+    #     elif self.xyBoundsMode == 'metadata':
+    #         imb = ImageBounds.extractFromMetadata(inp.mdh)
+    #     elif self.xyBoundsMode == 'manual':
+    #         imb.x0, imb.y0, imb.x1, imb.y1 = self.manualXYBounds
+            
+    #     cf.imageBounds = imb
+        
+
+    #     renderer = renderers.RENDERERS[str(self.renderingModule)](None, cf)
+
+    #     logger.debug('about to generate')
+
+    #     out = renderer.Generate(self.trait_get())
+
+    #     logger.debug(f'generated:{out.data_xyztc.shape}')
+
+    #     namespace[self.outputImage] = out
+
+    def run(self, inputLocalizations):
         from PYME.IO.image import ImageBounds
-        inp = namespace[self.inputLocalizations]
+        inp = inputLocalizations
         if not isinstance(inp, tabular.ColourFilter):
             cf = tabular.ColourFilter(inp, None)
             
@@ -103,7 +143,7 @@ class DensityMapping(ModuleBase):
 
         logger.debug(f'generated:{out.data_xyztc.shape}')
 
-        namespace[self.outputImage] = out
+        return out
         
     def _view_items(self, params=None):
         from traitsui.api import Group, Item, CSVListEditor
@@ -169,10 +209,59 @@ class Pipelineify(ModuleBase):
 
     outputLocalizations = Output('Localizations')
     
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.LMVis import pipeline
+    #     fitResults = namespace[self.inputFitResults]
+    #     mdh = fitResults.mdh
+
+    #     mapped_ds = tabular.MappingFilter(fitResults)
+
+
+    #     if not self.pixelSizeNM == 1: # TODO - check close instead?
+    #         mapped_ds.addVariable('pixelSize', self.pixelSizeNM)
+    #         mapped_ds.setMapping('x', 'x*pixelSize')
+    #         mapped_ds.setMapping('y', 'y*pixelSize')
+
+    #     #extract information from any events
+    #     if self.inputEvents != '':
+    #         # Use specified table for events if given (otherwise look for a `.events` attribute on the input data
+    #         # TODO: resolve how best to handle events (i.e. should they be a separate table, or should they be attached to data tables)
+    #         events = namespace.get(self.inputEvents, None)
+    #     else:
+    #         try:
+    #             events = fitResults.events
+    #         except AttributeError:
+    #             logger.debug('no events found')
+    #             events = None
+        
+    #     if isinstance(events, tabular.TabularBase):
+    #         events = events.to_recarray()
+
+    #     ev_maps, ev_charts = pipeline._processEvents(mapped_ds, events, mdh)
+    #     pipeline._add_missing_ds_keys(mapped_ds, ev_maps)
+
+    #     #Fit module specific filter settings
+    #     if 'Analysis.FitModule' in mdh.getEntryNames():
+    #         fitModule = mdh['Analysis.FitModule']
+
+    #         if 'LatGaussFitFR' in fitModule:
+    #             # TODO - move getPhotonNums() out of pipeline
+    #             mapped_ds.addColumn('nPhotons', pipeline.getPhotonNums(mapped_ds, mdh))
+            
+    #         if 'SplitterFitFNR' in fitModule:
+    #             mapped_ds.addColumn('nPhotonsg', pipeline.getPhotonNums({'A': mapped_ds['fitResults_Ag'], 'sig': mapped_ds['fitResults_sigma']}, mdh))
+    #             mapped_ds.addColumn('nPhotonsr', pipeline.getPhotonNums({'A': mapped_ds['fitResults_Ar'], 'sig': mapped_ds['fitResults_sigma']}, mdh))
+    #             mapped_ds.setMapping('nPhotons', 'nPhotonsg+nPhotonsr')
+
+    #     mapped_ds.mdh = mdh
+
+    #     namespace[self.outputLocalizations] = mapped_ds
+
+    def run(self, inputFitResults, inputEvents=None):
         from PYME.LMVis import pipeline
-        fitResults = namespace[self.inputFitResults]
-        mdh = fitResults.mdh
+        from PYME.IO import MetaDataHandler
+        fitResults = inputFitResults
+        mdh = MetaDataHandler.DictMDHandler(fitResults.mdh)
 
         mapped_ds = tabular.MappingFilter(fitResults)
 
@@ -183,10 +272,8 @@ class Pipelineify(ModuleBase):
             mapped_ds.setMapping('y', 'y*pixelSize')
 
         #extract information from any events
-        if self.inputEvents != '':
-            # Use specified table for events if given (otherwise look for a `.events` attribute on the input data
-            # TODO: resolve how best to handle events (i.e. should they be a separate table, or should they be attached to data tables)
-            events = namespace.get(self.inputEvents, None)
+        if inputEvents:
+            events = inputEvents
         else:
             try:
                 events = fitResults.events
@@ -215,7 +302,7 @@ class Pipelineify(ModuleBase):
 
         mapped_ds.mdh = mdh
 
-        namespace[self.outputLocalizations] = mapped_ds
+        return mapped_ds
         
 @register_module("ProcessColour")
 class ProcessColour(ModuleBase):
@@ -255,8 +342,49 @@ class ProcessColour(ModuleBase):
                 self.species_ratios[strucname] = ratio
                 self.species_dyes[strucname] = dye
     
-    def execute(self, namespace):
-        input = namespace[self.input]
+    # def execute(self, namespace):
+    #     input = namespace[self.input]
+    #     mdh = input.mdh
+        
+    #     if self.ratios_from_metadata:
+    #         # turn off invalidation so we don't get a recursive loop. TODO - fix this properly as it's gross to be changing
+    #         # our parameters here
+    #         invalidate = self._invalidate_parent
+    #         self._invalidate_parent = False
+    #         self._get_dye_ratios_from_metadata(mdh)
+    #         self._invalidate_parent = invalidate
+        
+    #     output = tabular.MappingFilter(input)
+    #     output.mdh = mdh
+    
+    #     if 'gFrac' in output.keys():
+    #         #ratiometric
+    #         #raise NotImplementedError('Ratiometric processing in recipes not implemented yet')
+    #         for structure, ratio in self.species_ratios.items():
+    #             if not ratio is None:
+    #                 output.setMapping('p_%s' % structure,
+    #                                         'exp(-(%f - gFrac)**2/(2*error_gFrac**2))/(error_gFrac*sqrt(2*numpy.pi))' % ratio)
+    #     else:
+    #         if 'probe' in output.keys():
+    #             #non-ratiometric (i.e. sequential) colour
+    #             #color channel is given in 'probe' column
+    #             output.setMapping('ColourNorm', '1.0 + 0*probe')
+                
+    #             for i in range(int(output['probe'].min()), int(output['probe'].max() + 1)):
+    #                 output.setMapping('p_chan%d' % i, '1.0*(probe == %d)' % i)
+            
+    #         nSeqCols = mdh.getOrDefault('Protocol.NumberSequentialColors', 1)
+    #         if nSeqCols > 1:
+    #             for i in range(nSeqCols):
+    #                 output.setMapping('ColourNorm', '1.0 + 0*t')
+    #                 cr = mdh['Protocol.ColorRange%d' % i]
+    #                 output.setMapping('p_chan%d' % i, '(t>= %d)*(t<%d)' % cr)
+                    
+    #     cached_output = tabular.CachingResultsFilter(output)
+    #     #cached_output.mdh = output.mdh
+    #     namespace[self.output] = cached_output
+
+    def run(self, input):
         mdh = input.mdh
         
         if self.ratios_from_metadata:
@@ -295,7 +423,7 @@ class ProcessColour(ModuleBase):
                     
         cached_output = tabular.CachingResultsFilter(output)
         #cached_output.mdh = output.mdh
-        namespace[self.output] = cached_output
+        return cached_output
 
 
 @register_module('TimeBlocks')
@@ -314,19 +442,46 @@ class TimeBlocks(ModuleBase):
     
     block_size = Int(100)
     
-    def execute(self, namespace):
-        input = namespace[self.input]
-        mdh = input.mdh
+    # def execute(self, namespace):
+    #     input = namespace[self.input]
+    #     mdh = input.mdh
     
+    #     output = tabular.MappingFilter(input)
+    #     output.mdh = mdh
+        
+    #     output.addColumn('block_id', np.mod((output['t']/self.block_size).astype('int'),2))
+
+    #     channel_names = [k for k in input.keys() if k.startswith('p_')]
+        
+    #     print(channel_names)
+    #     print(input.keys())
+        
+    #     if len(channel_names) == 0:
+    #         #single channel data - no channels defined.
+    #         output.setMapping('ColourNorm', '1.0 + 0*t')
+    #         output.setMapping('p_block0', '1.0*block_id')
+    #         output.setMapping('p_block1', '1.0 - block_id')
+    #     else:
+    #         #have colour channels - subdivide them
+    #         for k in channel_names:
+    #             output.setMapping('%s_block0' % k, '%s*block_id' % k)
+    #             output.setMapping('%s_block1' % k, '%s*(1.0 - block_id)' % k)
+            
+    #         #hide original channel names
+    #         output.hidden_columns.extend(channel_names)
+        
+
+    #     namespace[self.output] = output
+
+    def run(self, input):
         output = tabular.MappingFilter(input)
-        output.mdh = mdh
         
         output.addColumn('block_id', np.mod((output['t']/self.block_size).astype('int'),2))
 
         channel_names = [k for k in input.keys() if k.startswith('p_')]
         
-        print(channel_names)
-        print(input.keys())
+        #print(channel_names)
+        #print(input.keys())
         
         if len(channel_names) == 0:
             #single channel data - no channels defined.
@@ -341,9 +496,8 @@ class TimeBlocks(ModuleBase):
             
             #hide original channel names
             output.hidden_columns.extend(channel_names)
-        
 
-        namespace[self.output] = output
+        return output
     
 
 @register_module('MergeClumps')
@@ -353,18 +507,22 @@ class MergeClumps(ModuleBase):
     outputName = Output('merged')
     labelKey = CStr('clumpIndex')
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.Analysis.points.DeClump import pyDeClump
+
+    #     inp = namespace[self.inputName]
+
+    #     grouped = pyDeClump.mergeClumps(inp, labelKey=self.labelKey)
+    #     try:
+    #         grouped.mdh = inp.mdh
+    #     except AttributeError:
+    #         pass
+
+    #     namespace[self.outputName] = grouped
+
+    def run(self, inputName):
         from PYME.Analysis.points.DeClump import pyDeClump
-
-        inp = namespace[self.inputName]
-
-        grouped = pyDeClump.mergeClumps(inp, labelKey=self.labelKey)
-        try:
-            grouped.mdh = inp.mdh
-        except AttributeError:
-            pass
-
-        namespace[self.outputName] = grouped
+        return pyDeClump.mergeClumps(inputName, labelKey=self.labelKey)
 
 
 @register_module('IDTransientFrames')
@@ -378,27 +536,45 @@ class IDTransientFrames(ModuleBase): #FIXME - move to multi-view specific module
     framesPerStep = Float()
     outputName = Output('transientFiltered')
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.experimental import zMotionArtifactUtils
+
+    #     inp = namespace[self.inputName]
+
+    #     mapped = tabular.MappingFilter(inp)
+
+    #     if 'mdh' not in dir(inp):
+    #         if self.framesPerStep <= 0:
+    #             raise RuntimeError('idTransientFrames needs metadata')
+    #         else:
+    #             fps = self.framesPerStep
+    #     else:
+    #         fps = inp.mdh['StackSettings.FramesPerStep']
+
+    #     mask = zMotionArtifactUtils.flagMotionArtifacts(mapped, namespace[self.inputEvents], fps)
+    #     mapped.addColumn('piezoUnstable', mask)
+
+    #     mapped.mdh = inp.mdh
+
+    #     namespace[self.outputName] = mapped
+
+    def run(self, inputName, inputEvents):
         from PYME.experimental import zMotionArtifactUtils
 
-        inp = namespace[self.inputName]
+        mapped = tabular.MappingFilter(inputName)
 
-        mapped = tabular.MappingFilter(inp)
-
-        if 'mdh' not in dir(inp):
+        if 'mdh' not in dir(inputName):
             if self.framesPerStep <= 0:
                 raise RuntimeError('idTransientFrames needs metadata')
             else:
                 fps = self.framesPerStep
         else:
-            fps = inp.mdh['StackSettings.FramesPerStep']
+            fps = inputName.mdh['StackSettings.FramesPerStep']
 
-        mask = zMotionArtifactUtils.flagMotionArtifacts(mapped, namespace[self.inputEvents], fps)
+        mask = zMotionArtifactUtils.flagMotionArtifacts(mapped, inputEvents, fps)
         mapped.addColumn('piezoUnstable', mask)
 
-        mapped.mdh = inp.mdh
-
-        namespace[self.outputName] = mapped
+        return mapped
 
 @register_module('DBSCANClustering')
 class DBSCANClustering(ModuleBase):
@@ -436,10 +612,36 @@ class DBSCANClustering(ModuleBase):
 
     outputName = Output('dbscanClustered')
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from sklearn.cluster import dbscan
+
+    #     inp = namespace[self.inputName]
+    #     mapped = tabular.MappingFilter(inp)
+
+    #     # Note that sklearn gives unclustered points label of -1, and first value starts at 0.
+    #     if self.multithreaded:
+    #         core_samp, dbLabels = dbscan(np.vstack([inp[k] for k in self.columns]).T,
+    #                                      eps=self.searchRadius, min_samples=self.minClumpSize, n_jobs=self.numberOfJobs)
+    #     else:
+    #         #NB try-catch from Christians multithreaded example removed as I think we should see failure here
+    #         core_samp, dbLabels = dbscan(np.vstack([inp[k] for k in self.columns]).T,
+    #                                  eps=self.searchRadius, min_samples=self.minClumpSize)
+
+    #     # shift dbscan labels up by one to match existing convention that a clumpID of 0 corresponds to unclumped
+    #     mapped.addColumn(str(self.clumpColumnName), dbLabels + 1)
+
+    #     # propogate metadata, if present
+    #     try:
+    #         mapped.mdh = inp.mdh
+    #     except AttributeError:
+    #         pass
+
+    #     namespace[self.outputName] = mapped
+
+    def run(self, inputName):
         from sklearn.cluster import dbscan
 
-        inp = namespace[self.inputName]
+        inp = inputName
         mapped = tabular.MappingFilter(inp)
 
         # Note that sklearn gives unclustered points label of -1, and first value starts at 0.
@@ -454,13 +656,7 @@ class DBSCANClustering(ModuleBase):
         # shift dbscan labels up by one to match existing convention that a clumpID of 0 corresponds to unclumped
         mapped.addColumn(str(self.clumpColumnName), dbLabels + 1)
 
-        # propogate metadata, if present
-        try:
-            mapped.mdh = inp.mdh
-        except AttributeError:
-            pass
-
-        namespace[self.outputName] = mapped
+        return mapped
 
     @property
     def hide_in_overview(self):
@@ -512,16 +708,65 @@ class ClusterCountVsImagingTime(ModuleBase):
 
     outputName = Output('incremented')
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.IO import tabular
+
+    #     if self.lowerMinPtsPerCluster > self.higherMinPtsPerCluster:
+    #         print('Swapping low and high MinPtsPerCluster - input was reversed')
+    #         temp = self.lowerMinPtsPerCluster
+    #         self.lowerMinPtsPerCluster = self.higherMinPtsPerCluster
+    #         self.higherMinPtsPerCluster = temp
+
+    #     iters = (int(np.max(namespace[self.inputName]['t']))/int(self.stepSize)) + 2
+
+    #     # other counts
+    #     lowDensMinPtsClumps = np.empty(iters)
+    #     lowDensMinPtsClumps[0] = 0
+    #     hiDensMinPtsClumps = np.empty(iters)
+    #     hiDensMinPtsClumps[0] = 0
+    #     t = np.empty(iters)
+    #     t[0] = 0
+
+    #     inp = tabular.MappingFilter(namespace[self.inputName])
+
+    #     for ind in range(1, iters):  # start from 1 since t=[0,0] will yield no clumps
+    #         # filter time
+    #         inc = tabular.ResultsFilter(inp, t=[0, self.stepSize * ind])
+    #         t[ind] = np.max(inc['t'])
+
+    #         cid, counts = np.unique(inc[self.labelsKey], return_counts=True)
+    #         # cmask = np.in1d(inc['DBSCAN_allFrames'], cid)
+
+    #         cidL = cid[counts >= self.lowerMinPtsPerCluster]
+    #         lowDensMinPtsClumps[ind] = np.sum(cidL != -1)  # ignore unclumped in count
+    #         cid = cid[counts >= self.higherMinPtsPerCluster]
+    #         hiDensMinPtsClumps[ind] = np.sum(cid != -1)  # ignore unclumped in count
+
+
+    #     res = tabular.MappingFilter({'t': t,
+    #                                  'N_labelsWithLowMinPoints': lowDensMinPtsClumps,
+    #                                  'N_labelsWithHighMinPoints': hiDensMinPtsClumps})
+
+    #     # propagate metadata, if present
+    #     try:
+    #         res.mdh = namespace[self.inputName].mdh
+    #     except AttributeError:
+    #         pass
+
+    #     namespace[self.outputName] = res
+
+    def run(self, inputName):
         from PYME.IO import tabular
 
+        inp = tabular.MappingFilter(inputName)
+        
         if self.lowerMinPtsPerCluster > self.higherMinPtsPerCluster:
             print('Swapping low and high MinPtsPerCluster - input was reversed')
             temp = self.lowerMinPtsPerCluster
             self.lowerMinPtsPerCluster = self.higherMinPtsPerCluster
             self.higherMinPtsPerCluster = temp
 
-        iters = (int(np.max(namespace[self.inputName]['t']))/int(self.stepSize)) + 2
+        iters = (int(np.max(inp['t']))/int(self.stepSize)) + 2
 
         # other counts
         lowDensMinPtsClumps = np.empty(iters)
@@ -531,7 +776,6 @@ class ClusterCountVsImagingTime(ModuleBase):
         t = np.empty(iters)
         t[0] = 0
 
-        inp = tabular.MappingFilter(namespace[self.inputName])
 
         for ind in range(1, iters):  # start from 1 since t=[0,0] will yield no clumps
             # filter time
@@ -547,17 +791,9 @@ class ClusterCountVsImagingTime(ModuleBase):
             hiDensMinPtsClumps[ind] = np.sum(cid != -1)  # ignore unclumped in count
 
 
-        res = tabular.MappingFilter({'t': t,
+        return tabular.MappingFilter({'t': t,
                                      'N_labelsWithLowMinPoints': lowDensMinPtsClumps,
                                      'N_labelsWithHighMinPoints': hiDensMinPtsClumps})
-
-        # propagate metadata, if present
-        try:
-            res.mdh = namespace[self.inputName].mdh
-        except AttributeError:
-            pass
-
-        namespace[self.outputName] = res
 
 
 @register_module('LabelsFromImage')
@@ -596,26 +832,38 @@ class LabelsFromImage(ModuleBase):
 
     outputName = Output('labeled_points')
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.IO import tabular
+    #     from PYME.Analysis.points import cluster_morphology
+
+    #     inp = namespace[self.inputName]
+    #     img = namespace[self.inputImage]
+
+    #     ids, numPerObject = cluster_morphology.get_labels_from_image(img, inp, minimum_localizations=self.minimum_localizations)
+
+    #     labeled = tabular.MappingFilter(inp)
+    #     labeled.addColumn(self.label_key_name, ids)
+    #     labeled.addColumn(self.label_count_key_name, numPerObject[ids - 1])
+
+    #     # propagate metadata, if present
+    #     try:
+    #         labeled.mdh = namespace[self.inputName].mdh
+    #     except AttributeError:
+    #         pass
+
+    #     namespace[self.outputName] = labeled
+
+    def run(self, inputName, inputImage):
         from PYME.IO import tabular
         from PYME.Analysis.points import cluster_morphology
 
-        inp = namespace[self.inputName]
-        img = namespace[self.inputImage]
+        ids, numPerObject = cluster_morphology.get_labels_from_image(inputImage, inputName, minimum_localizations=self.minimum_localizations)
 
-        ids, numPerObject = cluster_morphology.get_labels_from_image(img, inp, minimum_localizations=self.minimum_localizations)
-
-        labeled = tabular.MappingFilter(inp)
+        labeled = tabular.MappingFilter(inputName)
         labeled.addColumn(self.label_key_name, ids)
         labeled.addColumn(self.label_count_key_name, numPerObject[ids - 1])
 
-        # propagate metadata, if present
-        try:
-            labeled.mdh = namespace[self.inputName].mdh
-        except AttributeError:
-            pass
-
-        namespace[self.outputName] = labeled
+        return labeled
 
 
 @register_module('MeasureClusters3D')
@@ -683,11 +931,62 @@ class MeasureClusters3D(ModuleBase):
 
     outputName = Output('clusterMeasures')
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.Analysis.points import cluster_morphology as cmorph
+    #     import numpy as np
+
+    #     inp = namespace[self.inputName]
+
+    #     labels = inp[self.labelKey].astype(np.int)
+    #     # make sure labeling scheme is consistent with what pyme conventions
+    #     if (len(labels) > 0) and  (labels.min() < 0):
+    #         raise UserWarning('This module expects 0-label for unclustered points, and no negative labels')
+        
+    #     I = np.argsort(labels)
+    #     I = I[labels[I] > 0]
+        
+    #     x_vals, y_vals, z_vals = inp['x'][I], inp['y'][I], inp['z'][I]
+    #     labels = labels[I]
+    #     maxLabel = labels[-1] if (len(labels) > 0) else 0
+        
+    #     #find the unique labels, and their separation in the sorted list of points
+    #     unique_labels, counts = np.unique(labels, return_counts=True)
+        
+    #     #allocate memory to store results in
+    #     measurements = np.zeros(maxLabel, cmorph.measurement_dtype)
+
+    #     # loop over labels, recalling that input is now sorted, and we know how many points are in each label.
+    #     # Note that missing labels result in zeroed entries (i.e. the initial values are not changed).
+    #     # Missing values can be filtered out later, if desired, by filtering on the 'counts' column, but having a dense
+    #     # array where index == label number makes any postprocessing in which we might want to find the data
+    #     # corresponding to a particular label MUCH easier and faster.
+    #     indi = 0
+    #     for label_num, ct in zip(unique_labels, counts):
+    #         indf = indi + ct
+
+    #         # create x,y,z arrays for this cluster, and calculate center of mass
+    #         x, y, z = x_vals[indi:indf], y_vals[indi:indf], z_vals[indi:indf]
+
+    #         cluster_index = label_num - 1  # we ignore the unclustered points, and start labeling at 1
+    #         cmorph.measure_3d(x, y, z, output=measurements[cluster_index])
+
+    #         indi = indf
+
+    #     meas = tabular.RecArraySource(measurements)
+
+    #     try:
+    #         meas.mdh = namespace[self.inputName].mdh
+    #     except AttributeError:
+    #         pass
+
+    #     namespace[self.outputName] = meas
+
+
+    def run(self, inputName):
         from PYME.Analysis.points import cluster_morphology as cmorph
         import numpy as np
 
-        inp = namespace[self.inputName]
+        inp = inputName
 
         labels = inp[self.labelKey].astype(np.int)
         # make sure labeling scheme is consistent with what pyme conventions
@@ -724,14 +1023,7 @@ class MeasureClusters3D(ModuleBase):
 
             indi = indf
 
-        meas = tabular.RecArraySource(measurements)
-
-        try:
-            meas.mdh = namespace[self.inputName].mdh
-        except AttributeError:
-            pass
-
-        namespace[self.outputName] = meas
+        return tabular.RecArraySource(measurements)
 
 
 @register_module('FiducialCorrection')
@@ -765,22 +1057,56 @@ class FiducialCorrection(ModuleBase):
     outputName = Output('corrected_localizations')
     outputFiducials = Output('corrected_fiducials')
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.IO import tabular
+    #     from PYME.Analysis.points import fiducials
+
+    #     locs = namespace[self.inputLocalizations]
+    #     fids = namespace[self.inputFiducials]
+        
+    #     t_fid, fid_trajectory, clump_index = fiducials.extractAverageTrajectory(fids, clumpRadiusVar=self.clumpRadiusVar,
+    #                                                     clumpRadiusMultiplier=float(self.clumpRadiusMultiplier),
+    #                                                     timeWindow=int(self.timeWindow),
+    #                                                     filter=self.temporalFilter, filterScale=float(self.temporalFilterScale))
+        
+    #     out = tabular.MappingFilter(locs)
+    #     t_out = out['t']
+
+    #     out_f = tabular.MappingFilter(fids)
+    #     out_f.addColumn('clumpIndex', clump_index)
+    #     t_out_f = out_f['t']
+
+    #     for dim in fid_trajectory.keys():
+    #         print(dim)
+    #         out.addColumn('fiducial_{0}'.format(dim), np.interp(t_out, t_fid, fid_trajectory[dim]))
+    #         out.setMapping(dim, '{0} - fiducial_{0}'.format(dim))
+
+    #         out_f.addColumn('fiducial_{0}'.format(dim), np.interp(t_out_f, t_fid, fid_trajectory[dim]))
+    #         out_f.setMapping(dim, '{0} - fiducial_{0}'.format(dim))
+
+    #     # propagate metadata, if present
+    #     try:
+    #         out.mdh = locs.mdh
+    #     except AttributeError:
+    #         pass
+
+    #     namespace[self.outputName] = out
+    #     namespace[self.outputFiducials] = out_f
+
+    def run(self, inputLocalizations, inputFiducials):
         from PYME.IO import tabular
         from PYME.Analysis.points import fiducials
-
-        locs = namespace[self.inputLocalizations]
-        fids = namespace[self.inputFiducials]
+        from PYME.IO import MetaDataHandler
         
-        t_fid, fid_trajectory, clump_index = fiducials.extractAverageTrajectory(fids, clumpRadiusVar=self.clumpRadiusVar,
+        t_fid, fid_trajectory, clump_index = fiducials.extractAverageTrajectory(inputFiducials, clumpRadiusVar=self.clumpRadiusVar,
                                                         clumpRadiusMultiplier=float(self.clumpRadiusMultiplier),
                                                         timeWindow=int(self.timeWindow),
                                                         filter=self.temporalFilter, filterScale=float(self.temporalFilterScale))
         
-        out = tabular.MappingFilter(locs)
+        out = tabular.MappingFilter(inputLocalizations)
         t_out = out['t']
 
-        out_f = tabular.MappingFilter(fids)
+        out_f = tabular.MappingFilter(inputFiducials)
         out_f.addColumn('clumpIndex', clump_index)
         t_out_f = out_f['t']
 
@@ -794,12 +1120,11 @@ class FiducialCorrection(ModuleBase):
 
         # propagate metadata, if present
         try:
-            out.mdh = locs.mdh
+            out.mdh = MetaDataHandler.DictMDHandler(inputLocalizations.mdh)
         except AttributeError:
             pass
 
-        namespace[self.outputName] = out
-        namespace[self.outputFiducials] = out_f
+        return {'outputName': out, 'outputFiducials' : out_f}
 
 
 @register_module('AutocorrelationDriftCorrection')
@@ -858,9 +1183,36 @@ class AutocorrelationDriftCorrection(ModuleBase):
     
         return np.array(tis), self.binsize * (sha - sha[0])
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.IO import tabular
+    #     locs = namespace[self.inputName]
+        
+    #     t_shift, shifts = self.calcCorrDrift(locs['x'], locs['y'], locs['t'])
+    #     shx = shifts[:, 0]
+    #     shy = shifts[:, 1]
+
+    #     out = tabular.MappingFilter(locs)
+    #     t_out = out['t']
+    #     dx = np.interp(t_out, t_shift, shx)
+    #     dy = np.interp(t_out, t_shift, shy)
+        
+        
+    #     out.addColumn('dx', dx)
+    #     out.addColumn('dy', dy)
+    #     out.setMapping('x', 'x + dx')
+    #     out.setMapping('y', 'y + dy')
+        
+    #     # propagate metadata, if present
+    #     try:
+    #         out.mdh = locs.mdh
+    #     except AttributeError:
+    #         pass
+        
+    #     namespace[self.outputName] = out
+
+    def run(self, inputName):
         from PYME.IO import tabular
-        locs = namespace[self.inputName]
+        locs = inputName
         
         t_shift, shifts = self.calcCorrDrift(locs['x'], locs['y'], locs['t'])
         shx = shifts[:, 0]
@@ -877,10 +1229,4 @@ class AutocorrelationDriftCorrection(ModuleBase):
         out.setMapping('x', 'x + dx')
         out.setMapping('y', 'y + dy')
         
-        # propagate metadata, if present
-        try:
-            out.mdh = locs.mdh
-        except AttributeError:
-            pass
-        
-        namespace[self.outputName] = out
+        return out

--- a/PYME/recipes/machine_learning.py
+++ b/PYME/recipes/machine_learning.py
@@ -14,7 +14,7 @@ from scipy import ndimage
 from PYME.IO.image import ImageStack
 
 @register_module('SVMSegment')
-class svmSegment(Filter):
+class SVMSegment(Filter):
     classifier = FileOrURI('')
     _classifier = CStr('')
     _cf = Instance(object, allow_none=True)

--- a/PYME/recipes/machine_learning.py
+++ b/PYME/recipes/machine_learning.py
@@ -135,19 +135,32 @@ class PointFeaturesPairwiseDist(PointFeatureBase):
 
     normaliseRelativeDensity = Bool(False) # divide by the sum of all radial bins. If not performed, the first principle component will likely be average density
     
-    def execute(self, namespace):
-        from PYME.Analysis.points import DistHist
-        points = namespace[self.inputLocalisations]
+    # def execute(self, namespace):
+    #     from PYME.Analysis.points import DistHist
+    #     points = namespace[self.inputLocalisations]
         
-        if self.threeD:
-            x, y, z = points['x'], points['y'], points['z']
-            f = np.array([DistHist.distanceHistogram3D(x[i], y[i], z[i], x, y, z, self.numBins, self.binWidth) for i in xrange(len(x))])
-        else:
-            x, y = points['x'], points['y']
-            f = np.array([DistHist.distanceHistogram(x[i], y[i], x, y, self.numBins, self.binWidth) for i in xrange(len(x))])
+    #     if self.threeD:
+    #         x, y, z = points['x'], points['y'], points['z']
+    #         f = np.array([DistHist.distanceHistogram3D(x[i], y[i], z[i], x, y, z, self.numBins, self.binWidth) for i in xrange(len(x))])
+    #     else:
+    #         x, y = points['x'], points['y']
+    #         f = np.array([DistHist.distanceHistogram(x[i], y[i], x, y, self.numBins, self.binWidth) for i in xrange(len(x))])
             
         
-        namespace[self.outputName] = self._process_features(points, f)
+    #     namespace[self.outputName] = self._process_features(points, f)
+
+    def run(self, inputLocalisations):
+        from PYME.Analysis.points import DistHist
+        
+        if self.threeD:
+            x, y, z = inputLocalisations['x'], inputLocalisations['y'], inputLocalisations['z']
+            f = np.array([DistHist.distanceHistogram3D(x[i], y[i], z[i], x, y, z, self.numBins, self.binWidth) for i in xrange(len(x))])
+        else:
+            x, y = inputLocalisations['x'], inputLocalisations['y']
+            f = np.array([DistHist.distanceHistogram(x[i], y[i], x, y, self.numBins, self.binWidth) for i in xrange(len(x))])
+
+        return self._process_features(inputLocalisations, f)
+
 
 
 @register_module('PointFeaturesVectorial')
@@ -181,17 +194,28 @@ class PointFeaturesVectorial(PointFeatureBase):
         
         return f.reshape([f.shape[0], -1])
     
-    def execute(self, namespace):
-        from PYME.Analysis.points.features import metal
-        points = namespace[self.inputLocalisations]
+    # def execute(self, namespace):
+    #     from PYME.Analysis.points.features import metal
+    #     points = namespace[self.inputLocalisations]
         
-        #if self.threeD:
-        x, y, z = points['x'], points['y'], points['z']
+    #     #if self.threeD:
+    #     x, y, z = points['x'], points['y'], points['z']
+    #     #f = np.array([self._reduce_features(DistHist.vectDistanceHistogram3D(x[i], y[i], z[i], x, y, z, self.numRadialBins, self.radialBinWidth, self.numAngleBins)) for i in xrange(len(x))])
+    #     f = metal.Backend().vector_features_3d(x, y, z, radial_bin_size=self.radialBinWidth, n_radial_bins=self.numRadialBins, n_angle_bins=self.numAngleBins)       
+    #     f = self._reduce_features(f)
+
+    #     namespace[self.outputName] = self._process_features(points, f)
+
+    def run(self, inputLocalisations):
+        from PYME.Analysis.points.features import metal
+
+        x, y, z = inputLocalisations['x'], inputLocalisations['y'], inputLocalisations['z']
         #f = np.array([self._reduce_features(DistHist.vectDistanceHistogram3D(x[i], y[i], z[i], x, y, z, self.numRadialBins, self.radialBinWidth, self.numAngleBins)) for i in xrange(len(x))])
         f = metal.Backend().vector_features_3d(x, y, z, radial_bin_size=self.radialBinWidth, n_radial_bins=self.numRadialBins, n_angle_bins=self.numAngleBins)       
         f = self._reduce_features(f)
 
-        namespace[self.outputName] = self._process_features(points, f)
+        return self._process_features(inputLocalisations, f)
+
     
 @register_module('AnnotatePoints')
 class AnnotatePoints(ModuleBase):
@@ -208,18 +232,29 @@ class AnnotatePoints(ModuleBase):
     outputName = Output('labeled')
 
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.IO.tabular import MappingFilter
+    #     from PYME.IO import MetaDataHandler
+
+    #     inp = namespace[self.inputLocalisations]
+    #     ann = namespace[self.inputAnnotations]
+
+    #     pts = np.array([inp['x'], inp['y']]).T
+        
+    #     labels = ann.label_points(pts)
+    #     out = MappingFilter(inp)
+    #     out.addColumn('labels', labels)
+    #     out.mdh = MetaDataHandler.NestedClassMDHandler(getattr(inp, 'mdh', None))
+
+    #     namespace[self.outputName] = out
+
+    def run(inputLocalisations, inputAnnotations):
         from PYME.IO.tabular import MappingFilter
         from PYME.IO import MetaDataHandler
 
-        inp = namespace[self.inputLocalisations]
-        ann = namespace[self.inputAnnotations]
-
-        pts = np.array([inp['x'], inp['y']]).T
+        pts = np.array([inputLocalisations['x'], inputLocalisations['y']]).T
         
-        labels = ann.label_points(pts)
-        out = MappingFilter(inp)
+        labels = inputAnnotations.label_points(pts)
+        out = MappingFilter(inputLocalisations)
         out.addColumn('labels', labels)
-        out.mdh = MetaDataHandler.NestedClassMDHandler(getattr(inp, 'mdh', None))
-
-        namespace[self.outputName] = out
+        return out

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -1321,17 +1321,17 @@ class Deconvolve(Filter):
         
         return res.squeeze()
 
-    def completeMetadata(self, im):
-        im.mdh['Deconvolution.Offset'] = self.offset
-        im.mdh['Deconvolution.Method'] = self.method
-        im.mdh['Deconvolution.Iterations'] = self.iterations
-        im.mdh['Deconvolution.PsfType'] = self.psfType
-        im.mdh['Deconvolution.PSFFilename'] = self.psfFilename
-        im.mdh['Deconvolution.LorentzianFWHM'] = self.lorentzianFWHM
-        im.mdh['Deconvolution.BeadDiameter'] = self.beadDiameter
-        im.mdh['Deconvolution.RegularisationLambda'] = self.regularisationLambda
-        im.mdh['Deconvolution.Padding'] = self.padding
-        im.mdh['Deconvolution.ZPadding'] = self.zPadding
+    # def completeMetadata(self, im):
+    #     im.mdh['Deconvolution.Offset'] = self.offset
+    #     im.mdh['Deconvolution.Method'] = self.method
+    #     im.mdh['Deconvolution.Iterations'] = self.iterations
+    #     im.mdh['Deconvolution.PsfType'] = self.psfType
+    #     im.mdh['Deconvolution.PSFFilename'] = self.psfFilename
+    #     im.mdh['Deconvolution.LorentzianFWHM'] = self.lorentzianFWHM
+    #     im.mdh['Deconvolution.BeadDiameter'] = self.beadDiameter
+    #     im.mdh['Deconvolution.RegularisationLambda'] = self.regularisationLambda
+    #     im.mdh['Deconvolution.Padding'] = self.padding
+    #     im.mdh['Deconvolution.ZPadding'] = self.zPadding
         
 
 @register_module('DeconvolveMotionCompensating')

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -1465,12 +1465,17 @@ class Deconvolve(Filter):
     padding = Int(0) #how much to pad the image by (to reduce edge effects)
     zPadding = Int(0) # padding along the z axis
 
+    overlap = Int(30, descr='Amount to overlap neighbouring blocks by (ignored when not using blocking)') 
+
     #  Make deconvolution 3D by default
     #processFramesIndividually = False
     dimensionality = Enum('XYZ', 'XY', desc='Which image dimensions should the filter be applied to?')
     
     _psfCache = {}
     _decCache = {}
+
+    def _block_overlap(self):
+        return int(self.overlap) 
 
     def default_traits_view(self):
         from traitsui.api import View, Item, Group

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -274,9 +274,38 @@ class OpticalFlow(ModuleBase):
     
         return flow_x, flow_y
         
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     import multiprocessing
+    #     image = namespace[self.inputName]
+    #     flow_x = []
+    #     flow_y = []
+    #     for chanNum in range(image.data.shape[3]):
+    #         if False:#(image.data.shape[2] > 10) and not multiprocessing.current_process().daemon:
+    #             #use multiple processes for computation
+    #             fx, fy = self.calc_flow_mp(image.data, chanNum)
+    #         else:
+    #             fx, fy = self.calc_flow(image.data, chanNum)
+                
+    #         flow_x.append(fx)
+    #         flow_y.append(fy)
+        
+    #     im = ImageStack(flow_x, titleStub = self.outputNameX)
+    #     im.mdh.copyEntriesFrom(image.mdh)
+    #     im.mdh['Parent'] = image.filename
+        
+    #     self.completeMetadata(im)
+    #     namespace[self.outputNameX] = im
+        
+    #     im = ImageStack(flow_y, titleStub = self.outputNameY)
+    #     im.mdh.copyEntriesFrom(image.mdh)
+    #     im.mdh['Parent'] = image.filename
+        
+    #     self.completeMetadata(im)
+    #     namespace[self.outputNameY] = im
+
+    def run(self, inputName):
         import multiprocessing
-        image = namespace[self.inputName]
+        image = inputName
         flow_x = []
         flow_y = []
         for chanNum in range(image.data.shape[3]):
@@ -289,19 +318,15 @@ class OpticalFlow(ModuleBase):
             flow_x.append(fx)
             flow_y.append(fy)
         
-        im = ImageStack(flow_x, titleStub = self.outputNameX)
-        im.mdh.copyEntriesFrom(image.mdh)
-        im.mdh['Parent'] = image.filename
+        imx = ImageStack(flow_x, titleStub = self.outputNameX)
+        #imx.mdh.copyEntriesFrom(image.mdh)
+        imx.mdh['Parent'] = image.filename
         
-        self.completeMetadata(im)
-        namespace[self.outputNameX] = im
-        
-        im = ImageStack(flow_y, titleStub = self.outputNameY)
-        im.mdh.copyEntriesFrom(image.mdh)
-        im.mdh['Parent'] = image.filename
-        
-        self.completeMetadata(im)
-        namespace[self.outputNameY] = im
+        imy = ImageStack(flow_y, titleStub = self.outputNameY)
+        #imy.mdh.copyEntriesFrom(image.mdh)
+        imy.mdh['Parent'] = image.filename
+
+        return {'outputNameX' : imx, 'outputNameY' : imy}
         
     # def completeMetadata(self, im):
     #     im.mdh['OpticalFlow.filterRadius'] = self.filterRadius
@@ -323,11 +348,28 @@ class WavefrontDetection(ModuleBase):
     gradientThreshold = Float(0.5)
     outputName = Output('wavefronts')
     
-    def execute(self, namespace):
-        from skimage.morphology import skeletonize
-        img = namespace[self.inputName]
+    # def execute(self, namespace):
+    #     from skimage.morphology import skeletonize
+    #     img = namespace[self.inputName]
         
-        data = img.data[:,:,:]
+    #     data = img.data[:,:,:]
+        
+    #     out = np.zeros_like(data)
+    #     for i in range(1, data.shape[2]):
+    #         frnt_i = (np.abs(data[:,:,i] - data[:,:,(i-1)]) < self.gradientThreshold)*(data[:,:,i] > self.intensityThreshold)
+    #         out[:,:,i] = skeletonize(frnt_i.squeeze())
+            
+    #     im = ImageStack(out, titleStub=self.outputName)
+    #     im.mdh.copyEntriesFrom(img.mdh)
+    #     im.mdh['Parent'] = img.filename
+        
+    #     namespace[self.outputName] = im
+
+    def run(self, inputName):
+        from skimage.morphology import skeletonize
+        #img = namespace[self.inputName]
+        
+        data = inputName.data[:,:,:]
         
         out = np.zeros_like(data)
         for i in range(1, data.shape[2]):
@@ -335,10 +377,11 @@ class WavefrontDetection(ModuleBase):
             out[:,:,i] = skeletonize(frnt_i.squeeze())
             
         im = ImageStack(out, titleStub=self.outputName)
-        im.mdh.copyEntriesFrom(img.mdh)
-        im.mdh['Parent'] = img.filename
+        #im.mdh.copyEntriesFrom(img.mdh)
+        im.mdh['Parent'] = iinputName.filename
+        return im
         
-        namespace[self.outputName] = im
+
         
 @register_module('WavefrontVelocity')
 class WavefrontVelocity(ModuleBase):
@@ -353,14 +396,111 @@ class WavefrontVelocity(ModuleBase):
         
         
     
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from skimage.measure import profile_line
+    #     print('Calculating wavefront velocities')
+    #     wavefronts = namespace[self.inputWavefronts]
+        
+    #     waves = wavefronts.data
+    #     flow_x = namespace[self.inputFlowX].data
+    #     flow_y = namespace[self.inputFlowY].data
+        
+    #     velocities = np.zeros(waves.shape, 'f')
+        
+    #     wave_coords = []
+    #     #precompute arrays of wavefront coordinates
+    #     for i in range(waves.shape[2]):
+    #         if waves[:, :, i].max() > 0:
+    #             xp, yp = np.argwhere(waves[:, :, i].squeeze()).T
+        
+    #             xf = flow_x[:, :, i][xp, yp]
+    #             yf = flow_y[:, :, i][xp, yp]
+        
+    #             flow_m = np.sqrt(xf * xf + yf * yf)
+    #             xf = xf / flow_m
+    #             yf = yf / flow_m
+                
+    #             wave_coords.append([xp, yp, xf, yf])
+    #         else:
+    #             wave_coords.append([np.empty(0), np.empty(0), np.empty(0), np.empty(0)])
+                
+    #     for i in range(waves.shape[2]):
+    #         xp, yp, xf, yf = wave_coords[i]
+    #         print('WaveV: %d' % i)
+    #         #print(len(xp), xp, waves[:,:,i].max())
+    #         if len(xp) >0:
+    #             j_vals = range(max(i - self.timeWindow, 0), min(i + self.timeWindow + 1, waves.shape[2]))
+    #             A = np.vstack([j_vals, np.ones_like(j_vals)]).T
+    #             #A = np.ones_like(xp)[:,None,None]*A[None,:,:]
+                
+    #             ks = np.zeros([len(xp), len(j_vals)])
+    #             j0 = j_vals[0]
+    #             I = np.arange(len(xp))
+    #             for j in j_vals:
+    #                 xp_j, yp_j, xf_j, yf_j = wave_coords[j]
+    #                 if len(xp_j) > 0:
+    #                     k = xf*(-xp[:,None] + xp_j[None,:]) + yf*(-yp[:,None] + yp_j[None,:])
+    #                     km = np.sqrt(k*k)
+    #                     #print k
+    #                     #print km.argmin(1)
+    #                     #print k[I,km.argmin(1)]
+    #                     ks[:, j-j0] = k[I,km.argmin(1)]
+    #                 else:
+    #                     ks[:, j - j0] = np.nan #mask out our matrix for the missing data
+           
+    #             #print ks
+    #             vels = np.zeros_like(xp, 'f')
+    #             for k in range(len(xp)):
+    #                 kk = ks[k,:]
+    #                 #print kk
+    #                 vels[k] = np.linalg.lstsq(A[~np.isnan(kk),:], kk[~np.isnan(kk)])[0][0]
+                
+    #             #print vels.shape, velocities[xp,yp,i].shape
+    #             velocities[xp, yp, i] = vels[:,None]
+                
+        
+        
+    #     # for i in range(waves.shape[2]):
+    #     #     print(i)
+    #     #     if waves[:,:,i].max() > 0:
+    #     #         xp, yp = np.argwhere(waves[:,:,i].squeeze()).T
+    #     #
+    #     #         xf = flow_x[:,:, i][xp,yp]
+    #     #         yf = flow_y[:,:, i][xp,yp]
+    #     #
+    #     #         flow_m = np.sqrt(xf*xf + yf*yf)
+    #     #         xf = xf/flow_m
+    #     #         yf = yf/flow_m
+    #     #
+    #     #         j_vals= range(max(i-self.timeWindow, 0), min(i+ self.timeWindow + 1, waves.shape[2]))
+    #     #         A = np.vstack([j_vals, np.ones_like(j_vals)]).T
+    #     #
+    #     #         for x_k, y_k, xf_k, yf_k in zip(xp, yp, xf, yf):
+    #     #             prof = []
+    #     #             start, end = (x_k - 50 * xf_k, y_k - 50 * yf_k), (x_k + 50 * xf_k, y_k + 50 * yf_k)
+    #     #             for j in j_vals:
+    #     #                 prof.append(np.argmax(profile_line(waves[:,:,j], start, end)))
+    #     #
+    #     #             prof = np.array(prof, 'f')
+    #     #
+    #     #             #print j_vals, prof
+    #     #             m, c = np.linalg.lstsq(A[prof>0, :], prof[prof>0])[0]
+    #     #
+    #     #             velocities[x_k,y_k,i] = m
+
+    #     im = ImageStack(velocities, titleStub=self.outputName)
+    #     im.mdh.copyEntriesFrom(wavefronts.mdh)
+    #     im.mdh['Parent'] = wavefronts.filename
+
+    #     namespace[self.outputName] = im
+
+    def run(self, inputWavefronts, inputFlowX, inputFlowY):
         from skimage.measure import profile_line
         print('Calculating wavefront velocities')
-        wavefronts = namespace[self.inputWavefronts]
         
-        waves = wavefronts.data
-        flow_x = namespace[self.inputFlowX].data
-        flow_y = namespace[self.inputFlowY].data
+        waves = inputWavefronts.data
+        flow_x = inputFlowX.data
+        flow_y = inputFlowY.data
         
         velocities = np.zeros(waves.shape, 'f')
         
@@ -446,10 +586,10 @@ class WavefrontVelocity(ModuleBase):
         #             velocities[x_k,y_k,i] = m
 
         im = ImageStack(velocities, titleStub=self.outputName)
-        im.mdh.copyEntriesFrom(wavefronts.mdh)
-        im.mdh['Parent'] = wavefronts.filename
+        im.mdh.copyEntriesFrom(inputWavefronts.mdh) # TODO - needed?
+        im.mdh['Parent'] = inputWavefronts.filename
 
-        namespace[self.outputName] = im
+        return im
                 
 
 class CaWave(object):
@@ -685,15 +825,49 @@ class FindCaWaves(ModuleBase):
     
     outputName = Output('waves')
     
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from scipy import ndimage
+    #     from PYME.IO.DataSources import CropDataSource
+    #     print('Finding Ca Waves ...')
+    #     wavefronts = namespace[self.inputWavefronts] #segmented wavefront mask
+    #     intensity = namespace[self.inputIntensity]
+    #     wavefront_I = np.array([wavefronts.data.getSlice(i).sum() for i in range(wavefronts.data.getNumSlices())]).squeeze()
+        
+        
+        
+    #     #a wave is a contiguous region of non-zero wavefronts
+    #     wave_labels, nWaves = ndimage.label(wavefront_I > float(self.minActivePixels))
+        
+    #     print('Detected %d wave candidates' % nWaves)
+        
+    #     waves = []
+        
+    #     #print(wave_labels, nWaves)
+        
+    #     for i in range(nWaves):
+    #         wv_idx = np.argwhere(wave_labels == (i+1))
+            
+    #         print('wave%d: wave at %d-%d' % (i, wv_idx[0], wv_idx[-1]))
+            
+    #         if len(wv_idx) >= self.minWaveFrames:
+                
+    #             trange = (wv_idx[0], wv_idx[-1])
+    #             # TODO - Fix to use new and improved XYZTC CropDataSource.DataSource
+    #             cropped_wavefronts = ImageStack(CropDataSource._DataSource(wavefronts.data, trange=trange),
+    #                                             mdh=getattr(wavefronts, 'mdh', None))
+    #             cropped_intensity = ImageStack(CropDataSource._DataSource(intensity.data, trange=trange),
+    #                                             mdh=getattr(intensity, 'mdh', None))
+    #             waves.append(CaWave(cropped_wavefronts, cropped_intensity, trange))
+                
+        
+    #     namespace[self.outputName] = waves
+
+    def run(self, inputWavefronts, inputIntensity):
         from scipy import ndimage
         from PYME.IO.DataSources import CropDataSource
         print('Finding Ca Waves ...')
-        wavefronts = namespace[self.inputWavefronts] #segmented wavefront mask
-        intensity = namespace[self.inputIntensity]
-        wavefront_I = np.array([wavefronts.data.getSlice(i).sum() for i in range(wavefronts.data.getNumSlices())]).squeeze()
         
-        
+        wavefront_I = np.array([inputWavefronts.data.getSlice(i).sum() for i in range(inputWavefronts.data.getNumSlices())]).squeeze()
         
         #a wave is a contiguous region of non-zero wavefronts
         wave_labels, nWaves = ndimage.label(wavefront_I > float(self.minActivePixels))
@@ -713,14 +887,14 @@ class FindCaWaves(ModuleBase):
                 
                 trange = (wv_idx[0], wv_idx[-1])
                 # TODO - Fix to use new and improved XYZTC CropDataSource.DataSource
-                cropped_wavefronts = ImageStack(CropDataSource._DataSource(wavefronts.data, trange=trange),
-                                                mdh=getattr(wavefronts, 'mdh', None))
-                cropped_intensity = ImageStack(CropDataSource._DataSource(intensity.data, trange=trange),
-                                                mdh=getattr(intensity, 'mdh', None))
+                cropped_wavefronts = ImageStack(CropDataSource._DataSource(inputWavefronts.data, trange=trange),
+                                                mdh=getattr(inputWavefronts, 'mdh', None))
+                cropped_intensity = ImageStack(CropDataSource._DataSource(inputIntensity.data, trange=trange),
+                                                mdh=getattr(inputIntensity, 'mdh', None))
                 waves.append(CaWave(cropped_wavefronts, cropped_intensity, trange))
                 
         
-        namespace[self.outputName] = waves
+        return waves
                 
         
         
@@ -760,31 +934,52 @@ class Gradient2D(ModuleBase):
         
         return np.concatenate(grad_x, 2),np.concatenate(grad_y, 2) 
         
-    def execute(self, namespace):
-        image = namespace[self.inputName]
+    # def execute(self, namespace):
+    #     image = namespace[self.inputName]
+    #     grad_x = []
+    #     grad_y = []
+    #     for chanNum in range(image.data.shape[3]):
+    #         fx, fy = self.calc_grad(image.data, chanNum)
+    #         if self.units == 'intensity/um':
+    #             fx /= (image.voxelsize_nm.x / 1e3)  # [data/pix] -> [data/um]
+    #             fy /= (image.voxelsize_nm.y / 1e3)
+    #         grad_x.append(fx)
+    #         grad_y.append(fy)
+        
+    #     im = ImageStack(grad_x, titleStub = self.outputNameX)
+    #     im.mdh.copyEntriesFrom(image.mdh)
+    #     im.mdh['Parent'] = image.filename
+        
+    #     #self.completeMetadata(im)
+    #     namespace[self.outputNameX] = im
+        
+    #     im = ImageStack(grad_y, titleStub = self.outputNameY)
+    #     im.mdh.copyEntriesFrom(image.mdh)
+    #     im.mdh['Parent'] = image.filename
+        
+    #     #self.completeMetadata(im)
+    #     namespace[self.outputNameY] = im
+
+    def run(self, inputName):
         grad_x = []
         grad_y = []
-        for chanNum in range(image.data.shape[3]):
-            fx, fy = self.calc_grad(image.data, chanNum)
+        for chanNum in range(inputName.data.shape[3]):
+            fx, fy = self.calc_grad(inputName.data, chanNum)
             if self.units == 'intensity/um':
-                fx /= (image.voxelsize_nm.x / 1e3)  # [data/pix] -> [data/um]
-                fy /= (image.voxelsize_nm.y / 1e3)
+                fx /= (inputName.voxelsize_nm.x / 1e3)  # [data/pix] -> [data/um]
+                fy /= (inputName.voxelsize_nm.y / 1e3)
             grad_x.append(fx)
             grad_y.append(fy)
         
-        im = ImageStack(grad_x, titleStub = self.outputNameX)
-        im.mdh.copyEntriesFrom(image.mdh)
-        im.mdh['Parent'] = image.filename
+        imx = ImageStack(grad_x, titleStub = self.outputNameX)
+        #im.mdh.copyEntriesFrom(inputName.mdh)
+        imx.mdh['Parent'] = inputName.filename
         
-        #self.completeMetadata(im)
-        namespace[self.outputNameX] = im
-        
-        im = ImageStack(grad_y, titleStub = self.outputNameY)
-        im.mdh.copyEntriesFrom(image.mdh)
-        im.mdh['Parent'] = image.filename
-        
-        #self.completeMetadata(im)
-        namespace[self.outputNameY] = im
+        imy = ImageStack(grad_y, titleStub = self.outputNameY)
+        #im.mdh.copyEntriesFrom(inputName.mdh)
+        imy.mdh['Parent'] = inputName.filename
+
+        return {'outputNameX' : imx, 'outputNameY' : imy}
 
 
 @register_module('Gradient3D')
@@ -813,33 +1008,54 @@ class Gradient3D(ModuleBase):
 
         return dx, dy, dz
 
-    def execute(self, namespace):
-        image = namespace[self.inputName]
+    # def execute(self, namespace):
+    #     image = namespace[self.inputName]
+    #     grad_x = []
+    #     grad_y = []
+    #     grad_z = []
+
+    #     for chanNum in range(image.data.shape[3]):
+    #         fx, fy, fz = self.calc_grad(image.data, chanNum)
+    #         if self.units == 'intensity/um':
+    #             fx /= (image.voxelsize_nm.x / 1e3)  # [data/pix] -> [data/um]
+    #             fy /= (image.voxelsize_nm.y / 1e3)
+    #             fz /= (image.voxelsize_nm.z / 1e3)
+    #         grad_x.append(fx)
+    #         grad_y.append(fy)
+    #         grad_z.append(fz)
+
+    #     im = ImageStack(grad_x, titleStub=self.outputNameX)
+    #     im.mdh.copyEntriesFrom(image.mdh)
+    #     namespace[self.outputNameX] = im
+
+    #     im = ImageStack(grad_y, titleStub=self.outputNameY)
+    #     im.mdh.copyEntriesFrom(image.mdh)
+    #     namespace[self.outputNameY] = im
+
+    #     im = ImageStack(grad_z, titleStub=self.outputNameY)
+    #     im.mdh.copyEntriesFrom(image.mdh)
+    #     namespace[self.outputNameZ] = im
+
+    def run(self, inputName):
         grad_x = []
         grad_y = []
         grad_z = []
 
-        for chanNum in range(image.data.shape[3]):
-            fx, fy, fz = self.calc_grad(image.data, chanNum)
+        for chanNum in range(inputName.data.shape[3]):
+            fx, fy, fz = self.calc_grad(inputName.data, chanNum)
             if self.units == 'intensity/um':
-                fx /= (image.voxelsize_nm.x / 1e3)  # [data/pix] -> [data/um]
-                fy /= (image.voxelsize_nm.y / 1e3)
-                fz /= (image.voxelsize_nm.z / 1e3)
+                fx /= (inputName.voxelsize_nm.x / 1e3)  # [data/pix] -> [data/um]
+                fy /= (inputName.voxelsize_nm.y / 1e3)
+                fz /= (inputName.voxelsize_nm.z / 1e3)
             grad_x.append(fx)
             grad_y.append(fy)
             grad_z.append(fz)
 
-        im = ImageStack(grad_x, titleStub=self.outputNameX)
-        im.mdh.copyEntriesFrom(image.mdh)
-        namespace[self.outputNameX] = im
+        return {'outputNameX' : ImageStack(grad_x, titleStub=self.outputNameX),
+                'outputNameY' : ImageStack(grad_y, titleStub=self.outputNameY),
+                'outputNameZ' : ImageStack(grad_z, titleStub=self.outputNameZ)}
+        
 
-        im = ImageStack(grad_y, titleStub=self.outputNameY)
-        im.mdh.copyEntriesFrom(image.mdh)
-        namespace[self.outputNameY] = im
-
-        im = ImageStack(grad_z, titleStub=self.outputNameY)
-        im.mdh.copyEntriesFrom(image.mdh)
-        namespace[self.outputNameZ] = im
 
 @register_module('DirectionToMask3D')
 class DirectionToMask3D(ModuleBase):
@@ -884,29 +1100,44 @@ class DirectionToMask3D(ModuleBase):
 
         return dx/norm2, dy/norm2, dz/norm2
 
-    def execute(self, namespace):
-        image = namespace[self.inputName]
+    # def execute(self, namespace):
+    #     image = namespace[self.inputName]
+    #     grad_x = []
+    #     grad_y = []
+    #     grad_z = []
+
+    #     for chanNum in range(image.data.shape[3]):
+    #         fx, fy, fz = self.calc_grad(image.data, chanNum)
+    #         grad_x.append(fx)
+    #         grad_y.append(fy)
+    #         grad_z.append(fz)
+
+    #     im = ImageStack(grad_x, titleStub=self.outputNameX)
+    #     im.mdh.copyEntriesFrom(image.mdh)
+    #     namespace[self.outputNameX] = im
+
+    #     im = ImageStack(grad_y, titleStub=self.outputNameY)
+    #     im.mdh.copyEntriesFrom(image.mdh)
+    #     namespace[self.outputNameY] = im
+
+    #     im = ImageStack(grad_z, titleStub=self.outputNameY)
+    #     im.mdh.copyEntriesFrom(image.mdh)
+    #     namespace[self.outputNameZ] = im
+
+    def run(self, inputName):
         grad_x = []
         grad_y = []
         grad_z = []
 
-        for chanNum in range(image.data.shape[3]):
-            fx, fy, fz = self.calc_grad(image.data, chanNum)
+        for chanNum in range(inputName.data.shape[3]):
+            fx, fy, fz = self.calc_grad(inputName.data, chanNum)
             grad_x.append(fx)
             grad_y.append(fy)
             grad_z.append(fz)
 
-        im = ImageStack(grad_x, titleStub=self.outputNameX)
-        im.mdh.copyEntriesFrom(image.mdh)
-        namespace[self.outputNameX] = im
-
-        im = ImageStack(grad_y, titleStub=self.outputNameY)
-        im.mdh.copyEntriesFrom(image.mdh)
-        namespace[self.outputNameY] = im
-
-        im = ImageStack(grad_z, titleStub=self.outputNameY)
-        im.mdh.copyEntriesFrom(image.mdh)
-        namespace[self.outputNameZ] = im
+        return {'outputNameX' : ImageStack(grad_x, titleStub=self.outputNameX),
+                'outputNameY' : ImageStack(grad_y, titleStub=self.outputNameY),
+                'outputNameZ' : ImageStack(grad_z, titleStub=self.outputNameZ)}
 
 @register_module('VectorfieldCurl')
 class VectorfieldCurl(ModuleBase):
@@ -931,28 +1162,42 @@ class VectorfieldCurl(ModuleBase):
     outputZ = Output('out_z')
 
 
-    def execute(self, namespace):
-        Fx = namespace[self.inputX].data[:,:,:,0].squeeze()
-        Fy = namespace[self.inputY].data[:, :, :, 0].squeeze()
-        Fz = namespace[self.inputZ].data[:, :, :, 0].squeeze()
+    # def execute(self, namespace):
+    #     Fx = namespace[self.inputX].data[:,:,:,0].squeeze()
+    #     Fy = namespace[self.inputY].data[:, :, :, 0].squeeze()
+    #     Fz = namespace[self.inputZ].data[:, :, :, 0].squeeze()
 
-        mdh = namespace[self.inputX].mdh
+    #     mdh = namespace[self.inputX].mdh
+
+    #     dFzdx, dFzdy, dFzdz = np.gradient(Fz)
+    #     dFydx, dFydy, dFydz = np.gradient(Fy)
+    #     dFxdx, dFxdy, dFxdz = np.gradient(Fx)
+
+    #     im = ImageStack(dFzdy - dFydz, titleStub=self.outputX)
+    #     im.mdh.copyEntriesFrom(mdh)
+    #     namespace[self.outputX] = im
+
+    #     im = ImageStack(dFxdz - dFzdx, titleStub=self.outputY)
+    #     im.mdh.copyEntriesFrom(mdh)
+    #     namespace[self.outputY] = im
+
+    #     im = ImageStack(dFydx - dFzdy, titleStub=self.outputZ)
+    #     im.mdh.copyEntriesFrom(mdh)
+    #     namespace[self.outputZ] = im
+
+    def run(self, inputX, inputY, inputZ):
+        Fx = inputX.data[:,:,:,0].squeeze()
+        Fy = inputY.data[:, :, :, 0].squeeze()
+        Fz = inputZ.data[:, :, :, 0].squeeze()
 
         dFzdx, dFzdy, dFzdz = np.gradient(Fz)
         dFydx, dFydy, dFydz = np.gradient(Fy)
         dFxdx, dFxdy, dFxdz = np.gradient(Fx)
 
-        im = ImageStack(dFzdy - dFydz, titleStub=self.outputX)
-        im.mdh.copyEntriesFrom(mdh)
-        namespace[self.outputX] = im
+        return {'outputX' : ImageStack(dFzdy - dFydz, titleStub=self.outputX),
+                'outputY': ImageStack(dFxdz - dFzdx, titleStub=self.outputY),
+                'outputZ' : ImageStack(dFydx - dFzdy, titleStub=self.outputZ)}
 
-        im = ImageStack(dFxdz - dFzdx, titleStub=self.outputY)
-        im.mdh.copyEntriesFrom(mdh)
-        namespace[self.outputY] = im
-
-        im = ImageStack(dFydx - dFzdy, titleStub=self.outputZ)
-        im.mdh.copyEntriesFrom(mdh)
-        namespace[self.outputZ] = im
 
 @register_module('VectorfieldNorm')
 class VectorfieldNorm(ModuleBase):
@@ -975,21 +1220,33 @@ class VectorfieldNorm(ModuleBase):
 
     outputName = Output('output')
 
-    def execute(self, namespace):
-        x = namespace[self.inputX].data[:,:,:,0].squeeze()
-        y = namespace[self.inputY].data[:, :, :, 0].squeeze()
-        if self.inputZ == '':
+    # def execute(self, namespace):
+    #     x = namespace[self.inputX].data[:,:,:,0].squeeze()
+    #     y = namespace[self.inputY].data[:, :, :, 0].squeeze()
+    #     if self.inputZ == '':
+    #         z = 0
+    #     else:
+    #         z = namespace[self.inputZ].data[:, :, :, 0].squeeze()
+
+    #     mdh = namespace[self.inputX].mdh
+
+    #     norm = np.sqrt(x*x + y*y + z*z)
+
+    #     im = ImageStack(norm, titleStub=self.outputName)
+    #     im.mdh.copyEntriesFrom(mdh)
+    #     namespace[self.outputName] = im
+
+    def run(self, inputX, inputY, inputZ):
+        x = inputX.data[:,:,:,0].squeeze()
+        y = inputY.data[:, :, :, 0].squeeze()
+        if not inputZ:
             z = 0
         else:
-            z = namespace[self.inputZ].data[:, :, :, 0].squeeze()
-
-        mdh = namespace[self.inputX].mdh
+            z = inputZ.data[:, :, :, 0].squeeze()
 
         norm = np.sqrt(x*x + y*y + z*z)
 
-        im = ImageStack(norm, titleStub=self.outputName)
-        im.mdh.copyEntriesFrom(mdh)
-        namespace[self.outputName] = im
+        return ImageStack(norm, titleStub=self.outputName)
         
 @register_module('VectorfieldAngle')
 class VectorfieldAngle(ModuleBase):
@@ -1015,33 +1272,54 @@ class VectorfieldAngle(ModuleBase):
     outputTheta = Output('theta')
     outputPhi = Output('phi')
 
-    def execute(self, namespace):
-        x = namespace[self.inputX].data[:,:,:,0].squeeze()
-        y = namespace[self.inputY].data[:, :, :, 0].squeeze()
+    # def execute(self, namespace):
+    #     x = namespace[self.inputX].data[:,:,:,0].squeeze()
+    #     y = namespace[self.inputY].data[:, :, :, 0].squeeze()
+        
+    #     theta = np.angle(x + 1j*y)
+        
+    #     if self.inputZ == '':
+    #         z = 0
+    #         phi = 0*theta
+    #     else:
+    #         z = namespace[self.inputZ].data[:, :, :, 0].squeeze()
+            
+    #         r = np.sqrt(x*x + y*y)
+            
+    #         phi = np.angle(r + 1j*z)
+
+    #     mdh = namespace[self.inputX].mdh
+
+        
+
+    #     im = ImageStack(theta, titleStub=self.outputTheta)
+    #     im.mdh.copyEntriesFrom(mdh)
+    #     namespace[self.outputTheta] = im
+
+    #     im = ImageStack(phi, titleStub=self.outputPhi)
+    #     im.mdh.copyEntriesFrom(mdh)
+    #     namespace[self.outputPhi] = im
+
+def run(self, inputX, inputY, inputZ):
+        x = inputX.data[:,:,:,0].squeeze()
+        y = inputY.data[:, :, :, 0].squeeze()
         
         theta = np.angle(x + 1j*y)
         
-        if self.inputZ == '':
+        if not inputZ:
             z = 0
             phi = 0*theta
         else:
-            z = namespace[self.inputZ].data[:, :, :, 0].squeeze()
+            z = inputZ.data[:, :, :, 0].squeeze()
             
             r = np.sqrt(x*x + y*y)
             
             phi = np.angle(r + 1j*z)
 
-        mdh = namespace[self.inputX].mdh
-
         
-
-        im = ImageStack(theta, titleStub=self.outputTheta)
-        im.mdh.copyEntriesFrom(mdh)
-        namespace[self.outputTheta] = im
-
-        im = ImageStack(phi, titleStub=self.outputPhi)
-        im.mdh.copyEntriesFrom(mdh)
-        namespace[self.outputPhi] = im
+        return {'outputTheta' : ImageStack(theta, titleStub=self.outputTheta),
+                'outputPhi': ImageStack(phi, titleStub=self.outputPhi)}
+        
 
 
 @register_module('ProjectOnVector')         
@@ -1078,32 +1356,44 @@ class ProjectOnVector(ModuleBase):
         
         return np.concatenate(proj_p, 2),np.concatenate(proj_s, 2) 
         
-    def execute(self, namespace):
-        inpX = namespace[self.inputX]
-        inpY = namespace[self.inputY]
-        dirX = namespace[self.inputDirX]
-        dirY = namespace[self.inputDirY]
+    # def execute(self, namespace):
+    #     inpX = namespace[self.inputX]
+    #     inpY = namespace[self.inputY]
+    #     dirX = namespace[self.inputDirX]
+    #     dirY = namespace[self.inputDirY]
         
+    #     proj_p = []
+    #     proj_s = []
+    #     for chanNum in range(inpX.data.shape[3]):
+    #         fx, fy = self.calc_proj(inpX.data, inpY.data, dirX.data, dirY.data, chanNum)
+    #         proj_p.append(fx)
+    #         proj_s.append(fy)
+        
+    #     im = ImageStack(proj_p, titleStub = self.outputNameP)
+    #     im.mdh.copyEntriesFrom(inpX.mdh)
+    #     im.mdh['Parent'] = inpX.filename
+        
+    #     #self.completeMetadata(im)
+    #     namespace[self.outputNameP] = im
+        
+    #     im = ImageStack(proj_s, titleStub = self.outputNameS)
+    #     im.mdh.copyEntriesFrom(inpX.mdh)
+    #     im.mdh['Parent'] = inpX.filename
+        
+    #     #self.completeMetadata(im)
+    #     namespace[self.outputNameS] = im
+
+    def run(self, inputX, inputY, inputDirX, inputDirY):
         proj_p = []
         proj_s = []
-        for chanNum in range(inpX.data.shape[3]):
-            fx, fy = self.calc_proj(inpX.data, inpY.data, dirX.data, dirY.data, chanNum)
+        for chanNum in range(inputX.data.shape[3]):
+            fx, fy = self.calc_proj(inputX.data, inputY.data, inputDirX.data, inputDirY.data, chanNum)
             proj_p.append(fx)
             proj_s.append(fy)
         
-        im = ImageStack(proj_p, titleStub = self.outputNameP)
-        im.mdh.copyEntriesFrom(inpX.mdh)
-        im.mdh['Parent'] = inpX.filename
+        return {'outputNameP' : ImageStack(proj_p, titleStub = self.outputNameP),
+                'outputNameS' : ImageStack(proj_s, titleStub = self.outputNameS)}
         
-        #self.completeMetadata(im)
-        namespace[self.outputNameP] = im
-        
-        im = ImageStack(proj_s, titleStub = self.outputNameS)
-        im.mdh.copyEntriesFrom(inpX.mdh)
-        im.mdh['Parent'] = inpX.filename
-        
-        #self.completeMetadata(im)
-        namespace[self.outputNameS] = im
         
 
 class PSFFile(FileOrURI):
@@ -1342,10 +1632,14 @@ class DeconvolveMotionCompensating(Deconvolve):
     inputFlowX = Input('flow_x')
     inputFlowY = Input('flow_y')
     
-    def execute(self, namespace):
-        self._flow_x = namespace[self.inputFlowX]
-        self._flow_y = namespace[self.inputFlowY]
-        namespace[self.outputName] = self.filter(namespace[self.inputName])
+    # def execute(self, namespace):
+    #     self._flow_x = namespace[self.inputFlowX]
+    #     self._flow_y = namespace[self.inputFlowY]
+    #     namespace[self.outputName] = self.filter(namespace[self.inputName])
+
+    def run(self, inputName, inputFlowX, inputFlowY):
+        self._flow_x, self._flow_y = inputFlowX, inputFlowY
+        return self.filter(inputName)
     
     def GetDec(self, dp, vshint):
         """Get a (potentially cached) deconvolution object"""
@@ -1574,14 +1868,20 @@ class Watershed(ModuleBase):
         else:
             return skimage.morphology.watershed(img, markers.astype('int16'))
         
-    def execute(self, namespace):
-        image = namespace[self.inputImage]
-        markers =  namespace[self.inputMarkers]
-        if self.inputMask in ['', 'none', 'None']:
-            namespace[self.outputName] = self.filter(image, markers)
+    # def execute(self, namespace):
+    #     image = namespace[self.inputImage]
+    #     markers =  namespace[self.inputMarkers]
+    #     if self.inputMask in ['', 'none', 'None']:
+    #         namespace[self.outputName] = self.filter(image, markers)
+    #     else:
+    #         mask = namespace[self.inputMask]
+    #         namespace[self.outputName] = self.filter(image, markers, mask)
+
+    def run(self, inputImage, inputMarkers, inputMask=None):
+        if inputMask:
+            return self.filter(inputImage, inputMarkers)
         else:
-            mask = namespace[self.inputMask]
-            namespace[self.outputName] = self.filter(image, markers, mask)
+            return self.filter(inputImage, inputMarkers, inputMask)
             
             
 @register_module('FlatfieldAndDarkCorrect')
@@ -1591,11 +1891,33 @@ class FlatfiledAndDarkCorrect(ModuleBase):
     darkFilename = CStr('')
     outputName = Output('corrected')
     
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.IO.DataSources import FlatFieldDataSource
+    #     #from PYME.IO import unifiedIO
+    #     from PYME.IO.image import ImageStack
+    #     image = namespace[self.inputImage]
+        
+    #     if self.flatfieldFilename != '':
+    #         flat = ImageStack(filename=self.flatfieldFilename).data_xyztc[:,:,0,0,0].squeeze()
+    #     else:
+    #         flat = None
+        
+    #     if not self.darkFilename == '':
+    #         dark = ImageStack(filename=self.darkFilename).data_xyztc[:,:,0, 0, 0].squeeze()
+    #     else:
+    #         dark = None
+        
+    #     ffd = FlatFieldDataSource.DataSource(image.data, image.mdh, flatfield=flat, dark=dark)
+
+    #     im = ImageStack(ffd, titleStub=self.outputName)
+    #     im.mdh.copyEntriesFrom(image.mdh)
+    #     im.mdh['Parent'] = image.filename
+    #     namespace[self.outputName] = im
+
+    def run(self, inputImage):
         from PYME.IO.DataSources import FlatFieldDataSource
         #from PYME.IO import unifiedIO
         from PYME.IO.image import ImageStack
-        image = namespace[self.inputImage]
         
         if self.flatfieldFilename != '':
             flat = ImageStack(filename=self.flatfieldFilename).data_xyztc[:,:,0,0,0].squeeze()
@@ -1607,12 +1929,13 @@ class FlatfiledAndDarkCorrect(ModuleBase):
         else:
             dark = None
         
-        ffd = FlatFieldDataSource.DataSource(image.data, image.mdh, flatfield=flat, dark=dark)
+        ffd = FlatFieldDataSource.DataSource(inputImage.data, inputImage.mdh, flatfield=flat, dark=dark)
 
         im = ImageStack(ffd, titleStub=self.outputName)
-        im.mdh.copyEntriesFrom(image.mdh)
-        im.mdh['Parent'] = image.filename
-        namespace[self.outputName] = im
+        #im.mdh.copyEntriesFrom(inputImage.mdh)
+        im.mdh['Parent'] = inputImage.filename
+
+        return im
 
 @register_module('Colocalisation')
 class Colocalisation(ModuleBase):
@@ -1628,25 +1951,58 @@ class Colocalisation(ModuleBase):
     inputRoiMask = Input('')
     outputTable = Output('coloc')
     
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.Analysis.Colocalisation import correlationCoeffs
+    #     from PYME.IO import tabular
+        
+    #     imA = namespace[self.inputImageA].data[:,:,:,0].squeeze()
+    #     imB = namespace[self.inputImageB].data[:,:,:,0].squeeze()
+    #     if not np.all(imB.shape == imA.shape):
+    #         raise RuntimeError('imageB (shape=%s) not the same size as image data (shape=%s)' % (imB.shape, imA.shape))
+
+    #     mA = namespace[self.inputMaskA].data[:,:,:,0].squeeze()
+    #     if not np.all(mA.shape == imA.shape):
+    #         raise RuntimeError('maskA (shape=%s) not the same size as image data (shape=%s)' % (mA.shape, imA.shape))
+        
+    #     mB = namespace[self.inputMaskB].data[:,:,:,0].squeeze()
+    #     if not np.all(mB.shape == imA.shape):
+    #         raise RuntimeError('maskB (shape=%s) not the same size as image data (shape=%s)' % (mB.shape, imA.shape))
+        
+    #     if not self.inputRoiMask == '':
+    #         roi_mask = namespace[self.inputRoiMask].data[:,:,:,0].squeeze() > 0.5
+    #         if not np.all(roi_mask.shape == imA.shape):
+    #             raise RuntimeError('ROI mask (shape=%s) not the same size as image data (shape=%s)' % (roi_mask.shape, imA.shape))
+
+    #     else:
+    #         roi_mask = None
+
+    #     print('Calculating Pearson and Manders coefficients ...')
+    #     pearson = correlationCoeffs.pearson(imA, imB, roi_mask=roi_mask)
+    #     MA, MB = correlationCoeffs.maskManders(imA, imB, mA, mB, roi_mask=roi_mask)
+        
+    #     out = tabular.DictSource({'pearson' : pearson, 'manders_A' : MA, 'manders_B' : MB})
+        
+    #     namespace[self.outputTable] = out
+
+    def run(self, inputImageA, inputMaskA, inputImageB, inputMaskB, inputRoiMask=None):
         from PYME.Analysis.Colocalisation import correlationCoeffs
         from PYME.IO import tabular
         
-        imA = namespace[self.inputImageA].data[:,:,:,0].squeeze()
-        imB = namespace[self.inputImageB].data[:,:,:,0].squeeze()
+        imA = inputImageA.data[:,:,:,0].squeeze()
+        imB = inputImageB.data[:,:,:,0].squeeze()
         if not np.all(imB.shape == imA.shape):
             raise RuntimeError('imageB (shape=%s) not the same size as image data (shape=%s)' % (imB.shape, imA.shape))
 
-        mA = namespace[self.inputMaskA].data[:,:,:,0].squeeze()
+        mA = inputMaskA.data[:,:,:,0].squeeze()
         if not np.all(mA.shape == imA.shape):
             raise RuntimeError('maskA (shape=%s) not the same size as image data (shape=%s)' % (mA.shape, imA.shape))
         
-        mB = namespace[self.inputMaskB].data[:,:,:,0].squeeze()
+        mB = inputMaskB.data[:,:,:,0].squeeze()
         if not np.all(mB.shape == imA.shape):
             raise RuntimeError('maskB (shape=%s) not the same size as image data (shape=%s)' % (mB.shape, imA.shape))
         
-        if not self.inputRoiMask == '':
-            roi_mask = namespace[self.inputRoiMask].data[:,:,:,0].squeeze() > 0.5
+        if inputRoiMask:
+            roi_mask = inputRoiMask.data[:,:,:,0].squeeze() > 0.5
             if not np.all(roi_mask.shape == imA.shape):
                 raise RuntimeError('ROI mask (shape=%s) not the same size as image data (shape=%s)' % (roi_mask.shape, imA.shape))
 
@@ -1657,9 +2013,7 @@ class Colocalisation(ModuleBase):
         pearson = correlationCoeffs.pearson(imA, imB, roi_mask=roi_mask)
         MA, MB = correlationCoeffs.maskManders(imA, imB, mA, mB, roi_mask=roi_mask)
         
-        out = tabular.DictSource({'pearson' : pearson, 'manders_A' : MA, 'manders_B' : MB})
-        
-        namespace[self.outputTable] = out
+        return tabular.DictSource({'pearson' : pearson, 'manders_A' : MA, 'manders_B' : MB})
           
 
 
@@ -1714,25 +2068,76 @@ class ColocalisationEDT(ModuleBase):
     binSizeNM = Float(100.)
     
     
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.IO import tabular
+    #     from PYME.Analysis.Colocalisation import edtColoc
+    #     from PYME.recipes.graphing import Plot
+        
+    #     bins = np.arange(float(self.minimumDistanceNM), float(self.maximumDistanceNM), float(self.binSizeNM))
+
+    #     im = namespace[self.inputImage]
+    #     imA = im.data[:, :, :, 0].squeeze()
+    #     voxelsize = im.voxelsize[:imA.ndim]
+        
+    #     m_im = namespace[self.inputMask]
+    #     mask = m_im.data[:,:,:,0].squeeze() > 0.5
+
+    #     if not np.all(mask.shape == imA.shape):
+    #         raise RuntimeError('Mask (shape=%s) not the same size as image data (shape=%s)' % (mask.shape, imA.shape))
+        
+    #     if not self.inputRoiMask == '':
+    #         roi_mask = namespace[self.inputRoiMask].data[:,:,:,0].squeeze() > 0.5
+    #         if not np.all(roi_mask.shape == imA.shape):
+    #             raise RuntimeError('ROI mask (shape=%s) not the same size as image data (shape=%s)' % (roi_mask.shape, imA.shape))
+    #     else:
+    #         roi_mask = None
+        
+
+    #     bins_, enrichment, enclosed, enclosed_area = edtColoc.image_enrichment_and_fraction_at_distance(imA, mask, voxelsize,
+    #                                                                                            bins, roi_mask=roi_mask)
+        
+    #     out = tabular.MappingFilter(tabular.DictSource({'bins' : bins[1:], 'enrichment' : enrichment, 'enclosed' : enclosed, 'enclosed_area' : enclosed_area}))
+    #     out.mdh = getattr(im, 'mdh', None)
+        
+    #     if not self.inputImageB == '':
+    #         imB = namespace[self.inputImageB].data[:,:, :,0].squeeze()
+    #         if not np.all(imB.shape == imA.shape):
+    #             raise RuntimeError(
+    #                 'ImageB (shape=%s) not the same size as image data (shape=%s)' % (imB.shape, imA.shape))
+            
+    #         bins_, enrichment_m, enclosed_m, _ = edtColoc.image_enrichment_and_fraction_at_distance(imB, mask, voxelsize,
+    #                                                                                          bins, roi_mask=roi_mask)
+    #         out.addColumn('enrichment_m', enrichment_m)
+    #         out.addColumn('enclosed_m', enclosed_m)
+            
+    #     else:
+    #         enrichment_m = None
+    #         enclosed_m = None
+
+    #     namespace[self.outputTable] = out
+    #     namespace[self.outputPlot] = Plot(lambda: edtColoc.plot_image_dist_coloc_figure(bins, enrichment, enrichment_m,
+    #                                                                                     enclosed, enclosed_m,
+    #                                                                                     enclosed_area,
+    #                                                                                     nameA=m_im.names[0],
+    #                                                                                     nameB=im.names[0]))
+
+    def run(self, inputImage, inputMask, inputImageB=None, inputRoiMask=None):
         from PYME.IO import tabular
         from PYME.Analysis.Colocalisation import edtColoc
         from PYME.recipes.graphing import Plot
         
         bins = np.arange(float(self.minimumDistanceNM), float(self.maximumDistanceNM), float(self.binSizeNM))
 
-        im = namespace[self.inputImage]
-        imA = im.data[:, :, :, 0].squeeze()
-        voxelsize = im.voxelsize[:imA.ndim]
+        imA = inputImage.data[:, :, :, 0].squeeze()
+        voxelsize = inputImage.voxelsize[:imA.ndim]
         
-        m_im = namespace[self.inputMask]
-        mask = m_im.data[:,:,:,0].squeeze() > 0.5
+        mask = inputMask.data[:,:,:,0].squeeze() > 0.5
 
         if not np.all(mask.shape == imA.shape):
             raise RuntimeError('Mask (shape=%s) not the same size as image data (shape=%s)' % (mask.shape, imA.shape))
         
-        if not self.inputRoiMask == '':
-            roi_mask = namespace[self.inputRoiMask].data[:,:,:,0].squeeze() > 0.5
+        if inputRoiMask :
+            roi_mask = inputRoiMask.data[:,:,:,0].squeeze() > 0.5
             if not np.all(roi_mask.shape == imA.shape):
                 raise RuntimeError('ROI mask (shape=%s) not the same size as image data (shape=%s)' % (roi_mask.shape, imA.shape))
         else:
@@ -1743,10 +2148,10 @@ class ColocalisationEDT(ModuleBase):
                                                                                                bins, roi_mask=roi_mask)
         
         out = tabular.MappingFilter(tabular.DictSource({'bins' : bins[1:], 'enrichment' : enrichment, 'enclosed' : enclosed, 'enclosed_area' : enclosed_area}))
-        out.mdh = getattr(im, 'mdh', None)
+        out.mdh = getattr(inputImage, 'mdh', None)
         
-        if not self.inputImageB == '':
-            imB = namespace[self.inputImageB].data[:,:, :,0].squeeze()
+        if inputImageB:
+            imB = inputImageB.data[:,:, :,0].squeeze()
             if not np.all(imB.shape == imA.shape):
                 raise RuntimeError(
                     'ImageB (shape=%s) not the same size as image data (shape=%s)' % (imB.shape, imA.shape))
@@ -1760,12 +2165,12 @@ class ColocalisationEDT(ModuleBase):
             enrichment_m = None
             enclosed_m = None
 
-        namespace[self.outputTable] = out
-        namespace[self.outputPlot] = Plot(lambda: edtColoc.plot_image_dist_coloc_figure(bins, enrichment, enrichment_m,
+        return {'outputTable' : out,
+                'outputPlot' : Plot(lambda: edtColoc.plot_image_dist_coloc_figure(bins, enrichment, enrichment_m,
                                                                                         enclosed, enclosed_m,
                                                                                         enclosed_area,
-                                                                                        nameA=m_im.names[0],
-                                                                                        nameB=im.names[0]))
+                                                                                        nameA=inputMask.names[0],
+                                                                                        nameB=inputImage.names[0]))}
 
         
         
@@ -1792,21 +2197,77 @@ class AverageFramesByZStep(ModuleBase):
     z_column_name = CStr('z')
     output = Output('averaged_by_frame')
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.Analysis import piezo_movement_correction
+    #     from scipy.stats import mode
+    #     import time
+
+    #     image_stack = namespace[self.input_image]
+
+    #     if self.input_zvals == '':
+    #         # z from events
+    #         frames = np.arange(image_stack.data.shape[2], dtype=int)
+
+    #         z_vals = piezo_movement_correction.correct_target_positions(frames, image_stack.events, image_stack.mdh)
+    #     else:
+    #         #z values are provided as input
+    #         z_vals = namespace[self.input_zvals][self.z_column_name]
+        
+    #     # later we will mash z with %3.3f, round here so we don't duplicate steps
+    #     # TODO - make rounding precision a parameter?
+    #     z_vals = np.round(z_vals, decimals=3)
+
+    #     # make sure everything is sorted. We'll carry the args to sort, rather than creating another full array
+    #     frames_z_sorted = np.argsort(z_vals)
+    #     z = z_vals[frames_z_sorted]
+    #     z_steps, count = np.unique(z, return_counts=True)
+
+    #     n_steps = len(z_steps)
+    #     logger.debug('Averaged stack size: %d' % n_steps)
+
+    #     new_stack = []
+    #    # TODO - should we default to zero or abort?
+    #     t = image_stack.mdh.getOrDefault('StartTime', 0)
+    #     fudged_events = []
+    #     cycle_time = image_stack.mdh.getOrDefault('Camera.CycleTime', 1.0)
+    #     for ci in range(image_stack.data.shape[3]):
+    #         data_avg = np.zeros((image_stack.data.shape[0], image_stack.data.shape[1], n_steps))
+    #         start = 0
+    #         for si in range(n_steps):
+    #             for fi in range(count[si]):
+    #                 # sum frames from this step directly into the output array
+    #                 data_avg[:, :, si] += image_stack.data[:, :, frames_z_sorted[start + fi], ci].squeeze()
+    #             start += count[si]
+    #             fudged_events.append(('ProtocolFocus', t, '%d, %3.3f' % (si, z_steps[si])))
+    #             fudged_events.append((('StartAq', t, '%d' % si)))
+    #             t += cycle_time
+    #         # complete the average for this color channel and append to output
+    #         new_stack.append(data_avg / count[None, None, :])
+
+    #     # FIXME  - make this follow the correct event dtype
+    #     fudged_events = np.array(fudged_events, dtype=[('EventName', 'S32'), ('Time', '<f8'), ('EventDescr', 'S256')])
+    #     averaged = ImageStack(new_stack, mdh=MetaDataHandler.NestedClassMDHandler(image_stack.mdh), events=fudged_events)
+
+    #     # fudge metadata, leaving breadcrumbs
+    #     averaged.mdh['Camera.CycleTime'] = cycle_time
+    #     averaged.mdh['StackSettings.NumSlices'] = n_steps
+    #     averaged.mdh['StackSettings.StepSize'] = abs(mode(np.diff(z))[0][0])
+
+    #     namespace[self.output] = averaged
+
+    def run(self, input_image, input_zvals=None):
         from PYME.Analysis import piezo_movement_correction
         from scipy.stats import mode
         import time
 
-        image_stack = namespace[self.input_image]
-
-        if self.input_zvals == '':
+        if not input_zvals:
             # z from events
-            frames = np.arange(image_stack.data.shape[2], dtype=int)
+            frames = np.arange(input_image.data.shape[2], dtype=int)
 
-            z_vals = piezo_movement_correction.correct_target_positions(frames, image_stack.events, image_stack.mdh)
+            z_vals = piezo_movement_correction.correct_target_positions(frames, input_image.events, input_image.mdh)
         else:
             #z values are provided as input
-            z_vals = namespace[self.input_zvals][self.z_column_name]
+            z_vals = input_zvals[self.z_column_name]
         
         # later we will mash z with %3.3f, round here so we don't duplicate steps
         # TODO - make rounding precision a parameter?
@@ -1822,16 +2283,16 @@ class AverageFramesByZStep(ModuleBase):
 
         new_stack = []
        # TODO - should we default to zero or abort?
-        t = image_stack.mdh.getOrDefault('StartTime', 0)
+        t = input_image.mdh.getOrDefault('StartTime', 0)
         fudged_events = []
-        cycle_time = image_stack.mdh.getOrDefault('Camera.CycleTime', 1.0)
-        for ci in range(image_stack.data.shape[3]):
-            data_avg = np.zeros((image_stack.data.shape[0], image_stack.data.shape[1], n_steps))
+        cycle_time = input_image.mdh.getOrDefault('Camera.CycleTime', 1.0)
+        for ci in range(input_image.data.shape[3]):
+            data_avg = np.zeros((input_image.data.shape[0], input_image.data.shape[1], n_steps))
             start = 0
             for si in range(n_steps):
                 for fi in range(count[si]):
                     # sum frames from this step directly into the output array
-                    data_avg[:, :, si] += image_stack.data[:, :, frames_z_sorted[start + fi], ci].squeeze()
+                    data_avg[:, :, si] += input_image.data[:, :, frames_z_sorted[start + fi], ci].squeeze()
                 start += count[si]
                 fudged_events.append(('ProtocolFocus', t, '%d, %3.3f' % (si, z_steps[si])))
                 fudged_events.append((('StartAq', t, '%d' % si)))
@@ -1841,14 +2302,14 @@ class AverageFramesByZStep(ModuleBase):
 
         # FIXME  - make this follow the correct event dtype
         fudged_events = np.array(fudged_events, dtype=[('EventName', 'S32'), ('Time', '<f8'), ('EventDescr', 'S256')])
-        averaged = ImageStack(new_stack, mdh=MetaDataHandler.NestedClassMDHandler(image_stack.mdh), events=fudged_events)
+        averaged = ImageStack(new_stack, mdh=MetaDataHandler.NestedClassMDHandler(input_image.mdh), events=fudged_events)
 
         # fudge metadata, leaving breadcrumbs
         averaged.mdh['Camera.CycleTime'] = cycle_time
         averaged.mdh['StackSettings.NumSlices'] = n_steps
         averaged.mdh['StackSettings.StepSize'] = abs(mode(np.diff(z))[0][0])
 
-        namespace[self.output] = averaged
+        return averaged
 
 
 @register_module('ResampleZ')
@@ -1875,19 +2336,59 @@ class ResampleZ(ModuleBase):
     z_sampling = Float(0.05)
     output = Output('regular_stack')
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.Analysis import piezo_movement_correction
+    #     from scipy.interpolate import RegularGridInterpolator
+
+    #     stack = namespace[self.input]
+
+    #     # grab z from events if we can
+    #     frames = np.arange(stack.data.shape[2], dtype=int)
+
+    #     z_vals = piezo_movement_correction.correct_target_positions(frames, stack.events, stack.mdh)
+
+    #     x = np.arange(0, stack.mdh['voxelsize.x'] * stack.data.shape[0], stack.mdh['voxelsize.x'])
+    #     y = np.arange(0, stack.mdh['voxelsize.y'] * stack.data.shape[1], stack.mdh['voxelsize.y'])
+
+    #     # generate grid for sampling
+    #     new_z = np.arange(np.min(z_vals), np.max(z_vals), self.z_sampling)
+    #     xx, yy, zz = np.meshgrid(x, y, new_z, indexing='ij')
+    #     # RegularGridInterpolator needs z to be strictly ascending need to average frames from the same step first
+    #     uni, counts = np.unique(z_vals, return_counts=True)
+    #     if np.any(counts > 1):
+    #         raise RuntimeError('Resampling requires one frame per z-step. Please run AverageFramesByZStep first')
+    #     I = np.argsort(z_vals)
+    #     sorted_z_vals = z_vals[I]
+    #     regular = []
+    #     for ci in range(stack.data.shape[3]):
+    #         interp = RegularGridInterpolator((x, y, sorted_z_vals), stack.data[:, :, :, ci][:,:,I], method='linear')
+    #         regular.append(interp((xx, yy, zz)))
+
+    #     mdh = MetaDataHandler.DictMDHandler({
+    #         'RegularizedStack': True,
+    #         'StackSettings.StepSize': self.z_sampling,
+    #         'StackSettings.StartPos': new_z[0],
+    #         'StackSettings.EndPos': new_z[-1],
+    #         'StackSettings.NumSlices': len(new_z),
+    #         'voxelsize.z': self.z_sampling
+    #     })
+    #     mdh.mergeEntriesFrom(stack.mdh)
+        
+    #     regular_stack = ImageStack(regular, mdh=mdh)
+
+    #     namespace[self.output] = regular_stack
+
+    def run(self, input):
         from PYME.Analysis import piezo_movement_correction
         from scipy.interpolate import RegularGridInterpolator
 
-        stack = namespace[self.input]
-
         # grab z from events if we can
-        frames = np.arange(stack.data.shape[2], dtype=int)
+        frames = np.arange(input.data.shape[2], dtype=int)
 
-        z_vals = piezo_movement_correction.correct_target_positions(frames, stack.events, stack.mdh)
+        z_vals = piezo_movement_correction.correct_target_positions(frames, input.events, input.mdh)
 
-        x = np.arange(0, stack.mdh['voxelsize.x'] * stack.data.shape[0], stack.mdh['voxelsize.x'])
-        y = np.arange(0, stack.mdh['voxelsize.y'] * stack.data.shape[1], stack.mdh['voxelsize.y'])
+        x = np.arange(0, input.mdh['voxelsize.x'] * input.data.shape[0], input.mdh['voxelsize.x'])
+        y = np.arange(0, input.mdh['voxelsize.y'] * input.data.shape[1], input.mdh['voxelsize.y'])
 
         # generate grid for sampling
         new_z = np.arange(np.min(z_vals), np.max(z_vals), self.z_sampling)
@@ -1899,8 +2400,8 @@ class ResampleZ(ModuleBase):
         I = np.argsort(z_vals)
         sorted_z_vals = z_vals[I]
         regular = []
-        for ci in range(stack.data.shape[3]):
-            interp = RegularGridInterpolator((x, y, sorted_z_vals), stack.data[:, :, :, ci][:,:,I], method='linear')
+        for ci in range(input.data.shape[3]):
+            interp = RegularGridInterpolator((x, y, sorted_z_vals), input.data[:, :, :, ci][:,:,I], method='linear')
             regular.append(interp((xx, yy, zz)))
 
         mdh = MetaDataHandler.DictMDHandler({
@@ -1911,11 +2412,9 @@ class ResampleZ(ModuleBase):
             'StackSettings.NumSlices': len(new_z),
             'voxelsize.z': self.z_sampling
         })
-        mdh.mergeEntriesFrom(stack.mdh)
+        mdh.mergeEntriesFrom(input.mdh)
         
-        regular_stack = ImageStack(regular, mdh=mdh)
-
-        namespace[self.output] = regular_stack
+        return ImageStack(regular, mdh=mdh)
 
 @register_module('BackgroundSubtractionMovingAverage')
 class BackgroundSubtractionMovingAverage(ModuleBase):
@@ -1947,21 +2446,36 @@ class BackgroundSubtractionMovingAverage(ModuleBase):
 
     percentile = 0
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.IO.DataSources import BGSDataSource
+    #     from PYME.IO.image import ImageStack
+    #     series = namespace[self.input_name]
+
+    #     bgs = BGSDataSource.DataSource(series.data, bgRange=self.window)
+    #     bgs.setBackgroundBufferPCT(self.percentile)
+
+    #     background = ImageStack(data=bgs, mdh=MetaDataHandler.NestedClassMDHandler(series.mdh))
+
+    #     background.mdh['Parent'] = series.filename
+    #     background.mdh['Processing.SlidingWindowBackground.Percentile'] = self.percentile
+    #     background.mdh['Processing.SlidingWindowBackground.Window'] = self.window
+
+    #     namespace[self.output_name] = background
+
+    def run(self, input_name):
         from PYME.IO.DataSources import BGSDataSource
         from PYME.IO.image import ImageStack
-        series = namespace[self.input_name]
 
-        bgs = BGSDataSource.DataSource(series.data, bgRange=self.window)
+        bgs = BGSDataSource.DataSource(input_name.data, bgRange=self.window)
         bgs.setBackgroundBufferPCT(self.percentile)
 
-        background = ImageStack(data=bgs, mdh=MetaDataHandler.NestedClassMDHandler(series.mdh))
+        background = ImageStack(data=bgs, mdh=MetaDataHandler.NestedClassMDHandler(input_name.mdh))
 
-        background.mdh['Parent'] = series.filename
-        background.mdh['Processing.SlidingWindowBackground.Percentile'] = self.percentile
-        background.mdh['Processing.SlidingWindowBackground.Window'] = self.window
+        background.mdh['Parent'] = input_name.filename
+        #background.mdh['Processing.SlidingWindowBackground.Percentile'] = self.percentile
+        #background.mdh['Processing.SlidingWindowBackground.Window'] = self.window
 
-        namespace[self.output_name] = background
+        return background
 
 @register_module('BackgroundSubtractionMovingPercentile')
 class BackgroundSubtractionMovingPercentile(BackgroundSubtractionMovingAverage):
@@ -2058,17 +2572,55 @@ class StatisticsByFrame(ModuleBase):
 
     output_name = Output('cluster_metrics')
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from scipy import stats
+
+    #     series = namespace[self.input_name]
+    #     data = series.data
+
+    #     if self.mask == '':
+    #         mask = None
+    #     else:
+    #         # again, handle our mask being either 2D, 3D, or 4D. NB - no color (4D) handling implemented at this point
+    #         mask = namespace[self.mask].data
+
+    #     var = np.empty(data.shape[2], dtype=float)
+    #     mean = np.empty_like(var)
+    #     median = np.empty_like(var)
+    #     mode = np.empty_like(var)
+
+    #     for si in range(data.shape[2]):
+    #         slice_data = data[:,:,si, 0]
+            
+    #         if mask is not None:
+    #             if mask.shape[2] == 1:
+    #                 slice_data = slice_data[mask[:,:,0,0].astype('bool')]
+    #             elif mask.shape[2] == data.shape[2]:
+    #                 slice_data = slice_data[mask[:,:,si,0].astype('bool')]
+    #             else:
+    #                 raise RuntimeError('Mask dimensions do not match data dimensions')
+
+    #         var[si] = np.var(slice_data)
+    #         mean[si] = np.mean(slice_data)
+    #         median[si] = np.median(slice_data)
+    #         mode[si] = stats.mode(slice_data, axis=None)[0][0]
+
+    #     # package up and ship-out results
+    #     res = tabular.DictSource({'variance': var, 'mean': mean, 'median': median, 'mode': mode})
+    #     try:
+    #         res.mdh = series.mdh
+    #     except:
+    #         pass
+            
+    #     namespace[self.output_name] = res
+
+    def run(self, input_name, mask=None):
         from scipy import stats
 
-        series = namespace[self.input_name]
-        data = series.data
-
-        if self.mask == '':
-            mask = None
-        else:
+        data = input_name.data
+        if mask:
             # again, handle our mask being either 2D, 3D, or 4D. NB - no color (4D) handling implemented at this point
-            mask = namespace[self.mask].data
+            mask = mask.data
 
         var = np.empty(data.shape[2], dtype=float)
         mean = np.empty_like(var)
@@ -2092,13 +2644,8 @@ class StatisticsByFrame(ModuleBase):
             mode[si] = stats.mode(slice_data, axis=None)[0][0]
 
         # package up and ship-out results
-        res = tabular.DictSource({'variance': var, 'mean': mean, 'median': median, 'mode': mode})
-        try:
-            res.mdh = series.mdh
-        except:
-            pass
-            
-        namespace[self.output_name] = res
+        return tabular.DictSource({'variance': var, 'mean': mean, 'median': median, 'mode': mode})
+       
 
 @register_module('DarkAndVarianceMap')
 class DarkAndVarianceMap(ModuleBase):
@@ -2111,18 +2658,29 @@ class DarkAndVarianceMap(ModuleBase):
     start = Int(0)
     end = Int(-1)
 
-    def execute(self, namespace):
-        from PYME.Analysis import gen_sCMOS_maps
+    # def execute(self, namespace):
+    #     from PYME.Analysis import gen_sCMOS_maps
 
-        image = namespace[self.input]
+    #     image = namespace[self.input]
         
-        dark_map, variance_map = gen_sCMOS_maps.generate_maps(image, self.start, self.end,
+    #     dark_map, variance_map = gen_sCMOS_maps.generate_maps(image, self.start, self.end,
+    #                                                           darkthreshold=self.dark_threshold,
+    #                                                           variancethreshold=self.variance_threshold,
+    #                                                           blemishvariance=self.blemish_variance)
+
+    #     namespace[self.output_dark] = dark_map
+    #     namespace[self.output_variance] = variance_map
+
+    def run(self, input):
+        from PYME.Analysis import gen_sCMOS_maps
+        
+        dark_map, variance_map = gen_sCMOS_maps.generate_maps(input, self.start, self.end,
                                                               darkthreshold=self.dark_threshold,
                                                               variancethreshold=self.variance_threshold,
                                                               blemishvariance=self.blemish_variance)
 
-        namespace[self.output_dark] = dark_map
-        namespace[self.output_variance] = variance_map
+        return {'output_dark' : dark_map, 'output_variance' : variance_map}
+        
         
 @register_module('Composite')
 class Composite(ModuleBase):
@@ -2150,6 +2708,7 @@ class Composite(ModuleBase):
 
 
     def execute(self, namespace):
+        # NB - this needs to define .execute() as we allow channel speficiation in the inputs
         from PYME.Analysis import composite
         
         imgs = []
@@ -2213,12 +2772,34 @@ class RawADUToElectronsPerSecond(ModuleBase):
     input_name = Input('raw_adu')
     output_name = Output('electrons_per_s')
     
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     from PYME.IO.image import ImageStack
+    #     from PYME.IO.MetaDataHandler import DictMDHandler
+    #     from PYME.IO.DataSources import ElectronsPerSecondDataSource
+        
+    #     series_adu = namespace[self.input_name]
+    #     epers_ds = ElectronsPerSecondDataSource.DataSource(series_adu.data, series_adu.mdh)
+    #     series_epers = ImageStack(data=epers_ds, events=series_adu.events, mdh=DictMDHandler(series_adu.mdh))
+    #     series_epers.mdh['Parent'] = series_adu.filename
+        
+    #     series_epers.mdh['Units.Intensity'] = 'e/s'
+        
+    #     # Fudge metadata 
+    #     # This should make metadata calibration more or less work where needed (at least until we have more comprehensive units support)
+    #     # note that in order for us to be able to get to electrons (not e/s) for noise models, we need to fudge either the gain or electrons
+    #     # per count with the integration time.
+    #     im.mdh['Camera.ElectronsPerCount'] = 1.0*series_adu.mdh['Camera.IntegrationTime']
+    #     im.mdh['Camera.TrueEMGain'] = 1.0
+    #     im.mdh['Camera.ADOffset'] = 0
+
+    #     namespace[self.output_name] = series_epers
+
+    def run(self, input_name):
         from PYME.IO.image import ImageStack
         from PYME.IO.MetaDataHandler import DictMDHandler
         from PYME.IO.DataSources import ElectronsPerSecondDataSource
         
-        series_adu = namespace[self.input_name]
+        series_adu = input_name
         epers_ds = ElectronsPerSecondDataSource.DataSource(series_adu.data, series_adu.mdh)
         series_epers = ImageStack(data=epers_ds, events=series_adu.events, mdh=DictMDHandler(series_adu.mdh))
         series_epers.mdh['Parent'] = series_adu.filename
@@ -2229,8 +2810,8 @@ class RawADUToElectronsPerSecond(ModuleBase):
         # This should make metadata calibration more or less work where needed (at least until we have more comprehensive units support)
         # note that in order for us to be able to get to electrons (not e/s) for noise models, we need to fudge either the gain or electrons
         # per count with the integration time.
-        im.mdh['Camera.ElectronsPerCount'] = 1.0*series_adu.mdh['Camera.IntegrationTime']
-        im.mdh['Camera.TrueEMGain'] = 1.0
-        im.mdh['Camera.ADOffset'] = 0
+        series_epers.mdh['Camera.ElectronsPerCount'] = 1.0*series_adu.mdh['Camera.IntegrationTime']
+        series_epers.mdh['Camera.TrueEMGain'] = 1.0
+        series_epers.mdh['Camera.ADOffset'] = 0
 
-        namespace[self.output_name] = series_epers
+        return series_epers

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -31,8 +31,8 @@ class SimpleThreshold(Filter):
         mask = data > self.threshold
         return mask
 
-    def completeMetadata(self, im):
-        im.mdh['Processing.SimpleThreshold'] = self.threshold
+    #def completeMetadata(self, im):
+    #    im.mdh['Processing.SimpleThreshold'] = self.threshold
         
 @register_module('FractionalThreshold') 
 class FractionalThreshold(Filter):
@@ -52,8 +52,8 @@ class FractionalThreshold(Filter):
         mask = data > threshold
         return mask
 
-    def completeMetadata(self, im):
-        im.mdh['Processing.FractionalThreshold'] = self.fractionThreshold
+    #def completeMetadata(self, im):
+    #    im.mdh['Processing.FractionalThreshold'] = self.fractionThreshold
         
 @register_module('Threshold')
 class Threshold(Filter):
@@ -115,8 +115,8 @@ class SelectLabel(Filter):
         mask = (data == self.label)
         return mask
 
-    def completeMetadata(self, im):
-        im.mdh['Processing.SelectedLabel'] = self.label
+    #def completeMetadata(self, im):
+    #    im.mdh['Processing.SelectedLabel'] = self.label
 
 @register_module('SelectLargestLabel') 
 class SelectLargestLabel(Filter):
@@ -132,8 +132,8 @@ class SelectLargestLabel(Filter):
         mask = (data == self.label)
         return mask
 
-    def completeMetadata(self, im):
-        im.mdh['Processing.SelectedLabel'] = self.label
+    #def completeMetadata(self, im):
+    #    im.mdh['Processing.SelectedLabel'] = self.label
 
 @register_module('LocalMaxima')         
 class LocalMaxima(Filter):
@@ -145,9 +145,9 @@ class LocalMaxima(Filter):
         im = data.astype('f')/data.max()
         return skimage.feature.peak_local_max(im, threshold_abs = self.threshold, min_distance = self.minDistance, indices=False)
 
-    def completeMetadata(self, im):
-        im.mdh['LocalMaxima.threshold'] = self.threshold
-        im.mdh['LocalMaxima.minDistance'] = self.minDistance
+    # def completeMetadata(self, im):
+    #     im.mdh['LocalMaxima.threshold'] = self.threshold
+    #     im.mdh['LocalMaxima.minDistance'] = self.minDistance
         
         
 # from PYME.IO.DataSources import BaseDataSource
@@ -303,9 +303,9 @@ class OpticalFlow(ModuleBase):
         self.completeMetadata(im)
         namespace[self.outputNameY] = im
         
-    def completeMetadata(self, im):
-        im.mdh['OpticalFlow.filterRadius'] = self.filterRadius
-        im.mdh['OpticalFlow.supportRadius'] = self.supportRadius
+    # def completeMetadata(self, im):
+    #     im.mdh['OpticalFlow.filterRadius'] = self.filterRadius
+    #     im.mdh['OpticalFlow.supportRadius'] = self.supportRadius
         
 @register_module('WavefrontDetection')
 class WavefrontDetection(ModuleBase):

--- a/PYME/recipes/simulation.py
+++ b/PYME/recipes/simulation.py
@@ -8,9 +8,9 @@ import numpy as np
 class RandomPoints(ModuleBase):
     output = Output('points')
 
-    def execute(self, namespace):
+    def run(self):
         from PYME.IO import tabular
-        namespace[self.output]= tabular.RandomSource(1000, 1000, 1000)
+        return tabular.RandomSource(1000, 1000, 1000)
 
 @register_module('TheoreticalPSF')
 class TheoreticalPSF(ModuleBase):
@@ -36,7 +36,7 @@ class TheoreticalPSF(ModuleBase):
     sted_wavelength = Float(775.)
     sted_saturation = Float(10., desc='I/I_sat')
 
-    def execute(self, namespace):
+    def run(self):
         from PYME.Analysis.PSFGen import fourierHNA
         from PYME.IO import image, MetaDataHandler
         from scipy import fftn, ifftn
@@ -88,4 +88,4 @@ class TheoreticalPSF(ModuleBase):
 
         self._params_to_metadata(psf_im.mdh)
 
-        namespace[self.output] = psf_im
+        return psf_im

--- a/PYME/recipes/tablefilters.py
+++ b/PYME/recipes/tablefilters.py
@@ -15,15 +15,18 @@ class Mapping(ModuleBase):
     mappings = DictStrStr()
     outputName = Output('mapped')
 
-    def execute(self, namespace):
-        inp = namespace[self.inputName]
+    # def execute(self, namespace):
+    #     inp = namespace[self.inputName]
 
-        mapped = tabular.MappingFilter(inp, **self.mappings)
+    #     mapped = tabular.MappingFilter(inp, **self.mappings)
 
-        if 'mdh' in dir(inp):
-            mapped.mdh = inp.mdh
+    #     if 'mdh' in dir(inp):
+    #         mapped.mdh = inp.mdh
 
-        namespace[self.outputName] = mapped
+    #     namespace[self.outputName] = mapped
+
+    def run(self, inputName):
+        return tabular.MappingFilter(inputName, **self.mappings)
 
 
 @register_module('FilterTable')
@@ -34,15 +37,19 @@ class FilterTable(ModuleBase):
     filters = DictStrList()
     outputName = Output('filtered')
 
-    def execute(self, namespace):
-        inp = namespace[self.inputName]
+    # def execute(self, namespace):
+    #     inp = namespace[self.inputName]
 
-        filtered = tabular.ResultsFilter(inp, **self.filters)
+    #     filtered = tabular.ResultsFilter(inp, **self.filters)
 
-        if 'mdh' in dir(inp):
-            filtered.mdh = inp.mdh
+    #     if 'mdh' in dir(inp):
+    #         filtered.mdh = inp.mdh
 
-        namespace[self.outputName] = filtered
+    #     namespace[self.outputName] = filtered
+
+    def run(self, inputName):
+        return tabular.ResultsFilter(inputName, **self.filters)
+
 
     @property
     def _ds(self):
@@ -69,15 +76,18 @@ class FilterTableByIDs(ModuleBase):
     ids = ListInt()
     outputName = Output('filtered')
 
-    def execute(self, namespace):
-        inp = namespace[self.inputName]
+    # def execute(self, namespace):
+    #     inp = namespace[self.inputName]
 
-        filtered = tabular.IdFilter(inp, id_column=self.idColumnName, valid_ids=self.ids)
+    #     filtered = tabular.IdFilter(inp, id_column=self.idColumnName, valid_ids=self.ids)
 
-        if 'mdh' in dir(inp):
-            filtered.mdh = inp.mdh
+    #     if 'mdh' in dir(inp):
+    #         filtered.mdh = inp.mdh
 
-        namespace[self.outputName] = filtered
+    #     namespace[self.outputName] = filtered
+
+    def run(self, inputName):
+        return tabular.IdFilter(inputName, id_column=self.idColumnName, valid_ids=self.ids)
 
     @property
     def _ds(self):
@@ -112,16 +122,19 @@ class ConcatenateTables(ModuleBase):
     inputName1 = Input('chan1')
     outputName = Output('output')
 
-    def execute(self, namespace):
-        inp0 = namespace[self.inputName0]
-        inp1 = namespace[self.inputName1]
+    # def execute(self, namespace):
+    #     inp0 = namespace[self.inputName0]
+    #     inp1 = namespace[self.inputName1]
 
-        concatenated = tabular.ConcatenateFilter(inp0, inp1)
+    #     concatenated = tabular.ConcatenateFilter(inp0, inp1)
 
-        if 'mdh' in dir(inp0):
-            concatenated.mdh = inp0.mdh
+    #     if 'mdh' in dir(inp0):
+    #         concatenated.mdh = inp0.mdh
 
-        namespace[self.outputName] = concatenated
+    #     namespace[self.outputName] = concatenated
+
+    def run(self, inputName0, inputName1):
+        return tabular.ConcatenateFilter(inputName0, inputName1)
 
 
 @register_legacy_module('AggregateMeasurements')
@@ -139,25 +152,38 @@ class AggregateMeasurements(ModuleBase):
     suffix4 = CStr('')
     outputName = Output('aggregatedMeasurements')
 
-    def execute(self, namespace):
+    # def execute(self, namespace):
+    #     import collections
+    #     res = collections.OrderedDict()
+    #     for mk, suffix in [(getattr(self, n), getattr(self, 'suffix' + n[-1])) for n in dir(self) if
+    #                        n.startswith('inputMeas')]:
+    #         if not mk == '':
+    #             meas = namespace[mk]
+
+    #             #res.update(meas)
+    #             for k in meas.keys():
+    #                 res[k + suffix] = meas[k]
+
+    #     meas1 = namespace[self.inputMeasurements1]
+    #     #res = pd.DataFrame(res)
+    #     res = tabular.DictSource(res)
+    #     if 'mdh' in dir(meas1):
+    #         res.mdh = meas1.mdh
+
+    #     namespace[self.outputName] = res
+
+    def run(self, inputMeasurements1, inputMeasurements2,inputMeasurements3,inputMeasurements4):
         import collections
         res = collections.OrderedDict()
-        for mk, suffix in [(getattr(self, n), getattr(self, 'suffix' + n[-1])) for n in dir(self) if
-                           n.startswith('inputMeas')]:
-            if not mk == '':
-                meas = namespace[mk]
+        for meas, suffix in [(inputMeasurements1, self.suffix1), (inputMeasurements2, self.suffix2),(inputMeasurements3, self.suffix3),(inputMeasurements4, self.suffix4)]:
+            if meas:
 
                 #res.update(meas)
                 for k in meas.keys():
                     res[k + suffix] = meas[k]
 
-        meas1 = namespace[self.inputMeasurements1]
-        #res = pd.DataFrame(res)
-        res = tabular.DictSource(res)
-        if 'mdh' in dir(meas1):
-            res.mdh = meas1.mdh
+        return tabular.DictSource(res)
 
-        namespace[self.outputName] = res
 
 
 @register_legacy_module('SelectMeasurementColumns') #deprecated - do not use
@@ -168,17 +194,20 @@ class SelectTableColumns(ModuleBase):
     keys = CStr('')
     outputName = Output('selectedMeasurements')
 
-    def execute(self, namespace):
-        meas = namespace[self.inputMeasurements]
+    # def execute(self, namespace):
+    #     meas = namespace[self.inputMeasurements]
 
-        out = tabular.CloneSource(meas, keys=self.keys.split())
-        # propagate metadata, if present
-        try:
-            out.mdh = meas.mdh
-        except AttributeError:
-            pass
+    #     out = tabular.CloneSource(meas, keys=self.keys.split())
+    #     # propagate metadata, if present
+    #     try:
+    #         out.mdh = meas.mdh
+    #     except AttributeError:
+    #         pass
 
-        namespace[self.outputName] = out
+    #     namespace[self.outputName] = out
+
+    def run(self, inputMeasurements):
+        return tabular.CloneSource(inputMeasurements, keys=self.keys.split())
 
 
 @register_module('RandomSubset')
@@ -206,10 +235,31 @@ class RandomSubset(ModuleBase):
     num_to_select = Int(100)
     strict = Bool(False)
     
-    def execute(self, namespace):
-        data = namespace[self.input]
+    # def execute(self, namespace):
+    #     data = namespace[self.input]
         
-        n_rows = len(data)
+    #     n_rows = len(data)
+        
+    #     if n_rows < self.num_to_select:
+    #         if self.strict:
+    #             raise IndexError('Trying to select %d from data with only %d rows. To allow truncation, use strict=False' % (self.num_to_select, n_rows))
+    #         else:
+    #             logger.info('RandomSubset: Truncating from %d to %d rows as data only has %d rows. To make this an error, use strict=True' % (self.num_to_select, n_rows, n_rows)) 
+        
+    #     if self.strict and (self.num_to_select > 0.5*n_rows):
+    #         logger.warning('RandomSubset: Selecting %d from %d rows will not be very random' % (self.num_to_select, n_rows))
+        
+    #     out = tabular.RandomSelectionFilter(data, num_Samples=min(n_rows, self.num_to_select))
+        
+    #     try:
+    #         out.mdh = MetaDataHandler.DictMDHandler(data.mdh)
+    #     except AttributeError:
+    #         pass
+
+    #     namespace[self.output] = out
+
+    def run(self, input):
+        n_rows = len(input)
         
         if n_rows < self.num_to_select:
             if self.strict:
@@ -220,11 +270,6 @@ class RandomSubset(ModuleBase):
         if self.strict and (self.num_to_select > 0.5*n_rows):
             logger.warning('RandomSubset: Selecting %d from %d rows will not be very random' % (self.num_to_select, n_rows))
         
-        out = tabular.RandomSelectionFilter(data, num_Samples=min(n_rows, self.num_to_select))
+        return tabular.RandomSelectionFilter(input, num_Samples=min(n_rows, self.num_to_select))
         
-        try:
-            out.mdh = MetaDataHandler.DictMDHandler(data.mdh)
-        except AttributeError:
-            pass
-
-        namespace[self.output] = out
+        


### PR DESCRIPTION
This is a somewhat major refactor of recipe modules, which replaces the `.execute()` method with a `.run()` method and takes the namespace access stuff out of user code.

There are several goals here:

1) it should reduce recipe boilerplate (fetching inputs and writing outputs etc results in an awful lot of overhead)
2) it should automate metadata propagation for all modules (no need to do this manually anymore)
3) hopefully easier learning curve (inputs come in as parameters and outputs get returned as one would expect, injection into and reading from the namespace are all done automatically)

This should also hopefully make writing extension modules easier .... there are, however, some more technical (and speculative) objectives behind this.

4) this should hopefully help us do chunk-parallel stuff for very large datasets (e.g. either through the use of dask or our own backend)
5) removing injection shifts us away from an "all intermediate results are written" (even if only to memory)  paradigm, and makes it conceptually easier to e.g. compile recipes such that consecutive modules execute together. Potentially even letting, e.g. two modules which use the GPU to leave their data on there. 

Everything is backwards compatible for now (defining execute still works).

@zacsimile , @barentine - Would appreciate any thoughts/ opinions.

