### PR TITLE
Enable sub-roi based drift tracking

### DIFF
--- a/PYME/Acquire/Hardware/driftTrackGUI.py
+++ b/PYME/Acquire/Hardware/driftTrackGUI.py
@@ -205,15 +205,30 @@ class ZFactorPlotPanel(PlotPanel):
 
 
 
-# add controls for lastAdjustment
+from PYME.DSView import overlays
+import weakref
+class DriftROIOverlay(overlays.Overlay):
+    # TODO - implement this - should display a box around the current sub-ROI
+    pass
+
 class DriftTrackingControl(wx.Panel):
-    def __init__(self, parent, driftTracker, winid=-1, showPlots=True):
+    def __init__(self, main_frame, driftTracker, winid=-1, showPlots=True):
+        ''' This class provides a GUI for controlling the drift tracking system. 
+        
+        It should be initialised with a reference to the PYMEAcquire main frame, which will stand in as a parent while other GUI items are
+        created. Note that the actual parent will be reassigned once the GUI tool panel is created using a Reparent() call.
+        '''
         # begin wxGlade: MyFrame1.__init__
         #kwds["style"] = wx.DEFAULT_FRAME_STYLE
-        wx.Panel.__init__(self, parent, winid)
+        wx.Panel.__init__(self, main_frame, winid)
         self.dt = driftTracker
         self.plotInterval = 10
         self.showPlots = showPlots
+
+        # keep a reference to the main frame. Do this as a weakref to avoid circular references.
+        # we need this to be able to access the view to get the current selection and to add overlays.
+        self._main_frame = weakref.proxy(main_frame)
+        self._view_overlay = None # dummy reference to the overlay so we only create it once
 
         sizer_1 = wx.BoxSizer(wx.VERTICAL)
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -236,6 +251,15 @@ class DriftTrackingControl(wx.Panel):
         self.bSetPostion = wx.Button(self, -1, 'Set focus to current')
         hsizer.Add(self.bSetPostion, 0, wx.ALL, 2) 
         self.bSetPostion.Bind(wx.EVT_BUTTON, self.OnBSetPostion)
+        #self.bSaveCalib = wx.Button(self, -1, 'Save Cal')
+        #hsizer.Add(self.bSaveCalib, 0, wx.ALL, 2)
+        #self.bSaveCalib.Bind(wx.EVT_BUTTON, self.OnBSaveCalib)
+        sizer_1.Add(hsizer, 0, wx.EXPAND, 0)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.tbSubROI = wx.ToggleButton(self, -1, 'Restrict to sub-ROI')
+        hsizer.Add(self.bSetPostion, 0, wx.ALL, 2) 
+        self.bSetPostion.Bind(wx.EVT_BUTTON, self.OnTBToggleSubROI)
         #self.bSaveCalib = wx.Button(self, -1, 'Save Cal')
         #hsizer.Add(self.bSaveCalib, 0, wx.ALL, 2)
         #self.bSaveCalib.Bind(wx.EVT_BUTTON, self.OnBSaveCalib)
@@ -335,6 +359,22 @@ class DriftTrackingControl(wx.Panel):
             
     def OnBSetPostion(self, event):
         self.dt.reCalibrate()
+
+    def OnTBToggleSubROI(self, event):
+        self.toggle_subroi(self.tbSubROI.GetValue())
+    
+    def toggle_subroi(self, new_state=True):
+        ''' Turn sub-ROI tracking on or off, using the current selection in the live image display'''
+        if new_state:
+            x0, x1, y0, y1, _, _ = self._main_frame.view.do.sorted_selection
+            self.dt.set_subroi((x0, x1, y0, y1)) # TODO - implement dt.set_subroi
+        else:
+            self.dt.set_subroi(None)
+
+        self.dt.reCalibrate() # FIXME - move to dt.set_subroi
+
+        if self._view_overlay is None:
+            self._view_overlay = self._main_frame.view.add_overlay(DriftROIOverlay(self.dt), 'Drift tracking Sub-ROI')
         
     def OnBSaveCalib(self, event):
         if not hasattr(self.dt, 'calibState') or (self.dt.calibState < self.dt.NCalibStates):

--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -173,9 +173,11 @@ class PYMEMainFrame(AUIFrame):
             self.time1.Start(500)
     
     def _refreshDataStack(self):
-        if 'vp' in dir(self):
-            if not (self.vp.do.ds.data is self.scope.frameWrangler.currentFrame):
-                self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
+        try:
+            if not (self.view.do.ds.data is self.scope.frameWrangler.currentFrame):
+                self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
+        except ArithmeticError:
+            pass
         
     def _start_polling_camera(self):
         self.scope.startFrameWrangler()
@@ -187,28 +189,27 @@ class PYMEMainFrame(AUIFrame):
         """
 
         if self.scope.cam.GetPicHeight() > 1:
-            if 'vp' in dir(self):
-                    self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
-            else:
-                self.vp = arrayViewPanel.ArrayViewPanel(self, self.scope.frameWrangler.currentFrame, initial_overlays=[])
-                self.vp.crosshairs = False
-                self.vp.showScaleBar = False
-                self.vp.do.leftButtonAction = self.vp.do.ACTION_SELECTION
-                self.vp.do.showSelection = True
-                self.vp.CenteringHandlers.append(self.scope.PanCamera)
+            try:
+                self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
+            except AttributeError:
+                self._view = arrayViewPanel.ArrayViewPanel(self, self.scope.frameWrangler.currentFrame, initial_overlays=[])
+                self.view.crosshairs = False
+                self.view.showScaleBar = False
+                self.view.do.leftButtonAction = self.view.do.ACTION_SELECTION
+                self.view.do.showSelection = True
+                self.view.CenteringHandlers.append(self.scope.PanCamera)
 
-                self.vsp = disppanel.dispSettingsPanel2(self, self.vp, self.scope)
+                self.vsp = disppanel.dispSettingsPanel2(self, self.view, self.scope)
 
 
                 self.time1.WantNotification.append(self.vsp.RefrData)
                 self.time1.WantNotification.append(self._refreshDataStack)
 
-                self.AddPage(page=self.vp, select=True,caption='Preview')
+                self.AddPage(page=self.view, select=True,caption='Preview')
 
                 self.AddCamTool(self.vsp, 'Display')
 
-            #self.scope.frameWrangler.WantFrameGroupNotification.append(self.vp.Redraw)
-            self.scope.frameWrangler.onFrameGroup.connect(self.vp.Redraw)
+            self.scope.frameWrangler.onFrameGroup.connect(self.view.Redraw)
 
         else:
             #1d data - use graph instead
@@ -517,12 +518,12 @@ class PYMEMainFrame(AUIFrame):
         logging.debug('Preparing frame wrangler for new ROI size')
 
         self.scope.frameWrangler.Prepare()
-        self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
+        self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
 
         logging.debug('Restarting frame wrangler with new ROI')
         self.scope.frameWrangler.start()
-        self.vp.Refresh()
-        self.vp.GetParent().Refresh()
+        self.view.Refresh()
+        self.view.GetParent().Refresh()
 
     def OnMCamSetPixelSize(self, event):
         from PYME.Acquire.ui import voxelSizeDialog
@@ -560,7 +561,7 @@ class PYMEMainFrame(AUIFrame):
                 self.scope.state['Camera.ROI'] = (0,0, self.scope.cam.GetCCDWidth(), self.scope.cam.GetCCDHeight())
                 self.roi_on = False
             else:
-                x1, y1, x2, y2 = self.vp.do.GetSliceSelection()
+                x1, y1, x2, y2 = self.view.do.GetSliceSelection()
     
                 #if we're splitting colours/focal planes across the ccd, then only allow symetric ROIs
                 if 'splitting' in dir(self.scope.cam):
@@ -595,14 +596,14 @@ class PYMEMainFrame(AUIFrame):
         #self.scope.cam.SetCOC()
         #self.scope.cam.GetStatus()
         self.scope.frameWrangler.Prepare()
-        self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
+        self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
         
-        self.vp.do.SetSelection((x1,y1,0), (x2,y2,0))
+        self.view.do.SetSelection((x1,y1,0), (x2,y2,0))
 
         logging.debug('Restarting frame wrangler with new ROI')
         self.scope.frameWrangler.start()
-        self.vp.Refresh()
-        self.vp.GetParent().Refresh()
+        self.view.Refresh()
+        self.view.GetParent().Refresh()
         #event.Skip()
 
     def SetCentredRoi(self, event=None, halfwidth=5):
@@ -632,20 +633,41 @@ class PYMEMainFrame(AUIFrame):
         #self.scope.cam.SetCOC()
         #self.scope.cam.GetStatus()
         self.scope.frameWrangler.Prepare()
-        self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
+        self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
         
-        self.vp.do.SetSelection((x1,y1,0), (x2,y2,0))
+        self.view.do.SetSelection((x1,y1,0), (x2,y2,0))
 
         self.scope.frameWrangler.start()
-        self.vp.Refresh()
-        self.vp.GetParent().Refresh()
+        self.view.Refresh()
+        self.view.GetParent().Refresh()
         #event.Skip()
 
     def OnMDisplayClearSel(self, event):
-        self.vp.ResetSelection()
+        self.view.ResetSelection()
         #event.Skip()
 
+    @property
+    def view(self):
+        '''Return the current view panel. This is the panel that is used to display the camera data.
+        
+        deprecates .vp
 
+        '''
+        try:
+            return self._view
+        except AttributeError:
+            raise AttributeError('View panel not yet created. This usually happens if .view is accessed too early in the initialisation process.')
+
+    @property
+    def vp(self):
+        ''' Backwards compatibility for access to the view panel
+        
+        Generates a deprecation warning - use .view instead
+        '''
+        import warnings
+        warnings.warn('The .vp attribute is deprecated. Use .view instead', DeprecationWarning)
+        return self.view
+    
     def OnCloseWindow(self, event):   
         self.scope.frameWrangler.stop()
         self.time1.Stop()


### PR DESCRIPTION
Initial steps towards implementing sub-roi awareness in the transmitted light drift tracking. This will enable the use of drift tracking on a small part of the image when the rest of the image contains useful information which we still want to record. This is most applicable when we do not have a dedicated tracking channel, but are rather re-using a transmitted or fluorescence channel. The principle application is to restrict tracking to fiducial(s) during live cell imaging when the cells themselves might be moving.

So far, just the GUI front-end has been implemented.


TODOS:
---------
- backend to record and apply an ROI in the Tracker object
- Display of the selected ROI as an overlay (expanding on the stub provided here)