### PR TITLE
Drift tracking bugfix and enhancement to better access the calibration parameters in GUI

### DIFF
--- a/PYME/Acquire/Hardware/driftTrackGUI.py
+++ b/PYME/Acquire/Hardware/driftTrackGUI.py
@@ -256,6 +256,24 @@ class DriftTrackingControl(wx.Panel):
         self.bSetTolerance.Bind(wx.EVT_BUTTON, self.OnBSetTolerance)
         sizer_1.Add(hsizer,0, wx.EXPAND, 0)
 
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, "Z increment [nm]:"), 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
+        self.tdeltaZ = wx.TextCtrl(self, -1, '%3.0f'% (1e3*self.dt.get_delta_Z()), size=[30,-1])
+        hsizer.Add(self.tdeltaZ, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
+        self.bSetdeltaZ = wx.Button(self, -1, 'Set', style=wx.BU_EXACTFIT)
+        hsizer.Add(self.bSetdeltaZ, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2) 
+        self.bSetdeltaZ.Bind(wx.EVT_BUTTON, self.OnBSetdeltaZ)
+        sizer_1.Add(hsizer,0, wx.EXPAND, 0)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, -1, "Stack halfsize:"), 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
+        self.tHalfsize = wx.TextCtrl(self, -1, '%3.0f'% (self.dt.get_stack_halfsize()), size=[30,-1])
+        hsizer.Add(self.tHalfsize, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
+        self.bSetHalfsize = wx.Button(self, -1, 'Set', style=wx.BU_EXACTFIT)
+        hsizer.Add(self.bSetHalfsize, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2) 
+        self.bSetHalfsize.Bind(wx.EVT_BUTTON, self.OnBSetHalfsize)
+        sizer_1.Add(hsizer,0, wx.EXPAND, 0)
+
         # hsizer = wx.BoxSizer(wx.HORIZONTAL)
         # hsizer.Add(wx.StaticText(self, -1, "Z-factor:"), 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
         # self.tZfactor = wx.TextCtrl(self, -1, '%3.1f'% self.dt.Zfactor, size=[30,-1])
@@ -363,6 +381,12 @@ class DriftTrackingControl(wx.Panel):
 
     def OnBSetTolerance(self, event):
         self.dt.set_focus_tolerance(float(self.tTolerance.GetValue())/1e3)
+
+    def OnBSetdeltaZ(self, event):
+        self.dt.set_delta_Z(float(self.tdeltaZ.GetValue())/1e3)
+
+    def OnBSetHalfsize(self, event):
+        self.dt.set_stack_halfsize(int(self.tHalfsize.GetValue()))
 
     def OnBSetZfactor(self, event):
         self.dt.Zfactor = float(self.tZfactor.GetValue())

--- a/PYME/Acquire/Hardware/driftTracking.py
+++ b/PYME/Acquire/Hardware/driftTracking.py
@@ -349,7 +349,7 @@ class Correlator(object):
             
         elif (self.calibState == self.NCalibStates):
             # print "cal finishing"
-            self.setRefN(frameData, int(self.calibState - 1))
+            self._setRefN(frameData, int(self.calibState - 1))
             
             #perform final bit of calibration - calcuate gradient between steps
             #self.dz = (self.refC - self.refB).ravel()

--- a/PYME/Acquire/Hardware/driftTracking.py
+++ b/PYME/Acquire/Hardware/driftTracking.py
@@ -125,9 +125,9 @@ class Correlator(object):
         if frame_source is None:
             self.frame_source = StandardFrameSource(scope.frameWrangler)
         
-        self.focusTolerance = .05 #how far focus can drift before we correct
-        self.deltaZ = 0.2 #z increment used for calibration
-        self.stackHalfSize = 35
+        self.focusTolerance = .01 #how far focus can drift before we correct
+        self.deltaZ = 0.3 #z increment used for calibration
+        self.stackHalfSize = 20
         self.NCalibStates = 2*self.stackHalfSize + 1
         self.calibState = 0
 
@@ -201,6 +201,38 @@ class Correlator(object):
 
     def get_focus_tolerance(self):
         return self.focusTolerance
+
+
+    def set_delta_Z(self, delta):
+        """ Set the Z increment for calibration stack
+
+        Parameters
+        ----------
+
+        delta : float
+            The delta in nm
+        """
+
+        self.deltaZ = delta
+
+    def get_delta_Z(self):
+        return self.deltaZ
+
+
+    def set_stack_halfsize(self, halfsize):
+        """ Set the calibration stack half size
+
+        Parameters
+        ----------
+
+        halfsize : int
+        """
+
+        self.stackHalfSize = halfsize
+
+    def get_stack_halfsize(self):
+        return self.stackHalfSize
+    
 
     def set_focus_lock(self, lock=True):
         """ Set locking on or off


### PR DESCRIPTION
**It contains a bugfix and an enhancement**

**Proposed changes:**
1. The first commit proposes a bugfix of a contribute error of `Correlator._setRefN` caused by a missing underline `_`.
2. The second commit proposes an enhancement to better access two parameters in drift tracking GUI: the calibration stack z increment and stack halfsize. This would be helpful when we do z-stacking localization microscopy acquisition with different step size and live cell imaging.

**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [√] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
