### PR TITLE
Log and deprecation cleanup

### DIFF
--- a/PYME/DSView/modules/annotation.py
+++ b/PYME/DSView/modules/annotation.py
@@ -59,7 +59,7 @@ class LabelPanel(wx.Panel):
         
         self.bAdjustSnake = wx.Button(self, label='Adj', style=wx.BU_EXACTFIT)
         self.bAdjustSnake.Bind(wx.EVT_BUTTON, self.on_adjust_snake)
-        self.bAdjustSnake.SetToolTipString('Adjust the parameters of fo the "snake" (active contour) used for curve locking')
+        self.bAdjustSnake.SetToolTip('Adjust the parameters of fo the "snake" (active contour) used for curve locking')
         
         sbsizer.Add(self.bAdjustSnake, 0, wx.ALIGN_CENTER_VERTICAL|wx.LEFT, 2)
         
@@ -70,10 +70,10 @@ class LabelPanel(wx.Panel):
         self.lLabels.InsertColumn(1, 'Structure')
         
         for i in range(10):
-            self.lLabels.InsertStringItem(i, '%d' % i)
-            self.lLabels.SetStringItem(i, 1, 'Structure %d' % i)
+            self.lLabels.InsertItem(i, '%d' % i)
+            self.lLabels.SetItem(i, 1, 'Structure %d' % i)
         
-        self.lLabels.SetStringItem(0, 1, 'No label')
+        self.lLabels.SetItem(0, 1, 'No label')
         
         self.lLabels.SetItemState(1, wx.LIST_STATE_SELECTED, wx.LIST_STATE_SELECTED)
         self.lLabels.SetColumnWidth(0, wx.LIST_AUTOSIZE)
@@ -92,7 +92,7 @@ class LabelPanel(wx.Panel):
         self.bAddLine = wx.Button(self, label='Add', style=wx.BU_EXACTFIT)
         hsizer.Add(self.bAddLine, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
         self.bAddLine.Bind(wx.EVT_BUTTON, self.labeler.add_curved_line)
-        self.bAddLine.SetToolTipString('Add a curve annotation (ctrl-L / cmd-L)')
+        self.bAddLine.SetToolTip('Add a curve annotation (ctrl-L / cmd-L)')
         vsizer.Add(hsizer, 0, wx.ALL | wx.EXPAND, 5)
         
         self.SetSizer(vsizer)

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -135,7 +135,7 @@ class VisGUICore(object):
         #logger.debug('Ev Idle')
         if self.glCanvas._is_initialized and not self.refv:
             self.refv = True
-            logger.debug((self.viewMode, self.pointDisplaySettings.colourDataKey))
+            #logger.debug((self.viewMode, self.pointDisplaySettings.colourDataKey))
             self.SetFit()
            
             if self._new_layers:

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -127,25 +127,25 @@ class VisGUICore(object):
         
     
     def OnIdle(self, event=None):
-       """ Refresh the glDisplay *after* all windows have been created and data loaded.
+        """ Refresh the glDisplay *after* all windows have been created and data loaded.
        
-       TODO - rename, as the OnIdle name is a historical artifact (was originally called using an wx.EVT_IDLE binding, 
-       now uses wx.CallLater with a delay.
-       """
+        TODO - rename, as the OnIdle name is a historical artifact (was originally called using an wx.EVT_IDLE binding, 
+        now uses wx.CallLater with a delay.
+        """
         #logger.debug('Ev Idle')
         if self.glCanvas._is_initialized and not self.refv:
             self.refv = True
             logger.debug((self.viewMode, self.pointDisplaySettings.colourDataKey))
             self.SetFit()
-            
+           
             if self._new_layers:
                 pass
-                # if self.pipeline.ready and not len(self.layers) > 0:
-                #     l = self.add_layer(method='points')
-                #     if 't' in self.pipeline.keys():
-                #         l.engine.set(vertexColour='t')
-                #     elif 'z' in self.pipeline.keys():
-                #         l.engine.set(vertexColour='t')
+               # if self.pipeline.ready and not len(self.layers) > 0:
+               #     l = self.add_layer(method='points')
+               #     if 't' in self.pipeline.keys():
+               #         l.engine.set(vertexColour='t')
+               #     elif 'z' in self.pipeline.keys():
+               #         l.engine.set(vertexColour='t')
             else:
                 self.RefreshView()
                 self.displayPane.OnPercentileCLim(None)

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -127,10 +127,10 @@ class VisGUICore(object):
         
     
     def OnIdle(self, event=None):
-        print('Ev Idle')
+        logger.debug('Ev Idle')
         if self.glCanvas._is_initialized and not self.refv:
             self.refv = True
-            print((self.viewMode, self.pointDisplaySettings.colourDataKey))
+            logger.debug((self.viewMode, self.pointDisplaySettings.colourDataKey))
             self.SetFit()
             
             if self._new_layers:
@@ -147,10 +147,10 @@ class VisGUICore(object):
                 
             self.glCanvas.Refresh()
             self.glCanvas.Update()
-            print('refreshed')
+            logger.debug('refreshed')
             
     def GenPanels(self, sidePanel):
-        print('GenPanels')
+        logger.debug('GenPanels')
         self.GenDataSourcePanel(sidePanel)
         
         #if HAVE_DRIFT_CORRECTION:
@@ -193,7 +193,7 @@ class VisGUICore(object):
     def GenDataSourcePanel(self, pnl):
         from PYME.recipes.vertical_recipe_display import RecipeDisplayPanel
         
-        print('Creating datasource panel')
+        logger.debug('Creating datasource panel')
         item = afp.foldingPane(pnl, -1, caption="Data Pipeline", pinned = True)
 
         pan = wx.Panel(item, -1)
@@ -792,13 +792,16 @@ class VisGUICore(object):
         while len(self.layers) > 0:
             self.layers.pop()
         
-        print('Creating Pipeline')
+        logger.debug('Creating Pipeline')
         if filename is None and not ds is None:
             self.pipeline.OpenFile(ds=ds)
         else:
             args = self._populate_open_args(filename)
+            if args is None:
+                logger.info("OpenFile was canceled or not a valid file format")
+                return
             self.pipeline.OpenFile(filename, **args)
-        print('Pipeline Created')
+        logger.debug('Pipeline Created')
         
         #############################
         #now do all the gui stuff
@@ -812,7 +815,7 @@ class VisGUICore(object):
             self._createNewTabs()
             
             #self.CreateFoldPanel()
-            print('Gui stuff done')
+            logger.debug('Gui stuff done')
         
         try:
             if recipe_callback:
@@ -828,9 +831,9 @@ class VisGUICore(object):
     def OpenChannel(self, filename, recipe_callback=None, channel_name=''):
         args = self._populate_open_args(filename)
     
-        print('Creating Pipeline')
+        logger.debug('Creating Pipeline')
         self.pipeline.OpenChannel(filename, channel_name=channel_name, **args)
-        print('Pipeline Created')
+        logger.debug('Pipeline Created')
     
         #############################
         #now do all the gui stuff
@@ -842,7 +845,7 @@ class VisGUICore(object):
         #     self._createNewTabs()
         #
         #     self.CreateFoldPanel()
-        #     print('Gui stuff done')
+        #     logger.debug('Gui stuff done')
         
         self.update_datasource_panel()
     

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -127,7 +127,12 @@ class VisGUICore(object):
         
     
     def OnIdle(self, event=None):
-        logger.debug('Ev Idle')
+       """ Refresh the glDisplay *after* all windows have been created and data loaded.
+       
+       TODO - rename, as the OnIdle name is a historical artifact (was originally called using an wx.EVT_IDLE binding, 
+       now uses wx.CallLater with a delay.
+       """
+        #logger.debug('Ev Idle')
         if self.glCanvas._is_initialized and not self.refv:
             self.refv = True
             logger.debug((self.viewMode, self.pointDisplaySettings.colourDataKey))

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -711,6 +711,7 @@ class VisGUICore(object):
                 self.add_pointcloud_layer(ds_name=('output.' + c), **layer_defaults.new_layer_settings('points_channel', i, overrides=dict(visible=False)))
                 
     def _populate_open_args(self, filename):
+        from PYME.warnings import warn
         args = {}
     
         if os.path.splitext(filename)[1] == '.h5r':
@@ -732,6 +733,7 @@ class VisGUICore(object):
                 
                     if not ret == wx.ID_OK:
                         dlg.Destroy()
+                        logger.info("opening Matlab file was canceled")
                         return #we cancelled
                 
                     args['FieldNames'] = dlg.GetFieldNames()
@@ -750,6 +752,7 @@ class VisGUICore(object):
                 
                     if not ret == wx.ID_OK:
                         dlg.Destroy()
+                        logger.info("opening Matlab file was canceled")
                         return #we cancelled
 
                     args['FieldNames'] = dlg.GetFieldNames()
@@ -767,6 +770,8 @@ class VisGUICore(object):
         
             if not ret == wx.ID_OK:
                 dlg.Destroy()
+                logger.info("opening Text/CSV file was canceled")
+                warn('Open file was canceled by user') # example how we could bring up a message box
                 return #we cancelled
             
             text_options = {'columnnames': dlg.GetFieldNames(),
@@ -798,7 +803,6 @@ class VisGUICore(object):
         else:
             args = self._populate_open_args(filename)
             if args is None:
-                logger.info("OpenFile was canceled or not a valid file format")
                 return
             self.pipeline.OpenFile(filename, **args)
         logger.debug('Pipeline Created')

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -147,7 +147,7 @@ class VisGUICore(object):
                 
             self.glCanvas.Refresh()
             self.glCanvas.Update()
-            logger.debug('refreshed')
+            logger.debug('Refreshed glCanvas after load')
             
     def GenPanels(self, sidePanel):
         logger.debug('GenPanels')

--- a/PYME/recipes/modules.py
+++ b/PYME/recipes/modules.py
@@ -40,9 +40,9 @@ from .base import ModuleCollection
 #load any custom recipe modules
 for mn in config.get_plugins('recipes'):
     try:
-        print('Trying to load 3rd party recipe module %s' % mn)
+        logger.debug('Trying to load 3rd party recipe module %s' % mn)
         m = __import__(mn, fromlist=mn.split('.')[:-1])
-        print('Loaded 3rd party recipe module %s' % mn)
+        logger.debug('Loaded 3rd party recipe module %s' % mn)
     except Exception as e:
         logger.exception('Error loading plugin: %s' % mn)
 

--- a/PYME/ui/AUIFrame.py
+++ b/PYME/ui/AUIFrame.py
@@ -5,6 +5,9 @@ import PYME.ui.manualFoldPanel as afp
 from PYME.ui import progress
 from PYME.misc import check_for_updates
 
+import logging
+logger = logging.getLogger(__name__)
+
 class AUIFrame(wx.Frame):
     """A class which encapsulated the common frame layout code used by
     dsviewer, VisGUI, and PYMEAcquire.
@@ -61,7 +64,7 @@ class AUIFrame(wx.Frame):
             self._mgr.Update()
             pn = self._mgr.GetPaneByName(self.pane0)
             if pn.IsNotebookPage():
-                print((pn.notebook_id))
+                logger.debug((pn.notebook_id))
                 nbs = self._mgr.GetNotebooks()
                 if len(nbs) > pn.notebook_id:
                     currPage = nbs[pn.notebook_id].GetSelection()
@@ -122,7 +125,7 @@ class AUIFrame(wx.Frame):
         loops over all the functions defined in self.paneHooks and calls them
         to generate the drawers.
         """
-        print('Creating fold panel')
+        logger.debug('Creating fold panel')
         pinfo = self._mgr.GetPaneByName('sidePanel')
         if pinfo.IsOk(): #we already have a sidepanel, clear
             self.sidePanel.Clear()

--- a/PYME/ui/AUIFrame.py
+++ b/PYME/ui/AUIFrame.py
@@ -64,7 +64,7 @@ class AUIFrame(wx.Frame):
             self._mgr.Update()
             pn = self._mgr.GetPaneByName(self.pane0)
             if pn.IsNotebookPage():
-                logger.debug((pn.notebook_id))
+                #logger.debug((pn.notebook_id))
                 nbs = self._mgr.GetNotebooks()
                 if len(nbs) > pn.notebook_id:
                     currPage = nbs[pn.notebook_id].GetSelection()


### PR DESCRIPTION
Addresses issue #1433 .

**Is this a bugfix or an enhancement?**
Bugfix **and** logging/depreciation cleanup.

**Proposed changes:**

- fix bug #1433 by checking return value from `_populate_open_args` for being `None` as indication of cancelation
- fix some wx deprecation warnings by moving to newer method names (hopefully compatible with min wx version we require)
- as part of general warning/message cleanup turn print statements into debug messages

Note that I am trying to cleanup messages to turn remaining print statements into log messages and fix deprecation warnings so that messages from PYMEVis are more readable and can be filtered as needed etc. I have not yet looked at dh5view for anything similar.

**Checks:**
Checked with latest master on macOS