### PR TITLE
allow test frame to handle not subtracting background in fit

### DIFF
--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -977,8 +977,9 @@ class LMAnalyser2(Plugin):
                 #figure()
                 #imshow()
             except AttributeError:
+                from numbers import Number
                 #d = self.image.data[:,:,zp].squeeze().T
-                if isinstance(ft.bg, np.ndarray):
+                if isinstance(ft.bg, np.ndarray) or isinstance(ft.bg, Number):
                     # We expect our background estimate to take the form of a numpy array, correct our data by subtracting the background
                     d = (ft.data - ft.bg).squeeze().T
                 elif hasattr(ft.bg, 'get_background'):

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -980,6 +980,7 @@ class LMAnalyser2(Plugin):
                 from numbers import Number
                 #d = self.image.data[:,:,zp].squeeze().T
                 if isinstance(ft.bg, np.ndarray) or isinstance(ft.bg, Number):
+                    # TODO - revisit special cases - should we check for the GPU stuff first and then just duck-type everything else?
                     # We expect our background estimate to take the form of a numpy array, correct our data by subtracting the background
                     d = (ft.data - ft.bg).squeeze().T
                 elif hasattr(ft.bg, 'get_background'):


### PR DESCRIPTION
Addresses issue `FFBase._get_roi` assigns 0 to the `background` attribute if subtract background in fit is unchecked, which then breaks `LMAnalyser2.testFrame` because it checks for an array type, which scalar 0 is not. np.isscalar isn't robust to e.g. str, so I propose a fix with `numbers.Number` 

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
