### PR TITLE
Queued actions improvements

### DIFF
--- a/PYME/Acquire/ActionManager.py
+++ b/PYME/Acquire/ActionManager.py
@@ -236,6 +236,12 @@ class ActionManager(object):
         
         if (self.isLastTaskDone is None) or self.isLastTaskDone():
             try:
+                self.currentTask.finalise(self.scope())
+                self.currentTask = None
+            except AttributeError:
+                pass
+
+            try:
                 self.currentTask = self.actionQueue.get_nowait()
                 nice, action, expiry, max_duration = self.currentTask
                 self._cur_task_kill_time = time.time() + max_duration

--- a/PYME/Acquire/Hardware/AndorNeo/AndorNeo.py
+++ b/PYME/Acquire/Hardware/AndorNeo/AndorNeo.py
@@ -454,7 +454,7 @@ class AndorBase(SDK3Camera):
         pass
 
     def StartExposure(self):
-        #make sure no acquisiton is running
+        #make sure no acquisition is running
         self.StopAq()
         self._temp = self.SensorTemperature.getValue()
         self._frameRate = self.FrameRate.getValue()

--- a/PYME/Acquire/Hardware/AndorNeo/AndorZyla.py
+++ b/PYME/Acquire/Hardware/AndorNeo/AndorZyla.py
@@ -552,7 +552,7 @@ class AndorBase(SDK3Camera, CameraMapMixin):
 
 
     def StartExposure(self):
-        #make sure no acquisiton is running
+        #make sure no acquisition is running
         self.StopAq()
         self._temp = self.SensorTemperature.getValue()
         self._frameRate = self.FrameRate.getValue()

--- a/PYME/Acquire/Hardware/pco/pco_sdk.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk.py
@@ -1123,7 +1123,7 @@ def get_acquire_mode(handle):
     Returns
     -------
     mode : unsigned short int
-        Camera acquisiton mode. One of PCO_ACQUIRE_AUTO (0), PCO_ACQUIRE_EXTERNAL (1), 
+        Camera acquisition mode. One of PCO_ACQUIRE_AUTO (0), PCO_ACQUIRE_EXTERNAL (1), 
         PCO_ACQUIRE_EXTERNAL_MODULATE (2).
     """
     mode = ctypes.wintypes.WORD()
@@ -1144,7 +1144,7 @@ def set_acquire_mode(handle, mode):
     handle : ctypes.wintypes.HANDLE
         Unique pco. camera handle (pointer).
     mode : unsigned short int
-        Camera acquisiton mode. One of PCO_ACQUIRE_AUTO (0), PCO_ACQUIRE_EXTERNAL (1), 
+        Camera acquisition mode. One of PCO_ACQUIRE_AUTO (0), PCO_ACQUIRE_EXTERNAL (1), 
         PCO_ACQUIRE_EXTERNAL_MODULATE (2).
     """
     check_status(sc2_cam.PCO_GetAcquireMode(handle, ctypes.wintypes.WORD(mode)))

--- a/PYME/Acquire/Scripts/init_sim_main.py
+++ b/PYME/Acquire/Scripts/init_sim_main.py
@@ -202,12 +202,12 @@ def drift_tracking(MainFrame, scope):
     import wx
 
 
-    def _drift_init():
+    #def _drift_init():
         #scope.p_drift = subprocess.Popen('%s "%s" -i init_drift_tracking.py -t "Drift Tracking" -m "compact"' % (sys.executable, PYMEAcquire.__file__), shell=True)
-        scope.p_drift = subprocess.Popen('%s "%s" -i init_sim_drift_tracking.py -s -p 8155 -t "Drift Tracking"' % (sys.executable, PYMEAcquire.__file__), shell=True)#, creationflags=subprocess.CREATE_NEW_CONSOLE)
+    scope.p_drift = subprocess.Popen('%s "%s" -i init_sim_drift_tracking.py -s -p 8155 -t "Drift Tracking"' % (sys.executable, PYMEAcquire.__file__), shell=True)#, creationflags=subprocess.CREATE_NEW_CONSOLE)
 
-    time.sleep(15)
-    _drift_init()
+    #time.sleep(15)
+    #_drift_init()
 
     # create a client for the drift tracking server process
     # this should be safe to do here, as the connection to the server is only made on demand

--- a/PYME/Acquire/Scripts/init_sim_main.py
+++ b/PYME/Acquire/Scripts/init_sim_main.py
@@ -1,0 +1,229 @@
+#!/usr/bin/python
+
+##################
+# init.py
+#
+# Copyright David Baddeley, 2009
+# d.baddeley@auckland.ac.nz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##################
+
+#!/usr/bin/python
+from PYME.Acquire.ExecTools import joinBGInit, HWNotPresent, init_gui, init_hardware
+from PYME import config
+import scipy
+import time
+
+# Set a microscope name which describes this hardware configuration (e.g. a room number or similar)
+# Used with the splitting ratio database and in other places where a microscope identifier is required.
+scope.microscope_name = 'PYMESimulator'
+
+# set some defaults for PYMEAcquire
+# uncomment the line below for high-thoughput style directory hashing
+# config.config['acquire-spool_subdirectories'] = True
+
+@init_hardware('Fake Piezos')
+def pz(scope):
+    from PYME.Acquire.Hardware.Simulator import fakePiezo
+    from PYME.Acquire.Hardware.Piezos import offsetPiezoREST
+
+    scope._fakePiezo = fakePiezo.FakePiezo(100)
+    #scope.register_piezo(scope.fakePiezo, 'z', needCamRestart=True)
+
+    scope.fakePiezo = offsetPiezoREST.server_class()(scope._fakePiezo)
+    scope.register_piezo(scope.fakePiezo, 'z', needCamRestart=True)
+
+    
+    scope.fakeXPiezo = fakePiezo.FakePiezo(10000)
+    scope.register_piezo(scope.fakeXPiezo, 'x')
+    
+    scope.fakeYPiezo = fakePiezo.FakePiezo(10000)
+    scope.register_piezo(scope.fakeYPiezo, 'y')
+
+pz.join() #piezo must be there before we start camera
+
+
+@init_hardware('Fake Camera')
+def cm(scope):
+    import numpy as np
+    from PYME.Acquire.Hardware.Simulator import fakeCam
+    cam = fakeCam.FakeCamera(256, #70*np.arange(0.0, 4*256.0),
+                                             256, #70*np.arange(0.0, 256.0),
+                                             fakeCam.NoiseMaker(),
+                                             scope.fakePiezo, xpiezo = scope.fakeXPiezo,
+                                             ypiezo = scope.fakeYPiezo,
+                                             pixel_size_nm=70.,
+                                             )
+    cam.SetEMGain(150)
+    scope.register_camera(cam,'Fake Camera')
+
+#scope.EnableJoystick = 'foo'
+
+#InitBG('Should Fail', """
+#raise Exception, 'test error'
+#time.sleep(1)
+#""")
+#
+#InitBG('Should not be there', """
+#raise HWNotPresent, 'test error'
+#time.sleep(1)
+#""")
+
+
+# @init_gui('Simulation UI')
+# def sim_controls(MainFrame, scope):
+#     from PYME.Acquire.Hardware.Simulator import dSimControl
+#     dsc = dSimControl.dSimControl(MainFrame, scope)
+#     MainFrame.AddPage(page=dsc, select=False, caption='Simulation Settings')
+#
+#     scope.dsc = dsc
+
+
+@init_gui('Simulation UI')
+def sim_controls(MainFrame, scope):
+    from PYME.Acquire.Hardware.Simulator import simcontrol, simui_wx
+    scope.simcontrol = simcontrol.SimController(scope)
+    dsc = simui_wx.dSimControl(MainFrame, scope.simcontrol)
+    MainFrame.AddPage(page=dsc, select=False, caption='Simulation Settings')
+    
+    scope.dsc = dsc
+
+@init_gui('Camera controls')
+def cam_controls(MainFrame, scope):
+    from PYME.Acquire.Hardware.AndorIXon import AndorControlFrame
+    scope.camControls['Fake Camera'] = AndorControlFrame.AndorPanel(MainFrame, scope.cam, scope)
+    MainFrame.camPanels.append((scope.camControls['Fake Camera'], 'EMCCD Properties', False))
+
+@init_gui('Sample database')
+def samp_db(MainFrame, scope):
+    from PYME.Acquire import sampleInformation
+    from PYME.IO import MetaDataHandler
+    
+    MetaDataHandler.provideStartMetadata.append(lambda mdh: sampleInformation.getSampleDataFailsafe(MainFrame, mdh))
+    
+    sampPan = sampleInformation.slidePanel(MainFrame)
+    MainFrame.camPanels.append((sampPan, 'Current Slide'))
+
+# @init_gui('Analysis settings')
+# def anal_settings(MainFrame, scope):
+#     from PYME.Acquire.ui import AnalysisSettingsUI
+#     AnalysisSettingsUI.Plug(scope, MainFrame)
+
+@init_gui('Fake DMD')
+def fake_dmd(MainFrame, scope):
+    from PYMEnf.Hardware import FakeDMD
+    from PYME.Acquire.Hardware import DMDGui
+    scope.LC = FakeDMD.FakeDMD(scope)
+    
+    LCGui = DMDGui.DMDPanel(MainFrame,scope.LC, scope)
+    MainFrame.camPanels.append((LCGui, 'DMD Control', False))
+
+
+#InitGUI("""
+#from PYME.Acquire.Hardware import ccdAdjPanel
+##import wx
+##f = wx.Frame(None)
+#snrPan = ccdAdjPanel.sizedCCDPanel(notebook1, scope, acf)
+#notebook1.AddPage(page=snrPan, select=False, caption='Image SNR')
+##camPanels.append((snrPan, 'SNR etc ...'))
+##f.Show()
+##time1.register_callback(snrPan.ccdPan.draw)
+#""")
+
+cm.join()
+
+@init_hardware('Lasers')
+def lasers(scope):
+    from PYME.Acquire.Hardware import lasers
+    scope.l488 = lasers.FakeLaser('l488',scope.cam,1, initPower=10)
+    scope.l488.register(scope)
+    scope.l405 = lasers.FakeLaser('l405',scope.cam,0, initPower=10)
+    scope.l405.register(scope)
+    
+
+@init_gui('Laser controls')
+def laser_controls(MainFrame, scope):
+    from PYME.Acquire.ui import lasersliders
+    
+    #lcf = lasersliders.LaserToggles(MainFrame.toolPanel, scope.state)
+    #MainFrame.time1.register_callback(lcf.update)
+    #MainFrame.camPanels.append((lcf, 'Laser Control'))
+    
+    lsf = lasersliders.LaserSliders(MainFrame.toolPanel, scope.state)
+    MainFrame.time1.register_callback(lsf.update)
+    MainFrame.camPanels.append((lsf, 'Laser Control'))
+
+@init_gui('Focus Keys')
+def focus_keys(MainFrame, scope):
+    from PYME.Acquire.Hardware import focusKeys
+    fk = focusKeys.FocusKeys(MainFrame, scope.piezos[0])
+
+
+#InitGUI("""
+#from PYME.Acquire.Hardware import splitter
+#splt = splitter.Splitter(MainFrame, None, scope, scope.cam)
+#""")
+
+@init_gui('Action manager')
+def action_manager(MainFrame, scope):
+    from PYME.Acquire.ui import actionUI
+    
+    ap = actionUI.ActionPanel(MainFrame, scope.actions, scope)
+    MainFrame.AddPage(ap, caption='Queued Actions')
+
+
+@init_gui('Tiling')
+def action_manager(MainFrame, scope):
+    from PYME.Acquire.ui import tile_panel
+    
+    ap = tile_panel.TilePanel(MainFrame, scope)
+    MainFrame.aqPanels.append((ap, 'Tiling'))
+
+@init_gui('Drift tracking')
+def drift_tracking(MainFrame, scope):
+    import subprocess
+    import sys
+    import time
+    from PYME.Acquire import PYMEAcquire
+    from PYME.Acquire import acquire_client
+    import wx
+
+
+    def _drift_init():
+        #scope.p_drift = subprocess.Popen('%s "%s" -i init_drift_tracking.py -t "Drift Tracking" -m "compact"' % (sys.executable, PYMEAcquire.__file__), shell=True)
+        scope.p_drift = subprocess.Popen('%s "%s" -i init_sim_drift_tracking.py -s -p 8155 -t "Drift Tracking"' % (sys.executable, PYMEAcquire.__file__), shell=True)#, creationflags=subprocess.CREATE_NEW_CONSOLE)
+
+    time.sleep(15)
+    _drift_init()
+
+    # create a client for the drift tracking server process
+    # this should be safe to do here, as the connection to the server is only made on demand
+    scope.remote_acquire_instance = acquire_client.AcquireClient('localhost', 8155)
+
+
+#must be here!!!
+joinBGInit() #wait for anyhting which was being done in a separate thread
+
+#import numpy
+#psf = numpy.load(r'd:\psf647.npy')
+#psf = numpy.maximum(psf, 0.)
+#from PYME.Analysis import MetaData
+#fakeCam.rend_im.setModel(psf, MetaData.TIRFDefault)
+
+#time.sleep(.5)
+scope.initDone = True
+
+

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -212,15 +212,8 @@ class SpoolController(object):
             return ['File', 'Cluster', 'Memory']
         
     def get_info(self):
-        info =  {'settings' : {'method' : self.spoolType,
-                                'hdf_compression_level': self.hdf_compression_level,
-                                'z_stepped' : self.protocol_settings.z_stepped,
-                                'z_dwell' : self.protocol_settings.z_dwell,
-                                'cluster_h5' : self.cluster_h5,
-                                'pzf_compression_settings' : self.pzf_compression_settings,
-                                'protocol_name' : self.protocol_settings.protocol.filename,
-                                'series_name' : self.seriesName
-                              },
+        info =  {'settings' : self.get_settings(),
+                 'series_name' : self.seriesName,
                  'available_spool_methods' : self.available_spool_methods
                 }
         
@@ -622,14 +615,13 @@ class SpoolController(object):
             # TODO - does this need to be longer for tiling??
             return 30*60  
     
-    def get_settings(self):
+    def get_settings(self, method_only=False):
         """Get the current settings for the spool controller
         
         Used when adding actions to the action manager - this should freeze
         the relevant settings for the acquisition type and method.
         """
-        settings = {'acquisiton_type' : self.acquisition_type,
-                    'method' : self.spoolType,
+        settings = {'method' : self.spoolType,
         }
 
         if self.spoolType == 'File':
@@ -639,9 +631,14 @@ class SpoolController(object):
             settings['cluster_h5'] = self.cluster_h5
             settings['pzf_compression_settings'] = self.pzf_compression_settings
 
-        settings.update(self.acquisition_types[self.acquisition_type].get_frozen_settings(self.scope, self)) 
+        if method_only:
+            return settings
         
-        return settings
+        else:
+            settings['acquisition_type'] = self.acquisition_type
+            settings.update(self.acquisition_types[self.acquisition_type].get_frozen_settings(self.scope, self)) 
+            
+            return settings
 
     
     def _display_image(self):

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -587,6 +587,28 @@ class SpoolController(object):
         #return a function which can be called to indicate if we are done
         return lambda : self.spooler.spool_complete
     
+    def get_settings(self):
+        """Get the current settings for the spool controller
+        
+        Used when adding actions to the action manager - this should freeze
+        the relevant settings for the acquisition type and method.
+        """
+        settings = {'acquisiton_type' : self.acquisition_type,
+                    'method' : self.spoolType,
+        }
+
+        if self.spoolType == 'File':
+            settings['hdf_compression_level'] = self.hdf_compression_level
+
+        if self.spoolType == 'Cluster':
+            settings['cluster_h5'] = self.cluster_h5
+            settings['pzf_compression_settings'] = self.pzf_compression_settings
+
+        settings.update(self.acquisition_types[self.acquisition_type].get_frozen_settings(self.scope, self)) 
+        
+        return settings
+
+    
     def _display_image(self):
         ''' Display the image in a viewer (for memory backend)
         '''

--- a/PYME/Acquire/acquisition_base.py
+++ b/PYME/Acquire/acquisition_base.py
@@ -73,7 +73,7 @@ class AcquisitionBase(abc.ABC):
         '''Start the acquisition
         
         This will usually record any metadata, connect self.on_frame to a frame source (i.e. scope.frameWrangler.onFrame), and initialise
-        the backend. It should not block, with the bulk of the acquisiton logic taking place in frame source handler.
+        the backend. It should not block, with the bulk of the acquisition logic taking place in frame source handler.
         
         '''
         pass

--- a/PYME/Acquire/acquisition_base.py
+++ b/PYME/Acquire/acquisition_base.py
@@ -58,6 +58,16 @@ class AcquisitionBase(abc.ABC):
         '''
         pass
 
+    @classmethod
+    def get_frozen_settings(cls, scope, spool_controller=None):
+        '''Return a dictionary of settings for the acquisition
+        
+        Used to "freeze" the state of the spool_controller and/or other settings objects when queueing
+        acquisitions for subsequent execution via the ActionManager
+        '''
+
+        return {}
+    
     @abc.abstractmethod
     def start(self):
         '''Start the acquisition

--- a/PYME/Acquire/actions.py
+++ b/PYME/Acquire/actions.py
@@ -25,6 +25,19 @@ class Action(object):
             return '- then -> %s' % repr(self._then)
         else:
             return ''
+        
+    def _estimated_duration(self, scope):
+        '''Return the estimated duration of the action in seconds'''
+        return 1.0
+    
+    def estimated_duration(self, scope):
+        t =  self._estimated_duration(scope)
+
+        then = getattr(self, '_then', None)
+        if then:
+            t += then.estimated_duration(scope)
+
+        return t
 
 
 class FunctionAction(Action):
@@ -128,6 +141,9 @@ class SpoolSeries(Action):
     
     def __repr__(self):
         return 'SpoolSeries(%s)' % ', '.join(['%s = %s' % (k,repr(v)) for k, v in self._args.items()])
+    
+    def _estimated_duration(self, scope):
+        return scope.spoolController.estimate_spool_time(**self._args)
 
 
 def action_from_dict(serialised):

--- a/PYME/Acquire/actions.py
+++ b/PYME/Acquire/actions.py
@@ -18,6 +18,13 @@ class Action(object):
             d['then'] = then.serialise()
         
         return {self.__class__.__name__: d}
+    
+    @property
+    def _repr_then(self):
+        if self._then is not None:
+            return '- then -> %s' % repr(self._then)
+        else:
+            return ''
 
 
 class FunctionAction(Action):
@@ -39,7 +46,7 @@ class FunctionAction(Action):
         return fcn(**self._args)
     
     def __repr__(self):
-        return 'FunctionAction: %s(%s)' % (self._fcn, self._args)
+        return 'FunctionAction: %s(%s)' % (self._fcn, self._args) + self._repr_then
 
 
 class StateAction(Action):
@@ -72,10 +79,33 @@ class UpdateState(StateAction):
         return self._do_then(scope)
     
     def __repr__(self):
-        return 'UpdateState: %s' % self._state
+        return 'UpdateState: %s' % self._state + self._repr_then
 
+class MoveTo(StateAction):
+    """
+    Move to a specific position in absolute stage coordinates.
+
+    Most useful when queueing actions to return to a specific
+    already identified position.
+    """
+    def __init__(self, x, y):
+        StateAction.__init__(self, x=x, y=y)
+        self.x, self.y = x, y
+    
+    def __call__(self, scope):
+        scope.SetPos(x=self.x, y=self.y)
+        return self._do_then(scope)
+    
+    def __repr__(self):
+        return 'MoveTo: %f, %f (x, y)' % (self.x, self.y) + self._repr_then
 
 class CentreROIOn(StateAction):
+    """
+    Centre the ROI on a specific position in absolute stage coordinates.
+
+    Most useful when queueing actions where target have been automatically
+    identified.
+    """
     def __init__(self, x, y):
         StateAction.__init__(self, x=x, y=y)
         self.x, self.y = x, y
@@ -85,7 +115,7 @@ class CentreROIOn(StateAction):
         return self._do_then(scope)
     
     def __repr__(self):
-        return 'CentreROIOn: %f, %f (x, y)' % (self.x, self.y)
+        return 'CentreROIOn: %f, %f (x, y)' % (self.x, self.y) + self._repr_then
 
 
 class SpoolSeries(Action):

--- a/PYME/Acquire/microscope.py
+++ b/PYME/Acquire/microscope.py
@@ -398,6 +398,18 @@ class Microscope(object):
         dx, dy = self.get_roi_offset()
         
         self.SetPos(x=(x-dx), y=(y-dy))
+
+    def get_roi_centre(self):
+        """Convenience function to get the centre of the ROI
+        
+        exists to allow both automatically and manually specified actions to use the same code
+        """
+        dx, dy = self.get_roi_offset()
+        pos = self.GetPos()
+
+        return pos['x'] + dx, pos['y'] + dy
+
+
             
     def GetPosRange(self):
         #Todo - fix to use positioning

--- a/PYME/Acquire/protocol_acquisition.py
+++ b/PYME/Acquire/protocol_acquisition.py
@@ -131,7 +131,16 @@ class ProtocolAcquisition(AcquisitionBase):
                     maxFrames=settings.get('max_frames', sys.maxsize),
                     stack_settings=settings.get('stack_settings', None),
                     backend=backend, backend_kwargs=backend_kwargs,) 
-                   
+
+    @classmethod
+    def get_frozen_settings(cls, scope, spool_controller=None):
+        settings = {'z_stepped' : spool_controller.protocol_settings.z_stepped,
+                'z_dwell' : spool_controller.protocol_settings.z_dwell,} 
+        
+        if not spool_controller.protocol_settings.protocol in [p.NullProtocol, p.NullZProtocol]:
+            settings['protocol_name'] = spool_controller.protocol_settings.protocol.filename
+
+        return settings           
 
 
     def _create_backend(self, backend_type=acquisition_backends.HDFBackend, **kwargs):

--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##################
-"""The GUI controls for streaming acquisiton.
+"""The GUI controls for streaming acquisition.
 
 """
 

--- a/PYME/Acquire/ui/actionUI.py
+++ b/PYME/Acquire/ui/actionUI.py
@@ -11,6 +11,7 @@ import time
 
 from PYME.Acquire import actions
 from PYME.ui import cascading_layout
+from PYME.ui import progress
 
 logger = logging.getLogger(__name__)
 
@@ -29,11 +30,11 @@ class ActionList(wx.ListCtrl):
         self.InsertColumn(3, "Expiry")
         self.InsertColumn(4, 'Max Duration')
         
-        self.SetColumnWidth(0, 50)
+        self.SetColumnWidth(0, 60)
         self.SetColumnWidth(1, 50)
         self.SetColumnWidth(2, 600)
         #self.SetColumnWidth(2, 450)
-        self.SetColumnWidth(3, 50)
+        self.SetColumnWidth(3, 60)
         self.SetColumnWidth(4, 200)
 
 
@@ -49,7 +50,11 @@ class ActionList(wx.ListCtrl):
                 return time.strftime('%H:%M:%S', time.localtime(when))
         
         val = vals[col-1]
-        return repr(val)
+
+        if col == 3: # expiry is a timestamp
+            return time.strftime('%H:%M:%S', time.localtime(val))
+        else:
+            return repr(val)
         
     def update(self, **kwargs):
         self._queueItems = list(self.actionManager.actionQueue.queue)
@@ -80,6 +85,7 @@ except ImportError:
 class SingleActionPanel(wx.Panel, cascading_layout.CascadingLayoutMixin):
     description='An action that does something'
     supports_then =True
+    num_actions = 1
 
     def __init__(self, parent, actionManager, scope):
         wx.Panel.__init__(self, parent)
@@ -100,7 +106,7 @@ class SingleActionPanel(wx.Panel, cascading_layout.CascadingLayoutMixin):
             self.cThen.Bind(wx.EVT_CHOICE, self.OnThenChanged)
             hsizer.Add(self.cThen, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
 
-            sizer.Add(hsizer, 0, wx.EXPAND, 0)
+            sizer.Add(hsizer, 0, wx.EXPAND|wx.TOP, 5)
 
             self._then_sizer = wx.BoxSizer(wx.VERTICAL)
             sizer.Add(self._then_sizer, 0, wx.EXPAND|wx.LEFT, 20)
@@ -125,18 +131,23 @@ class SingleActionPanel(wx.Panel, cascading_layout.CascadingLayoutMixin):
 
         #print('re-layouting')
         self.cascading_layout()
-        
 
-    def get_action(self):
-        action = self._get_action()
+    def _set_then(self, then):
+        self.cThen.SetSelection(ACTION_TYPES.index(then)+1)
+        self.OnThenChanged(None)
+    
+    def get_action(self, idx=0):
+        action = self._get_action(idx)
         
         if self._pan_then:
-            return action.then(self._pan_then.get_action())
+            return action.then(self._pan_then.get_action(idx))
         else:
             return action
         
-
-    def _get_action(self):
+    def get_actions(self):
+        return [self.get_action(i) for i in range(self.num_actions)]
+        
+    def _get_action(self, idx=0):
         """Return an Action object that represents the current state of the panel
         
         This should be implemented in an action-specific subclass.
@@ -165,7 +176,7 @@ class MoveToPanel(SingleActionPanel):
         self.tX.SetValue('%.2f' % pos['x'])
         self.tY.SetValue('%.2f' % pos['y'])
 
-    def _get_action(self):
+    def _get_action(self, idx=0):
         x = float(self.tX.GetValue())
         y = float(self.tY.GetValue())
         return actions.MoveTo(x, y)
@@ -179,28 +190,161 @@ class UpdateStatePanel(SingleActionPanel):
         
         sizer.Add(hsizer, 0, wx.EXPAND, 0)
 
-    def _get_action(self):
+    def _get_action(self, idx=0):
         # TODO - use a cleaner dictionary editor
         state = eval('dict(%s)' % self.tState.GetValue())
         return actions.UpdateState(state)
 
 class CenterROIOnPanel(SingleActionPanel):
     def _init_controls(self, sizer):
+        
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
-        hsizer.Add(wx.StaticText(self, -1, 'X:'), 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
+        self.rbModeSingle = wx.RadioButton(self, -1, 'Single ROI', style=wx.RB_GROUP)
+        self.rbModeSingle.SetValue(True)
+        self.rbModeSingle.Bind(wx.EVT_RADIOBUTTON, self.OnSetMode)
+        hsizer.Add(self.rbModeSingle, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
+
+        self.rbModeROIList = wx.RadioButton(self, -1, 'ROI List')
+        self.rbModeROIList.Bind(wx.EVT_RADIOBUTTON, self.OnSetMode)
+        hsizer.Add(self.rbModeROIList, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
+
+        sizer.Add(hsizer, 0, wx.EXPAND, 0)
+        
+        # single mode
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.stXLabel = wx.StaticText(self, -1, 'X:')
+        hsizer.Add(self.stXLabel, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
         self.tX = wx.TextCtrl(self, -1, '0', size=(50, -1))
         hsizer.Add(self.tX, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
         
-        hsizer.Add(wx.StaticText(self, -1, 'Y:'), 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
+        self.stYLabel = wx.StaticText(self, -1, 'Y:')
+        hsizer.Add(self.stYLabel, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
         self.tY = wx.TextCtrl(self, -1, '0', size=(50, -1))
         hsizer.Add(self.tY, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
+
+        self.bSetCurrent = wx.Button(self, -1, 'Use current centre')
+        self.bSetCurrent.Bind(wx.EVT_BUTTON, self.OnSetCurrent)
+        hsizer.Add(self.bSetCurrent, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
         
         sizer.Add(hsizer, 0, wx.EXPAND, 0)
 
-    def _get_action(self):
-        x = float(self.tX.GetValue())
-        y = float(self.tY.GetValue())
-        return actions.CentreROIOn(x, y)
+        #ROI list mode
+        self.stROIList = wx.StaticText(self, -1, 'No rois specified')
+        sizer.Add(self.stROIList, 0, wx.EXPAND, 0)
+        
+        hsizer = wx.BoxSizer(wx.HORIZONTAL) #wx.StaticBoxSizer(wx.StaticBox(self, label='Queue acquisitions for each ROI'), wx.HORIZONTAL)
+
+        self.stSortFcnLabel = wx.StaticText(self, -1, 'Sort Function:')
+        hsizer.Add(self.stSortFcnLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 2)
+        self.SortSelect = wx.ComboBox(self, -1, 'None', choices=list(SORT_FUNCTIONS.keys()), size=(150, -1))
+        hsizer.Add(self.SortSelect, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 2)
+
+        self.bQueueROIsFromFile = wx.Button(self, -1, 'from file')
+        self.bQueueROIsFromFile.Bind(wx.EVT_BUTTON, self.OnROIsFromFile)
+        hsizer.Add(self.bQueueROIsFromFile, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
+
+        self.bQueueROIsFromTileviewer = wx.Button(self, -1, 'from Tile Viewer')
+        self.bQueueROIsFromTileviewer.Bind(wx.EVT_BUTTON, self.OnROIsFromTileviewer)
+        hsizer.Add(self.bQueueROIsFromTileviewer, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 2)
+
+        sizer.Add(hsizer, 0, wx.EXPAND, 0)
+
+        self.OnSetMode(None)
+
+        wx.CallAfter(self._set_then, 'SpoolSeries')
+
+    def OnSetCurrent(self, event):
+        x, y = self.scope.get_roi_centre()
+        self.tX.SetValue('%.2f' % x)
+        self.tY.SetValue('%.2f' % y)
+
+    def _get_action(self, idx=0):
+        if self.rbModeSingle.GetValue():
+            x = float(self.tX.GetValue())
+            y = float(self.tY.GetValue())
+            return actions.CentreROIOn(x, y)
+        else:
+            try:
+                x, y = self._rois[idx, :]
+            except AttributeError:
+                raise ValueError('No ROIs have been loaded')
+            return actions.CentreROIOn(x, y)
+        
+    @property
+    def num_actions(self):
+        if self.rbModeSingle.GetValue():
+            return 1
+        else:
+            try:
+                return len(self._rois)
+            except AttributeError:
+                raise ValueError('No ROIs have been loaded')
+    
+    def OnSetMode(self, event):
+        if self.rbModeSingle.GetValue():
+            self.stXLabel.Show()
+            self.tX.Show()
+            self.stYLabel.Show()
+            self.tY.Show()
+            self.bSetCurrent.Show()
+
+            self.stROIList.Hide()
+            self.stSortFcnLabel.Hide()
+            self.SortSelect.Hide()
+            self.bQueueROIsFromFile.Hide()
+            self.bQueueROIsFromTileviewer.Hide()
+        else:
+            self.stXLabel.Hide()
+            self.tX.Hide()
+            self.stYLabel.Hide()
+            self.tY.Hide()
+            self.bSetCurrent.Hide()
+
+            self.stROIList.Show()
+            self.stSortFcnLabel.Show()
+            self.SortSelect.Show()
+            self.bQueueROIsFromFile.Show()
+            self.bQueueROIsFromTileviewer.Show()
+
+        wx.CallAfter(self.cascading_layout)
+
+    def _add_ROIs(self, rois):
+        positions = np.reshape(rois, (len(rois), 2)).astype(float)
+        
+        # apply sorting function
+        scope_pos = self.scope.GetPos()
+        positions = SORT_FUNCTIONS[self.SortSelect.GetValue()](positions, (scope_pos['x'], scope_pos['y']))
+
+        self._rois = positions
+
+        self.stROIList.SetLabel('Loaded %d ROIs' % len(self._rois))
+
+
+    def OnROIsFromFile(self, event):
+        # TODO - support .csv as well
+        import wx
+        from PYME.IO import tabular
+
+        filename = wx.FileSelector("Load ROI Positions:", wildcard="*.hdf", flags=wx.FD_OPEN)
+        if not filename == '':
+            rois = tabular.HDFSource(filename, tablename='roi_locations')
+            
+            rois = [(x, y) for x, y in zip(rois['x_um'], rois['y_um'])]
+            
+            self._add_ROIs(rois)
+    
+    def OnROIsFromTileviewer(self, event):
+        import requests
+        resp = requests.get('http://localhost:8979/get_roi_locations')
+        if resp.status_code != 200:
+            raise requests.HTTPError('Could not get ROI locations')
+
+        rois = np.array(resp.json())
+        self._add_ROIs(rois)
+
+
+        
+        
 
 class SpoolSeriesPanel(SingleActionPanel):
     supports_then = False
@@ -220,7 +364,7 @@ class SpoolSeriesPanel(SingleActionPanel):
         hsizer.Add(self.tNumFrames, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
         sizer.Add(hsizer, 0, wx.EXPAND, 0)
 
-    def _get_action(self):
+    def _get_action(self, idx=0):
         settings = self.scope.spoolController.get_settings()
         settings['max_frames']  = int(self.tNumFrames.GetValue())
         return actions.SpoolSeries(settings=settings, preflight_mode='warn', )  
@@ -252,7 +396,7 @@ class FunctionActionPanel(SingleActionPanel):
         self.tArgs = wx.TextCtrl(self, -1, '', size=(150, -1))
         hsizer.Add(self.tArgs, 1, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
 
-    def _get_action(self):
+    def _get_action(self, idx=0):
         function_name = self.tFunction.GetValue()
         args = eval('dict(%s)' % self.tArgs.GetValue())
         return actions.FunctionAction(function_name, args)
@@ -268,16 +412,17 @@ class ActionPanel(wx.Panel, cascading_layout.CascadingLayoutMixin):
         self.actionList = ActionList(self, self.actionManager)
         vsizer.Add(self.actionList, 1, wx.EXPAND, 0)
         
-        self.add_single_sizer = wx.StaticBoxSizer(wx.StaticBox(self, label='Add Single Action'), wx.VERTICAL)
+        self.add_single_sizer = wx.StaticBoxSizer(wx.StaticBox(self, label='Add Action(s)'), wx.VERTICAL)
 
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
         hsizer.Add(wx.StaticText(self, -1, 'Action type:'), 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
         self.cActionType = wx.Choice(self, -1, choices=ACTION_TYPES)
+        self.cActionType.SetSelection(ACTION_TYPES.index('CenterROIOn'))
         self.cActionType.Bind(wx.EVT_CHOICE, self.OnActionChanged)
         hsizer.Add(self.cActionType, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
         self.add_single_sizer.Add(hsizer, 0, wx.EXPAND, 0)
 
-        self._pan_action = MoveToPanel(self, self.actionManager, self.scope)
+        self._pan_action = CenterROIOnPanel(self, self.actionManager, self.scope)
         self._pan_action_sizer = wx.BoxSizer(wx.VERTICAL)
         self._pan_action_sizer.Add(self._pan_action, 0, wx.EXPAND, 0)
         self.add_single_sizer.Add(self._pan_action_sizer, 0, wx.EXPAND|wx.LEFT, 20)
@@ -297,33 +442,17 @@ class ActionPanel(wx.Panel, cascading_layout.CascadingLayoutMixin):
         hsizer.Add(self.tTimeout, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
 
         hsizer.Add(wx.StaticText(self, -1, 'Max duration[s]:'), 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
-        self.t_duration = wx.TextCtrl(self, -1, '%.1f' % np.finfo(float).max, size=(50, -1))
+        self.t_duration = wx.TextCtrl(self, -1, '3600', size=(50, -1))
         hsizer.Add(self.t_duration, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
 
         hsizer.AddStretchSpacer()
 
         self.bAdd = wx.Button(self, -1, 'Add', style=wx.BU_EXACTFIT)
-        self.bAdd.Bind(wx.EVT_BUTTON, self.OnAddAction)
+        self.bAdd.Bind(wx.EVT_BUTTON, progress.managed(self.OnAddAction, self, 'Adding action'))
         hsizer.Add(self.bAdd, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
         
         self.add_single_sizer.Add(hsizer, 0, wx.EXPAND|wx.TOP, 10)
         vsizer.Add(self.add_single_sizer, 0, wx.EXPAND, 0)
-       
-        hsizer = wx.StaticBoxSizer(wx.StaticBox(self, label='Queue acquisitions for each ROI'), wx.HORIZONTAL)
-
-        hsizer.Add(wx.StaticText(self, -1, 'Sort Function:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 2)
-        self.SortSelect = wx.ComboBox(self, -1, 'None', choices=list(SORT_FUNCTIONS.keys()), size=(150, -1))
-        hsizer.Add(self.SortSelect, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 2)
-
-        self.bQueueROIsFromFile = wx.Button(self, -1, 'from file')
-        self.bQueueROIsFromFile.Bind(wx.EVT_BUTTON, self.OnROIsFromFile)
-        hsizer.Add(self.bQueueROIsFromFile, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
-
-        self.bQueueROIsFromTileviewer = wx.Button(self, -1, 'from Tile Viewer')
-        self.bQueueROIsFromTileviewer.Bind(wx.EVT_BUTTON, self.OnROIsFromTileviewer)
-        hsizer.Add(self.bQueueROIsFromTileviewer, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 2)
-
-        vsizer.Add(hsizer, 0, wx.EXPAND, 0)
 
         
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -365,6 +494,7 @@ class ActionPanel(wx.Panel, cascading_layout.CascadingLayoutMixin):
             self.actionManager.paused = True
             self.bPause.SetLabel('Resume')
     
+
     def OnAddAction(self, event):
         delay = float(self.tDelay.GetValue())
         nice = float(self.tNice.GetValue())
@@ -379,32 +509,17 @@ class ActionPanel(wx.Panel, cascading_layout.CascadingLayoutMixin):
             execute_after = 0
 
         #self.actionManager.QueueAction(functionName, args, nice, timeout,
-        #                               max_duration, execute_after=execute_after)
-        self.actionManager.queue_actions([self._pan_action.get_action()], nice, timeout, max_duration, execute_after=execute_after)
+        #                               max_duration, execute_after=execute_after)'
+        actions = self._pan_action.get_actions()
 
-    # def OnAddMove(self, event):
-    #     nice = float(self.tNice.GetValue())
-    #     timeout = float(self.tTimeout.GetValue())
-    #     max_duration = float(self.t_duration.GetValue())
+        # FIXME - this is a very empirical - maybe revisit
+        t_est = actions[0].estimated_duration(self.scope)
+        logger.debug('Expect actions to complete in %.1f s' % t_est)
+        max_duration = max(2*t_est, max_duration)
+        timeout = max(max_duration*len(actions), timeout)
 
-    #     state =  {'Positioning.x': self.scope.state['Positioning.x'],
-    #               'Positioning.y': self.scope.state['Positioning.y'],
-    #               'Positioning.z': self.scope.state['Positioning.z']}
+        self.actionManager.queue_actions(actions, nice, timeout, max_duration, execute_after=execute_after)
 
-    #     self.actionManager.queue_actions([actions.UpdateState(state),],
-    #                                      nice, timeout, max_duration)
-        
-
-    # def OnAddSequence(self, event):
-    #     nice = float(self.tNice.GetValue())
-    #     timeout = float(self.tTimeout.GetValue())
-    #     max_duration = float(self.t_duration.GetValue())
-
-    #     settings = {'max_frames': int(self.tNumFrames.GetValue()), 'z_stepped': bool(self.rbZStepped.GetValue())}
-        
-    #     self.actionManager.queue_actions([actions.SpoolSeries(settings=settings, preflight_mode='warn'),],
-    #                                      nice , timeout,max_duration)
-        
     
     def _add_ROIs(self, rois):
         """
@@ -457,24 +572,4 @@ class ActionPanel(wx.Panel, cascading_layout.CascadingLayoutMixin):
             
         self.actionManager.queue_actions(acts, nice, timeout, 2 * time_est)
     
-    def OnROIsFromFile(self, event):
-        import wx
-        from PYME.IO import tabular
-
-        filename = wx.FileSelector("Load ROI Positions:", wildcard="*.hdf", flags=wx.FD_OPEN)
-        if not filename == '':
-            rois = tabular.HDFSource(filename, tablename='roi_locations')
-            
-            rois = [(x, y) for x, y in zip(rois['x_um'], rois['y_um'])]
-            
-            self._add_ROIs(rois)
     
-    def OnROIsFromTileviewer(self, event):
-        import requests
-        resp = requests.get('http://localhost:8979/get_roi_locations')
-        if resp.status_code != 200:
-            raise requests.HTTPError('Could not get ROI locations')
-
-        rois = np.array(resp.json())
-        #print(rois.shape)
-        self._add_ROIs(rois)

--- a/PYME/Acquire/ui/actionUI.py
+++ b/PYME/Acquire/ui/actionUI.py
@@ -382,28 +382,28 @@ class ActionPanel(wx.Panel, cascading_layout.CascadingLayoutMixin):
         #                               max_duration, execute_after=execute_after)
         self.actionManager.queue_actions([self._pan_action.get_action()], nice, timeout, max_duration, execute_after=execute_after)
 
-    def OnAddMove(self, event):
-        nice = float(self.tNice.GetValue())
-        timeout = float(self.tTimeout.GetValue())
-        max_duration = float(self.t_duration.GetValue())
+    # def OnAddMove(self, event):
+    #     nice = float(self.tNice.GetValue())
+    #     timeout = float(self.tTimeout.GetValue())
+    #     max_duration = float(self.t_duration.GetValue())
 
-        state =  {'Positioning.x': self.scope.state['Positioning.x'],
-                  'Positioning.y': self.scope.state['Positioning.y'],
-                  'Positioning.z': self.scope.state['Positioning.z']}
+    #     state =  {'Positioning.x': self.scope.state['Positioning.x'],
+    #               'Positioning.y': self.scope.state['Positioning.y'],
+    #               'Positioning.z': self.scope.state['Positioning.z']}
 
-        self.actionManager.queue_actions([actions.UpdateState(state),],
-                                         nice, timeout, max_duration)
+    #     self.actionManager.queue_actions([actions.UpdateState(state),],
+    #                                      nice, timeout, max_duration)
         
 
-    def OnAddSequence(self, event):
-        nice = float(self.tNice.GetValue())
-        timeout = float(self.tTimeout.GetValue())
-        max_duration = float(self.t_duration.GetValue())
+    # def OnAddSequence(self, event):
+    #     nice = float(self.tNice.GetValue())
+    #     timeout = float(self.tTimeout.GetValue())
+    #     max_duration = float(self.t_duration.GetValue())
 
-        settings = {'max_frames': int(self.tNumFrames.GetValue()), 'z_stepped': bool(self.rbZStepped.GetValue())}
+    #     settings = {'max_frames': int(self.tNumFrames.GetValue()), 'z_stepped': bool(self.rbZStepped.GetValue())}
         
-        self.actionManager.queue_actions([actions.SpoolSeries(settings=settings, preflight_mode='warn'),],
-                                         nice , timeout,max_duration)
+    #     self.actionManager.queue_actions([actions.SpoolSeries(settings=settings, preflight_mode='warn'),],
+    #                                      nice , timeout,max_duration)
         
     
     def _add_ROIs(self, rois):

--- a/PYME/Acquire/ui/spool_panel.py
+++ b/PYME/Acquire/ui/spool_panel.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##################
-"""The GUI controls for streaming acquisiton.
+"""The GUI controls for streaming acquisition.
 
 """
 

--- a/PYME/Acquire/xyztc.py
+++ b/PYME/Acquire/xyztc.py
@@ -72,6 +72,10 @@ class XYZTCAcquisition(AcquisitionBase):
         self.shape_x, self.shape_y = scope.frameWrangler.currentFrame.shape[:2]
         
         if stack_settings:
+            if isinstance(stack_settings, dict):
+                from PYME.Acquire.stackSettings import StackSettings
+                stack_settings = StackSettings(scope, **stack_settings)
+
             self.shape_z = stack_settings.GetSeqLength()
         else:
             self.shape_z = 1
@@ -105,8 +109,6 @@ class XYZTCAcquisition(AcquisitionBase):
                    time_settings=settings.get('time_settings', None), 
                    channel_settings=settings.get('channel_settings', None), 
                    backend=backend, backend_kwargs=backend_kwargs)
-        
-    
     
     @property
     def shape(self):
@@ -255,3 +257,7 @@ class ZStackAcquisition(XYZTCAcquisition):
                     time_settings=settings.get('time_settings', None), 
                     channel_settings=settings.get('channel_settings', None), 
                     backend=backend, backend_kwargs=backend_kwargs)
+    
+    @classmethod
+    def get_frozen_settings(cls, scope, spool_controller=None):
+        return {'stack_settings' : scope.stackSettings.settings(),}

--- a/PYME/IO/MetaDataHandler.py
+++ b/PYME/IO/MetaDataHandler.py
@@ -23,7 +23,7 @@
 
 #!/usr/bin/python
 """
-Defines metadata handlers for the saving of acquisiton metadata to a variety 
+Defines metadata handlers for the saving of acquisition metadata to a variety 
 of file formats, as well as keeping track of metadata sources. 
 
 Metadata sources

--- a/PYME/LMVis/Extras/pointSetGeneration.py
+++ b/PYME/LMVis/Extras/pointSetGeneration.py
@@ -190,26 +190,26 @@ There should be no need to modify this from the default and it is accordingly no
             pipeline.imageBounds = self.source.get_bounds()
         except AttributeError:
             pipeline.imageBounds = ImageBounds.estimateFromSource(ds)
+
+        from PYME.IO.MetaDataHandler import NestedClassMDHandler
+        ds.mdh = NestedClassMDHandler()
+        ds.mdh['Camera.ElectronsPerCount'] = 1
+        ds.mdh['Camera.TrueEMGain'] = 1
+        ds.mdh['Camera.CycleTime'] = 1
+        ds.mdh['voxelsize.x'] = .110
+        # some info about the parameters
+        ds.mdh['GeneratedPoints.MeanIntensity'] = self.meanIntensity
+        ds.mdh['GeneratedPoints.MeanDuration'] = self.meanDuration
+        ds.mdh['GeneratedPoints.MeanEventNumber'] = self.meanEventNumber
+        ds.mdh['GeneratedPoints.BackgroundIntensity'] = self.backgroundIntensity
+        ds.mdh['GeneratedPoints.ScaleFactor'] = self.scaleFactor
+        ds.mdh['GeneratedPoints.MeanTime'] = self.meanTime
+        ds.mdh['GeneratedPoints.Mode'] = self.mode
+        # the source info
+        self.source.genMetaData(ds.mdh)
             
         pipeline.addDataSource('Generated Points', ds)
         pipeline.selectDataSource('Generated Points')
-
-        from PYME.IO.MetaDataHandler import NestedClassMDHandler
-        pipeline.mdh = NestedClassMDHandler()
-        pipeline.mdh['Camera.ElectronsPerCount'] = 1
-        pipeline.mdh['Camera.TrueEMGain'] = 1
-        pipeline.mdh['Camera.CycleTime'] = 1
-        pipeline.mdh['voxelsize.x'] = .110
-        # some info about the parameters
-        pipeline.mdh['GeneratedPoints.MeanIntensity'] = self.meanIntensity
-        pipeline.mdh['GeneratedPoints.MeanDuration'] = self.meanDuration
-        pipeline.mdh['GeneratedPoints.MeanEventNumber'] = self.meanEventNumber
-        pipeline.mdh['GeneratedPoints.BackgroundIntensity'] = self.backgroundIntensity
-        pipeline.mdh['GeneratedPoints.ScaleFactor'] = self.scaleFactor
-        pipeline.mdh['GeneratedPoints.MeanTime'] = self.meanTime
-        pipeline.mdh['GeneratedPoints.Mode'] = self.mode
-        # the source info
-        self.source.genMetaData(pipeline.mdh)
 
         try:
             pipeline.filterKeys.pop('sig')

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -293,7 +293,7 @@ def _processEvents(ds, events, mdh):
 
     return ev_mappings, eventCharts
 
-class Pipeline:
+class Pipeline(object):
     def __init__(self, filename=None, visFr=None, execute_on_invalidation=True):
         self.filter = None
         self.mapping = None
@@ -310,7 +310,7 @@ class Pipeline:
         self.objects = None
 
         self.imageBounds = ImageBounds(0,0,0,0)
-        self.mdh = MetaDataHandler.NestedClassMDHandler()
+        #self.mdh = MetaDataHandler.NestedClassMDHandler()
         
         self.Triangles = None
         self.edb = None
@@ -340,6 +340,10 @@ class Pipeline:
             self.OpenFile(filename)
             
         #renderers.renderMetadataProviders.append(self.SaveMetadata)
+            
+    @property
+    def mdh(self):
+        return self.selectedDataSource.mdh
             
     @property
     def output(self):
@@ -776,7 +780,7 @@ class Pipeline:
         self.mapping = None
         self.colourFilter = None
         self.events = None
-        self.mdh = MetaDataHandler.NestedClassMDHandler()
+        #self.mdh = MetaDataHandler.NestedClassMDHandler()
         
         self.filename = filename
         
@@ -791,15 +795,15 @@ class Pipeline:
                 # This won't effect local file loading even if loading is lazy (i.e. shouldn't cause a regression)
                 ds = self._ds_from_file(fn, **kwargs)
                 self.events = getattr(ds, 'events', None)
-                self.mdh.copyEntriesFrom(ds.mdh)
+                #self.mdh.copyEntriesFrom(ds.mdh)
 
         # skip the MappingFilter wrapping, etc. in self.addDataSource and add this datasource as-is
         self.dataSources['FitResults'] = ds
 
         # Fit module specific filter settings
         # TODO - put all the defaults here and use a local variable rather than in __init__ (self.filterKeys is largely an artifact of pre-recipe based pipeline)
-        if 'Analysis.FitModule' in self.mdh.getEntryNames():
-            fitModule = self.mdh['Analysis.FitModule']
+        if 'Analysis.FitModule' in ds.mdh.getEntryNames():
+            fitModule = ds.mdh['Analysis.FitModule']
             if 'Interp' in fitModule:
                 self.filterKeys['A'] = (5, 100000)
             if fitModule == 'SplitterShiftEstFR':


### PR DESCRIPTION
Adds the ability to set a delay for queued acquisitions to allow timelapse type acquisitions. Also contains:

- a lot of tidying to ensure that multiple different acquisition types can be queued with different settings (i.e. remembering the settings at time of queueing). This enables queueing of both ZStacks and blinking series (and any other acquisition types we might want to add) 
- Some long-overdue UI improvements.

<img width="1280" alt="image" src="https://github.com/python-microscopy/python-microscopy/assets/19475296/fe0397e1-9e7c-4198-8a7b-483aa830fcf2">


### Remaining TODOs
- ui functions for queueing repetitive acquisitions (rather than queueuing them each separately with a different delay)
- fix queue from txt and TileViewer so that they also keep settings.
- Find a more robust way of setting timeout for queue from file and queue from tileviewer (we can no longer do anything sensible based on frames per second). 

@Yujin-Bao 