### PR TITLE
sCMOS map integration time fix - change to rounding

### DIFF
--- a/PYME/Analysis/gen_sCMOS_maps.py
+++ b/PYME/Analysis/gen_sCMOS_maps.py
@@ -44,7 +44,7 @@ def _meanvards(dataSource, start=0, end=-1):
 
 def map_filename(mdh, type):
     if type != 'flatfield':
-        itime = int(1000*mdh['Camera.IntegrationTime'])
+        itime = round(1000*mdh['Camera.IntegrationTime'])
         return '%s_%dms.tif' % (type,itime)
     else:
         return '%s.tif' % (type)

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -516,7 +516,7 @@ class FitDefaults(object):
         from PYME.IO.FileUtils.nameUtils import getCalibrationDir
         
         caldir = getCalibrationDir(self.analysisMDH['Camera.SerialNumber'])
-        itime = int(1000*self.analysisMDH['Camera.IntegrationTime'])
+        itime = round(1000*self.analysisMDH['Camera.IntegrationTime'])
         darkpath = os.path.join(caldir,'dark_%dms.tif' % (itime))
         varpath = os.path.join(caldir,'variance_%dms.tif' % (itime))
         flatpath = os.path.join(caldir,'flatfield.tif')


### PR DESCRIPTION
We see very annoying rounding issues in the naming of sCMOS map matching. PYME uses the frame integration time for map naming and depending on ROI choice and camera type, the frame integration time can change very subtly, so that a simple int conversion as is in the code now gives sometimes, for example, 99 ms versus 100 ms leading to a map mismatch.

This fix introduces rounding and should be entirely inconsequential for anybody who has not seen this rounding issue before and help those who have seen it.