### PR TITLE
InterpFitR-3D fit info visualization and two-modality acquisition

### DIFF
--- a/PYME/Acquire/Hardware/driftTracking.py
+++ b/PYME/Acquire/Hardware/driftTracking.py
@@ -343,7 +343,8 @@ class Correlator(object):
             self.history.append((time.time(), dx, dy, dz, cCoeff, self.corrRef, self.piezo.GetOffset(), self.piezo.GetPos(0)))
             eventLog.logEvent('PYME2ShiftMeasure', '%3.4f, %3.4f, %3.4f' % (dx, dy, dz))
             
-            self.lockActive = self.lockFocus and (cCoeff > .5*self.corrRef)
+            #self.lockActive = self.lockFocus and (cCoeff > .5*self.corrRef)
+            self.lockActive = self.lockFocus
             if self.lockActive:
                 if abs(self.piezo.GetOffset()) > 20.0:
                     self.lockFocus = False
@@ -414,6 +415,7 @@ class ServerThread(threading.Thread):
         threading.Thread.__init__(self)
         import Pyro.core
         import Pyro.naming
+        from PYME.Acquire.Hardware.Piezos.offsetPiezo import piezoOffsetProxy
 
         import socket
         ip_addr = socket.gethostbyname(socket.gethostname())

--- a/PYME/Acquire/xyztc.py
+++ b/PYME/Acquire/xyztc.py
@@ -17,6 +17,18 @@ class XYZTCAcquisition(object):
         self.dim_order = dim_order
         self.scope = scope
         
+        self.focus_locked = self.scope.dt.is_tracking()   # determine if the focus lock has been engaged before acquisition
+        self.cropped = False                # determine if a smaller ROI has been cropped before acquisition
+        if self.scope.dt.is_tracking():
+            self.scope.dt.set_focus_lock(lock=False)           # disable focus lock
+            self.scope.dt.tick()
+            self.scope.dt.deregister()
+        self.shape_x, self.shape_y = scope.frameWrangler.currentFrame.shape[:2]
+        if self.shape_x < 2048 or self.shape_y < 2048:
+            self.scope.crop()(event=0)
+            self.shape_x, self.shape_y = scope.frameWrangler.currentFrame.shape[:2]
+            self.cropped = True
+
         self.shape_x, self.shape_y = scope.frameWrangler.currentFrame.shape[:2]
         self.shape_z = stack_settings.GetSeqLength()
         self.shape_t = getattr(time_settings, 'num_timepoints', 1)
@@ -102,6 +114,14 @@ class XYZTCAcquisition(object):
         self.scope.frameWrangler.stop()
         self.scope.frameWrangler.onFrame.disconnect(self.on_frame)
         self.scope.frameWrangler.start()
+        self.scope.stackSettings.pieozoGoHome()   # reset the piezo to the original position after acquiring an OI-DIC z-stack
+        
+        if self.cropped:
+            self.scope.crop()(event=0)
+            self.cropped = False
+        if self.focus_locked:
+            self.scope.dt.register()
+            self.scope.dt.set_focus_lock(lock=True)    # engage the focus lock back after finishing acquisition
         
         self.on_series_end.send(self)
         

--- a/PYME/localization/FitFactories/InterpFitR.py
+++ b/PYME/localization/FitFactories/InterpFitR.py
@@ -89,7 +89,8 @@ def genFitImage(fitResults, metadata, fitfcn=f_Interp3d):
     xslice = slice(*fitResults['slicesUsed']['x'])
     yslice = slice(*fitResults['slicesUsed']['y'])
 
-    vx, vy = metadata.voxelsize_nm
+    #vx, vy = metadata.voxelsize_nm
+    vx, vy, vz = metadata.voxelsize_nm
     
     #position in nm from camera origin
     roi_x0, roi_y0 = get_camera_roi_origin(metadata)
@@ -162,7 +163,8 @@ class PSFFitFactory(FFBase.FFBase):
         #this is just here to make sure we clear our calibration when we change models        
         startPosEstimator = __import__('PYME.localization.FitFactories.zEstimators.' + estimatorModule , fromlist=['PYME', 'localization', 'FitFactories', 'zEstimators'])        
         
-        if interpolator.setModelFromFile(md.PSFFile, md):
+        #if interpolator.setModelFromFile(md.PSFFile, md):
+        if interpolator.setModelFromFile(md['PSFFile'], md):
             print('model changed')
             startPosEstimator.splines.clear()
 


### PR DESCRIPTION
**Is this a bugfix or an enhancement?**
Bugfix: plots in the fit info not showing up
Enhancement: OI-DIC acquisition coordinate with transmitted-light drift tracking

**Proposed changes:**
- When using InterpFitR-3D in LMAnalysis, some plots in the 'fit info' dialog do not show up after clicking 'test this frame'. The first commit fixes this issue.
- I realize z-stacking PAINT makes cCoeff smaller but the focus lock still works. The change in the second commit will not de-active the focus lock when cCoeff is small.
- The third change coordinated the OI-DIC acquisition with enabling/disabling the drift tracking. I feel I am using a very aggressive way and there may be better ways to do this.