### PR TITLE
add a recipe module to modify the origin when needed

### DIFF
--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -2906,3 +2906,23 @@ class Offset(Filter):
             return data - self.offset_constant
         elif self.offset_selection == 'offset by minimum':
             return data - np.min(data)
+        
+
+@register_module('ModifyOrigin')
+class ModifyOrigin(Filter):
+    """
+    Modify the origin metadata 
+
+    Parameters
+    ----------
+    ROI_OriginX : the origin of x that the image will set to, int
+    ROI_OriginY : the origin of y that the image will set to, int
+    """
+    ROI_OriginX = Int(578)
+    ROI_OriginY = Int(519)
+    dimensionality = Enum('XY', desc='Which image dimensions should the filter be applied to?')
+
+    def applyFilter(self, data, chanNum, i, im):
+        im.mdh.Camera.ROIOriginX = self.ROI_OriginX
+        im.mdh.Camera.ROIOriginY = self.ROI_OriginY
+        return data


### PR DESCRIPTION
**Is this a bugfix or an enhancement?**
Enchancement

**Proposed changes:**
With this module we could modify the xy origin in PYMEImage. This could serve as the initial coarse offset before calculating the shiftmap of two cameras/modalities. I did not try do to it in PYMEAcquire because practically there would be some drift and the shiftmap should be calibrated regularly (once every 2 to 3 weeks). Every time the initial offset is a little bit different.

**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [√] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [√] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
