### PR TITLE
Make ROI half size in InterpFitR accessible and tunable in GUI

### DIFF
--- a/PYME/localization/FitFactories/InterpFitR.py
+++ b/PYME/localization/FitFactories/InterpFitR.py
@@ -228,7 +228,8 @@ PARAMETERS = [#mde.ChoiceParam('Analysis.InterpModule','Interp:','CSInterpolator
               #mde.FloatParam('Analysis.AxialShift', 'Z Shift [nm]:', 0),
               mde.ChoiceParam('Analysis.EstimatorModule', 'Z Start Est:', 'astigEstimator', choices=zEstimators.estimatorList),
               mde.ChoiceParam('PRI.Axis', 'PRI Axis:', 'none', choices=['x', 'y', 'none']),
-              mde.BoolParam('Analysis.FitBackground', 'Fit Background', True),]
+              mde.BoolParam('Analysis.FitBackground', 'Fit Background', True),
+              mde.IntParam('Analysis.ROISize', u'ROI half size', 7),]
               
 DESCRIPTION = '3D, single colour fitting using an interpolated measured PSF.'
 LONG_DESCRIPTION = '3D, single colour fitting using an interpolated measured PSF. Should work for any 3D engineered PSF, with the default parameterisation optimised for astigmatism.'

--- a/PYME/localization/FitFactories/InterpFitWFR.py
+++ b/PYME/localization/FitFactories/InterpFitWFR.py
@@ -103,6 +103,7 @@ PARAMETERS = [#mde.ChoiceParam('Analysis.InterpModule','Interp:','CSInterpolator
               #mde.FloatParam('Analysis.AxialShift', 'Z Shift [nm]:', 0),
               #mde.ChoiceParam('Analysis.EstimatorModule', 'Z Start Est:', 'astigEstimator', choices=zEstimators.estimatorList),
               #mde.ChoiceParam('PRI.Axis', 'PRI Axis:', 'y', choices=['x', 'y'])
+              mde.IntParam('Analysis.ROISize', u'ROI half size', 5),
               ]
               
 

--- a/PYME/localization/FitFactories/LatGaussFitFR.py
+++ b/PYME/localization/FitFactories/LatGaussFitFR.py
@@ -208,6 +208,13 @@ FitFactory = GaussianFitFactory
 FitResult = GaussianFitResultR
 FitResultsDType = fresultdtype #only defined if returning data as numarray
 
+import PYME.localization.MetaDataEdit as mde
+
+PARAMETERS = [
+    mde.IntParam('Analysis.ROISize', u'ROI half size', 5),
+
+]
+
 DESCRIPTION = 'Vanilla 2D Gaussian fit.'
 LONG_DESCRIPTION = 'Single colour 2D Gaussian fit. This should be the first stop for simple analyisis.'
 USE_FOR = '2D single-colour'

--- a/PYME/localization/FitFactories/MultiviewFitInterpNR.py
+++ b/PYME/localization/FitFactories/MultiviewFitInterpNR.py
@@ -393,6 +393,7 @@ PARAMETERS = [#mde.ChoiceParam('Analysis.InterpModule','Interp:','CSInterpolator
               mde.ChoiceParam('PRI.Axis', 'PRI Axis:', 'none', choices=['x', 'y', 'none']),
               mde.BoolParam('Analysis.FitBackground', 'Fit Background', True),
               #mde.FloatListParam('chroma.ChannelRatios', 'Channel Ratios', [0.7]),
+              mde.IntParam('Analysis.ROISize', u'ROI half size', 7),
               ]
               
 DESCRIPTION = 'Ratiometric multi-colour 3D PSF fit (large shifts).'

--- a/PYME/localization/FitFactories/PRInterpFitR.py
+++ b/PYME/localization/FitFactories/PRInterpFitR.py
@@ -216,7 +216,8 @@ PARAMETERS = [#mde.ChoiceParam('Analysis.InterpModule','Interp:','CSInterpolator
               #mde.IntParam('Analysis.DebounceRadius', 'Debounce r:', 4),
               #mde.FloatParam('Analysis.AxialShift', 'Z Shift [nm]:', 0),
               mde.ChoiceParam('Analysis.EstimatorModule', 'Z Start Est:', 'priEstimator', choices=zEstimators.estimatorList),
-              mde.ChoiceParam('PRI.Axis', 'PRI Axis:', 'y', choices=['x', 'y'])]
+              mde.ChoiceParam('PRI.Axis', 'PRI Axis:', 'y', choices=['x', 'y']),
+              mde.IntParam('Analysis.ROISize', u'ROI half size', 5),]
               
 DESCRIPTION = '3D fitting for the PRI PSF with variable lobe heights.'
 LONG_DESCRIPTION = '3D fitting for the PRI PSF with variable lobe heights. A special version of InterpFit which allows us to measure the realative strength of the two PRI lobes. Fairly specialised use cases - unless you know you need it use InterpFitR instead.'

--- a/PYME/localization/FitFactories/ROIExtractNR.py
+++ b/PYME/localization/FitFactories/ROIExtractNR.py
@@ -85,6 +85,7 @@ PARAMETERS = [#mde.ChoiceParam('Analysis.InterpModule','Interp:','LinearInterpol
               #mde.FloatParam('Analysis.AxialShift', 'Z Shift [nm]:', 0),
               #mde.ChoiceParam('Analysis.EstimatorModule', 'Z Start Est:', 'astigEstimator', choices=zEstimators.estimatorList),
               #mde.ChoiceParam('PRI.Axis', 'PRI Axis:', 'y', choices=['x', 'y'])
+              mde.IntParam('Analysis.ROISize', u'ROI half size', 7),
               ]
               
 DESCRIPTION = 'Cut out ROI for subsequent analysis - no fitting'

--- a/PYME/localization/FitFactories/SplitterFitFNR.py
+++ b/PYME/localization/FitFactories/SplitterFitFNR.py
@@ -304,6 +304,7 @@ PARAMETERS = [#mde.ChoiceParam('Analysis.InterpModule','Interp:','LinearInterpol
               #mde.FloatParam('Analysis.AxialShift', 'Z Shift [nm]:', 0),
               #mde.ChoiceParam('Analysis.EstimatorModule', 'Z Start Est:', 'astigEstimator', choices=zEstimators.estimatorList),
               #mde.ChoiceParam('PRI.Axis', 'PRI Axis:', 'y', choices=['x', 'y'])
+              mde.IntParam('Analysis.ROISize', u'ROI half size', 5),
               ]
               
 DESCRIPTION = 'Ratiometric multi-colour 2D Gaussian fit (large shifts).'

--- a/PYME/localization/FitFactories/SplitterFitInterpBNR.py
+++ b/PYME/localization/FitFactories/SplitterFitInterpBNR.py
@@ -350,6 +350,7 @@ PARAMETERS = [#mde.ChoiceParam('Analysis.InterpModule','Interp:','CSInterpolator
               mde.ChoiceParam('PRI.Axis', 'PRI Axis:', 'none', choices=['x', 'y', 'none']),
               mde.BoolParam('Analysis.FitBackground', 'Fit Background', True),
               mde.FloatListParam('chroma.ChannelRatios', 'Channel Ratios', [0.7]),
+              mde.IntParam('Analysis.ROISize', u'ROI half size', 7),
               ]
               
 DESCRIPTION = 'Ratiometric multi-colour 3D PSF fit (large shifts).'

--- a/PYME/localization/FitFactories/SplitterFitInterpNR.py
+++ b/PYME/localization/FitFactories/SplitterFitInterpNR.py
@@ -336,6 +336,7 @@ PARAMETERS = [#mde.ChoiceParam('Analysis.InterpModule','Interp:','CSInterpolator
               mde.ChoiceParam('PRI.Axis', 'PRI Axis:', 'none', choices=['x', 'y', 'none']),
               mde.BoolParam('Analysis.FitBackground', 'Fit Background', True),
               #mde.FloatListParam('chroma.ChannelRatios', 'Channel Ratios', [0.7]),
+              mde.IntParam('Analysis.ROISize', u'ROI half size', 7),
               ]
               
 DESCRIPTION = 'Ratiometric multi-colour 3D PSF fit (large shifts).'

--- a/PYME/localization/FitFactories/SplitterROIExtractNR.py
+++ b/PYME/localization/FitFactories/SplitterROIExtractNR.py
@@ -83,6 +83,7 @@ PARAMETERS = [#mde.ChoiceParam('Analysis.InterpModule','Interp:','LinearInterpol
               #mde.FloatParam('Analysis.AxialShift', 'Z Shift [nm]:', 0),
               #mde.ChoiceParam('Analysis.EstimatorModule', 'Z Start Est:', 'astigEstimator', choices=zEstimators.estimatorList),
               #mde.ChoiceParam('PRI.Axis', 'PRI Axis:', 'y', choices=['x', 'y'])
+              mde.IntParam('Analysis.ROISize', u'ROI half size', 7),
               ]
               
 DESCRIPTION = 'Cut out ROI for subsequent analysis - no fitting'


### PR DESCRIPTION
**Is this a bugfix or an enhancement?**
Enhancement

**Proposed changes:**
The ROI half size can be adjusted in GUI when using InterpFitR fitfactory, similar to AstigGaussFitFR. I think this would be helpful because, for example, the astigmatic PSF is usually larger than non-astigmatic PSF, but the default ROI half size value is 5, which may not be ideal. Now I set the initial/default value to 7, and could be easily further adjusted.

**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [√] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [√] Does this change how users interact with the software? How will these changes be communicated?
This adds an interaction between users and ROI half size, but does not change any previously existing interactions.
- [√] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
