### PR TITLE
LMAnalysis: cleaning up messages and also spurious creation of accelerators on macos

### DIFF
--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -214,7 +214,7 @@ class AnalysisSettingsView(object):
 
         #find out what fit factories we have
         self.fitFactories = PYME.localization.FitFactories.resFitFactories
-        logger.debug((self.fitFactories))
+        logger.debug("registered FitFactories: ",(self.fitFactories))
 
         vsizer = wx.BoxSizer(wx.VERTICAL)
         hsizer = wx.BoxSizer(wx.HORIZONTAL)

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -214,13 +214,15 @@ class AnalysisSettingsView(object):
 
         #find out what fit factories we have
         self.fitFactories = PYME.localization.FitFactories.resFitFactories
-        print((self.fitFactories))
+        logger.debug((self.fitFactories))
 
         vsizer = wx.BoxSizer(wx.VERTICAL)
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
 
         hsizer.Add(wx.StaticText(pan, -1, 'Type:'), 0,wx.RIGHT|wx.ALIGN_CENTER_VERTICAL, 5)
-        self.cFitType = wx.Choice(pan, -1, choices = ['{:<35} \t- {:} '.format(f, PYME.localization.FitFactories.useFor[f]) for f in self.fitFactories], size=(110, -1))
+        # the original tab character (\t) creates warnings and discards the strings after the tab as this are incorrectly interpreted as accelerators
+        # leaving out the tab seems fine on both mac and windows
+        self.cFitType = wx.Choice(pan, -1, choices = ['{:<35} - {:} '.format(f, PYME.localization.FitFactories.useFor[f]) for f in self.fitFactories], size=(110, -1))
         
         if 'Analysis.FitModule' in self.analysisMDH.getEntryNames():
             #has already been analysed - most likely to want the same method again


### PR DESCRIPTION
This PR is focused only on the `LMAnalysis` module asking for comments how to change logging consistently and how to fix a subtle issue on macos.

**1. accidental accelerator issue:**

On macos an issue comes comes up when `LMAnalysis` is loaded that manifests as a bunch of debug messages (presumably from wx) and all the explanation messages for the fit factories remain unavailable in the dialogue, see below.

**2. message cleanup:**

`LMAnalysis` contains a number of print messages. So far this edit suggests only one conversion into a `logger.debug` statement.

There is also a module specific `debugPrint` approach:

```
debug = True

def debugPrint(msg):
    if debug:
        print(msg)
```
Does it make sense to replace all of the `depugPrint` calls with `logger.debug` or any reason not to convert?

**accidental accelerator issue symptoms:**

![Screenshot 2023-10-11 at 13 37 47](https://github.com/python-microscopy/python-microscopy/assets/3750860/03dfa49c-3d70-4537-958c-bd8cb82934de)


```
13:33:03: Debug: Unknown accel modifier: '- 2D single'

13:33:03: Debug: Unrecognized accel key 'colour', accel string ignored.

13:33:03: Debug: Unrecognized accel key '- 3D via Astigmatism, with sCMOS noise model', accel string ignored.

13:33:03: Debug: Unrecognized accel key '- 3D astigmatism calibrations', accel string ignored.

13:33:03: Debug: Unrecognized accel key '- Debugging to ensure reproducible ROI extraction and background correction', accel string ignored.

13:33:03: Debug: Unrecognized accel key '- Debugging to ensure frame data and background are reproducible', accel string ignored.

13:33:03: Debug: Unrecognized accel key '- Debugging to ensure frame data and background are reproducible', accel string ignored.

13:33:03: Debug: Unknown accel modifier: '- 3D single'
....
```

**Source of accelerator issue:**

**Original code:**

        self.cFitType = wx.Choice(pan, -1, choices = ['{:<35} \t- {:} '.format(f, PYME.localization.FitFactories.useFor[f]) for f in self.fitFactories], size=(110, -1))

**Proposed fix:**

 (essentially remove the tab character which does not seem to help formatting anyway). Possibly there is a also a way to tell wx on macos to not interpret the tab as accelerator indicator but I do not know how.

        # the original tab character (\t) creates warnings and discards the strings after the tab as this are incorrectly interpreted as accelerators
        # leaving out the tab seems fine on both mac and windows
        self.cFitType = wx.Choice(pan, -1, choices = ['{:<35} - {:} '.format(f, PYME.localization.FitFactories.useFor[f]) for f in self.fitFactories], size=(110, -1))

**After the fix:**

No more debug messages from wx and choice selector shows all text.

![Screenshot 2023-10-11 at 13 48 09](https://github.com/python-microscopy/python-microscopy/assets/3750860/af00dddd-9e38-4a3d-b1f3-25ac7b046c11)
