### PR TITLE
Fix dialog windows in dark mode

### DIFF
--- a/PYME/ui/traitsui_constants.py
+++ b/PYME/ui/traitsui_constants.py
@@ -50,7 +50,7 @@ EditableColor = OKColor
 
 #: Color for background of windows (like dialog background color)
 if is_mac:
-    WindowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_INFOBK)
+    WindowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_3DFACE)
     BorderedGroupColor = wx.Colour(224, 224, 224)
 else:
     WindowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_MENUBAR)

--- a/PYME/ui/traitsui_constants.py
+++ b/PYME/ui/traitsui_constants.py
@@ -40,10 +40,7 @@ else:
 ReadonlyColor = wx.Colour(244, 243, 238)
 
 #: Color for background of fields where objects can be dropped
-if is_dark:
-    DropColor = wx.Colour(94, 131, 167)
-else:
-    DropColor = wx.Colour(215, 242, 255)
+DropColor = wx.Colour(215, 242, 255)
 
 #: Color for an editable field
 EditableColor = OKColor

--- a/PYME/ui/traitsui_constants.py
+++ b/PYME/ui/traitsui_constants.py
@@ -50,7 +50,7 @@ EditableColor = OKColor
 
 #: Color for background of windows (like dialog background color)
 if is_mac:
-    WindowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)
+    WindowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_INFOBK)
     BorderedGroupColor = wx.Colour(224, 224, 224)
 else:
     WindowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_MENUBAR)

--- a/PYME/ui/traitsui_constants.py
+++ b/PYME/ui/traitsui_constants.py
@@ -48,6 +48,7 @@ EditableColor = OKColor
 #: Color for background of windows (like dialog background color)
 if is_mac:
     WindowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)
+    BorderedGroupColor = wx.Colour(224, 224, 224)
 else:
     WindowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_MENUBAR)
 

--- a/PYME/ui/traitsui_constants.py
+++ b/PYME/ui/traitsui_constants.py
@@ -20,6 +20,7 @@ from pyface.api import SystemMetrics
 
 #: Define platform and wx version constants:
 is_mac = sys.platform == "darwin"
+is_dark = wx.SystemSettings.GetAppearance().IsDark()
 
 #: Default dialog title
 DefaultTitle = "Edit properties"
@@ -30,21 +31,26 @@ DefaultTitle = "Edit properties"
 OKColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)# wx.WHITE
 
 #: Color to highlight input errors
-ErrorColor = wx.Colour(255, 192, 192)
+if is_dark:
+    ErrorColor = wx.Colour(0xcf, 0x66, 0x79)
+else:
+    ErrorColor = wx.Colour(255, 192, 192)
 
 #: Color for background of read-only fields
 ReadonlyColor = wx.Colour(244, 243, 238)
 
 #: Color for background of fields where objects can be dropped
-DropColor = wx.Colour(215, 242, 255)
+if is_dark:
+    DropColor = wx.Colour(94, 131, 167)
+else:
+    DropColor = wx.Colour(215, 242, 255)
 
 #: Color for an editable field
 EditableColor = OKColor
 
 #: Color for background of windows (like dialog background color)
 if is_mac:
-    WindowColor = wx.Colour(232, 232, 232)
-    BorderedGroupColor = wx.Colour(224, 224, 224)
+    WindowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)
 else:
     WindowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_MENUBAR)
 

--- a/PYME/ui/traitsui_constants.py
+++ b/PYME/ui/traitsui_constants.py
@@ -20,7 +20,10 @@ from pyface.api import SystemMetrics
 
 #: Define platform and wx version constants:
 is_mac = sys.platform == "darwin"
-is_dark = wx.SystemSettings.GetAppearance().IsDark()
+try:
+    is_dark = wx.SystemSettings.GetAppearance().IsDark()
+except AttributeError:
+    is_dark = False
 
 #: Default dialog title
 DefaultTitle = "Edit properties"


### PR DESCRIPTION
Follow up to #1500. Fix an issue I ran into when adding a `MappingFilter` to the pipeline:

<img width="324" alt="image" src="https://github.com/python-microscopy/python-microscopy/assets/1263313/7393106b-7ef6-44b1-8028-3d104af4fdb6">

<img width="324" alt="image" src="https://github.com/python-microscopy/python-microscopy/assets/1263313/7d5ddac6-73e9-4b07-8a29-073770a330e9">