### PR TITLE
recipe execution - remove indiscriminate print() statements

### DIFF
--- a/PYME/recipes/recipe.py
+++ b/PYME/recipes/recipe.py
@@ -198,7 +198,7 @@ class Recipe(HasTraits):
         #remove anything which is downstream from changed inputs
         
         try:
-            #print('recipe.execute()')  # possibly change these into logging/debug messages
+            logger.debug('recipe.execute()')  
             #print self.namespace.keys()
             for k, v in kwargs.items():
                 #print k, v

--- a/PYME/recipes/recipe.py
+++ b/PYME/recipes/recipe.py
@@ -198,18 +198,18 @@ class Recipe(HasTraits):
         #remove anything which is downstream from changed inputs
         
         try:
-            print('recipe.execute()')
+            #print('recipe.execute()')  # possibly change these into logging/debug messages
             #print self.namespace.keys()
             for k, v in kwargs.items():
                 #print k, v
                 try:
                     if not (self.namespace[k] == v):
                         #input has changed
-                        print('pruning: ', k)
+                        # print('pruning: ', k) # possibly change these into logging/debug messages
                         self.prune_dependencies_from_namespace([k])
                 except KeyError:
                     #key wasn't in namespace previously
-                    print('KeyError')
+                    # print('KeyError')  # possibly change these into logging/debug messages
                     pass
             
             self.namespace.update(kwargs)


### PR DESCRIPTION
`recipe.execute` still retains some indiscriminate print statements that were presumably useful in debugging. As I use recipe updates in Jupyter notebooks these show up as somewhat annoying 'noise' in outputs, e.g.

```
Opening %s using pandas (set TextFileSource-use_pandas: False in config.yaml to use legacy np.genfromtxt instead)
recipe.execute()
recipe.execute()
recipe.execute()
recipe.execute()
```

**Is this a bugfix or an enhancement?**
No bug per se, rather a cleanup.

**Proposed changes:**
In the PR I have so far just commented the print statements out but if they do serve a purpose perhaps conversion into logging/debug statements could be advisable?
