### PR TITLE
Modification to #1497

### DIFF
--- a/PYME/Acquire/xyztc.py
+++ b/PYME/Acquire/xyztc.py
@@ -81,6 +81,9 @@ class XYZTCAcquisition(AcquisitionBase):
         else:
             self.shape_z = 1
 
+        #keep a reference to the stack settings so we can home the piezo appropriately
+        self._stack_settings = stack_settings
+
         self.shape_t = getattr(time_settings, 'num_timepoints', 1)
         self.shape_c = getattr(channel_settings, 'num_channels', 1)
         
@@ -184,7 +187,9 @@ class XYZTCAcquisition(AcquisitionBase):
             self.storage.initialise()
 
             self._running = True
-            self.scope.stackSettings.SetPrevPos(self.scope.stackSettings._CurPos())
+
+            if self._stack_settings:
+                self._stack_settings.SetPrevPos(self._stack_settings._CurPos())
 
             self.dtStart = datetime.datetime.now() #for spooler compatibility - FIXME
             #self.scope.frameWrangler.start()
@@ -194,7 +199,10 @@ class XYZTCAcquisition(AcquisitionBase):
     def stop(self):
         self.scope.frameWrangler.stop()
         self.scope.frameWrangler.onFrame.disconnect(self.on_frame)
-        self.scope.stackSettings.piezoGoHome()
+        
+        if self._stack_settings:
+            self._stack_settings.piezoGoHome()
+        
         self.scope.frameWrangler.start()
 
         try:

--- a/PYME/Acquire/xyztc.py
+++ b/PYME/Acquire/xyztc.py
@@ -6,6 +6,7 @@ from PYME.contrib import dispatch
 from PYME.IO import MetaDataHandler
 from PYME.IO.acquisition_backends import MemoryBackend
 from PYME.Acquire.acquisition_base import AcquisitionBase
+from PYME.Acquire import eventLog
 
 
 class TimeSettings(object):
@@ -186,6 +187,7 @@ class XYZTCAcquisition(AcquisitionBase):
 
             self.dtStart = datetime.datetime.now() #for spooler compatibility - FIXME
             #self.scope.frameWrangler.start()
+        eventLog.register_event_handler(self.storage.event_logger)
 
         
     def stop(self):
@@ -193,6 +195,11 @@ class XYZTCAcquisition(AcquisitionBase):
         self.scope.frameWrangler.onFrame.disconnect(self.on_frame)
         self.scope.stackSettings.piezoGoHome()
         self.scope.frameWrangler.start()
+
+        try:
+            eventLog.remove_event_handler(self.storage.event_logger)
+        except ValueError:
+            pass
 
         self.storage.finalise()
         

--- a/PYME/Acquire/xyztc.py
+++ b/PYME/Acquire/xyztc.py
@@ -184,6 +184,7 @@ class XYZTCAcquisition(AcquisitionBase):
             self.storage.initialise()
 
             self._running = True
+            self.scope.stackSettings.SetPrevPos(self.scope.stackSettings._CurPos())
 
             self.dtStart = datetime.datetime.now() #for spooler compatibility - FIXME
             #self.scope.frameWrangler.start()


### PR DESCRIPTION
contains logging fix from #1497, but a modified piezo-return fix as this should be acquisition-type specific. 

We might need to further modify this to ensure that 

a) return happens on the correct channel
b) we only return if we are actually controlling the piezo (i.e. z-stacking) so that we don't inadvertently mess with a simultaeneous acquisition that is controlling the piezo.