### PR TITLE
PYME.Analysis.composite.make_composite docstring and handle if im0 is tuple or direclty an imagestack

### DIFF
--- a/PYME/Analysis/composite.py
+++ b/PYME/Analysis/composite.py
@@ -69,6 +69,29 @@ def remap_data_2d(image, chan, shape, voxelsize, origin, shiftField=None, ignore
 
 
 def make_composite(images, ignoreZ=True, interp=True, shape=None, origin=None, voxelsize=None):
+    """Make a composite image from multiple ImageStacks, interpolating if necessary
+
+    Parameters
+    ----------
+    images : list-like
+        ImageStack objects to combine, potentially as a list of tuples with the second element being the channel to use,
+        and the third element being a chromatic shift field to apply
+    ignoreZ : bool, optional
+        ignore z origin when combining, by default True
+    interp : bool, optional
+        whether to interpolate with a cubic spline (True) or linear (False), by default True
+    shape : list-like, optional
+        xyztc shape of the composite, if different than the shape of the first image (default, None)
+    origin : list-like, optional
+        XYZ origin of the composite image, if different than the origin of the first image (default, None)
+    voxelsize : MetaDataHandler.VoxelSize, optional
+        voxelsize to construct the composite image, if different than that of the first image (default, None)
+
+    Returns
+    -------
+    PYME.IO.image.ImageStack
+        composite image
+    """
     from PYME.IO import MetaDataHandler
     from PYME.IO.image import ImageStack
     
@@ -77,7 +100,10 @@ def make_composite(images, ignoreZ=True, interp=True, shape=None, origin=None, v
     newNames = []
     newData = []
     
-    im0 = images[0][0]
+    if isinstance(images[0], tuple):
+        im0 = images[0][0]
+    else:
+        im0 = images[0]
     
     if voxelsize is None:
         voxelsize = im0.voxelsize


### PR DESCRIPTION
Addresses issue # .

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
-add docstrings to `make_composite`
-actually allow a list-like of image stacks as input, rather than only checking for this in the loop

**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
