### PR TITLE
fix for AttributeError: 'LMAnalyser2' object has no attribute '_ovl'

### DIFF
--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -741,7 +741,8 @@ class LMAnalyser2(Plugin):
             self.progPan.fitResults = self.fitResults
             # self._ovl.points = np.vstack(
             #    (self.fitResults['fitResults']['x0'], self.fitResults['fitResults']['y0'], self.fitResults['tIndex'])).T
-            self._ovl.filter.setResults(self.fitResults)
+            if hasattr(self, '_ovl') and hasattr(self._ovl, 'filter'): # is this the correct check? should we have a valid _ovl?
+                self._ovl.filter.setResults(self.fitResults)
             self.numEvents = len(self.fitResults)
         
             try:


### PR DESCRIPTION
We regularly get (inconsequential) errors

      'LMAnalyser2' object has no attribute '_ovl'

when running PYMEAcquire.

This PR fixes that but should be looked at if the `_ovl` is an overhang from something that should be changed upstream from this fix.
