### PR TITLE
add "discard trivial" switch to MergeClumps module

### DIFF
--- a/PYME/Analysis/points/DeClump/pyDeClump.py
+++ b/PYME/Analysis/points/DeClump/pyDeClump.py
@@ -234,7 +234,7 @@ def coalesceClumps(fitResults, assigned, nphotons=None):
     return fres
 
 
-def mergeClumps(datasource, labelKey='clumpIndex'):
+def mergeClumps(datasource, labelKey='clumpIndex', discard_trivial=False):
     from PYME.IO.tabular import CachingResultsFilter, MappingFilter, DictSource
     from PYME.Analysis.points.multiview import coalesce_dict_sorted
 
@@ -256,7 +256,7 @@ def mergeClumps(datasource, labelKey='clumpIndex'):
     I = np.argsort(datasource[labelKey])
     sorted_src = {k: datasource[k][I] for k in all_keys}
 
-    grouped = coalesce_dict_sorted(sorted_src, sorted_src[labelKey], keys_to_aggregate, aggregation_weights)
+    grouped = coalesce_dict_sorted(sorted_src, sorted_src[labelKey], keys_to_aggregate, aggregation_weights,discard_trivial=discard_trivial)
     return DictSource(grouped)
 
 

--- a/PYME/recipes/localisations.py
+++ b/PYME/recipes/localisations.py
@@ -352,13 +352,14 @@ class MergeClumps(ModuleBase):
     inputName = Input('clumped')
     outputName = Output('merged')
     labelKey = CStr('clumpIndex')
+    discardTrivial = Bool(False)
 
     def execute(self, namespace):
         from PYME.Analysis.points.DeClump import pyDeClump
 
         inp = namespace[self.inputName]
 
-        grouped = pyDeClump.mergeClumps(inp, labelKey=self.labelKey)
+        grouped = pyDeClump.mergeClumps(inp, labelKey=self.labelKey, discard_trivial=self.discardTrivial)
         try:
             grouped.mdh = inp.mdh
         except AttributeError:


### PR DESCRIPTION
The `MergeClumps` recipe module uses in its implementation the `multiview.coalesce_dict_sorted` function which has a useful `discard_trivial` keyword option which is currently not exposed through the `MergeClumps` interface.

I have recently encountered several cases where I need to remove "trivial" clumps that are retained (identified by `clumpSize=0`), such as external clumpIndices that are not contiguous etc. Simply switching on discard trivial is then very convenient and gets saved with recipes when stored to disk.

This PR proposes to expose the `discard_trivial` option via a `discardTrivial` input of `MergeClumps`.

**Is this a bugfix or an enhancement?**
Enhancement.

The enhancement is backwards compatible as it is set to `False` by default, perserving previous behaviour and correct interpretation of older saved recipes (e.g. in yaml form).
