### PR TITLE
Changes to text import behavior.

### DIFF
--- a/PYME/IO/csv_flavours.py
+++ b/PYME/IO/csv_flavours.py
@@ -203,7 +203,7 @@ def guess_flavour(colNames, delim=None, ext=None):
     for flavour in csv_flavours:
         if (not flavour == 'default') and all(idn in colNames for idn in csv_flavours[flavour]['idnames']):
             if fl is not None:
-                warnings.warn('Ambiguous flavour database: file matches both %s and %s' % (fl, flavour))
+                warnings.warn('Ambiguous flavour database: file matches both %s and %s. Using default flavour.' % (fl, flavour))
                 fl = 'default'
                 break
             fl = flavour
@@ -214,7 +214,7 @@ def guess_flavour(colNames, delim=None, ext=None):
         for flavour in csv_flavours:
             if (not flavour == 'default') and ext in csv_flavours[flavour].get('ext',[]):
                 if fl is not None:
-                    warnings.warn('Ambiguous flavour database: file matches both %s and %s' % (fl, flavour))
+                    warnings.warn('Ambiguous flavour database: file matches both %s and %s. Using default flavour.' % (fl, flavour))
                     fl = 'default'
                     break
                 if not all(idn in colNames for idn in csv_flavours[flavour]['column_name_mappings'].keys()):

--- a/PYME/IO/csv_flavours.py
+++ b/PYME/IO/csv_flavours.py
@@ -8,7 +8,7 @@ def isnumber(s):
     try:
         float(s)
         return True
-    except:
+    except ValueError:
         return False
 
 
@@ -99,7 +99,7 @@ def parse_csv_header(filename):
     n = 0
     commentLines = []
     dataLines = []
-    headerNameLines = []
+    # headerNameLines = []
 
     def is_header_candidate(line, delims):
         guessedDelim = guess_delim(line,delims)
@@ -202,7 +202,9 @@ def guess_flavour(colNames, delim=None, ext=None):
     for flavour in csv_flavours:
         if (not flavour == 'default') and all(idn in colNames for idn in csv_flavours[flavour]['idnames']):
             if fl is not None:
-                raise RuntimeError('Ambiguous flavour database: file matches both %s and %s' % (fl, flavour))
+                logger.info('Ambiguous flavour database: file matches both %s and %s' % (fl, flavour))
+                fl = 'default'
+                break
             fl = flavour
 
     # If this failed, guess csv flavor by matching file type. This means it's a
@@ -211,7 +213,9 @@ def guess_flavour(colNames, delim=None, ext=None):
         for flavour in csv_flavours:
             if (not flavour == 'default') and ext in csv_flavours[flavour].get('ext',[]):
                 if fl is not None:
-                    raise RuntimeError('Ambiguous flavour database: file matches both %s and %s' % (fl, flavour))
+                    logger.info('Ambiguous flavour database: file matches both %s and %s' % (fl, flavour))
+                    fl = 'default'
+                    break
                 if not all(idn in colNames for idn in csv_flavours[flavour]['column_name_mappings'].keys()):
                     continue
                 fl = flavour

--- a/PYME/IO/csv_flavours.py
+++ b/PYME/IO/csv_flavours.py
@@ -1,5 +1,6 @@
 import os
 from PYME.IO import MetaDataHandler
+from PYME import warnings
 
 import logging
 logger = logging.getLogger(__file__)
@@ -202,7 +203,7 @@ def guess_flavour(colNames, delim=None, ext=None):
     for flavour in csv_flavours:
         if (not flavour == 'default') and all(idn in colNames for idn in csv_flavours[flavour]['idnames']):
             if fl is not None:
-                logger.info('Ambiguous flavour database: file matches both %s and %s' % (fl, flavour))
+                warnings.warn('Ambiguous flavour database: file matches both %s and %s' % (fl, flavour))
                 fl = 'default'
                 break
             fl = flavour
@@ -213,7 +214,7 @@ def guess_flavour(colNames, delim=None, ext=None):
         for flavour in csv_flavours:
             if (not flavour == 'default') and ext in csv_flavours[flavour].get('ext',[]):
                 if fl is not None:
-                    logger.info('Ambiguous flavour database: file matches both %s and %s' % (fl, flavour))
+                    warnings.warn('Ambiguous flavour database: file matches both %s and %s' % (fl, flavour))
                     fl = 'default'
                     break
                 if not all(idn in colNames for idn in csv_flavours[flavour]['column_name_mappings'].keys()):

--- a/PYME/LMVis/importTextDialog.py
+++ b/PYME/LMVis/importTextDialog.py
@@ -252,6 +252,9 @@ class ImportTextDialog(ColumnMappingDialog):
         self.change_text_flavour(self.chFlavour.GetStringSelection())
         self.CheckColNames()
 
+        # Update the GUI selection
+        for ci, cn in enumerate(self.colNames):
+            self.combos[ci].SetValue(cn)
 
 class ImportMatDialog(wx.Dialog):
     # Old-style MATLAB importer


### PR DESCRIPTION
These are just usability changes I propose to make it easier to open unknown file types that overlap with some of our existing flavors. It is in response to a weird CSV I have to open.

- Make the import dialog display even if ambiguous flavours are found, rather than raise an error. This allows the user to still map the columns.
- Make the GUI comboboxes update on flavour changes so we can see which columns are mapped to what in the GUI.