### PR TITLE
listctrlMixins fix - used to use a now changed wxWindows API access

### DIFF
--- a/PYME/contrib/listctrlMixins.py
+++ b/PYME/contrib/listctrlMixins.py
@@ -301,7 +301,10 @@ class ListCtrlAutoWidthMixin(object):
         listWidth = self.GetClientSize().width
         if wx.Platform != '__WXMSW__':
             if self.GetItemCount() > self.GetCountPerPage():
-                scrollWidth = wx.SystemSettings_GetMetric(wx.SYS_VSCROLL_X)
+                try:
+                    scrollWidth = wx.SystemSettings_GetMetric(wx.SYS_VSCROLL_X)
+                except AttributeError:
+                    scrollWidth = wx.SystemSettings.GetMetric(wx.SYS_VSCROLL_X)
                 listWidth = listWidth - scrollWidth
 
         totColWidth = 0 # Width of all columns except last one.

--- a/PYME/contrib/listctrlMixins.py
+++ b/PYME/contrib/listctrlMixins.py
@@ -302,9 +302,10 @@ class ListCtrlAutoWidthMixin(object):
         if wx.Platform != '__WXMSW__':
             if self.GetItemCount() > self.GetCountPerPage():
                 try:
-                    scrollWidth = wx.SystemSettings_GetMetric(wx.SYS_VSCROLL_X)
-                except AttributeError:
                     scrollWidth = wx.SystemSettings.GetMetric(wx.SYS_VSCROLL_X)
+                except AttributeError:
+                    # fallback for old wx - TODO - do we still actually need this?
+                    scrollWidth = wx.SystemSettings_GetMetric(wx.SYS_VSCROLL_X)
                 listWidth = listWidth - scrollWidth
 
         totColWidth = 0 # Width of all columns except last one.


### PR DESCRIPTION
this fix seems needed with more recent wxWindows; previously I either got a warning that the original use is now deprecated or even a bug was raised when a PYME module used the listctrlMixins...