### PR TITLE
reinstantiate point display overlay if we don't have a filter

### DIFF
--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -593,7 +593,7 @@ class LMAnalyser2(Plugin):
 
         mdh = self.analysisController.analysisMDH
 
-        if not hasattr(self, '_ovl'):
+        if not hasattr(self, '_ovl') or not hasattr(self._ovl, 'filter'):
             from PYME.DSView import overlays
             from PYME.IO import tabular
             filt = tabular.FitResultsSource(self.fitResults)


### PR DESCRIPTION
Addresses issue #1343 .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
if we have a `PointsDisplayOverlay` without a filter attribute when we run test frame, just go ahead and make a new `PointsDisplayOverlay` that does.






**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
