### PR TITLE
Add `anndata` data source

### DIFF
--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -1224,3 +1224,65 @@ class CloneSource(TabularBase):
     def keys(self):
         return list(self.cache.keys())
 
+class AnndataSource(TabularBase):
+    """Interfaces with anndata/scanpy/squidpy packages for spatialomics."""
+    _name = "Anndata Source"
+
+    def __init__(self, filename):
+        try:
+            import anndata as ad
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("No module named anndata. Please install anndata to use this source.")
+        
+        # backed='r' keeps us from loading the full file into memory
+        # TODO: Is this the behaviour we want?
+        self.res = ad.read(filename) #, backed='r')
+
+        # Flatten the anndata structure as best we can to fit our tabular structure
+        self._keys = list(self.res.var_names) + list(self.res.obs.keys())
+        self._keys_attrs = {**{k: 'X' for k in self.res.var_names}, **{k: 'obs' for k in self.res.obs_keys()}}
+        for k, v in self.res.obsm.items():
+            n_var = v.shape[1]
+            if k == "spatial" or k == "spatial3d":
+                if n_var == 2:
+                    proposed_keys = ['x', 'y']
+                elif n_var == 3:
+                    proposed_keys = ['x', 'y', 'z']
+                else:
+                    print(f"Could not load spatial data. Unsupported number of dimensions {n_var}.")
+                    proposed_keys = None
+                
+                for i, kk in enumerate(proposed_keys):
+                    count = 0
+                    while proposed_keys[i] in self._keys:
+                        proposed_keys[i] = f"{kk}{count}"
+                        count += 1
+                    self._keys += [proposed_keys[i]]
+                    self._keys_attrs.update({proposed_keys[i]: {'obsm': {k: i}}})
+            else:
+                self._keys += [f"{k}_{j}" for j in range(n_var)]
+                self._keys_attrs.update({f"{k}_{j}": 'obsm' for j in range(n_var)})
+
+    def keys(self):
+        return self._keys
+
+    def __getitem__(self, key):
+        key, sl = self._getKeySlice(key)
+        if key not in self._keys:
+            raise KeyError('Key (%s) not found' % key)
+        
+        if self._keys_attrs[key] == "X":
+            return self.res[sl, key].X.toarray().squeeze()
+        elif isinstance(self._keys_attrs[key], dict):
+            first_key = next(iter(self._keys_attrs[key]))
+            if first_key == "obsm":
+                d = self._keys_attrs[key][first_key]
+                dkey = next(iter(d))
+                return getattr(self.res, first_key)[dkey][:,d[dkey]]
+            else:
+                raise KeyError(f"Unknown subkeys starting from {first_key}.")
+        else:
+            return getattr(self.res, self._keys_attrs[key])[key][sl].to_numpy().squeeze()
+
+    def getInfo(self):
+        return f"Anndata Data Source\n\n {self.res.X.shape[0]} points"

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -1261,7 +1261,7 @@ class AnndataSource(TabularBase):
                     self._keys_attrs.update({proposed_keys[i]: {'obsm': {k: i}}})
             else:
                 self._keys += [f"{k}_{j}" for j in range(n_var)]
-                self._keys_attrs.update({f"{k}_{j}": 'obsm' for j in range(n_var)})
+                self._keys_attrs.update({f"{k}_{j}": {'obsm': {k: j}} for j in range(n_var)})
 
     def keys(self):
         return self._keys
@@ -1270,9 +1270,14 @@ class AnndataSource(TabularBase):
         key, sl = self._getKeySlice(key)
         if key not in self._keys:
             raise KeyError('Key (%s) not found' % key)
+            
+        print(f"Getting {key}")
         
         if self._keys_attrs[key] == "X":
-            return self.res[sl, key].X.toarray().squeeze()
+            x = self.res[sl, key].X
+            if isinstance(x, np.ndarray):
+                return x.squeeze()
+            return x.toarray().squeeze()
         elif isinstance(self._keys_attrs[key], dict):
             first_key = next(iter(self._keys_attrs[key]))
             if first_key == "obsm":

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -1236,7 +1236,7 @@ class AnndataSource(TabularBase):
         
         # backed='r' keeps us from loading the full file into memory
         # TODO: Is this the behaviour we want?
-        self.res = ad.read(filename) #, backed='r')
+        self.res = ad.read(filename, backed='r')
 
         # Flatten the anndata structure as best we can to fit our tabular structure
         self._keys = list(self.res.var_names) + list(self.res.obs.keys())

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -717,6 +717,9 @@ class Pipeline:
                         field_names.append('probe')  # don't forget to copy this field over
                     ds = tabular.MappingFilter(ds, **{new_field : old_field for new_field, old_field in zip(field_names, ds.keys())})
 
+        elif os.path.splitext(filename)[1] == '.h5ad':
+            ds = tabular.AnndataSource(filename)
+            
         else: #assume it's a delimited (tab or csv) text file
             # use provided `text_options` argument to Open(), or guess using csv_flavours
             text_options = kwargs.get('text_options', None)

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -717,6 +717,8 @@ class VisGUICore(object):
             pass
         elif os.path.splitext(filename)[1] == '.hdf':
             pass
+        elif os.path.splitext(filename)[1] == '.h5ad':
+            pass
         elif os.path.splitext(filename)[1] == '.mat':
             from PYME.LMVis import importTextDialog
             from scipy.io import loadmat

--- a/PYME/misc/colormaps.py
+++ b/PYME/misc/colormaps.py
@@ -100,7 +100,13 @@ _hsv_part = {'red':   ((0., 1., 1.),(0.25, 1.000000, 1.000000),
 
 ndat = {'r':_r, 'g':_g, 'b':_b, 'c':_c, 'm':_m, 'y':_y, 'hsp': _hsv_part}
 
-cm.update({cmapname: colors.LinearSegmentedColormap(cmapname, ndat[cmapname], mp_cm.LUTSIZE) for cmapname in ndat.keys()})
+# Newer versions of matplotlib use _LUTSIZE
+try:
+    lutsize = mp_cm.LUTSIZE
+except AttributeError:
+    lutsize = mp_cm._LUTSIZE
+
+cm.update({cmapname: colors.LinearSegmentedColormap(cmapname, ndat[cmapname], lutsize) for cmapname in ndat.keys()})
 
 #solid colour colormaps for VisGUI multichannel and isosurface display
 @cm.register_cmap('SolidRed', solid=True)


### PR DESCRIPTION
This adds the ability to open `anndata` data sources in PYME. These are used in `scanpy` and `squidpy` for storing results of omics processing. For example, this enables us to open the MERFISH data set from https://squidpy.readthedocs.io/en/stable/notebooks/tutorials/tutorial_merfish.html and visualize the gene enrichment scores on top of the localizations.

Also includes a random fix for `colormaps.py` I ran into with a new version of `matplotlib`.

<img width="1547" alt="image" src="https://github.com/python-microscopy/python-microscopy/assets/1263313/6496a4b7-604a-4b37-82dd-eb8496f95efb">
