### PR TITLE
add support for obis controller echo

### DIFF
--- a/PYME/Acquire/Hardware/Coherent/OBIS.py
+++ b/PYME/Acquire/Hardware/Coherent/OBIS.py
@@ -34,7 +34,7 @@ from PYME.Acquire.Hardware.lasers import Laser
 
 class CoherentOBISLaser(Laser):
     power_controllable = True
-    def __init__(self, serial_port='COM8', turn_on=False, name='OBIS', init_power=5, **kwargs):
+    def __init__(self, serial_port='COM8', turn_on=False, name='OBIS', init_power=5, reply_ok=False, **kwargs):
         """
 
         Parameters
@@ -47,10 +47,15 @@ class CoherentOBISLaser(Laser):
             Name of the laser
         init_power: float
             In units of mW
+        reply_ok: bool
+            Whether this laser is configured to reply 'OK' after each message or not.
+            Note this has been observed when communicating throughthe OBIS power supply
+            rather than directly with the head unit.
         kwargs
         """
         self.serial_port = serial.Serial(serial_port, timeout=.1)
         self.lock = threading.Lock()
+        self._reply_OK = int(reply_ok)
 
 
 
@@ -94,7 +99,7 @@ class CoherentOBISLaser(Laser):
         with self.lock:
             self.serial_port.reset_input_buffer()
             self.serial_port.write(command)
-            reply = [self.serial_port.readline() for line in range(lines_expected)]
+            reply = [self.serial_port.readline() for line in range(lines_expected + self._reply_OK)]
             self.serial_port.reset_input_buffer()
         return reply
 


### PR DESCRIPTION
Addresses issue throwing an existing setup into PYMEAcquire, and this setup uses a Coherent power supply / controller for the OBIS, rather than a self-sourced power supply / direct USB com to the head unit like we used in Joerg's lab. This controller takes the same commands, but replies 'OK' in a separate line after e.g. the minimum power query. Likely this echo setting could be turned off somehow, but I don't have the serial commands in front of me, so I did this for now.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- add reply_ok arg to OBIS init, to read the extra echo line after each serial command







**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
