### PR TITLE
Pull fitfactory-specific default parameters in recipes.measurement.FitPoints

### DIFF
--- a/PYME/recipes/measurement.py
+++ b/PYME/recipes/measurement.py
@@ -238,11 +238,10 @@ class FitPoints(ModuleBase):
 
         ps = inputImage.pixelSize
         print('pixel size: %s' % ps)
-        bg = np.zeros_like(inputImage.data_xytc[:,:,0,self.channel])
         for x, y, t, i in zip(inputPositions['x'], inputPositions['y'], inputPositions['t'].astype(int), range(len(inputPositions['x']))):
             if not t == ff_t:
                 md['tIndex'] = t
-                ff = fitMod.FitFactory(np.atleast_3d(inputImage.data[:, :, t, self.channel]), md, background=bg)
+                ff = fitMod.FitFactory(np.atleast_3d(inputImage.data[:, :, t, self.channel]), md)
                 ff_t = t
 
             #print x/ps, y/ps

--- a/PYME/recipes/measurement.py
+++ b/PYME/recipes/measurement.py
@@ -220,10 +220,6 @@ class FitPoints(ModuleBase):
         md['voxelsize.x'] = .001
         md['voxelsize.y'] = .001
 
-        #copy across the entries from the real image, replacing the defaults
-        #if necessary
-        md.copyEntriesFrom(inputImage.mdh)
-
         fitMod = __import__('PYME.localization.FitFactories.' + self.fitModule,
                             fromlist=['PYME', 'localization', 'FitFactories']) #import our fitting module
         try:
@@ -231,6 +227,10 @@ class FitPoints(ModuleBase):
                 md[param.paramName] = param.default
         except AttributeError:
             pass
+        
+        #copy across the entries from the real image, replacing the defaults
+        #if necessary
+        md.copyEntriesFrom(inputImage.mdh)
 
         r = np.zeros(len(inputPositions['x']), dtype=fitMod.FitResultsDType)
 


### PR DESCRIPTION
Addresses issue Currently FitPoints does not fill fitfactory-specific metadata (i.e. the PARAMETERS list is ignored), which will fail a fit factory if it hard-pulls fit factory-specific metadata. 

**Is this a bugfix or an enhancement?**
in between
**Proposed changes:**
- take default fit factory parameters for measurement.FitPoints. Doing so allows hard-pulls on fit module specific metadata, and also propagates this metadata into the results.






**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
