### PR TITLE
pickle now throws an pickle.UnpicklingError; ds auto_promote fix

### DIFF
--- a/PYME/Acquire/Hardware/splitter.py
+++ b/PYME/Acquire/Hardware/splitter.py
@@ -179,7 +179,8 @@ class Splitter:
             self.SetShiftField(sfname)
 
     def SetShiftField(self, sfname):
-        self.shiftField = numpy.load(sfname)
+        from PYME.IO.compatibility import np_load_legacy
+        self.shiftField = np_load_legacy(sfname)
         self.shiftFieldName = sfname
         self.unmixer.SetShiftField(self.shiftField, self.scope)
 

--- a/PYME/IO/DataSources/BaseDataSource.py
+++ b/PYME/IO/DataSources/BaseDataSource.py
@@ -397,7 +397,12 @@ class XYZTCWrapper(XYZTCDataSource):
                 size_t = 1
                 size_z = data.shape[2]
 
-        return cls(data, input_order=dim_order, size_z=size_z,size_t=size_t, size_c=data.shape[3])
+        if len(data.shape) >= 4:
+            size_c = data.shape[3]
+        else:
+            size_c = 1
+        
+        return cls(data, input_order=dim_order, size_z=size_z,size_t=size_t, size_c=size_c)
     
     
     def getSlice(self, ind):

--- a/PYME/IO/compatibility.py
+++ b/PYME/IO/compatibility.py
@@ -1,11 +1,12 @@
 import numpy
+import pickle
 
 # this should serve as a drop in replacement for numpy.load calls that need
 # some backwards compatibility
 def np_load_legacy(f):
     try:
         ret = numpy.load(f, allow_pickle=True)
-    except OSError:
+    except (OSError, pickle.UnpicklingError):
         # this one based on tips from https://rebeccabilbro.github.io/convert-py2-pickles-to-py3/
         ret = numpy.load(f, allow_pickle=True, encoding="latin1")
     return ret


### PR DESCRIPTION
Addresses issue with loading older style shift fields.

Issue can be reproduced with current master by attempting to open using `dh5view` the shiftfield `PYME/localization/Test/30_9_series_A_1.sf`  which is in the PYME github repo.

**Is this a bugfix or an enhancement?**
Mostly bugfix.

**Proposed changes:**

Fix a change in pickle which now throws a `pickle.UnpicklingError` and also the datasource code needs a small fix in `auto_promote`. With the fix `PYME/localization/Test/30_9_series_A_1.sf` can be successfully opened.

**Checking:**

Checked with latest master and Python 3.7.X.