### PR TITLE
test coundir import separate, expect fail on windows

### DIFF
--- a/tests/PYME/IO/test_countdir.py
+++ b/tests/PYME/IO/test_countdir.py
@@ -1,4 +1,8 @@
 
+import pytest
+import sys
+
+@pytest.mark.xfail(sys.platform=='win32', reason='countdir.c not compiled on non-posix platforms')
 def test_dirsize():
     from PYME.IO import countdir
     import os

--- a/tests/PYME/IO/test_countdir.py
+++ b/tests/PYME/IO/test_countdir.py
@@ -2,7 +2,7 @@
 import pytest
 import sys
 
-@pytest.mark.xfail(sys.platform=='win32', reason='countdir.c not compiled on non-posix platforms')
+@pytest.mark.skipif(sys.platform=='win32', reason='countdir.c not compiled on non-posix platforms')
 def test_dirsize():
     from PYME.IO import countdir
     import os

--- a/tests/PYME/test_imports.py
+++ b/tests/PYME/test_imports.py
@@ -1,7 +1,7 @@
 """ This just trys importing all the modules. Should cause test failures for py3k syntax errors (e.g. print statements)"""
 
 import pytest
-
+import sys
 
 # mark some tests as expected to fail if we are testing on a headless system
 try:
@@ -17,9 +17,13 @@ def test_IO_imports():
     from PYME.IO import clusterIO, clusterListing, clusterResults, clusterUpload
     from PYME.IO import dataExporter, dataWrap, dcimg, h5rFile
     from PYME.IO import image, load_psf, MetaDataHandler, PZFFormat
-    from PYME.IO import ragged, tabular, unifiedIO, countdir
+    from PYME.IO import ragged, tabular, unifiedIO
     
     #from PYME.IO import clusterDuplication #Known failure due to dependence on pyro
+
+@pytest.mark.xfail(sys.platform == 'win32', reason='countdir.c not compiled on non-posix systems')
+def test_countdir_import():
+    from PYME.IO import countdir
     
 @pytest.mark.xfail(not HAVE_WX, reason="Depends on wx, which is not installed on this platform")
 def test_DSView_imports():

--- a/tests/PYME/test_imports.py
+++ b/tests/PYME/test_imports.py
@@ -21,7 +21,7 @@ def test_IO_imports():
     
     #from PYME.IO import clusterDuplication #Known failure due to dependence on pyro
 
-@pytest.mark.xfail(sys.platform == 'win32', reason='countdir.c not compiled on non-posix systems')
+@pytest.mark.skipif(sys.platform == 'win32', reason='countdir.c not compiled on non-posix systems')
 def test_countdir_import():
     from PYME.IO import countdir
     


### PR DESCRIPTION
Addresses issue we don't compile coundir.c on non-posix systems, but we fail the test on all currently
issue #1393 

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- test countdir import separate of other io imports
- mark xfail on win32






**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
