### PR TITLE
supress debug printing of metadatahandler contents when recipes are executed

### DIFF
--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -281,7 +281,7 @@ class ModuleBase(HasStrictTraits):
                 v.mdh = MetaDataHandler.DictMDHandler()
 
             v.mdh.mergeEntriesFrom(mdhin) #merge, to allow e.g. voxel size overrides due to downsampling
-            print(v.mdh, mdh)
+            #print(v.mdh, mdh)
             v.mdh.copyEntriesFrom(mdh) # copy / overwrite with module processing parameters
 
         namespace.update(out)


### PR DESCRIPTION
Since the recipe refactor a sizable list of mdh printouts are generated when recipes are executed.
I suspect this reflects a debug leftover...

**Is this a bugfix or an enhancement?**
I'd consider it a bugfix (or rather cleanup)

**Proposed changes:**
remove left over `print()` statement

**Related question:**
The use of `DictMDHandler` in `execute` causes a number of warnings of the type

```
warnings.warn('DictMDHandler is not yet fully supported, and will likely cause failures for anything related to localisation fitting')
```

when recipes are excuted. This is a little distracting in Jupyter Notebooks. I can override as a user with

```
import warnings
# supress warnings from the DictMDHandler about inability to handle localisations
warnings.filterwarnings("ignore",message=r'DictMDHandler')
```

Just wondering it it makes sense that these warnings are always generated now that `DictMDHandler` is generally used in `recipes.base.execute()`? Is `DictMDHandler` still unsafe to use as part of standard modules?
