### PR TITLE
Fix AAOptoMDS(AOTF) initiation error

### DIFF
--- a/PYME/Acquire/Hardware/AAOptoelectronics/MDS.py
+++ b/PYME/Acquire/Hardware/AAOptoelectronics/MDS.py
@@ -58,7 +58,7 @@ class AAOptoMDS(AOTF):
         # initialize serial
         self.timeout = serial_timeout
         # initialize and configure the serial port without opening it
-        self.com_port = serial.Serial(com_port, timeout=serial_timeout)
+        self.com_port = serial.Serial(com_port, 57600, timeout=serial_timeout)
         self.lock = threading.Lock()
         self.is_on = True
         # set to internal control mode, grab a couple extra lines to give the unit time to write before clearing buffer

--- a/PYME/Acquire/Hardware/AAOptoelectronics/MDS.py
+++ b/PYME/Acquire/Hardware/AAOptoelectronics/MDS.py
@@ -37,7 +37,7 @@ class AAOptoMDS(AOTF):
     because we connect to it through an external USB hub. As a result we keep the serial ports open rather than using
     context managers.
     """
-    def __init__(self, calibrations, com_port='COM6', name='AAOptoMDS', n_chans=8, serial_timeout=1):
+    def __init__(self, calibrations, com_port='COM6', name='AAOptoMDS', n_chans=8, serial_timeout=1, baud_rate=57600):
         """
         Parameters
         ----------
@@ -58,7 +58,7 @@ class AAOptoMDS(AOTF):
         # initialize serial
         self.timeout = serial_timeout
         # initialize and configure the serial port without opening it
-        self.com_port = serial.Serial(com_port, 57600, timeout=serial_timeout)
+        self.com_port = serial.Serial(com_port, baud_rate, timeout=serial_timeout)
         self.lock = threading.Lock()
         self.is_on = True
         # set to internal control mode, grab a couple extra lines to give the unit time to write before clearing buffer


### PR DESCRIPTION
**This is a bugfix for an AOTF initiation error in PYMEAcquire initiation script**

**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [√] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands of non-functional changes with a few functional changes scattered amoungst them]

