### PR TITLE
remove ref collision for PYMEVis / legacy VisGUI doc pages

### DIFF
--- a/docs/LocalisationAnalysis.rst
+++ b/docs/LocalisationAnalysis.rst
@@ -142,7 +142,7 @@ clicking the **Go** button. The results will automatically be saved as ``.h5r`` 
 ``PYMEDATADIR`` directory (if the environment variable was set earlier), or in a directory
 called ``PYMEData`` in the users home directory (``c:\\Users\\<username>\\`` under windows).
 
-The resulting ``.h5r`` files can be opened in :ref:`VisGUI <VisGUI>`.
+The resulting ``.h5r`` files can be opened in :ref:`PYMEVisualize <visgui>`.
 
 
 Localizing directly from PYMEAcquire

--- a/docs/VisGUI.rst
+++ b/docs/VisGUI.rst
@@ -1,4 +1,4 @@
-.. _visgui:
+.. _oldvisgui:
 
 **PYMEVisualise (VisGUI)** - Visualising Localization Data Sets
 ***************************************************************


### PR DESCRIPTION
Addresses issue currently the VisGUI link on our [localization analysis page](https://python-microscopy.org/doc/LocalisationAnalysis.html) is to the old VisGUI doc rather than the new PYMEVis user guide doc. Both the VisGUI.rst and PYMEVisualise.rst pages set `_visgui` as ref labels. I propose we change the ref tag in VisGUI.rst to oldvisgui so we can dodge the collision.
