### PR TITLE
Sub ROI drift tracking - follow up of PR #1479

### DIFF
--- a/PYME/Acquire/Hardware/driftTrackGUI.py
+++ b/PYME/Acquire/Hardware/driftTrackGUI.py
@@ -261,7 +261,7 @@ class DriftTrackingControl(wx.Panel):
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
         self.tbSubROI = wx.ToggleButton(self, -1, 'Restrict to sub-ROI')
         hsizer.Add(self.tbSubROI, 0, wx.ALL, 2)
-        self.tbSubROI.Bind(wx.EVT_BUTTON, self.OnTBToggleSubROI)
+        self.tbSubROI.Bind(wx.EVT_TOGGLEBUTTON, self.OnTBToggleSubROI)
         #self.bSaveCalib = wx.Button(self, -1, 'Save Cal')
         #hsizer.Add(self.bSaveCalib, 0, wx.ALL, 2)
         #self.bSaveCalib.Bind(wx.EVT_BUTTON, self.OnBSaveCalib)

--- a/PYME/Acquire/Hardware/driftTrackGUI.py
+++ b/PYME/Acquire/Hardware/driftTrackGUI.py
@@ -208,8 +208,22 @@ class ZFactorPlotPanel(PlotPanel):
 from PYME.DSView import overlays
 import weakref
 class DriftROIOverlay(overlays.Overlay):
-    # TODO - implement this - should display a box around the current sub-ROI
-    pass
+    def __init__(self, driftTracker):
+        self.dt = driftTracker
+    
+    def __call__(self, view, dc):
+        if self.dt.sub_roi is not None:
+            dc.SetPen(wx.Pen(colour=wx.CYAN, width=1))
+            dc.SetBrush(wx.TRANSPARENT_BRUSH)
+            x0, x1, y0, y1 = self.dt.sub_roi
+            x0c, y0c = view.pixel_to_screen_coordinates(x0, y0)
+            x1c, y1c = view.pixel_to_screen_coordinates(x1, y1)
+            sX, sY = x1c-x0c, y1c-y0c
+            dc.DrawRectangle(int(x0c), int(y0c), int(sX), int(sY))
+            dc.SetPen(wx.NullPen)
+        else:
+            dc.SetBackground(wx.TRANSPARENT_BRUSH)
+            dc.Clear()
 
 class DriftTrackingControl(wx.Panel):
     def __init__(self, main_frame, driftTracker, winid=-1, showPlots=True):

--- a/PYME/Acquire/Hardware/driftTrackGUI.py
+++ b/PYME/Acquire/Hardware/driftTrackGUI.py
@@ -369,11 +369,9 @@ class DriftTrackingControl(wx.Panel):
         ''' Turn sub-ROI tracking on or off, using the current selection in the live image display'''
         if new_state:
             x0, x1, y0, y1, _, _ = self._main_frame.view.do.sorted_selection
-            self.dt.set_subroi((x0, x1, y0, y1)) # TODO - implement dt.set_subroi
+            self.dt.set_subroi((x0, x1, y0, y1))
         else:
             self.dt.set_subroi(None)
-
-        self.dt.reCalibrate() # FIXME - move to dt.set_subroi
 
         if self._view_overlay is None:
             self._view_overlay = self._main_frame.view.add_overlay(DriftROIOverlay(self.dt), 'Drift tracking Sub-ROI')

--- a/PYME/Acquire/Hardware/driftTrackGUI.py
+++ b/PYME/Acquire/Hardware/driftTrackGUI.py
@@ -260,8 +260,8 @@ class DriftTrackingControl(wx.Panel):
         
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
         self.tbSubROI = wx.ToggleButton(self, -1, 'Restrict to sub-ROI')
-        hsizer.Add(self.bSetPostion, 0, wx.ALL, 2) 
-        self.bSetPostion.Bind(wx.EVT_BUTTON, self.OnTBToggleSubROI)
+        hsizer.Add(self.tbSubROI, 0, wx.ALL, 2)
+        self.tbSubROI.Bind(wx.EVT_BUTTON, self.OnTBToggleSubROI)
         #self.bSaveCalib = wx.Button(self, -1, 'Save Cal')
         #hsizer.Add(self.bSaveCalib, 0, wx.ALL, 2)
         #self.bSaveCalib.Bind(wx.EVT_BUTTON, self.OnBSaveCalib)

--- a/PYME/Acquire/Hardware/driftTracking.py
+++ b/PYME/Acquire/Hardware/driftTracking.py
@@ -198,7 +198,7 @@ class Correlator(object):
             The pixel position (x0, x1, y0, y1) in int
         """
 
-        self.sub_roi = position
+        self.sub_roi = bounds
         self.reCalibrate()
 
 

--- a/PYME/Acquire/Hardware/driftTracking.py
+++ b/PYME/Acquire/Hardware/driftTracking.py
@@ -201,6 +201,13 @@ class Correlator(object):
         self.sub_roi = bounds
         self.reCalibrate()
 
+    def _crop_frame(self, frame_data):
+        if self.sub_roi is None:
+            return frame_data.squeeze()   # we may as well do the squeeze here to avoid lots of squeezes elsewhere
+        else:
+            x0, x1, y0, y1 = self.sub_roi
+            return frame_data.squeeze()[x0:x1, y0:y1]
+
 
     def set_focus_tolerance(self, tolerance):
         """ Set the tolerance for locking position
@@ -369,10 +376,13 @@ class Correlator(object):
     def tick(self, frameData = None, **kwargs):
         if frameData is None:
             raise ValueError('frameData must be specified')
+        else:
+            frameData = self._crop_frame(frameData)
         
         targetZ = self.piezo.GetTargetPos(0)
         
-        if not 'mask' in dir(self) or not self.frame_source.shape[:2] == self.mask.shape[:2]:
+        #if not 'mask' in dir(self) or not self.frame_source.shape[:2] == self.mask.shape[:2]:
+        if not 'mask' in dir(self) or not frameData.shape[:2] == self.mask.shape[:2]:
             self._initialise(frameData)
             
         #called on a new frame becoming available

--- a/PYME/Acquire/Hardware/driftTracking.py
+++ b/PYME/Acquire/Hardware/driftTracking.py
@@ -188,7 +188,7 @@ class Correlator(object):
         self.calFTs[:,:,N] = ifftn(ref)
         self.calImages[:,:,N] = ref*self.mask
         
-    def set_subroi(self, position):
+    def set_subroi(self, bounds):
         """ Set the position of the roi to crop
 
         Parameters

--- a/PYME/Acquire/Hardware/driftTracking.py
+++ b/PYME/Acquire/Hardware/driftTracking.py
@@ -118,7 +118,7 @@ class OIDICFrameSource(StandardFrameSource):
             # clobber all frames coming from camera when not in the correct DIC orientation
             pass
 class Correlator(object):
-    def __init__(self, scope, piezo=None, frame_source=None, focusTolerance=.05, deltaZ=0.2, stackHalfSize=35):
+    def __init__(self, scope, piezo=None, frame_source=None, sub_roi=None, focusTolerance=.05, deltaZ=0.2, stackHalfSize=35):
         self.piezo = piezo
 
         if frame_source is None:
@@ -126,7 +126,7 @@ class Correlator(object):
         else:
             self.frame_source = frame_source
 
-        
+        self.sub_roi = sub_roi
         self.focusTolerance = focusTolerance #how far focus can drift before we correct
         self.deltaZ = deltaZ #z increment used for calibration
         self.stackHalfSize = stackHalfSize
@@ -188,6 +188,19 @@ class Correlator(object):
         self.calFTs[:,:,N] = ifftn(ref)
         self.calImages[:,:,N] = ref*self.mask
         
+    def set_subroi(self, position):
+        """ Set the position of the roi to crop
+
+        Parameters
+        ----------
+
+        position : tuple
+            The pixel position (x0, x1, y0, y1) in int
+        """
+
+        self.sub_roi = position
+        self.reCalibrate()
+
 
     def set_focus_tolerance(self, tolerance):
         """ Set the tolerance for locking position

--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -173,9 +173,11 @@ class PYMEMainFrame(AUIFrame):
             self.time1.Start(500)
     
     def _refreshDataStack(self):
-        if 'vp' in dir(self):
-            if not (self.vp.do.ds.data is self.scope.frameWrangler.currentFrame):
-                self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
+        try:
+            if not (self.view.do.ds.data is self.scope.frameWrangler.currentFrame):
+                self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
+        except ArithmeticError:
+            pass
         
     def _start_polling_camera(self):
         self.scope.startFrameWrangler()
@@ -187,28 +189,27 @@ class PYMEMainFrame(AUIFrame):
         """
 
         if self.scope.cam.GetPicHeight() > 1:
-            if 'vp' in dir(self):
-                    self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
-            else:
-                self.vp = arrayViewPanel.ArrayViewPanel(self, self.scope.frameWrangler.currentFrame, initial_overlays=[])
-                self.vp.crosshairs = False
-                self.vp.showScaleBar = False
-                self.vp.do.leftButtonAction = self.vp.do.ACTION_SELECTION
-                self.vp.do.showSelection = True
-                self.vp.CenteringHandlers.append(self.scope.PanCamera)
+            try:
+                self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
+            except AttributeError:
+                self._view = arrayViewPanel.ArrayViewPanel(self, self.scope.frameWrangler.currentFrame, initial_overlays=[])
+                self.view.crosshairs = False
+                self.view.showScaleBar = False
+                self.view.do.leftButtonAction = self.view.do.ACTION_SELECTION
+                self.view.do.showSelection = True
+                self.view.CenteringHandlers.append(self.scope.PanCamera)
 
-                self.vsp = disppanel.dispSettingsPanel2(self, self.vp, self.scope)
+                self.vsp = disppanel.dispSettingsPanel2(self, self.view, self.scope)
 
 
                 self.time1.WantNotification.append(self.vsp.RefrData)
                 self.time1.WantNotification.append(self._refreshDataStack)
 
-                self.AddPage(page=self.vp, select=True,caption='Preview')
+                self.AddPage(page=self.view, select=True,caption='Preview')
 
                 self.AddCamTool(self.vsp, 'Display')
 
-            #self.scope.frameWrangler.WantFrameGroupNotification.append(self.vp.Redraw)
-            self.scope.frameWrangler.onFrameGroup.connect(self.vp.Redraw)
+            self.scope.frameWrangler.onFrameGroup.connect(self.view.Redraw)
 
         else:
             #1d data - use graph instead
@@ -517,12 +518,12 @@ class PYMEMainFrame(AUIFrame):
         logging.debug('Preparing frame wrangler for new ROI size')
 
         self.scope.frameWrangler.Prepare()
-        self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
+        self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
 
         logging.debug('Restarting frame wrangler with new ROI')
         self.scope.frameWrangler.start()
-        self.vp.Refresh()
-        self.vp.GetParent().Refresh()
+        self.view.Refresh()
+        self.view.GetParent().Refresh()
 
     def OnMCamSetPixelSize(self, event):
         from PYME.Acquire.ui import voxelSizeDialog
@@ -560,7 +561,7 @@ class PYMEMainFrame(AUIFrame):
                 self.scope.state['Camera.ROI'] = (0,0, self.scope.cam.GetCCDWidth(), self.scope.cam.GetCCDHeight())
                 self.roi_on = False
             else:
-                x1, y1, x2, y2 = self.vp.do.GetSliceSelection()
+                x1, y1, x2, y2 = self.view.do.GetSliceSelection()
     
                 #if we're splitting colours/focal planes across the ccd, then only allow symetric ROIs
                 if 'splitting' in dir(self.scope.cam):
@@ -595,14 +596,14 @@ class PYMEMainFrame(AUIFrame):
         #self.scope.cam.SetCOC()
         #self.scope.cam.GetStatus()
         self.scope.frameWrangler.Prepare()
-        self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
+        self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
         
-        self.vp.do.SetSelection((x1,y1,0), (x2,y2,0))
+        self.view.do.SetSelection((x1,y1,0), (x2,y2,0))
 
         logging.debug('Restarting frame wrangler with new ROI')
         self.scope.frameWrangler.start()
-        self.vp.Refresh()
-        self.vp.GetParent().Refresh()
+        self.view.Refresh()
+        self.view.GetParent().Refresh()
         #event.Skip()
 
     def SetCentredRoi(self, event=None, halfwidth=5):
@@ -632,20 +633,41 @@ class PYMEMainFrame(AUIFrame):
         #self.scope.cam.SetCOC()
         #self.scope.cam.GetStatus()
         self.scope.frameWrangler.Prepare()
-        self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
+        self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
         
-        self.vp.do.SetSelection((x1,y1,0), (x2,y2,0))
+        self.view.do.SetSelection((x1,y1,0), (x2,y2,0))
 
         self.scope.frameWrangler.start()
-        self.vp.Refresh()
-        self.vp.GetParent().Refresh()
+        self.view.Refresh()
+        self.view.GetParent().Refresh()
         #event.Skip()
 
     def OnMDisplayClearSel(self, event):
-        self.vp.ResetSelection()
+        self.view.ResetSelection()
         #event.Skip()
 
+    @property
+    def view(self):
+        '''Return the current view panel. This is the panel that is used to display the camera data.
+        
+        deprecates .vp
+        '''
+        try:
+            return self._view
+        except AttributeError:
+            raise AttributeError('View panel not yet created. This usually happens if \
+                                 .view is accessed too early in the initialisation process.')
 
+    @property
+    def vp(self):
+        ''' Backwards compatibility for access to the view panel
+
+        Generates a deprecation warning - use .view instead
+        '''
+        import warnings
+        warnings.warn('The .vp attribute is deprecated. Use .view instead', DeprecationWarning)
+        return self.view
+    
     def OnCloseWindow(self, event):   
         self.scope.frameWrangler.stop()
         self.time1.Stop()

--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -176,7 +176,8 @@ class PYMEMainFrame(AUIFrame):
         try:
             if not (self.view.do.ds.data is self.scope.frameWrangler.currentFrame):
                 self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
-        except ArithmeticError:
+        except AttributeError:
+
             pass
         
     def _start_polling_camera(self):

--- a/PYME/Acquire/acquirewx.py
+++ b/PYME/Acquire/acquirewx.py
@@ -169,9 +169,11 @@ class PYMEMainFrame(acquire_server.AcquireHTTPServer, AUIFrame):
             self.time1.Start(500)
     
     def _refreshDataStack(self):
-        if 'vp' in dir(self):
-            if not (self.vp.do.ds.data is self.scope.frameWrangler.currentFrame):
-                self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
+        try:
+            if not (self.view.do.ds.data is self.scope.frameWrangler.currentFrame):
+                self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
+        except ArithmeticError:
+            pass
         
     
     def _add_live_view(self):
@@ -181,28 +183,27 @@ class PYMEMainFrame(acquire_server.AcquireHTTPServer, AUIFrame):
         """
 
         if self.scope.cam.GetPicHeight() > 1:
-            if 'vp' in dir(self):
-                    self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
-            else:
-                self.vp = arrayViewPanel.ArrayViewPanel(self, self.scope.frameWrangler.currentFrame, initial_overlays=[])
-                self.vp.crosshairs = False
-                self.vp.showScaleBar = False
-                self.vp.do.leftButtonAction = self.vp.do.ACTION_SELECTION
-                self.vp.do.showSelection = True
-                self.vp.CenteringHandlers.append(self.scope.PanCamera)
+            try:
+                self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
+            except AttributeError:
+                self._view = arrayViewPanel.ArrayViewPanel(self, self.scope.frameWrangler.currentFrame, initial_overlays=[])
+                self.view.crosshairs = False
+                self.view.showScaleBar = False
+                self.view.do.leftButtonAction = self.view.do.ACTION_SELECTION
+                self.view.do.showSelection = True
+                self.view.CenteringHandlers.append(self.scope.PanCamera)
 
-                self.vsp = disppanel.dispSettingsPanel2(self, self.vp, self.scope)
+                self.vsp = disppanel.dispSettingsPanel2(self, self.view, self.scope)
 
 
                 self.time1.WantNotification.append(self.vsp.RefrData)
                 self.time1.WantNotification.append(self._refreshDataStack)
 
-                self.AddPage(page=self.vp, select=True,caption='Preview')
+                self.AddPage(page=self.view, select=True,caption='Preview')
 
                 self.AddCamTool(self.vsp, 'Display')
 
-            #self.scope.frameWrangler.WantFrameGroupNotification.append(self.vp.Redraw)
-            self.scope.frameWrangler.onFrameGroup.connect(self.vp.Redraw)
+            self.scope.frameWrangler.onFrameGroup.connect(self.view.Redraw)
 
         else:
             #1d data - use graph instead
@@ -504,12 +505,12 @@ class PYMEMainFrame(acquire_server.AcquireHTTPServer, AUIFrame):
         logging.debug('Preparing frame wrangler for new ROI size')
 
         self.scope.frameWrangler.Prepare()
-        self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
+        self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
 
         logging.debug('Restarting frame wrangler with new ROI')
         self.scope.frameWrangler.start()
-        self.vp.Refresh()
-        self.vp.GetParent().Refresh()
+        self.view.Refresh()
+        self.view.GetParent().Refresh()
 
     def OnMCamSetPixelSize(self, event):
         from PYME.Acquire.ui import voxelSizeDialog
@@ -521,8 +522,6 @@ class PYMEMainFrame(acquire_server.AcquireHTTPServer, AUIFrame):
     def OnMCamRoi(self, event):
         logging.debug('Stopping frame wrangler to set ROI')
         self.scope.frameWrangler.stop()
-        
-        #print (self.scope.vp.selection.start.x, self.scope.vp.selection.start.y, self.scope.vp.selection.finish.x, self.scope.vp.selection.finish.y)
 
         if 'validROIS' in dir(self.scope.cam) and self.scope.cam.ROIsAreFixed():
             #special case for cameras with restricted ROIs - eg Neo
@@ -547,7 +546,7 @@ class PYMEMainFrame(acquire_server.AcquireHTTPServer, AUIFrame):
                 self.scope.state['Camera.ROI'] = (0,0, self.scope.cam.GetCCDWidth(), self.scope.cam.GetCCDHeight())
                 self.roi_on = False
             else:
-                x1, y1, x2, y2 = self.vp.do.GetSliceSelection()
+                x1, y1, x2, y2 = self.view.do.GetSliceSelection()
     
                 #if we're splitting colours/focal planes across the ccd, then only allow symetric ROIs
                 if 'splitting' in dir(self.scope.cam):
@@ -582,20 +581,18 @@ class PYMEMainFrame(acquire_server.AcquireHTTPServer, AUIFrame):
         #self.scope.cam.SetCOC()
         #self.scope.cam.GetStatus()
         self.scope.frameWrangler.Prepare()
-        self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
+        self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
         
-        self.vp.do.SetSelection((x1,y1,0), (x2,y2,0))
+        self.view.do.SetSelection((x1,y1,0), (x2,y2,0))
 
         logging.debug('Restarting frame wrangler with new ROI')
         self.scope.frameWrangler.start()
-        self.vp.Refresh()
-        self.vp.GetParent().Refresh()
+        self.view.Refresh()
+        self.view.GetParent().Refresh()
         #event.Skip()
 
     def SetCentredRoi(self, event=None, halfwidth=5):
         self.scope.frameWrangler.stop()
-
-        #print (self.scope.vp.selection.start.x, self.scope.vp.selection.start.y, self.scope.vp.selection.finish.x, self.scope.vp.selection.finish.y)
 
         w = self.scope.cam.GetCCDWidth()
         h = self.scope.cam.GetCCDHeight()
@@ -619,20 +616,41 @@ class PYMEMainFrame(acquire_server.AcquireHTTPServer, AUIFrame):
         #self.scope.cam.SetCOC()
         #self.scope.cam.GetStatus()
         self.scope.frameWrangler.Prepare()
-        self.vp.SetDataStack(self.scope.frameWrangler.currentFrame)
+        self.view.SetDataStack(self.scope.frameWrangler.currentFrame)
         
-        self.vp.do.SetSelection((x1,y1,0), (x2,y2,0))
+        self.view.do.SetSelection((x1,y1,0), (x2,y2,0))
 
         self.scope.frameWrangler.start()
-        self.vp.Refresh()
-        self.vp.GetParent().Refresh()
+        self.view.Refresh()
+        self.view.GetParent().Refresh()
         #event.Skip()
 
     def OnMDisplayClearSel(self, event):
-        self.vp.ResetSelection()
+        self.view.ResetSelection()
         #event.Skip()
 
+    @property
+    def view(self):
+        '''Return the current view panel. This is the panel that is used to display the camera data.
+        
+        deprecates .vp
+        
+        '''
+        try:
+            return self._view
+        except AttributeError:
+            raise AttributeError('View panel not yet created. This usually happens if .view is accessed too early in the initialisation process.')
 
+    @property
+    def vp(self):
+        ''' Backwards compatibility for access to the view panel
+        
+        Generates a deprecation warning - use .view instead
+        '''
+        import warnings
+        warnings.warn('The .vp attribute is deprecated. Use .view instead', DeprecationWarning)
+        return self.view
+    
     def OnCloseWindow(self, event):   
         self.scope.frameWrangler.stop()
         self.time1.Stop()


### PR DESCRIPTION
**Is this a bugfix or an enhancement?**
This is an enhancement with some small bugfix.

**Proposed changes:**
Apart from the GUI front-end that has been implemented in PR #1479, this further implements:
 - The `sub_roi` attribute for the `Correlator` object.
 - The `set_subroi` method.
 - The subclass `DriftROIOverlay` to draw an overlay.
