### PR TITLE
expose andor cam setemgainmode from the ixon class

### DIFF
--- a/PYME/Acquire/Hardware/AndorIXon/AndorIXon.py
+++ b/PYME/Acquire/Hardware/AndorIXon/AndorIXon.py
@@ -213,9 +213,18 @@ class iXonCamera(Camera):
 
         
     def SetEMGainMode(self, mode=0):
-        """change the calibration mode used for EMGain values
-
+        """Change the calibration mode used for EMGain values
+        
         See Andor manual / SDK for more information.
+
+        NOTE: Use anything other than mode 0 (default) with caution as mode 0 is assumed
+        by the gain calibration and reporting functionality in PYMEAcquire. This code replaces
+        and removes the need for the more advanced modes in the SDK, which are not available for all cameras. 
+        If you do use anything other than mode 0, ensure that gain is set at startup (immediately after creating the
+        camera object) and does not change between sessions. If changing the gain mode after
+        you have already calibrated the camera, ensure that you run a re-calibration after
+        changing the gain mode.
+        
         Parameters
         ----------
         mode : int, optional
@@ -228,6 +237,8 @@ class iXonCamera(Camera):
         ------
         RuntimeError
             if the mode cannot be set
+
+        
         """
         ret = ac.SetEMGainMode(mode)
         if not ret == ac.DRV_SUCCESS:

--- a/PYME/Acquire/Hardware/AndorIXon/AndorIXon.py
+++ b/PYME/Acquire/Hardware/AndorIXon/AndorIXon.py
@@ -40,6 +40,11 @@ from PYME.Acquire import eventLog
 
 from PYME.Acquire.Hardware.Camera import Camera
 class iXonCamera(Camera):
+    """ Andor iXon camera class
+
+    Note that the camera will initialize in the default EM gain mode (0)
+    with EMGain of 0, and the shutter open.
+    """
     numpy_frames=False
 
     @property
@@ -184,9 +189,7 @@ class iXonCamera(Camera):
         if not ret == ac.DRV_SUCCESS:
             raise RuntimeError('Error setting image size: %s' % ac.errorCodes[ret])
 
-        ret = ac.SetEMGainMode(0)
-        if not ret == ac.DRV_SUCCESS:
-            raise RuntimeError('Error setting EM Gain Mode: %s' % ac.errorCodes[ret])
+        self.SetEMGainMode(0) # use the default
 
         self.EMGain = 0 #start with zero EM gain
         ret = ac.SetEMCCDGain(self.EMGain)
@@ -209,7 +212,26 @@ class iXonCamera(Camera):
             print(('Error setting shutter: %s' % ac.errorCodes[ret]))
 
         
+    def SetEMGainMode(self, mode=0):
+        """change the calibration mode used for EMGain values
 
+        See Andor manual / SDK for more information.
+        Parameters
+        ----------
+        mode : int, optional
+            0: The EM Gain is controlled by DAC settings in the range 0-255. Default mode.
+            1: The EM Gain is controlled by DAC settings in the range 0-4095.
+            2: Linear mode.
+            3: Real EM gain
+
+        Raises
+        ------
+        RuntimeError
+            if the mode cannot be set
+        """
+        ret = ac.SetEMGainMode(mode)
+        if not ret == ac.DRV_SUCCESS:
+            raise RuntimeError('Error setting EM Gain Mode: %s' % ac.errorCodes[ret])
 
     def _InitSpeedInfo(self):
         #temporary vars for function returns

--- a/PYME/Acquire/Hardware/AndorIXon/AndorIXon.py
+++ b/PYME/Acquire/Hardware/AndorIXon/AndorIXon.py
@@ -219,9 +219,9 @@ class iXonCamera(Camera):
         Parameters
         ----------
         mode : int, optional
-            0: The EM Gain is controlled by DAC settings in the range 0-255. Default mode.
-            1: The EM Gain is controlled by DAC settings in the range 0-4095.
-            2: Linear mode.
+            0: The EM Gain is controlled by settings in the range 0-255. Default mode
+            1: The EM Gain is controlled by settings in the range 0-4095
+            2: Linear mode
             3: Real EM gain
 
         Raises


### PR DESCRIPTION
Addresses issue our lab members tend to run their setups with gain mode 3, and have each individually hacked it in

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- expose SetEMGainMode from the iXon class






**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
