### PR TITLE
Add threaded version of PIPython GCSPiezo and some GCSPiezo fixes

### DIFF
--- a/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
@@ -6,10 +6,11 @@
 
 
 from PYME.Acquire.Hardware.Piezos.base_piezo import PiezoBase
-from pipython import GCSDevice
+from pipython import GCSDevice, pitools
 from pipython import PILogger, WARNING
 import numpy as np
 import logging
+import time
 PILogger.setLevel(WARNING)
 
 logger = logging.getLogger(__name__)
@@ -136,3 +137,219 @@ class GCSPiezo(PiezoBase):
     
     def close(self):
         self.pi.CloseConnection()
+
+
+import threading
+from PYME.Acquire.eventLog import logEvent
+class GCSPiezoThreaded(PiezoBase):
+    units_um = 1  # assumes controllers is configured in units of um.
+    def __init__(self, description=None, axes=None, update_rate=0.01):
+        """
+        Parameters
+        ----------
+        descriptions: str
+            description as found by GCS enumerate, e.g. 
+            PI E-727 Controller SN 0118035989.
+        axes : list
+            list of axes if this is a multi-axis controller. e.g. [1, 2, 3]
+            for a 3-axis stage. Note some PI firmwares assume ['a', 'b', 'c'],
+            or ['x', 'y', 'z']. After initialization these will be indexed into
+            for method calls, i.e. GetPos(iChannel=0) will use axes[0] for the
+            GCS axis descriptor.
+
+        """
+        PiezoBase.__init__(self)
+        self.pi = GCSDevice()
+        self.pi.ConnectUSB(description)
+        assert self.pi.IsConnected()
+        self._lock = threading.Lock()
+
+        if axes is None:
+            self.axes = [1]  # default to the first axis
+        else:
+            self.axes = axes
+        
+        self._min = [self.GetMin(iChan) for iChan in range(len(self.axes))]
+        self._max = [self.GetMax(iChan) for iChan in range(len(self.axes))]
+
+        self.positions = np.array([self.pi.qPOS([axis])[axis] for axis in self.axes])
+        self.target_positions = np.copy(self.positions)
+        self._last_target_positions = np.copy(self.positions)
+        self._all_on_target = True
+        self._on_target = np.asarray([True for axis in self.axes])
+
+        self._update_rate = update_rate
+        self._start_loop()
+        # try:
+        #     units = self.pi.qPUN(self.axes)
+        #     logger.debug('stage units: %s' % [units[axis] for axis in self.axes])
+        # except:
+        #     pass
+        # PI appears to use unicoded um to set units to um, not funcitonal at the moment, but
+        # ideally we would remove the unit check/log above and just force to um here.
+        # self.pi.PUN(axes, values)
+
+    def SetServo(self, val=1):
+        with self._lock:
+            # due to form of SetServo in the baseclass, just set all axes for now
+            self.pi.SVO(self.axes, [val for axis in self.axes])
+    
+    def MoveTo(self, iChannel, fPos, bTimeOut=True):
+        self.target_positions[iChannel] = fPos
+        # self.pi.MOV(self.axes[iChannel], fPos)
+    
+    def MoveRel(self, iChannel, incr, bTimeOut=True):
+        """ relative to current target position
+        @param axes: Axis or list of axes or dictionary {axis : value}.
+        @param values : Float or list of floats or None.
+        """
+        new_pos = self.target_positions[iChannel] + incr
+        self.target_positions[iChannel] = new_pos
+        # self.pi.MVR(self.axes[iChannel], incr)
+    
+    def GetPos(self, iChannel=1):
+        try:
+            assert np.isscalar(iChannel)
+        except:
+            raise AssertionError('GetPos only supports single-axis query')
+        return self.positions[iChannel]
+        # axis = self.axes[iChannel]
+        # return self.pi.qPOS([axis])[axis]
+    
+    def GetTargetPos(self, iChannel=1):
+        # assume that target pos = current pos. Over-ride in derived class if possible
+        # axis = self.axes[iChannel]
+        # return self.GetPos(iChannel)
+        return self.target_positions[iChannel]
+    
+    def GetMin(self, iChan=1):
+        """
+        Get lower limits ("soft limits")
+        """
+        try:
+            assert np.isscalar(iChan)
+        except:
+            raise AssertionError('GetMin only supports single-axis query')
+
+        try:
+            return self._min[iChan]
+        except KeyError:
+            logger.debug('Fetching %s axis min' % iChan)
+            axis = self.axes[iChan]
+            with self._lock:
+                self._min[iChan] = pitools.getmintravelrange(self.pi, axis)[axis]  # self.pi.qTMN(axis)[axis]
+            return self._min[iChan]
+        # return self.pi.qNLM(axes=[iChan])[iChan]
+        # qCMN min commandable closed-loop target
+    
+    def GetMax(self, iChan=1):
+        """
+        Get upper limits ("soft limits")
+        """
+        try:
+            assert np.isscalar(iChan)
+        except:
+            raise AssertionError('GetMax only supports single-axis query')
+        try:
+            return self._max[iChan]
+        except KeyError:
+            logger.debug('Fetching %s axis max' % iChan)
+            axis = self.axes[iChan]
+            with self._lock:
+                self._max[iChan] = pitools.getmaxtravelrange(self.pi, axis)[axis]  # self.pi.qTMX(axis)[axis]
+            return self._max[iChan]
+    
+    def GetFirmwareVersion(self):
+        raise NotImplementedError
+    
+    def OnTarget(self):
+        """
+        For multiaxis stages, query with None reports for all of them
+        """
+        return self._all_on_target
+        if axes is None:
+            return all(self._on_target)
+        else:
+            raise NotImplementedError
+        # return all(self.pi.qONT(axes))
+    
+    def close(self):
+        self.loop_active = False
+        with self._lock:
+            self.pi.CloseConnection()
+    
+    def _start_loop(self):
+        self.loop_active = True
+        self.tloop = threading.Thread(target=self._Loop)
+        self.tloop.daemon=True
+        self.tloop.start()
+
+    def _Loop(self):
+        while self.loop_active:
+            with self._lock:
+                try:
+                    # check position
+                    time.sleep(self._update_rate)
+                    for ind, axis in enumerate(self.axes):
+                        # does this need a lock?
+                        self.positions[ind] = self.pi.qPOS([axis])[axis]
+                    
+                    # update ontarget
+                    old_on_target = np.copy(self._on_target)
+                    self._on_target = np.asarray([pitools.ontarget(self.pi)[axis] for axis in self.axes])
+
+                    if not np.all(self._on_target == old_on_target):
+                        # FIXME - something to log which axis would be cool?
+                        logEvent('PiezoOnTarget', '%s' % self.positions, time.time())
+                        self._all_on_target = np.all(self._on_target)
+                    
+                    targets_matched = np.isclose(self.target_positions, self._last_target_positions)
+                    if all(targets_matched):
+                        self._all_on_target = True
+                    else:
+                        self._all_on_target = False
+                        for ind, matched in enumerate(targets_matched):
+                            if not matched:
+                                new_pos = np.clip(self.target_positions[ind], self._min[ind], self._max[ind])
+                                self.pi.MOV(self.axes[ind], new_pos)
+                                self._on_target[ind] = False
+                        
+                        self._last_target_positions = np.copy(self.target_positions)
+
+                    #     gcs.MOV(self.id, b'A', pos[:1])
+                    #     self.lastTargetPosition = pos.copy()
+                    #     # print('p')
+                    #     # logging.debug('Moving piezo to target: %f' % (pos[0],))
+
+                    # if np.allclose(self.position, self.targetPosition, atol=self._target_tol):
+                    #     if not self.onTarget:
+                    #         logEvent('PiezoOnTarget', '%.3f' % self.position[0], time.time())
+                    #         self.onTarget = True
+                
+                except Exception as e:
+                    # gcs.fcnWrap.HandleError throws Runtimes for everything
+                    logger.error(str(e))
+                    # try:
+                    #     self.errCode = int(gcs.qERR(self.id))
+                    #     logger.error('error code: %s' % str(self.errCode))
+                    # except:
+                    #     logger.error('no error code retrieved')
+                    # if '-1' in str(e):
+                    #     logger.debug('reinitializing GCS connection, 10 s pause')
+                    #     gcs.CloseConnection(self.id)
+                    #     time.sleep(10.0)  # this takes at least more than 1 s
+                    #     try:
+                    #         self.id = gcs.ConnectUSB(self._identifier)
+                    #         logger.debug('restablished connection to piezo')
+                    #     except RuntimeError as e:
+                    #         logger.error('trying to get new device ID')
+                    #         devices = get_connected_devices()
+                    #         self._identifier = devices[0]
+                    #         logger.debug('new device ID acquired')
+                    #         self.id = gcs.ConnectUSB(self._identifier)
+                    #     time.sleep(1.0)
+                    #     logger.debug('turning on servo')
+                    #     gcs.SVO(self.id, b'A', [1])
+                    #     time.sleep(1.0)
+        logger.debug('exiting')
+   

--- a/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
@@ -4,6 +4,22 @@
 # Tested with a E-727 controller, on pipython 2.9.0.4 (pypi)
 # see https://github.com/PI-PhysikInstrumente/PIPython
 
+# GETTING STARTED:
+# 1. Install https://github.com/PI-PhysikInstrumente/PIPython
+# 2. In a Python shell, import this file and call get_gcs_usb()
+# to find your stage (assuming it has the drivers it needs, is turned on, etc.)
+# 3. Use the full description string returned by get_gcs_usb() to 
+# find the axes names as used by PI by calling
+# get_stage_axes(description). You'll want to use this description
+# exactly in the next step, as PIPython can be sensitive to e.g.
+# ['1', '2'] vs [1, 2], or '['A', 'B'] vs. ['a', 'b'].
+# 4. Initialize the stage with GCSPiezo(description, axes) in your
+# PYME init script.
+# 5: Consider using GCSPiezoThreaded for performance improvements,
+# particularly if you are using a multi-axis stage, or multiple GCSPiezos
+# in your setup, as updating the position of stages happens in order to
+# update the GUI and can slow down PYMEAcquire considerably.
+
 
 from PYME.Acquire.Hardware.Piezos.base_piezo import PiezoBase
 from pipython import GCSDevice, pitools
@@ -277,11 +293,6 @@ class GCSPiezoThreaded(PiezoBase):
         For multiaxis stages, query with None reports for all of them
         """
         return self._all_on_target
-        if axes is None:
-            return all(self._on_target)
-        else:
-            raise NotImplementedError
-        # return all(self.pi.qONT(axes))
     
     def close(self):
         self.loop_active = False
@@ -324,41 +335,9 @@ class GCSPiezoThreaded(PiezoBase):
                                 self._on_target[ind] = False
                         
                         self._last_target_positions = np.copy(self.target_positions)
-
-                    #     gcs.MOV(self.id, b'A', pos[:1])
-                    #     self.lastTargetPosition = pos.copy()
-                    #     # print('p')
-                    #     # logging.debug('Moving piezo to target: %f' % (pos[0],))
-
-                    # if np.allclose(self.position, self.targetPosition, atol=self._target_tol):
-                    #     if not self.onTarget:
-                    #         logEvent('PiezoOnTarget', '%.3f' % self.position[0], time.time())
-                    #         self.onTarget = True
                 
                 except Exception as e:
-                    # gcs.fcnWrap.HandleError throws Runtimes for everything
                     logger.error(str(e))
-                    # try:
-                    #     self.errCode = int(gcs.qERR(self.id))
-                    #     logger.error('error code: %s' % str(self.errCode))
-                    # except:
-                    #     logger.error('no error code retrieved')
-                    # if '-1' in str(e):
-                    #     logger.debug('reinitializing GCS connection, 10 s pause')
-                    #     gcs.CloseConnection(self.id)
-                    #     time.sleep(10.0)  # this takes at least more than 1 s
-                    #     try:
-                    #         self.id = gcs.ConnectUSB(self._identifier)
-                    #         logger.debug('restablished connection to piezo')
-                    #     except RuntimeError as e:
-                    #         logger.error('trying to get new device ID')
-                    #         devices = get_connected_devices()
-                    #         self._identifier = devices[0]
-                    #         logger.debug('new device ID acquired')
-                    #         self.id = gcs.ConnectUSB(self._identifier)
-                    #     time.sleep(1.0)
-                    #     logger.debug('turning on servo')
-                    #     gcs.SVO(self.id, b'A', [1])
-                    #     time.sleep(1.0)
+                
         logger.debug('exiting')
    

--- a/docs/supported_hardware.rst
+++ b/docs/supported_hardware.rst
@@ -11,7 +11,7 @@ Cameras / Detectors
 
 Stages / Translation
 ====================
-* PI piezos (using e255, e662, e709, e727 and e816 controller interface boards, covers most PI piezos, likely easily modifyable to new controllers)
+* PI piezos (using e255, e517, e662, e709, e727 and e816 controller interface boards, covers most PI piezos, likely easily modifyable to new controllers)
 * PI piezo linear motor stages using the C867 controller (M686 stage and similar)
 * PI stepper motor stages using the Mercury command set
 * Marzhauser Tango translation stages and joystick


### PR DESCRIPTION
Addresses issue running a 3-axis fine stage and a 2-axis coarse stage with the non-threaded class was a serious brick on PYMEAcquire smoothness (i.e. updating scope state was taking some time that it doesn't need to)

**Is this a bugfix or an enhancement?**
enhancement and a couple bugfixes
**Proposed changes:**
- add GCSPiezoThreaded class
- fix a couple of GCSPiezo calls that wouldn't previously work for axes with names that aren't int's
- cache min/max on GCSPiezo (unthreaded)
- if axes aren't specified, grab the list from PIPython and use all






**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
