### PR TITLE
fix "Test This Frame" behaviour to properly work on current frame in dh5view

### DIFF
--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -367,7 +367,7 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
             x = self.filter['x']/self.voxelsize[0]
             y = self.filter['y']/self.voxelsize[1]
             
-            xb, yb, zb = self.visible_bounds
+            xb, yb, zb, tb = self.visible_bounds
             
             IFoc = (x >= xb[0])*(y >= yb[0])*(t >= zb[0])*(x < xb[1])*(y < yb[1])*(t < zb[1])
 
@@ -391,7 +391,7 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
     @property
     def visible_bounds(self):
         """
-        The currently visible bounds of the image, in image pixel coordinates [x, y, z]
+        The currently visible bounds of the image, in image pixel coordinates [x, y, z, t]
 
         Used to avoid drawing overlays in regions of the image which are not shown.
 
@@ -403,11 +403,11 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
         sX, sY = self.imagepanel.Size
         
         if self.do.slice == self.do.SLICE_XY:
-            bnds = [(x0/sc, (x0+sX)/sc), (y0/sc, (y0+sY)/sc), (self.do.zp-.5, self.do.zp+.5)]
+            bnds = [(x0/sc, (x0+sX)/sc), (y0/sc, (y0+sY)/sc), (self.do.zp-.5, self.do.zp+.5), (self.do.tp-.5, self.do.tp+.5)]
         elif self.do.slice == self.do.SLICE_XZ:
-            bnds = [(x0/sc, (x0+sX)/sc), (self.do.yp-.5, self.do.yp+.5), (y0/sc, (y0+sY)/sc)]
+            bnds = [(x0/sc, (x0+sX)/sc), (self.do.yp-.5, self.do.yp+.5), (y0/sc, (y0+sY)/sc), (self.do.tp-.5, self.do.tp+.5)]
         elif self.do.slice == self.do.SLICE_YZ:
-            bnds = [(self.do.xp-.5, self.do.xp+.5),(x0/sc, (x0+sX)/sc), (y0/sc, (y0+sY)/sc)]
+            bnds = [(self.do.xp-.5, self.do.xp+.5),(x0/sc, (x0+sX)/sc), (y0/sc, (y0+sY)/sc), (self.do.tp-.5, self.do.tp+.5)]
 
         return bnds
         

--- a/PYME/DSView/fitInfo.py
+++ b/PYME/DSView/fitInfo.py
@@ -164,14 +164,16 @@ class FitInfoPanel(wx.Panel):
     def DrawOverlays(self, vp, dc):
         do = vp.do
 
-        if do.ds.shape[2] > 1:
-            # stack has z
-            zp = do.zp
-        else:
+        if do.ds.shape[3] > 1:
             # stack is a time series
-            zp = do.tp
+            t = do.tp
+        else:
+            # stack is a formatted as a z-stack - pretend it's a time series
+            # this can occur due to limitations in the backwards compatibility code that guesses
+            # whether a stack is a time series or not
+            t = do.zp
         
-        frameResults = self.fitResults[self.fitResults['tIndex'] == zp]
+        frameResults = self.fitResults[self.fitResults['tIndex'] == t]
         
         vx, vy, _ = self.mdh.voxelsize_nm
         

--- a/PYME/DSView/fitInfo.py
+++ b/PYME/DSView/fitInfo.py
@@ -163,7 +163,15 @@ class FitInfoPanel(wx.Panel):
         
     def DrawOverlays(self, vp, dc):
         do = vp.do
-        frameResults = self.fitResults[self.fitResults['tIndex'] == do.zp]
+
+        if do.ds.shape[2] > 1:
+            # stack has z
+            zp = do.zp
+        else:
+            # stack is a time series
+            zp = do.tp
+        
+        frameResults = self.fitResults[self.fitResults['tIndex'] == zp]
         
         vx, vy, _ = self.mdh.voxelsize_nm
         
@@ -326,7 +334,7 @@ class fitDispPanel(wxPlotPanel.PlotPanel):
                 
             return np.hstack([g,r])  - self.mdh.get('Camera.ADOffset', 0)
         else:
-            return self.ds[slice(*fri['slicesUsed']['x']), slice(*fri['slicesUsed']['y']), zi, ci, ti].squeeze()  - self.mdh.get('Camera.ADOffset', 0)
+            return self.ds[slice(*fri['slicesUsed']['x']), slice(*fri['slicesUsed']['y']), zi, ti, ci].squeeze()  - self.mdh.get('Camera.ADOffset', 0)
 
     def _extractROI_1(self, fri):
         from PYME.IO.MetaDataHandler import get_camera_roi_origin

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -814,8 +814,14 @@ class LMAnalyser2(Plugin):
 
     def update(self, dsviewer):
         if 'fitInf' in dir(self) and not self.dsviewer.playbackpanel.playback_running:
+            if self.do.ds.shape[2] > 1:
+                # stack has z
+                zp = self.do.zp
+            else:
+                # stack is a time series
+                zp = self.do.tp
             try:
-                self.fitInf.UpdateDisp(self._ovl.points_hit_test(self.do.xp, self.do.yp, self.do.zp, voxelsize=self.view.voxelsize))
+                self.fitInf.UpdateDisp(self._ovl.points_hit_test(self.do.xp, self.do.yp, zp, voxelsize=self.view.voxelsize))
             except:
                 import traceback
                 print((traceback.format_exc()))
@@ -910,7 +916,12 @@ class LMAnalyser2(Plugin):
             matplotlib.interactive(False)
             plt.figure()
         
-        zp = self.do.zp
+        if self.do.ds.shape[2] > 1:
+            # stack has z
+            zp = self.do.zp
+        else:
+            # stack is a time series
+            zp = self.do.tp
 
         analysisMDH = self.analysisController.analysisMDH
         

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -814,14 +814,17 @@ class LMAnalyser2(Plugin):
 
     def update(self, dsviewer):
         if 'fitInf' in dir(self) and not self.dsviewer.playbackpanel.playback_running:
-            if self.do.ds.shape[2] > 1:
-                # stack has z
-                zp = self.do.zp
-            else:
+            if self.do.ds.shape[3] > 1:
                 # stack is a time series
-                zp = self.do.tp
+                idx = self.do.tp
+            else:
+                # stack is a formatted as a z-stack - pretend it's a time series
+                # this can occur due to limitations in the backwards compatibility code that guesses
+                # whether a stack is a time series or not
+                idx = self.do.zp
+            
             try:
-                self.fitInf.UpdateDisp(self._ovl.points_hit_test(self.do.xp, self.do.yp, zp, voxelsize=self.view.voxelsize))
+                self.fitInf.UpdateDisp(self._ovl.points_hit_test(self.do.xp, self.do.yp, idx, voxelsize=self.view.voxelsize))
             except:
                 import traceback
                 print((traceback.format_exc()))

--- a/PYME/DSView/modules/annotation.py
+++ b/PYME/DSView/modules/annotation.py
@@ -346,7 +346,7 @@ class Annotater(Plugin):
 
     def _visibletest(self, clump, bounds):
     
-        xb, yb, zb = bounds
+        xb, yb, zb, tb = bounds
         
         x, y = np.array(clump['points']).T
         t = clump['z']

--- a/PYME/DSView/modules/flowView.py
+++ b/PYME/DSView/modules/flowView.py
@@ -107,7 +107,7 @@ class FlowView(HasTraits):
         if (not self.showFlow) or flow is None:
             return
         
-        xb, yb, zb = view.visible_bounds
+        xb, yb, zb, tb = view.visible_bounds
         x0, x1 = xb
         y0, y1 = yb 
                 
@@ -178,7 +178,7 @@ class FlowView(HasTraits):
         if (not self.showFlow) or flow is None:
             return
         
-        xb, yb, zb = view.visible_bounds
+        xb, yb, zb, tb = view.visible_bounds
         x0, x1 = xb
         y0, y1 = yb 
                 

--- a/PYME/DSView/modules/particleTracking.py
+++ b/PYME/DSView/modules/particleTracking.py
@@ -383,7 +383,7 @@ class ParticleTrackingView(HasTraits, Plugin):
         if (not clump.enabled) or (clump.nEvents < 2):
             return False
             
-        xb, yb, zb = bounds
+        xb, yb, zb, tb = bounds
         vx, vy, vz = self.image.voxelsize
         
         x = clump['x']/vx

--- a/PYME/DSView/overlays.py
+++ b/PYME/DSView/overlays.py
@@ -98,7 +98,12 @@ class PointDisplayOverlay(Overlay):
                 x = self.filter['x']/vx
                 y = self.filter['y']/vy
                 
+                # note: the proper fix for 5D compliant behaviour probably involves fixing up visible_bounds (see comments therein)
                 xb, yb, zb = vp.visible_bounds
+                # the below is currently a hack and almost certainly needs to be replaced by a proper fix!!!!
+                if vp.do.ds.shape[2] <= 1:
+                    # time series
+                    zb = [-0.5,vp.do.ds.shape[3]] # here we assume XYZTC data source # not sure how to test for it
                 
                 IFoc = (x >= xb[0])*(y >= yb[0])*(t >= zb[0])*(x < xb[1])*(y < yb[1])*(t < zb[1])
                     

--- a/PYME/DSView/overlays.py
+++ b/PYME/DSView/overlays.py
@@ -99,7 +99,7 @@ class PointDisplayOverlay(Overlay):
                 y = self.filter['y']/vy
                 
                 # note: the proper fix for 5D compliant behaviour probably involves fixing up visible_bounds (see comments therein)
-                xb, yb, zb = vp.visible_bounds
+                xb, yb, zb, tb = vp.visible_bounds
                 # the below is currently a hack and almost certainly needs to be replaced by a proper fix!!!!
                 if vp.do.ds.shape[2] <= 1:
                     # time series

--- a/PYME/DSView/overlays.py
+++ b/PYME/DSView/overlays.py
@@ -98,14 +98,13 @@ class PointDisplayOverlay(Overlay):
                 x = self.filter['x']/vx
                 y = self.filter['y']/vy
                 
-                # note: the proper fix for 5D compliant behaviour probably involves fixing up visible_bounds (see comments therein)
                 xb, yb, zb, tb = vp.visible_bounds
-                # the below is currently a hack and almost certainly needs to be replaced by a proper fix!!!!
-                if vp.do.ds.shape[2] <= 1:
-                    # time series
-                    zb = [-0.5,vp.do.ds.shape[3]] # here we assume XYZTC data source # not sure how to test for it
                 
-                IFoc = (x >= xb[0])*(y >= yb[0])*(t >= zb[0])*(x < xb[1])*(y < yb[1])*(t < zb[1])
+                if vp.do.ds.shape[3] <= 1:
+                    # stack is a pure z-series, pretend it's a time series for backwards compatibility
+                    tb = zb
+                
+                IFoc = (x >= xb[0])*(y >= yb[0])*(t >= tb[0])*(x < xb[1])*(y < yb[1])*(t < tb[1])
                     
                 pFoc = np.vstack((x[IFoc], y[IFoc], t[IFoc])).T
 


### PR DESCRIPTION
Addresses issue #1423 .

**Is this a bugfix or an enhancement?**
Bugfix.

**Proposed changes:**

Tries to fix the code that figures out the current frame to work on to be compatible with 5D data model.

Note that the fix has been tested with single channel data only and is probably still a hack in that it does currently **not** properly fix `visible_bounds` in `arrayViewPanel.py` where the fix should probably go (see comment in code).

_This is only a work in progress_ and hopefully the proper fix in `visible_bounds` can be made by working on this PR, I am still not sure about the 5D logic fully at this stage...

**Screenshots:**

Works as expected with this fix:

![Screenshot 2023-09-15 at 12 13 22](https://github.com/python-microscopy/python-microscopy/assets/3750860/60b5fb01-20bb-405f-ad3c-6ce815dbdece)

![Screenshot 2023-09-15 at 12 13 39](https://github.com/python-microscopy/python-microscopy/assets/3750860/1f9df672-ed56-4df5-bf8b-356ce56ad97d)


**Checklist:**

Tested for basic functionality with single channel data on macos with latest code from master and this fix in.