### PR TITLE
add pipython-based piezo class, note that e727 controller is supported

### DIFF
--- a/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
@@ -1,0 +1,144 @@
+
+# Defines a GCSPiezo class which uses the pipython package distributed 
+# by Physik Instrumente to initialize and run their stages.
+# Tested with a E-727 controller, on pipython 2.9.0.4 (pypi)
+# see https://github.com/PI-PhysikInstrumente/PIPython
+
+
+from PYME.Acquire.Hardware.Piezos.base_piezo import PiezoBase
+from pipython import GCSDevice
+from pipython import PILogger, WARNING
+import numpy as np
+import logging
+PILogger.setLevel(WARNING)
+
+logger = logging.getLogger(__name__)
+
+
+def get_gcs_usb():
+    """
+    returns list of PI devices connected by USB and their serial numbers. Use
+    to get str description suitable for initializing GCSPiezo, e.g.
+    'PI E-727 Controller SN 0118035989'
+    """
+    with GCSDevice() as pidev:
+        return pidev.EnumerateUSB()
+
+
+class GCSPiezo(PiezoBase):
+    units_um = 1  # assumes controllers is configured in units of um.
+    def __init__(self, description=None, axes=None):
+        """
+        Parameters
+        ----------
+        descriptions: str
+            description as found by GCS enumerate, e.g. 
+            PI E-727 Controller SN 0118035989.
+        axes : list
+            list of axes if this is a multi-axis controller. e.g. [1, 2, 3]
+            for a 3-axis stage. Note some PI firmwares assume ['a', 'b', 'c']
+
+        """
+        PiezoBase.__init__(self)
+        self.pi = GCSDevice()
+        self.pi.ConnectUSB(description)
+        assert self.pi.IsConnected()
+
+        if axes is None:
+            self.axes = [1]  # default to the first axis
+        else:
+            self.axes = axes
+        
+        units = self.GetUnits(axes)
+        logger.debug('stage units: %s' % units)
+        # if any([r'\u03BCm' != unit for unit in units]):
+        #     raise AssertionError('PYME expects stage to be in units of um, found: %s' % units)
+        # self.SetUnits(self.axes, None)  # None default sets all axes to um
+        
+    
+    def GetUnits(self, axes=None):
+        """
+        @return : Ordered dictionary {axis: unit}, unit as string.
+        """
+        if axes is None:
+            axes = self.axes
+        units = self.pi.qPUN(axes)
+        return [units[axis] for axis in axes]
+    
+    def SetUnits(self, axes=None, values=None):
+        """
+        Set the physical unit of 'axes' to 'values'.
+        @param axes: Axis or list of axes or dictionary {axis : value}.
+        @param values : String or list of them or None.
+            Default None will set all axes to um
+            
+        """
+        raise NotImplementedError
+        if axes is None:
+            axes = self.axes
+        if values is None:
+            values = ['um' for axis in axes]
+        # PI uses unicoded um to set um, so smooth over 'u' here
+        # vals = [val if val!='um' else '\u03BCm'.encode('utf-8') for val in values]
+        self.pi.PUN(axes, values)
+
+    def SetServo(self, val=1):
+        # due to form of SetServo in the baseclass, just set all axes for now
+        self.pi.SVO(self.axes, [val for axis in self.axes])
+    
+    def MoveTo(self, iChannel, fPos, bTimeOut=True):
+        self.pi.MOV(iChannel, fPos)
+    
+    def MoveRel(self, iChannel, incr, bTimeOut=True):
+        """ relative to current target position
+        @param axes: Axis or list of axes or dictionary {axis : value}.
+        @param values : Float or list of floats or None.
+        """
+        self.pi.MVR(iChannel, incr)
+    
+    def GetPos(self, iChannel=1):
+        try:
+            assert np.isscalar(iChannel)
+        except:
+            raise AssertionError('GetPos only supports single-axis query')
+        return self.pi.qPOS([iChannel])[iChannel]
+    
+    def GetTargetPos(self, iChannel=1):
+        # assume that target pos = current pos. Over-ride in derived class if possible
+        return self.GetPos(iChannel)
+    
+    def GetMin(self, iChan=1):
+        """
+        Get lower limits ("soft limits")
+        """
+        try:
+            assert np.isscalar(iChan)
+        except:
+            raise AssertionError('GetMin only supports single-axis query')
+        return self.pi.qTMN(iChan)[iChan]
+        # return self.pi.qNLM(axes=[iChan])[iChan]
+        # qCMN min commandable closed-loop target
+    
+    def GetMax(self, iChan=1):
+        """
+        Get upper limits ("soft limits")
+        """
+        try:
+            assert np.isscalar(iChan)
+        except:
+            raise AssertionError('GetMax only supports single-axis query')
+        return self.pi.qTMX(iChan)[iChan]
+        # return self.pi.qPLM([iChan])[iChan]
+        # qCMX max commandable closed-loop target
+    
+    def GetFirmwareVersion(self):
+        raise NotImplementedError
+    
+    def OnTarget(self, axes=None):
+        """
+        For multiaxis stages, query with None reports for all of them
+        """
+        return all(self.pi.qONT(axes))
+    
+    def close(self):
+        self.pi.CloseConnection()

--- a/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
@@ -49,38 +49,11 @@ class GCSPiezo(PiezoBase):
         else:
             self.axes = axes
         
-        units = self.GetUnits(axes)
-        logger.debug('stage units: %s' % units)
-        # if any([r'\u03BCm' != unit for unit in units]):
-        #     raise AssertionError('PYME expects stage to be in units of um, found: %s' % units)
-        # self.SetUnits(self.axes, None)  # None default sets all axes to um
-        
-    
-    def GetUnits(self, axes=None):
-        """
-        @return : Ordered dictionary {axis: unit}, unit as string.
-        """
-        if axes is None:
-            axes = self.axes
-        units = self.pi.qPUN(axes)
-        return [units[axis] for axis in axes]
-    
-    def SetUnits(self, axes=None, values=None):
-        """
-        Set the physical unit of 'axes' to 'values'.
-        @param axes: Axis or list of axes or dictionary {axis : value}.
-        @param values : String or list of them or None.
-            Default None will set all axes to um
-            
-        """
-        raise NotImplementedError
-        if axes is None:
-            axes = self.axes
-        if values is None:
-            values = ['um' for axis in axes]
-        # PI uses unicoded um to set um, so smooth over 'u' here
-        # vals = [val if val!='um' else '\u03BCm'.encode('utf-8') for val in values]
-        self.pi.PUN(axes, values)
+        units = self.pi.qPUN(self.axes)
+        logger.debug('stage units: %s' % [units[axis] for axis in self.axes])
+        # PI appears to use unicoded um to set units to um, not funcitonal at the moment, but
+        # ideally we would remove the unit check/log above and just force to um here.
+        # self.pi.PUN(axes, values)
 
     def SetServo(self, val=1):
         # due to form of SetServo in the baseclass, just set all axes for now

--- a/docs/supported_hardware.rst
+++ b/docs/supported_hardware.rst
@@ -11,7 +11,7 @@ Cameras / Detectors
 
 Stages / Translation
 ====================
-* PI piezos (using e255, e662, e709 and e816 controller interface boards, covers most PI piezos, likely easily modifyable to new controllers)
+* PI piezos (using e255, e662, e709, e727 and e816 controller interface boards, covers most PI piezos, likely easily modifyable to new controllers)
 * PI piezo linear motor stages using the C867 controller (M686 stage and similar)
 * PI stepper motor stages using the Mercury command set
 * Marzhauser Tango translation stages and joystick


### PR DESCRIPTION
**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
add a pipython-based GCS piezo class. I used this for an e727 stage, but hope would be we can remove some GCS boiler plate/ maitenance using their[ pipython package](https://github.com/PI-PhysikInstrumente/PIPython)


** note **
Would be really nice to set controller units to um. I didn't immediately get the encoding of um the way the DLL wanted it, but my controller was already in um so I left this alone for now.


**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
