### PR TITLE
PIPython based Piezo class tweaks

### DIFF
--- a/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
@@ -316,7 +316,13 @@ class GCSPiezoThreaded(PiezoBase):
         return self._max[iChan]
     
     def GetFirmwareVersion(self):
-        raise NotImplementedError
+        if self.pi.HasqVER():
+            ver = self.pi.qVER() # under lock?
+            verinfo = ver.strip()
+        else:
+            verinfo = 'Controller has no version info'
+
+        return verinfo
     
     def OnTarget(self):
         """

--- a/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
@@ -240,7 +240,7 @@ class GCSPiezoThreaded(PiezoBase):
             self.disable_joystick() # this includes enabling updating_ontarget
         else:
             self.enable_updating_ontarget()
-        
+
         self._update_rate = update_rate
         self._start_loop()
 
@@ -248,15 +248,15 @@ class GCSPiezoThreaded(PiezoBase):
         if self.joystick is None:
             return
         self.disable_updating_ontarget()
-        # running this command under lock seemed to hang
-        self.joystick.enablecommands()
+        with self._lock:
+            self.joystick.enablecommands()
         self._joystick_enabled = True
 
     def disable_joystick(self):
         if self.joystick is None:
             return
-        # running this command under lock seemed to hang
-        self.joystick.disablecommands()
+        with self._lock:
+            self.joystick.disablecommands()
         self.enable_updating_ontarget()
         self._joystick_enabled = False
 

--- a/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
@@ -355,7 +355,7 @@ class GCSPiezoThreaded(PiezoBase):
 
     def _Loop(self):
         while self.loop_active:
-            time.sleep(self._update_rate) # I imagine we should sleep while not holding the lock so that others can grab it if needed
+            time.sleep(self._update_rate) # we should sleep while NOT holding the lock so that others can grab it if needed
             with self._lock:
                 try:
                     # check position
@@ -393,11 +393,12 @@ class GCSPiezoThreaded(PiezoBase):
         logger.debug('exiting')
    
 
-# a piezo_pipython_gcs compatible joystick class needs
-# - Enable() and IsEnabled() methods for use by PYME position ui and scope object
+# a piezo_pipython_gcs compatible joystick class
+# - provides Enable() and IsEnabled() methods for use by PYME position ui and scope object
 # - an init() method to set the joystick parameters via GCS commands and register the gcspiezo "parent" instance
 # - an enablecommands() method of GCS commands that will be used by the gcspiezo "parent" object to enable the joystick
 # - a disablecommands() method of GCS commands that will be used by the gcspiezo "parent" object to disable the joystick
+
 # example usage:
 #    from PYME.Acquire.Hardware.Piezos.piezo_pipython_gcs import GCSPiezoThreaded
 #    from PYMEcs.Acquire.Hardware.Piezos.joystick_c867_digital import DigitalJoystick
@@ -412,10 +413,13 @@ class JoystickBase(object):
     # this method needs to be tweaked to the specific controller and joystick model in derived class
     def init(self,gcspiezo):
         # register the piezo device
-        self.gcspiezo = gcspiezo
+        self.gcspiezo = gcspiezo # needs to be retained in derived class implementation
+        
         # further initialisation code should go below (e.g. GCS commands)
-        # this method needs to be implemented in a derived class
-        #   and retain the registration of the gcspiezo attribute!
+        # i.e., this method needs to be implemented in a derived class
+        
+        # when completed needs to set the initialised flag: self._initialised = True
+        
         raise NotImplementedError('Needs to be implemented in derived class.')
 
     def Enable(self, enabled = True):
@@ -432,14 +436,14 @@ class JoystickBase(object):
 
     def check_initialised(self):
         if not self._initialised:
-            raise RuntimeError("joystick must have been initialised before using these methods")
+            raise RuntimeError("joystick must be initialised before using these methods")
 
     # GCS commands to enable the joystick
-    def enablecommands(self): # this method should only be used from the parent gcspiezo object
+    def enablecommands(self): # this method is supposed to be used from the parent gcspiezo object
         #    e.g. self.gcspiezo.pi.HIN(self.gcspiezo.axes,[True for axis in self.gcspiezo.axes])
         raise NotImplementedError('Needs to be implemented in derived class.')
 
     # GCS commands to enable the joystick
-    def disablecommands(self): # this method should only be used from the parent gcspiezo object
+    def disablecommands(self): # this method is supposed to be used from the parent gcspiezo object
         #    e.g. self.gcspiezo.pi.HIN(self.gcspiezo.axes,[False for axis in self.gcspiezo.axes])
         raise NotImplementedError('Needs to be implemented in derived class.')

--- a/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
@@ -247,16 +247,16 @@ class GCSPiezoThreaded(PiezoBase):
             return
         with self._lock:
             self.joystick.enablecommands(self.pi)
-            self.disable_updating_ontarget()
-            self._joystick_enabled = True
+        self.disable_updating_ontarget()
+        self._joystick_enabled = True
 
     def disable_joystick(self):
         if self.joystick is None:
             return
         with self._lock:
             self.joystick.disablecommands(self.pi)
-            self.enable_updating_ontarget()
-            self._joystick_enabled = False
+        self.enable_updating_ontarget()
+        self._joystick_enabled = False
 
     def SetServo(self, val=1):
         with self._lock:
@@ -344,7 +344,7 @@ class GCSPiezoThreaded(PiezoBase):
             # now also switch the flag
             self._updating_ontarget = True
 
-    def disable_updating_ontarget(self): # do we need a lock?
+    def disable_updating_ontarget(self): # does this need a lock, any race conditions?
         self._updating_ontarget = False
 
     def _Loop(self):

--- a/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
@@ -232,6 +232,8 @@ class GCSPiezoThreaded(PiezoBase):
         self._min = [pitools.getmintravelrange(self.pi, axis)[axis] for axis in self.axes]
         self._max = [pitools.getmaxtravelrange(self.pi, axis)[axis] for axis in self.axes]
 
+        # before the loop is active, need to query positions explicitly to make self.positions valid
+        self.positions = np.array([self.pi.qPOS([axis])[axis] for axis in self.axes])
         self.joystick = joystick
         if self.joystick is not None:
             self.joystick.init(self) # the joystick object should have an init method
@@ -245,16 +247,16 @@ class GCSPiezoThreaded(PiezoBase):
     def enable_joystick(self):
         if self.joystick is None:
             return
-        with self._lock:
-            self.joystick.enablecommands(self.pi)
         self.disable_updating_ontarget()
+        # running this command under lock seemed to hang
+        self.joystick.enablecommands(self.pi)
         self._joystick_enabled = True
 
     def disable_joystick(self):
         if self.joystick is None:
             return
-        with self._lock:
-            self.joystick.disablecommands(self.pi)
+        # running this command under lock seemed to hang
+        self.joystick.disablecommands(self.pi)
         self.enable_updating_ontarget()
         self._joystick_enabled = False
 
@@ -334,25 +336,23 @@ class GCSPiezoThreaded(PiezoBase):
         self.tloop.start()
 
     def enable_updating_ontarget(self):
-        with self._lock:
-            # first reset the relevant variables
-            self.positions = np.array([self.pi.qPOS([axis])[axis] for axis in self.axes])
-            self.target_positions = np.copy(self.positions)
-            self._last_target_positions = np.copy(self.positions)
-            self._all_on_target = True
-            self._on_target = np.asarray([True for axis in self.axes])
-            # now also switch the flag
-            self._updating_ontarget = True
+        # first reset the relevant variables
+        self.target_positions = np.copy(self.positions)
+        self._last_target_positions = np.copy(self.positions)
+        self._all_on_target = True
+        self._on_target = np.asarray([True for axis in self.axes])
+        # now also switch the flag
+        self._updating_ontarget = True
 
     def disable_updating_ontarget(self): # does this need a lock, any race conditions?
         self._updating_ontarget = False
 
     def _Loop(self):
         while self.loop_active:
+            time.sleep(self._update_rate) # I imagine we should sleep while not holding the lock so that others can grab it if needed
             with self._lock:
                 try:
                     # check position
-                    time.sleep(self._update_rate)
                     for ind, axis in enumerate(self.axes):
                         # does this need a lock?
                         self.positions[ind] = self.pi.qPOS([axis])[axis]


### PR DESCRIPTION
This is an enhancement of the PIPython based generic PI interface that @barentine had kindly created. It was superuseful in getting our new stages to go with PYME (a C-867 based PIline x-y stage and a E-727 fine 3D stage).

The additions in this PR add a few enhancements for simpler and more complete generic use from init files:

  - startup and referencing options added to `GCSPiezoThreaded` constructor
  - addition of a generic joystick class (we use the C-867 with a digital joystick)
  - a small fix to the threadloop to take the sleep command out of the locked code section
  - implemented the firmware method (potentially useful when issues encountered)
 
No equivalent enhancements have been added to the (non-threaded) `GCSPiezo` class. Perhaps its use should be deprecated or altogether removed?

**Is this a bugfix or an enhancement?**

Enhancement, see details above.

**Example usage**

Here is example usage from a working init file which starts and exercises the stages we have just fine with PYME, including switching joystick on and off fine from the GUI etc.

```python
@init_hardware('XY and 3D Fine Stage')
def xy_stage(scope):
    from PYME.Acquire.Hardware.Piezos.piezo_pipython_gcs import GCSPiezoThreaded
    from PYMEcs.Acquire.Hardware.Piezos.joystick_c867_digital import DigitalJoystick
    scope.stage = GCSPiezoThreaded('PI C-867 Piezomotor Controller SN 0122013807', axes=['1', '2'],
                                   refmodes='FRF',joystick=DigitalJoystick())
    scope.stage.units_um = 1000
    # the stage should match the camera reference frame -
    # i.e. the 'x' channel should be the one which results in lateral
    # movement on the camera, and the y channel should result in vertical movement on the camera
    # multipliers should be set (+1 or -1) so that the direction also matches.
    # NOTE: need to check channel and multiplier for our system
    scope.register_piezo(scope.stage, 'x', needCamRestart=False, channel=0, multiplier=-1)
    scope.register_piezo(scope.stage, 'y', needCamRestart=False, channel=1, multiplier=1)
    scope.joystick = scope.stage.joystick
    scope.CleanupFunctions.append(scope.stage.close)

    # note that both stages need to be started in the same thread as the pitools.startup calls seem not thread safe!!!
    scope.fine_stage = GCSPiezoThreaded('PI E-727 Controller SN 0123022828', axes = ['1', '2', '3'],
                                        update_rate=0.01)
    scope.register_piezo(scope.fine_stage, 'x_fine', needCamRestart=False, channel=0, multiplier=1)
    scope.register_piezo(scope.fine_stage, 'y_fine', needCamRestart=False, channel=1, multiplier=1)
    scope.register_piezo(scope.fine_stage, 'z_fine', needCamRestart=False, channel=2, multiplier=1)
    scope.CleanupFunctions.append(scope.fine_stage.close)
```
