### PR TITLE
fix typo in mergeClumps argument

### DIFF
--- a/PYME/recipes/localisations.py
+++ b/PYME/recipes/localisations.py
@@ -527,7 +527,7 @@ class MergeClumps(ModuleBase):
 
     def run(self, inputName):
         from PYME.Analysis.points.DeClump import pyDeClump
-        return pyDeClump.mergeClumps(inp, labelKey=self.labelKey, discard_trivial=self.discardTrivial)
+        return pyDeClump.mergeClumps(inputName, labelKey=self.labelKey, discard_trivial=self.discardTrivial)
 
 
 @register_module('IDTransientFrames')


### PR DESCRIPTION
Addresses issue #1350 .

**Is this a bugfix or an enhancement?**
bugfix

**Proposed changes:**
fix argument type to correct use of `inputName`
