### PR TITLE
Allow visualization of localizations colored by cluster measurements

### DIFF
--- a/PYME/recipes/localisations.py
+++ b/PYME/recipes/localisations.py
@@ -1030,8 +1030,11 @@ class MeasureClusters3D(ModuleBase):
             cmorph.measure_3d(x, y, z, output=measurements[cluster_index])
 
             indi = indf
-
-        return tabular.RecArraySource(measurements)
+        
+        # propagate the labelKey used to generate these measurements
+        output = tabular.MappingFilter(tabular.RecArraySource(measurements))
+        output.addColumn(self.labelKey, unique_labels)
+        return output
 
 
 @register_module('FiducialCorrection')

--- a/PYME/recipes/localisations.py
+++ b/PYME/recipes/localisations.py
@@ -1069,7 +1069,7 @@ class AddMeasurementsByLabel(ModuleBase):
         # only propagate 1D measurements
         annotations = dict()
         for k in input_measurements.keys():
-            if input_measurements[k].ndim == 1:
+            if input_measurements[k].ndim == 1: #TODO - also check for object dtype?
                 annotations[k] = np.zeros(len(input_points), dtype=input_measurements[k].dtype)
         
         try:

--- a/PYME/recipes/localisations.py
+++ b/PYME/recipes/localisations.py
@@ -1037,6 +1037,69 @@ class MeasureClusters3D(ModuleBase):
         return output
 
 
+@register_module('AddMeasurementsByLabel')
+class AddMeasurementsByLabel(ModuleBase):
+    input_points = Input('input')
+    input_measurements = Input('clusterMeasures')
+    label_key = CStr('label')
+    output_points = Output('annotated_points')
+
+    def run(self, input_points, input_measurements):
+        """
+        Propagate measurements from e.g. MeasureClusters3D back to points they were calcualted from.
+        This is particularly useful for visualizing e.g. the gyration radius of a cluster in PYMEVis
+        while looking at the original localization data.
+
+        Parameters
+        ----------
+        input_points : PYME.IO.tabular.TabularBase
+            points used to generate the measurements
+        input_measurements : PYME.IO.tabular.TabularBase
+            measurements to propagate back to the points
+
+        Returns
+        -------
+        PYME.IO.tabular.TabularBase
+            point data with new columns added, one for each scalar measurement in input_measurements, which
+            can be accessed by '<label_key>_<measurement_key>', e.g. 'clumpIndex_gyrationRadius'.
+        
+        """
+        from PYME.IO.tabular import MappingFilter
+        
+        # only propagate 1D measurements
+        annotations = dict()
+        for k in input_measurements.keys():
+            if input_measurements[k].ndim == 1:
+                annotations[k] = np.zeros(len(input_points), dtype=input_measurements[k].dtype)
+        
+        try:
+            labels = np.unique(input_measurements[self.label_key])
+        except KeyError:
+            logger.exception('Label key %s not found in input_measurements, RISKY: continuing with assumption measurements are sorted by label and all present' % self.label_key)
+            labels = np.arange(1, len(input_measurements) + 1)  # MeasureClusters3D ignores the unclustered points 'label 0' so index 0 corresponds to 'label 1'
+        
+        for label in labels:
+            points_mask = label == input_points[self.label_key]
+            try:
+                measurement_mask = label == input_measurements[self.label_key]
+            except KeyError:
+                measurement_mask = label - 1  # MeasureClusters3D ignores the unclustered points 'label 0' so index 0 corresponds to 'label 1'
+            
+            for k in annotations.keys():
+                annotations[k][points_mask] = input_measurements[k][measurement_mask]
+
+        output_points = MappingFilter(input_points)
+        try:
+            output_points.mdh = input_points.mdh
+        except AttributeError:
+            pass
+        
+        for k in annotations.keys():
+            output_points.addColumn(self.label_key + '_' + k, annotations[k])
+        
+        return output_points
+
+
 @register_module('FiducialCorrection')
 class FiducialCorrection(ModuleBase):
     """

--- a/PYME/recipes/localisations.py
+++ b/PYME/recipes/localisations.py
@@ -1033,7 +1033,7 @@ class MeasureClusters3D(ModuleBase):
         
         # propagate the labelKey used to generate these measurements
         output = tabular.MappingFilter(tabular.RecArraySource(measurements))
-        output.addColumn(self.labelKey, unique_labels)
+        output.addColumn(self.labelKey, np.arange(maxLabel))
         return output
 
 


### PR DESCRIPTION
Addresses issue at the moment folks can't run a clustering, map a density, then filter on this density, and see what that actually looks like applied to the localizations themselves. 

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- record the labelKey each cluster corresponds to in `MeasureClusters3D`. Not strictly necessary, but feels like a safer option than assuming everything will stay sorted later
- add a module to map per-cluster quantities (scalar) onto the localizations used to generate them, such that they can be visualized in the GUI. 

Example recipe for something that's been clustered with a label key `gmm_label`:

```
- localisations.AddPipelineDerivedVars:
    inputEvents: ''
    inputFitResults: FitResults
    outputLocalizations: Localizations
- localisations.ProcessColour:
    input: Localizations
    output: colour_mapped
- tablefilters.FilterTable:
    inputName: colour_mapped
    outputName: filtered_localizations
- localisations.MeasureClusters3D:
    inputName: filtered_localizations
    labelKey: gmm_label
    outputName: clusterMeasures
- localisations.AddMeasurementsByLabel:
    input_measurements: mapped
    input_points: filtered_localizations
    label_key: gmm_label
    output_points: annotated_points
- tablefilters.Mapping:
    inputName: clusterMeasures
    mappings:
      circular_density: count / (np.pi * (gyrationRadius ** 2))
    outputName: mapped
- tablefilters.FilterTable:
    filters:
      gmm_label_circular_density:
      - 0.005
      - 9000000000.0
    inputName: annotated_points
    outputName: filtered_and_annotated
```





**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
