### PR TITLE
add an external sync acquisition / readout mode, particularly for Hamamatsu cmos

### DIFF
--- a/PYME/Acquire/Hardware/Camera.py
+++ b/PYME/Acquire/Hardware/Camera.py
@@ -116,6 +116,7 @@ class Camera(object):
     MODE_SOFTWARE_TRIGGER = 2
     MODE_HARDWARE_TRIGGER = 3
     MODE_HARDWARE_START_TRIGGER = 4
+    MODE_HARDWARE_TRIGGER_SYNC = 5
 
 
     def __init__(self, *args, **kwargs):
@@ -616,6 +617,11 @@ class Camera(object):
                 MODE_HARDWARE_START_TRIGGER
                     camera waits for an external hardware trigger and enters 
                     free-running internal timing mode once received
+                MODE_HARDWARE_TRIGGER_SYNC
+                    (stops then) starts exposing a frame every time an
+                    external hardware trigger is received by the camera.
+                    Allows timing the camera frames entirely off an external
+                    clock.
 
         See Also
         --------
@@ -654,7 +660,12 @@ class Camera(object):
                 MODE_HARDWARE_START_TRIGGER
                     camera waits for an external hardware trigger and enters 
                     free-running internal timing mode once received
-
+                MODE_HARDWARE_TRIGGER_SYNC
+                    (stops then) starts exposing a frame every time an
+                    external hardware trigger is received by the camera.
+                    Allows timing the camera frames entirely off an external
+                    clock.
+        
         Returns
         -------
         None

--- a/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
@@ -571,11 +571,7 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
         rising : bool
             toggles whether active edge is positive going (rising=True) or
             falling
-
-        Notes
-        -----
-        Currently hardcoded to trigger on the rising/falling edge of the trigger,
-        depending on the instance attribute `_external_trigger_rising`.
+        
         """
         if rising:
             self.setCamPropValue('TRIGGER POLARITY',

--- a/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
@@ -574,7 +574,8 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
 
         Notes
         -----
-        Currently hardcoded to trigger on the rising edge of the trigger.
+        Currently hardcoded to trigger on the rising/falling edge of the trigger,
+        depending on the instance attribute `_external_trigger_rising`.
         """
         if rising:
             self.setCamPropValue('TRIGGER POLARITY',

--- a/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
@@ -75,8 +75,12 @@ DCAMPROP_TRIGGERSOURCE_INTERNAL = 1
 DCAMPROP_TRIGGERSOURCE_EXTERNAL = 2
 DCAMPROP_TRIGGERSOURCE_SOFTWARE = 3
 
+DCAMPROP_TRIGGER_MODE__NORMAL = 1
 DCAMPROP_TRIGGER_MODE__START = 6
 DCAMPROP_TRIGGERACTIVE__EDGE = 1
+DCAMPROP_TRIGGERACTIVE__SYNCREADOUT = 3
+DCAMPROP_TRIGGERPOLARITY__NEGATIVE = 1  # falling edge / low level
+DCAMPROP_TRIGGERPOLARITY__POSITIVE = 2  # rising edge / high level
 
 DCAMPROP_OUTPUTTRIGGER_SOURCE__EXPOSURE = 1
 DCAMPROP_OUTPUTTRIGGER_SOURCE__READOUTEND = 2
@@ -128,6 +132,7 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
 
         # initialize other properties needed
         self.external_shutter = None
+        self._external_trigger_rising = True  # True for rising, False for falling
 
     def Init(self):
         logger.debug('Initializing Hamamatsu Orca')
@@ -190,7 +195,8 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
 
     def SetAcquisitionMode(self, mode):
         if mode in [self.MODE_CONTINUOUS, self.MODE_SOFTWARE_TRIGGER, 
-                    self.MODE_SINGLE_SHOT, self.MODE_HARDWARE_START_TRIGGER]:
+                    self.MODE_SINGLE_SHOT, self.MODE_HARDWARE_START_TRIGGER,
+                    self.MODE_HARDWARE_TRIGGER, self.MODE_HARDWARE_TRIGGER_SYNC]:
             self._mode = mode
         else:
             raise RuntimeError('Mode %d not supported' % mode)
@@ -238,6 +244,19 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
         
         elif self._mode == self.MODE_HARDWARE_START_TRIGGER:
             self._set_trigger_start_mode()
+            self.checkStatus(dcam.dcamcap_start(self.handle,
+                                                DCAMCAP_START_SEQUENCE),
+                                                "dcamcap_start")
+        
+        elif self._mode == self.MODE_HARDWARE_TRIGGER:
+            self._set_ext_trigger_mode('normal', self._external_trigger_rising)
+            self.checkStatus(dcam.dcamcap_start(self.handle,
+                                                DCAMCAP_START_SEQUENCE),
+                                                "dcamcap_start")
+        
+        elif self._mode == self.MODE_HARDWARE_TRIGGER_SYNC:
+            # sets hardware trigger with exposure active between external pulses
+            self._set_ext_trigger_mode('syncreadout', self._external_trigger_rising)
             self.checkStatus(dcam.dcamcap_start(self.handle,
                                                 DCAMCAP_START_SEQUENCE),
                                                 "dcamcap_start")
@@ -537,6 +556,61 @@ class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
             pass
         self.setCamPropValue('TRIGGER SOURCE', DCAMPROP_TRIGGERSOURCE_EXTERNAL)
         self.setCamPropValue('TRIGGER MODE', DCAMPROP_TRIGGER_MODE__START)
+    
+    def _set_ext_trigger_mode(self, trigger_mode='normal', rising=True):
+        """Use to time acquisitions with external hardware triggers starting
+        each frame exposure. (currently hardcoded to edge)
+
+        Parameters
+        ----------
+        trigger_mode : str
+            Currently supports:
+                normal: trigger edge starts a frame exposure
+                readoutsync: exposure starts on edge and continues until next
+                    edge, at which point another exposure begins
+        rising : bool
+            toggles whether active edge is positive going (rising=True) or
+            falling
+
+        Notes
+        -----
+        Currently hardcoded to trigger on the rising edge of the trigger.
+        """
+        if rising:
+            self.setCamPropValue('TRIGGER POLARITY',
+                                 DCAMPROP_TRIGGERPOLARITY__POSITIVE)
+        else:
+            self.setCamPropValue('TRIGGER POLARITY', 
+                                 DCAMPROP_TRIGGERPOLARITY__NEGATIVE)
+        if trigger_mode == 'syncreadout':
+            self.setCamPropValue('TRIGGER ACTIVE',
+                                 DCAMPROP_TRIGGERACTIVE__SYNCREADOUT)
+        else:
+            try:
+                self.setCamPropValue('TRIGGER ACTIVE', DCAMPROP_TRIGGERACTIVE__EDGE)
+            except:
+                # Sometimes TRIGGER ACTIVE is not writable
+                pass
+        self.setCamPropValue('TRIGGER SOURCE', DCAMPROP_TRIGGERSOURCE_EXTERNAL)
+        self.setCamPropValue('TRIGGER MODE', DCAMPROP_TRIGGER_MODE__NORMAL)
+    
+    def SetTriggerDelay(self, delay):
+        """Set the delay between a received ext hardware or software trigger and
+        the camera response. 
+
+        Parameters
+        ----------
+        delay : float
+            delay before e.g. exposing a frame. [s]
+        
+        Notes
+        -----
+        That there there is a short delay from receiving a trigger to actioning on it
+        which will depend on the readout speed selected. This delay is in addition to
+        that and can be particularly useful when synchronizing the camera to another
+        clock such as an optical chopper, where there's some phase to be matched.
+        """
+        self.setCamPropValue('TRIGGER DELAY', float(delay))
     
     def _get_global_exposure_delay(self):
         """How long from the beginning of exposure does it take before


### PR DESCRIPTION
Addresses issue I needed to synchronize my acquisition with a chopper, and the chopper drive I have doesn't have a phase-locked loop, meaning it has to be the clock for my entire acquisition. 

The modifications here allow me to run the camera such that the chopper sync-out edge sets the time barrier between frames (stops then starts the next exposure), and to set an appropriate delay between receiving that trigger and performing that start/stop so I can chop my beam at the appropriate time relative to the (rolling shutter) frame exposure.  

**Is this a bugfix or an enhancement?**
- enhancement

**Proposed changes:**
- add `SetTriggerDelay` method, currently just to the HamamatsuOrca class
- add an acquisition mode, `HARDWARE_TRIGGER_SYNC`, to denote this acquisition mode with hardware trigger and a trigger to start/stop each frames.



Some of these things should likely end up in the base class at some point, potentially as properties w/ setters, e.g. trigger_delay





**Checklist:**
- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
