### PR TITLE
Follow up of drift tracking refactoring for combining it with OIDIC

### DIFF
--- a/PYME/Acquire/Hardware/driftTracking.py
+++ b/PYME/Acquire/Hardware/driftTracking.py
@@ -123,7 +123,9 @@ class Correlator(object):
 
         if frame_source is None:
             self.frame_source = StandardFrameSource(scope.frameWrangler)
-        self.frame_source = frame_source
+        else:
+            self.frame_source = frame_source
+
         
         self.focusTolerance = focusTolerance #how far focus can drift before we correct
         self.deltaZ = deltaZ #z increment used for calibration

--- a/PYME/Acquire/Hardware/driftTracking.py
+++ b/PYME/Acquire/Hardware/driftTracking.py
@@ -109,11 +109,10 @@ class OIDICFrameSource(StandardFrameSource):
         self._target_orientation = oidic_orientation
 
     def tick(self, *args, **kwargs):
-        # FIXME - change to match actual naming etc ... in OIDIC code.
         # FIXME - check when onFrameGroup is emitted relative to when the OIDIC orientation is set.
         # Is this predictable, or does it depend on the order in which OIDIC and drift tracking are
         # registered with the frameWrangler?
-        if self._oidic.orientation == self._target_orientation:
+        if self._oidic.current_channel == self._target_orientation:
             super().tick(*args, **kwargs)
         else:
             # clobber all frames coming from camera when not in the correct DIC orientation
@@ -124,6 +123,7 @@ class Correlator(object):
 
         if frame_source is None:
             self.frame_source = StandardFrameSource(scope.frameWrangler)
+        self.frame_source = frame_source
         
         self.focusTolerance = focusTolerance #how far focus can drift before we correct
         self.deltaZ = deltaZ #z increment used for calibration


### PR DESCRIPTION
**This is an enhancement with a bugfix**

**Proposed changes:**
1. Change to match actual naming in OIDIC code in `OIDICFrameSource` class.
2. Bugfix for adding `frame_source` attribute to `Correlator`.

**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [√] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [√] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [√] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
