### PR TITLE
scaffold for sub-pixel drift correction for time series

### DIFF
--- a/PYME/DSView/modules/drift_correct.py
+++ b/PYME/DSView/modules/drift_correct.py
@@ -1,0 +1,94 @@
+import numpy as np
+from ._base import Plugin
+
+class DriftCorrector(Plugin):
+    def __init__(self, dsviewer):
+        Plugin.__init__(self, dsviewer)
+
+        dsviewer.AddMenuItem('Processing', 'Sub-pixel Drift Correction', self.OnSubPixelDriftCorrect)
+
+
+    def OnSubPixelDriftCorrect(self, event):
+        """sub-pixel lateral drift correction based on the drift tracking events
+        in the transmitted-light channel
+        """
+        from scipy import ndimage
+        from PYME.Analysis import piecewiseMapping as piecewise_mapping
+        from PYME.IO.DataSources import ArrayDataSource
+        from PYME.IO.DataSources import BaseDataSource
+        from PYME.IO.image import ImageStack
+        from PYME.DSView import ViewIm3D
+
+        ShiftMeasure_positions = []
+
+        if self.image.mdh.ActiveCamera == 'PcoEdge42LT':
+            print('oidic correction')
+        # image from single shot mode camera, cannot use piecewiseMapping.times_to_frames
+        # to match ShiftMeasure positions to the number of frames
+        #FIXME
+            for event in self.image.events:
+                if event['EventName'] == b'PYME2ShiftMeasure':
+                    positions = event['EventDescr'].decode('ascii').split(', ')
+                    ShiftMeasure_positions.append(np.array([float(pos) for pos in positions]))
+            ShiftMeasure_frames = np.arange(1, self.image.data_xyztc.shape[3]+1)
+            print(ShiftMeasure_frames)
+
+        else:
+            print('smlm correction')
+            ShiftMeasure_times= []
+            for event in self.image.events:
+                if event['EventName'] == b'ShiftMeasure':
+                    ShiftMeasure_times.append(float(event['Time']))
+                    positions = event['EventDescr'].decode('ascii').split(', ')
+                    ShiftMeasure_positions.append(np.array([float(pos) for pos in positions]))
+            ShiftMeasure_times = np.asarray(ShiftMeasure_times)
+            ShiftMeasure_frames = piecewise_mapping.times_to_frames(ShiftMeasure_times, 
+                                                                self.image.events, self.image.mdh).astype(int)
+            #ShiftMeasure_frames = ShiftMeasure_frames[0: ShiftMeasure_frames.shape[0]-1]
+            #print(np.shape(ShiftMeasure_positions))
+            #print(ShiftMeasure_frames.shape)
+    
+        X, Y, Z = np.mgrid[0:self.image.data_xyztc.shape[0], 0:self.image.data_xyztc.shape[1], 0:self.image.data_xyztc.shape[2]]
+    
+        vx, vy, vz = self.image.voxelsize
+        if vz == 0:
+            vz = 1
+
+        x0, y0, z0 = self.image.origin
+
+        Xnm = X * vx + x0
+        Ynm = Y * vy + y0
+        Znm = Z * vz + z0
+
+        print('Start correcting')
+        
+        drift_corrected = []
+        idx = 0
+        for t in ShiftMeasure_frames:
+            if t <= self.image.data_xyztc.shape[3]-1:
+                print(t)
+                corrected = ndimage.map_coordinates(np.atleast_3d(self.image.data_xyztc[:,:,:,t,0]), 
+                                          [(Xnm + ShiftMeasure_positions[idx][0]*vx - x0)/vx, 
+                                           (Ynm + ShiftMeasure_positions[idx][1]*vy - y0)/vy, 
+                                           (Znm + ShiftMeasure_positions[idx][2]*1000 - z0)/vz],
+                                   mode='nearest', order=3)
+                drift_corrected.append(corrected)
+                idx += 1
+
+        print('End correcting')
+
+        drift_corrected = np.asarray(drift_corrected)
+        drift_corrected.shape = (self.image.data_xyztc.shape[0], self.image.data_xyztc.shape[1], self.image.data_xyztc.shape[2], idx, 1)
+        #print(drift_corrected.shape)
+        im = BaseDataSource.XYZTCWrapper(ArrayDataSource.ArrayDataSource(drift_corrected), 'XYZTC', self.image.data_xyztc.shape[2], drift_corrected.shape[3], 1)
+        im = ImageStack(im)
+        #print(im.data_xyztc.shape)
+        im.mdh.copyEntriesFrom(self.image.mdh)
+
+        print('Start plotting')
+        ViewIm3D(im, mode=self.dsviewer.mode, glCanvas=self.dsviewer.glCanvas)
+
+
+def Plug(dsviewer):
+    return DriftCorrector(dsviewer)
+

--- a/PYME/DSView/modules/drift_correct.py
+++ b/PYME/DSView/modules/drift_correct.py
@@ -12,80 +12,35 @@ class DriftCorrector(Plugin):
         """sub-pixel lateral drift correction based on the drift tracking events
         in the transmitted-light channel
         """
-        from scipy import ndimage
-        from PYME.Analysis import piecewiseMapping as piecewise_mapping
-        from PYME.IO.DataSources import ArrayDataSource
-        from PYME.IO.DataSources import BaseDataSource
+        #from scipy import ndimage
+        #from PYME.IO.DataSources import ArrayDataSource
+        #from PYME.IO.DataSources import BaseDataSource
         from PYME.IO.image import ImageStack
         from PYME.DSView import ViewIm3D
+        from PYME.LMVis import pipeline
+        from PYME.IO.DataSources import DriftCorrectDataSource
 
-        ShiftMeasure_positions = []
+        # read lateral drift values from events
+        ev_mappings, _ = pipeline._processEvents(self.image.data_xyztc, self.image.events, self.image.mdh)
+        driftx = ev_mappings['driftx']
+        drifty = ev_mappings['drifty']
+        dx = driftx(np.arange(1, self.image.data_xyztc.shape[3]+1))   # in pixel unit
+        dy = drifty(np.arange(1, self.image.data_xyztc.shape[3]+1))   # in pixel unit
 
-        if self.image.mdh.ActiveCamera == 'PcoEdge42LT':
-            print('oidic correction')
-        # image from single shot mode camera, cannot use piecewiseMapping.times_to_frames
-        # to match ShiftMeasure positions to the number of frames
-        #FIXME
-            for event in self.image.events:
-                if event['EventName'] == b'PYME2ShiftMeasure':
-                    positions = event['EventDescr'].decode('ascii').split(', ')
-                    ShiftMeasure_positions.append(np.array([float(pos) for pos in positions]))
-            ShiftMeasure_frames = np.arange(1, self.image.data_xyztc.shape[3]+1)
-            print(ShiftMeasure_frames)
+        """
+        # correct lateral drift
+        drift_corrected = np.ones_like(self.image.data_xyztc[:,:,:,:,:].squeeze())
+        for t in range(self.image.data_xyztc.shape[3]):
+            corrected = ndimage.shift(self.image.data_xyztc.getSlice(t), shift=[-dx[t], -dy[t]], order=3, mode='nearest')
+            drift_corrected[:,:,t] *= corrected
 
-        else:
-            print('smlm correction')
-            ShiftMeasure_times= []
-            for event in self.image.events:
-                if event['EventName'] == b'ShiftMeasure':
-                    ShiftMeasure_times.append(float(event['Time']))
-                    positions = event['EventDescr'].decode('ascii').split(', ')
-                    ShiftMeasure_positions.append(np.array([float(pos) for pos in positions]))
-            ShiftMeasure_times = np.asarray(ShiftMeasure_times)
-            ShiftMeasure_frames = piecewise_mapping.times_to_frames(ShiftMeasure_times, 
-                                                                self.image.events, self.image.mdh).astype(int)
-            #ShiftMeasure_frames = ShiftMeasure_frames[0: ShiftMeasure_frames.shape[0]-1]
-            #print(np.shape(ShiftMeasure_positions))
-            #print(ShiftMeasure_frames.shape)
-    
-        X, Y, Z = np.mgrid[0:self.image.data_xyztc.shape[0], 0:self.image.data_xyztc.shape[1], 0:self.image.data_xyztc.shape[2]]
-    
-        vx, vy, vz = self.image.voxelsize
-        if vz == 0:
-            vz = 1
-
-        x0, y0, z0 = self.image.origin
-
-        Xnm = X * vx + x0
-        Ynm = Y * vy + y0
-        Znm = Z * vz + z0
-
-        print('Start correcting')
-        
-        drift_corrected = []
-        idx = 0
-        for t in ShiftMeasure_frames:
-            if t <= self.image.data_xyztc.shape[3]-1:
-                print(t)
-                corrected = ndimage.map_coordinates(np.atleast_3d(self.image.data_xyztc[:,:,:,t,0]), 
-                                          [(Xnm + ShiftMeasure_positions[idx][0]*vx - x0)/vx, 
-                                           (Ynm + ShiftMeasure_positions[idx][1]*vy - y0)/vy, 
-                                           (Znm + ShiftMeasure_positions[idx][2]*1000 - z0)/vz],
-                                   mode='nearest', order=3)
-                drift_corrected.append(corrected)
-                idx += 1
-
-        print('End correcting')
-
-        drift_corrected = np.asarray(drift_corrected)
-        drift_corrected.shape = (self.image.data_xyztc.shape[0], self.image.data_xyztc.shape[1], self.image.data_xyztc.shape[2], idx, 1)
-        #print(drift_corrected.shape)
-        im = BaseDataSource.XYZTCWrapper(ArrayDataSource.ArrayDataSource(drift_corrected), 'XYZTC', self.image.data_xyztc.shape[2], drift_corrected.shape[3], 1)
+        im = BaseDataSource.XYZTCWrapper(ArrayDataSource.ArrayDataSource(drift_corrected), 'XYZTC', self.image.data_xyztc.shape[2], drift_corrected.shape[2], 1)
         im = ImageStack(im)
-        #print(im.data_xyztc.shape)
         im.mdh.copyEntriesFrom(self.image.mdh)
+        """
 
-        print('Start plotting')
+        ds = DriftCorrectDataSource.XYZTCDriftCorrectSource(self.image.data_xyztc, dx, dy, x_scale=1.0, y_scale=1.0)
+        im = ImageStack(ds[:,:,:,:,:], mdh=ds.mdh)
         ViewIm3D(im, mode=self.dsviewer.mode, glCanvas=self.dsviewer.glCanvas)
 
 

--- a/PYME/DSView/modules/drift_correct.py
+++ b/PYME/DSView/modules/drift_correct.py
@@ -24,8 +24,8 @@ class DriftCorrector(Plugin):
         ev_mappings, _ = pipeline._processEvents(self.image.data_xyztc, self.image.events, self.image.mdh)
         driftx = ev_mappings['driftx']
         drifty = ev_mappings['drifty']
-        dx = driftx(np.arange(1, self.image.data_xyztc.shape[3]+1))   # in pixel unit
-        dy = drifty(np.arange(1, self.image.data_xyztc.shape[3]+1))   # in pixel unit
+        #dx = driftx(np.arange(1, self.image.data_xyztc.shape[3]+1))   # in pixel unit
+        #dy = drifty(np.arange(1, self.image.data_xyztc.shape[3]+1))   # in pixel unit
 
         """
         # correct lateral drift
@@ -39,7 +39,7 @@ class DriftCorrector(Plugin):
         im.mdh.copyEntriesFrom(self.image.mdh)
         """
 
-        ds = DriftCorrectDataSource.XYZTCDriftCorrectSource(self.image.data_xyztc, dx, dy, x_scale=1.0, y_scale=1.0)
+        ds = DriftCorrectDataSource.XYZTCDriftCorrectSource(self.image.data_xyztc, driftx, drifty, x_scale=1.0, y_scale=1.0)
         im = ImageStack(ds[:,:,:,:,:], mdh=ds.mdh)
         ViewIm3D(im, mode=self.dsviewer.mode, glCanvas=self.dsviewer.glCanvas)
 

--- a/PYME/IO/DataSources/DriftCorrectDataSource.py
+++ b/PYME/IO/DataSources/DriftCorrectDataSource.py
@@ -4,7 +4,7 @@ from scipy import ndimage
 
 class XYZTCDriftCorrectSource(XYZTCDataSource):
     moduleName = 'DriftCorrectDataSource'
-    
+    '''
     def __init__(self, datasource, x_mapping, y_mapping, x_scale=1.0, y_scale=1.0):
         if (not isinstance(datasource, XYZTCDataSource)) and (not datasource.ndim == 5) :
             datasource = XYZTCWrapper.auto_promote(datasource)
@@ -18,10 +18,32 @@ class XYZTCDriftCorrectSource(XYZTCDataSource):
         self._y_scale = y_scale
         
         XYZTCDataSource.__init__(self, input_order=datasource._input_order, size_z=size_z, size_t=size_t, size_c=size_c)
-    
+    '''
+    def __init__(self, datasource, x_mapping, y_mapping, px0, py0, px1, py1, relative_rotation_angle):
+        if (not isinstance(datasource, XYZTCDataSource)) and (not datasource.ndim == 5) :
+            datasource = XYZTCWrapper.auto_promote(datasource)
+        
+        self._datasource = datasource
+        size_z, size_t, size_c = datasource.shape[2:]
+
+        self._x_map = x_mapping # a piecewise mapping object
+        self._y_map = y_mapping
+        self._xx_scale = px0/px1
+        self._xy_scale = px0/py1
+        self._yx_scale = py0/px1
+        self._yy_scale = py0/py1
+        self._theta = relative_rotation_angle     # prepare for an affine transformation to allow for scaling and rotation
+        
+        XYZTCDataSource.__init__(self, input_order=datasource._input_order, size_z=size_z, size_t=size_t, size_c=size_c)
+
     def getSlice(self, ind):
         sl = self._datasource.getSlice(ind)
-        return ndimage.shift(sl, [-self._x_scale*self._x_map(np.array([ind+1])), -self._y_scale*self._y_map(np.array([ind+1]))], order=3, mode='nearest') 
+        x0 = self._x_map(np.array([ind+1]))
+        y0 = self._y_map(np.array([ind+1]))
+        x1 = x0*self._xx_scale*np.cos(self._theta) + y0*self._yx_scale*np.sin(self._theta)
+        y1 = y0*self._yy_scale*np.cos(self._theta) - x0*self._xy_scale*np.sin(self._theta)
+        #return ndimage.shift(sl, [-self._x_scale*self._x_map(np.array([ind+1])), -self._y_scale*self._y_map(np.array([ind+1]))], order=3, mode='nearest') 
+        return ndimage.shift(sl, [-x1, -y1], order=3, mode='nearest') 
     
    # proxy original data source attributes 
     def __getattr__(self, item):

--- a/PYME/IO/DataSources/DriftCorrectDataSource.py
+++ b/PYME/IO/DataSources/DriftCorrectDataSource.py
@@ -1,0 +1,43 @@
+from .BaseDataSource import XYZTCDataSource, XYZTCWrapper
+import numpy as np
+from scipy import ndimage
+
+class XYZTCDriftCorrectSource(XYZTCDataSource):
+    moduleName = 'DriftCorrectDataSource'
+    
+    def __init__(self, datasource, x_mapping, y_mapping, x_scale=1.0, y_scale=1.0):
+        if (not isinstance(datasource, XYZTCDataSource)) and (not datasource.ndim == 5) :
+            datasource = XYZTCWrapper.auto_promote(datasource)
+        
+        self._datasource = datasource
+        size_z, size_t, size_c = datasource.shape[2:]
+
+        self._x_map = x_mapping # a piecewise mapping object
+        self._x_scale = x_scale #allows conversion between different camera pixel units. TODO - make it an affine transformation matrix to allow for rotation as well.
+        self._y_map = y_mapping
+        self._y_scale = y_scale
+        
+        XYZTCDataSource.__init__(self, input_order=datasource._input_order, size_z=size_z, size_t=size_t, size_c=size_c)
+    
+    def getSlice(self, ind):
+        sl = self._datasource.getSlice(ind)
+        return ndimage.shift(sl, [self._x_scale*self._x_map(ind), self._y_scale*self._y_map(ind)]) 
+    
+   # proxy original data source attributes 
+    def __getattr__(self, item):
+        return getattr(self._datasource, item)
+        
+    def getSliceShape(self):
+        return self._datasource.getSliceShape()
+
+    def getNumSlices(self):
+        return self._datasource.getNumSlices()
+
+    def getEvents(self):
+        return self._datasource.getEvents()
+
+    @property
+    def is_complete(self):
+        return self._datasource.is_complete()
+    
+    

--- a/PYME/IO/DataSources/DriftCorrectDataSource.py
+++ b/PYME/IO/DataSources/DriftCorrectDataSource.py
@@ -21,7 +21,7 @@ class XYZTCDriftCorrectSource(XYZTCDataSource):
     
     def getSlice(self, ind):
         sl = self._datasource.getSlice(ind)
-        return ndimage.shift(sl, [-self._x_scale*self._x_map[ind], -self._y_scale*self._y_map[ind]], order=3, mode='nearest') 
+        return ndimage.shift(sl, [-self._x_scale*self._x_map(np.array([ind+1])), -self._y_scale*self._y_map(np.array([ind+1]))], order=3, mode='nearest') 
     
    # proxy original data source attributes 
     def __getattr__(self, item):

--- a/PYME/IO/DataSources/DriftCorrectDataSource.py
+++ b/PYME/IO/DataSources/DriftCorrectDataSource.py
@@ -21,7 +21,7 @@ class XYZTCDriftCorrectSource(XYZTCDataSource):
     
     def getSlice(self, ind):
         sl = self._datasource.getSlice(ind)
-        return ndimage.shift(sl, [self._x_scale*self._x_map(ind), self._y_scale*self._y_map(ind)]) 
+        return ndimage.shift(sl, [-self._x_scale*self._x_map[ind], -self._y_scale*self._y_map[ind]], order=3, mode='nearest') 
     
    # proxy original data source attributes 
     def __getattr__(self, item):
@@ -39,5 +39,4 @@ class XYZTCDriftCorrectSource(XYZTCDataSource):
     @property
     def is_complete(self):
         return self._datasource.is_complete()
-    
     

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -273,6 +273,23 @@ def _processEvents(ds, events, mdh):
 
             # self.eventCharts = eventCharts
             # self.ev_mappings = ev_mappings
+
+        if b'PYME2ShiftMeasure' in evKeyNames:
+            driftx = piecewiseMapping.GeneratePMFromEventList(events, mdh, mdh.getEntry('StartTime'), 0, b'PYME2ShiftMeasure',
+                                                              0)
+            drifty = piecewiseMapping.GeneratePMFromEventList(events, mdh, mdh.getEntry('StartTime'), 0, b'PYME2ShiftMeasure',
+                                                              1)
+            driftz = piecewiseMapping.GeneratePMFromEventList(events, mdh, mdh.getEntry('StartTime'), 0, b'PYME2ShiftMeasure',
+                                                              2)
+
+            ev_mappings['driftx'] = driftx
+            ev_mappings['drifty'] = drifty
+            ev_mappings['driftz'] = driftz
+
+            eventCharts.append(('X Drift [px]', driftx, 'PYME2ShiftMeasure'))
+            eventCharts.append(('Y Drift [px]', drifty, 'PYME2ShiftMeasure'))
+            eventCharts.append(('Z Drift [px]', driftz, 'PYME2ShiftMeasure'))
+
     elif all(k in mdh.keys() for k in ['StackSettings.FramesPerStep', 'StackSettings.StepSize',
                                        'StackSettings.NumSteps', 'StackSettings.NumCycles']):
         # TODO - Remove this code - anytime we get here it's generally the result of an error in the input data

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -2916,17 +2916,26 @@ class SubPixelDriftCorrect(ModuleBase):
 
     Parameters
     ----------
-    input_name : Input
+    input : Input
         PYME.IO.ImageStack
+    drift_tracking_channel_pixel_size_x : Float
+        Pixel value of the drift tracking channel in x, in nm unit
+    drift_tracking_channel_pixel_size_y : Float
+        Pixel value of the drift tracking channel in y, in nm unit
+    relative_rotation : Float
+        relative rotation degree from the drift tracking channel to the channel to be corrected, in degree
 
     Returns
     -------
-    output_name = Output
+    output = Output
         PYME.IO.ImageStack
 
     """
 
     input = Input('input')
+    drift_tracking_channel_pixel_size_x = Float(64.5)
+    drift_tracking_channel_pixel_size_y = Float(64.5)
+    relative_rotation = Float(0.0)
     output = Output('sub_pixel_drift_corrected')
 
     def run(self, input):
@@ -2939,8 +2948,14 @@ class SubPixelDriftCorrect(ModuleBase):
         ev_mappings, _ = pipeline._processEvents(input.data_xyztc, input.events, input.mdh)
         driftx = ev_mappings['driftx']
         drifty = ev_mappings['drifty']
+
+        px0 = self.drift_tracking_channel_pixel_size_x
+        py0 = self.drift_tracking_channel_pixel_size_y
+        px1 = input.mdh.voxelsize.x * 1e3
+        py1 = input.mdh.voxelsize.y * 1e3
+        theta = self.relative_rotation * np.pi/180
     
-        ds = DriftCorrectDataSource.XYZTCDriftCorrectSource(input.data_xyztc, driftx, drifty, x_scale=1.0, y_scale=1.0)
+        ds = DriftCorrectDataSource.XYZTCDriftCorrectSource(input.data_xyztc, driftx, drifty, px0, py0, px1, py1, theta)
         im = ImageStack(ds[:,:,:,:,:], mdh=input.mdh)
         #ViewIm3D(im, mode=self.dsviewer.mode, glCanvas=self.dsviewer.glCanvas)
 


### PR DESCRIPTION
**Is this a bugfix or an enhancement?**
Enhancement

**Proposed changes:**
Sub-pixel drift correction for time series. This is a work in progress, currently only showing a scaffold of the idea. It runs but: the result is problematic; the speed is slow; the code is system-specific for the microscope I am building. Would like to see if there would be any ideas.
@David-Baddeley 





**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [Yes] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [Yes] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [Yes] Does this change how users interact with the software? How will these changes be communicated? This function can be used in `PYMEImage` by clicking the drop down menu Modules-->drift_correct and then clicking the drop down menu Processing-->Sub-pixel Drift Correction. The drift corrected image will be shown in a new window.
- [Yes] Does this maintain backwards compatibility with old data?
- [No] Does this change the required dependencies?
- [No] Are there any other side effects of the change?
