### PR TITLE
Remove deprecated np.bool calls

### DIFF
--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -835,7 +835,7 @@ class ResultsFilter(SelectionFilter):
 
         #by default select everything
         #self.Index = np.ones(self.resultsSource[list(resultsSource.keys())[0]].shape[0]) >  0.5
-        self.Index = np.ones(len(self.resultsSource), dtype=np.bool)
+        self.Index = np.ones(len(self.resultsSource), dtype=bool)
 
         for k in kwargs.keys():
             if not k in self.resultsSource.keys():
@@ -952,7 +952,7 @@ class CachingResultsFilter(TabularBase):
         self.cache = {}
 
         #by default select everything
-        self.Index = np.ones(len(self.resultsSource), dtype=np.bool)
+        self.Index = np.ones(len(self.resultsSource), dtype=bool)
 
         for k in kwargs.keys():
             if not k in self.resultsSource.keys():


### PR DESCRIPTION
Fixes

```
Traceback (most recent call last):
  File "/Users/zachcm/Code/python-microscopy/PYME/recipes/recipe.py", line 237, in execute
    m.execute(self.namespace)
  File "/Users/zachcm/Code/python-microscopy/PYME/recipes/base.py", line 259, in execute
    ret = self.run(**inputs)
  File "/Users/zachcm/Code/python-microscopy/PYME/recipes/localisations.py", line 427, in run
    cached_output = tabular.CachingResultsFilter(output)
  File "/Users/zachcm/Code/python-microscopy/PYME/IO/tabular.py", line 955, in __init__
    self.Index = np.ones(len(self.resultsSource), dtype=np.bool)
  File "/Users/zachcm/miniforge3/envs/pyme/lib/python3.8/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
DEBUG:PYME.recipes.recipe:removing failed module dependencies
DEBUG:PYME.recipes.recipe:notifying failure
Traceback (most recent call last):
  File "/Users/zachcm/Code/python-microscopy/PYME/recipes/recipe.py", line 237, in execute
    m.execute(self.namespace)
  File "/Users/zachcm/Code/python-microscopy/PYME/recipes/base.py", line 259, in execute
    ret = self.run(**inputs)
  File "/Users/zachcm/Code/python-microscopy/PYME/recipes/localisations.py", line 427, in run
    cached_output = tabular.CachingResultsFilter(output)
  File "/Users/zachcm/Code/python-microscopy/PYME/IO/tabular.py", line 955, in __init__
    self.Index = np.ones(len(self.resultsSource), dtype=np.bool)
  File "/Users/zachcm/miniforge3/envs/pyme/lib/python3.8/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/zachcm/miniforge3/envs/pyme/lib/python3.8/site-packages/wx/core.py", line 2346, in Notify
    self.notify()
  File "/Users/zachcm/miniforge3/envs/pyme/lib/python3.8/site-packages/wx/core.py", line 3552, in Notify
    self.result = self.callable(*self.args, **self.kwargs)
  File "/Users/zachcm/Code/python-microscopy/PYME/LMVis/visCore.py", line 814, in OpenFile
    self.pipeline.OpenFile(filename, **args)
  File "/Users/zachcm/Code/python-microscopy/PYME/LMVis/pipeline.py", line 829, in OpenFile
    self.recipe.execute()
  File "/Users/zachcm/Code/python-microscopy/PYME/recipes/recipe.py", line 282, in execute
    raise RecipeExecutionError('Recipe execution failed in module %s' % self._failing_module._module_name, self ) from e
```