### PR TITLE
MetaData unpickling of some values, add 'latin1' encoding option

### DIFF
--- a/PYME/IO/MetaDataHandler.py
+++ b/PYME/IO/MetaDataHandler.py
@@ -868,7 +868,9 @@ class XMLMDHandler(MDHandlerBase):
         elif cls == 'pickle':
             #return None
             try:
-                val = pickle.loads(base64.b64decode(val.encode('ascii')))
+                # note that we seem to need 'latin1' option for pickle.loads after the base64 decoding
+                # this seems to work in all instances of older metadata tested so far
+                val = pickle.loads(base64.b64decode(val.encode('ascii')),encoding='latin1')
             except:
                 logger.exception(u'Error loading metadata from pickle')
 


### PR DESCRIPTION
Addresses issue #1435 .

**Is this a bugfix or an enhancement?**
bugfix

**Proposed changes:**
Add `enconding='latin1'` option to relevant `pickle.loads` command

**Checks:**
Tested with old and current data, seems to work for old data and not clobber newer data reading.

**Screenshots:**
Before
![Screenshot 2023-10-10 at 13 32 17](https://github.com/python-microscopy/python-microscopy/assets/3750860/25aad446-f366-43a0-b646-61818b16f36c)

After


![Screenshot 2023-10-10 at 13 42 58](https://github.com/python-microscopy/python-microscopy/assets/3750860/d6389fa9-22e8-4cbf-af52-ae9b4bd043cd)

