### PR TITLE
fix trait name in clusterAnalysis measure clusters

### DIFF
--- a/PYME/LMVis/Extras/clusterAnalysis.py
+++ b/PYME/LMVis/Extras/clusterAnalysis.py
@@ -345,7 +345,7 @@ class ClusterAnalyser:
 
         Parameters
         ----------
-        labelsKey: pipeline key to access array of label assignments. Measurements will be calculated for each label.
+        labelKey: key name to access array of label assignments. Measurements will be calculated for each label.
 
 
         """
@@ -355,7 +355,7 @@ class ClusterAnalyser:
         # build a recipe programatically
         measrec = Recipe()
 
-        measrec.add_module(localisations.MeasureClusters3D(measrec, inputName='input', labelsKey='dbscanClustered',
+        measrec.add_module(localisations.MeasureClusters3D(measrec, inputName='input', labelKey='dbscanClumpID',
                                                        outputName='output'))
 
         measrec.namespace['input'] = self.pipeline.output


### PR DESCRIPTION
labelskey is not the name of the trait for `PYME.recipes.localisations.MeasureClusters3D`

Addresses issue `Analysis > Clustering > Measure clusters` throws an error because it tries to configure a trait that doesn't exist

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- use the correct trait name, and change its default so it matches the dbscan default label key (currently it defaults to dbscanClustered, which is the datasource name, not the key).


Note that it would also be nice to revisit whether we can add the measurements to the pipeline, as they currently don't show up - just as an attribute for the plugin.
