### PR TITLE
fix code object namespace error in traits patch, note minimum wxpython verison in pip requirements.txt

### DIFF
--- a/PYME/ui/patch_traitsui.py
+++ b/PYME/ui/patch_traitsui.py
@@ -72,6 +72,9 @@ def StepColour(c, ialpha):
 aui_utilities.StepColour.__code__ = StepColour.__code__
 
 def GetBaseColour():
+    # this import may not be needed on all wxpython / python versions (but is for 4.1 / 3.7)
+    from wx.lib.agw.aui import aui_utilities
+    
     base_colour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_3DFACE)
 
     # the base_colour is too pale to use as our base colour,
@@ -79,8 +82,7 @@ def GetBaseColour():
     if ((255-base_colour.Red()) +
         (255-base_colour.Green()) +
         (255-base_colour.Blue()) < 60):
-        # this import may not be needed on all wxpython / python versions (but is for 4.1 / 3.7)
-        from wx.lib.agw.aui import aui_utilities  
+
         base_colour = aui_utilities.StepColour(base_colour, 92)
 
     return base_colour

--- a/PYME/ui/patch_traitsui.py
+++ b/PYME/ui/patch_traitsui.py
@@ -79,7 +79,8 @@ def GetBaseColour():
     if ((255-base_colour.Red()) +
         (255-base_colour.Green()) +
         (255-base_colour.Blue()) < 60):
-
+        # this import may not be needed on all wxpython / python versions (but is for 4.1 / 3.7)
+        from wx.lib.agw.aui import aui_utilities  
         base_colour = aui_utilities.StepColour(base_colour, 92)
 
     return base_colour

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 numpy>=1.14.* # we build and test against 1.14, but should work against any higher version. Try numpy==1.14.* if you run into issues.
 scipy
 matplotlib
-wxpython
+wxpython>=4.1
 tables #<=3.4.2
 pyopengl
 traits


### PR DESCRIPTION
Addresses issue see conversation in #1500 

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- import aui_utilities in StepBaseColour. Why is this not needed in Py3.8 on mac? I don't know, but the code object doesn't generally get packaged with context from the module (e.g. the previous import?) and does not have aui_utilities within the namespace when called by wxpython on python 3.7 on windows.
- note the minimum wxpython verison is now 4.1. This will also need to be updated in the PYME conda-recipes repository. 





**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
