### PR TITLE
fix fitfactory import in customAnalysisPanel for plug-in compatibility

### DIFF
--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -166,10 +166,10 @@ class AnalysisSettingsView(object):
             vsizer.Add(pg, 0,wx.BOTTOM|wx.EXPAND, 5)    
         
     def _populateCustomAnalysisPanel(self, pan, vsizer):
+        from PYME.localization.FitFactories import import_fit_factory
         try:
             fitMod = self.fitFactories[self.cFitType.GetSelection()]
-            pkg = PYME.localization.FitFactories.package[fitMod]
-            fm = importlib.import_module('.'.join([pkg, fitMod]), pkg)
+            fm = import_fit_factory(fitMod)
             
             #vsizer = wx.BoxSizer(wx.VERTICAL)
             for param in fm.PARAMETERS:


### PR DESCRIPTION
Addresses issue opening an h5 file in PYMEImage currently fails:
```
WARNING:PYME.DSView.modules:Plugin [LMAnalysis] injects into parent namespace, could result in circular references
Creating fold panel
['AstigGaussFitFR', 'AstigGaussGPUFitFR', 'BeadConvolvedAstigGaussFit', 'ChecksumFR', 'ChecksumGPUFR', 'ChecksumMultifitSR', 'ConfocCOIR', 'Dumbell3DFitR', 'DumbellFitR', 'Gauss3DFitR', 'GaussFitConstrR', 'GaussMultifitLinesR', 'GaussMultifitR', 'GaussMultifitSR', 'InterpFitR', 'InterpFitWFR', 'LatFitCOIR', 'LatGaussFitFR', 'LatObjFindFR', 'LatPSFFitR', 'MultiviewFitInterpNR', 'PRInterpFitQR', 'PRInterpFitR', 'ROIExtractNR', 'SpecGaussFitFR', 'SplitterFitCOIR', 'SplitterFitFNR', 'SplitterFitFusionR', 'SplitterFitInterpBNR', 'SplitterFitInterpNR', 'SplitterFitScavNR', 'SplitterMultifitSR', 'SplitterObjFindR', 'SplitterROIExtractNR', 'SplitterShiftEstFR', 'double_helix.FitFactories.DoubleHelixFit_SepGuess', 'double_helix.FitFactories.DoubleHelixFit_Theta']
Traceback (most recent call last):
  File "C:\Users\aesb\Miniconda3\envs\pymedev\lib\site-packages\wx\core.py", line 3259, in <lambda>
    lambda event: event.callable(*event.args, **event.kw) )
  File "c:\userfiles\andrew\code\python-microscopy\PYME\DSView\dsviewer.py", line 470, in LoadData
    vframe = DSViewFrame(im, None, im.filename, mode = mode)
  File "c:\userfiles\andrew\code\python-microscopy\PYME\DSView\dsviewer.py", line 181, in __init__
    self.CreateFoldPanel()
  File "c:\userfiles\andrew\code\python-microscopy\PYME\ui\AUIFrame.py", line 139, in CreateFoldPanel
    genFcn(self.sidePanel)
  File "c:\userfiles\andrew\code\python-microscopy\PYME\DSView\modules\LMAnalysis.py", line 258, in GenAnalysisPanel
    self._populateCustomAnalysisPanel(self.customOptionsPan, self.customOptionsSizer)
  File "c:\userfiles\andrew\code\python-microscopy\PYME\DSView\modules\LMAnalysis.py", line 171, in _populateCustomAnalysisPanel
    pkg = PYME.localization.FitFactories.package[fitMod]
KeyError: 'LatGaussFitFR'
```

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- use `import_fit_factories` in custom analysis panel initialization






**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
