### PR TITLE
fix remaining numpy dtype expiries

### DIFF
--- a/PYME/Analysis/Tracking/trackUtils.py
+++ b/PYME/Analysis/Tracking/trackUtils.py
@@ -95,7 +95,7 @@ class Clump(object):
         self.pipeline = pipeline
         self.clumpID = clumpID
         
-        self.index = np.array(pipeline['clumpIndex'] == clumpID, dtype=np.bool)
+        self.index = np.array(pipeline['clumpIndex'] == clumpID, dtype=bool)
         self.nEvents = self.index.sum()
         self.enabled = True
         self.cache = {}

--- a/PYME/Analysis/points/spherical_harmonics.py
+++ b/PYME/Analysis/points/spherical_harmonics.py
@@ -211,7 +211,7 @@ def generate_icosahedron():
                         zip(np.zeros(5),idxs[::2],np.roll(idxs[::2],-1))])
     lower_cap = np.vstack([[v0,v2,v1] for v0,v1,v2 in 
                         zip(11*np.ones(5),np.roll(idxs[1::2],-1),idxs[1::2])])
-    faces = np.vstack([upper_cap, upper_middle_strip, lower_middle_strip, lower_cap]).astype(np.int)
+    faces = np.vstack([upper_cap, upper_middle_strip, lower_middle_strip, lower_cap]).astype(int)
     
     return azimuth, zenith, faces
 
@@ -270,7 +270,7 @@ def icosahedron_mesh(n_subdivision=1):
         f0 = np.vstack([faces[:,0], new_idxs[:,0], new_idxs[:,2]]).T
         f1 = np.vstack([faces[:,1], new_idxs[:,1], new_idxs[:,0]]).T
         f2 = np.vstack([faces[:,2], new_idxs[:,2], new_idxs[:,1]]).T
-        faces = np.vstack([f0,f1,f2,new_idxs]).astype(np.int)
+        faces = np.vstack([f0,f1,f2,new_idxs]).astype(int)
         
         # Append the new vertices to azimuth
         azimuth = np.hstack([azimuth, new_v[:,0]])

--- a/PYME/DSView/modules/vis3D.py
+++ b/PYME/DSView/modules/vis3D.py
@@ -117,7 +117,7 @@ class MeshViewFrame(AUIFrame):
                 faces = vertex_lookup[layer.datasource.faces]
 
                 colors = np.zeros((live_vertices.size, 3), dtype=np.ubyte)
-                colors[faces.ravel().astype(np.int)] = np.floor(layer._colors[:,:3]*255).astype(np.ubyte)
+                colors[faces.ravel().astype(int)] = np.floor(layer._colors[:,:3]*255).astype(np.ubyte)
                     
                 layer.datasource.to_ply(filename, colors)
             else:

--- a/PYME/IO/DataSources/BGSDataSource.py
+++ b/PYME/IO/DataSources/BGSDataSource.py
@@ -141,7 +141,7 @@ class bgFrameBuffer:
         bufShape = (size,) + shape #[:2]
         self.frameBuffer = self.MAXSHORT*np.ones(bufShape, dtype)
         self.indices = self.MAXIDX*np.ones(bufShape, np.uint16)
-        self.validData = np.zeros(size, np.bool)
+        self.validData = np.zeros(size, bool)
         
     def _growBuffer(self, data=None):
         if self.frameBuffer is None:

--- a/PYME/IO/buffers.py
+++ b/PYME/IO/buffers.py
@@ -150,7 +150,7 @@ class bgFrameBuffer:
         bufShape = (size,) + shape #[:2]
         self.frameBuffer = self.MAXSHORT*np.ones(bufShape, dtype)
         self.indices = self.MAXIDX*np.ones(bufShape, np.uint16)
-        self.validData = np.zeros(size, np.bool)
+        self.validData = np.zeros(size, bool)
         
     def _growBuffer(self, data=None):
         if self.frameBuffer is None:

--- a/PYME/LMVis/Extras/extra_layers.py
+++ b/PYME/LMVis/Extras/extra_layers.py
@@ -214,7 +214,7 @@ def save_surface(visFr):
                 faces = vertex_lookup[visFr.pipeline.dataSources[key].faces]
 
                 colors = np.zeros((live_vertices.size, 3), dtype=np.ubyte)
-                colors[faces.ravel().astype(np.int)] = np.floor(layer._colors[:,:3]*255).astype(np.ubyte)
+                colors[faces.ravel().astype(int)] = np.floor(layer._colors[:,:3]*255).astype(np.ubyte)
                 
             visFr.pipeline.dataSources[key].to_ply(filename, colors)
         else:

--- a/PYME/LMVis/layers/tracks.py
+++ b/PYME/LMVis/layers/tracks.py
@@ -215,7 +215,7 @@ class TrackRenderLayer(EngineLayer):
             self.clumpSizes = [len(cl_i) for cl_i in clist]
 
             #reorder x, y, z, c in clump order  
-            I = np.hstack([np.array(cl) for cl in clist]).astype(np.int)
+            I = np.hstack([np.array(cl) for cl in clist]).astype(int)
 
             x = x[I]
             y = y[I]

--- a/PYME/contrib/cpmath/cpmorphology.py
+++ b/PYME/contrib/cpmath/cpmorphology.py
@@ -156,7 +156,7 @@ def adjacent(labels):
     """
     high = labels.max()+1
     if high > np.iinfo(labels.dtype).max:
-        labels = labels.astype(np.int)
+        labels = labels.astype(int)
     image_with_high_background = labels.copy()
     image_with_high_background[labels == 0] = high
     min_label = scind.minimum_filter(image_with_high_background,
@@ -773,8 +773,8 @@ def triangle_areas(p1,p2,p3):
     
     p1,p2,p3 - three Nx2 arrays of points
     """
-    v1 = (p2 - p1).astype(np.float)
-    v2 = (p3 - p1).astype(np.float)
+    v1 = (p2 - p1).astype(float)
+    v2 = (p3 - p1).astype(float)
     # Original:
     #   cross1 = v1[:,1] * v2[:,0]
     #   cross2 = v2[:,1] * v1[:,0]

--- a/PYME/contrib/cpmath/filter.py
+++ b/PYME/contrib/cpmath/filter.py
@@ -98,7 +98,7 @@ def median_filter(data, mask, radius, percent=50):
     #
     # Normalize the ranked data to 0-255
     #
-    if (not np.issubdtype(data.dtype, np.int) or
+    if (not np.issubdtype(data.dtype, int) or
         np.min(data) < 0 or np.max(data) > 255):
         ranked_data,translation = rank_order(data[mask])
         max_ranked_data = np.max(ranked_data)

--- a/PYME/contrib/cpmath/radial_power_spectrum.py
+++ b/PYME/contrib/cpmath/radial_power_spectrum.py
@@ -25,8 +25,8 @@ def rps(img):
         img = img / np.median(abs(img - img.mean())) # intensity invariant
     mag = abs(fft2(img - np.mean(img)))
     power = mag**2
-    radii = np.floor(np.sqrt(radii2)).astype(np.int) + 1
-    labels = np.arange(2, np.floor(maxwidth)).astype(np.int).tolist() # skip DC component
+    radii = np.floor(np.sqrt(radii2)).astype(int) + 1
+    labels = np.arange(2, np.floor(maxwidth)).astype(int).tolist() # skip DC component
     if len(labels) > 0:
         magsum = nd_sum(mag, radii, labels)
         powersum = nd_sum(power, radii, labels)

--- a/PYME/experimental/triangle_mesh.py
+++ b/PYME/experimental/triangle_mesh.py
@@ -2276,7 +2276,7 @@ class TriangleMesh(TrianglesBase):
         # Construct a re-indexing for non-negative vertices
         live_vertices = np.flatnonzero(self._vertices['halfedge'] != -1)
         new_vertex_indices = np.arange(live_vertices.shape[0])
-        vertex_lookup = np.zeros(self._vertices.shape[0], dtype=np.int)
+        vertex_lookup = np.zeros(self._vertices.shape[0], dtype=int)
         
         vertex_lookup[live_vertices] = new_vertex_indices
 

--- a/PYME/experimental/triangular_mesh.py
+++ b/PYME/experimental/triangular_mesh.py
@@ -2244,7 +2244,7 @@ class TriangleMesh(object):
         # Construct a re-indexing for non-negative vertices
         live_vertices = np.flatnonzero(self._vertices['halfedge'] != -1)
         new_vertex_indices = np.arange(live_vertices.shape[0])
-        vertex_lookup = np.zeros(self._vertices.shape[0], dtype=np.int)
+        vertex_lookup = np.zeros(self._vertices.shape[0], dtype=int)
         
         vertex_lookup[live_vertices] = new_vertex_indices
 

--- a/PYME/recipes/localisations.py
+++ b/PYME/recipes/localisations.py
@@ -996,7 +996,7 @@ class MeasureClusters3D(ModuleBase):
 
         inp = inputName
 
-        labels = inp[self.labelKey].astype(np.int)
+        labels = inp[self.labelKey].astype(int)
         # make sure labeling scheme is consistent with what pyme conventions
         if (len(labels) > 0) and  (labels.min() < 0):
             raise UserWarning('This module expects 0-label for unclustered points, and no negative labels')


### PR DESCRIPTION
Fixes issues on numpy >= 1.24 which I now hit with more recent python based installs (notably python 3.10). See also https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations.

See also already merged #1460 which already fixed a couple of `np.bool` deprecations. I hit a few more when running with numpy >= 1.24 and did a quick grep

        grep -r '\(np\.bool\|np\.float\|np\.int\|np\.str\|np\.object\)[^a-z,0-9,_(]' . --include \*.py

which revealed the ones fixed in this PR.

Replacements are generally `np.X` to just `X` with `X` in `int`, `float`, `bool` which I think should be ok. Some of these are in rarely exercised code so not really explictly tested by me but should just work.
