### PR TITLE
Fix for performance issue with remote spooling

### DIFF
--- a/PYME/Acquire/ActionManager.py
+++ b/PYME/Acquire/ActionManager.py
@@ -238,6 +238,7 @@ class ActionManager(object):
             try:
                 self.currentTask.finalise(self.scope())
                 self.currentTask = None
+                self.isLastTaskDone = None # prevent us from continuing to poll the last task if it's done
             except AttributeError:
                 pass
 

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -960,6 +960,8 @@ class LMAnalyser2(Plugin):
             
         ft = remFitBuf.fitTask(dataSourceID=self.image.seriesName, frameIndex=zp, metadata=mdh, dataSourceModule=mn)
         res = ft(gui=gui,taskQueue=self.tq)
+
+        #print(res.driftResults)
         
         if gui:
             plt.figure()
@@ -969,7 +971,7 @@ class LMAnalyser2(Plugin):
                 plt.imshow(d, cmap=plt.cm.hot, interpolation='nearest', clim=(np.median(d.ravel()), d.max()))
                 plt.plot([p.x for p in ft.ofd], [p.y for p in ft.ofd], 'o', mew=2, mec='g', mfc='none', ms=9)
                 if ft.driftEst:
-                    plt.plot([p.x for p in ft.ofdDr], [p.y for p in ft.ofdDr], 'o', mew=2, mec='b', mfc='none', ms=9)
+                    plt.plot([p.x for p in ft.ofdDr], [p.y for p in ft.ofdDr], 'o', mew=2, mec='b', mfc='none', ms=19)
                 #if ft.fitModule in remFitBuf.splitterFitModules:
                 #        plot([p.x for p in ft.ofd], [d.shape[0] - p.y for p in ft.ofd], 'o', mew=2, mec='g', mfc='none', ms=9)
                 #axis('tight')
@@ -996,6 +998,11 @@ class LMAnalyser2(Plugin):
                     plt.xticks([])
                     plt.yticks([])
                     plt.plot(res.results['fitResults']['x0']/vx, res.results['fitResults']['y0']/vy, '+b')
+
+                try:
+                    plt.plot(res.driftResults['fitResults']['x0']/vx, res.driftResults['fitResults']['y0']/vy, '*y', mew=2)
+                except AttributeError:
+                    pass
                     
                 #figure()
                 #imshow()

--- a/PYME/IO/MetaDataHandler.py
+++ b/PYME/IO/MetaDataHandler.py
@@ -76,6 +76,8 @@ except ImportError:
 import six
 from collections import namedtuple
 
+from PYME import config
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -549,7 +551,9 @@ class HDFMDHandler(MDHandlerBase):
 
         currGroup = self.h5file._get_or_create_path('/'.join(['', 'MetaData']+ ep), True)
         currGroup._f_setattr(en, value)
-        self.h5file.flush()
+
+        if config.get('HDF-ZealousFlush', False):
+            self.h5file.flush()
 
 
     def getEntry(self,entryName):

--- a/PYME/IO/events.py
+++ b/PYME/IO/events.py
@@ -3,6 +3,8 @@ import numpy as np
 import tables
 import time
 
+from PYME import config
+
 # numpy/pytables event representation
 EVENTS_DTYPE = np.dtype([('EventDescr', 'S256'), ('EventName', 'S32'), ('Time', '<f8')])
 
@@ -118,7 +120,13 @@ class HDFEventLogger(EventLogger):
             
             ev.append()
             #print(ev, (eventName, eventDescr, timestamp))
-            self.evts.flush()
+            
+            if config.get('HDF-ZealousFlush', False):
+                # flush after every event - this is slow, but ensures that data is written to disk
+                # and that all events which were logged prior to a crash are preserved.
+                # It probably only makes sense to do this for very critical data (hence the default of False).
+                self.evts.flush()
+            
 
 class MemoryEventLogger(EventLogger):
     """ Event backend which records events to memory, to be saved at a later time"""

--- a/PYME/localization/remFitBuf.py
+++ b/PYME/localization/remFitBuf.py
@@ -509,6 +509,7 @@ class fitTask(taskDef.Task):
             fiducialROISize = self.md.getOrDefault('Analysis.FiducialROISize', 11)
             fiducialSize = self.md.getOrDefault('Analysis.FiducalSize', 1000.)
             self._findFiducials(sfunc, debounce, fiducialSize)
+            #logger.debug('Found %d fiducials' % len(self.ofdDr))
                 
         
         #####################################################################


### PR DESCRIPTION
Fixes issue where a performance degradation was noticed after triggering a remote acquisition due to the polling cost of checking whether it was complete. @Yujin-Bao - let me know if this helps

Also has a few minor tweaks related to .hdf flushing (the fairly paranoid flushing of events was causing looking issues in the hdf library and decresasing performance)

### TODOs.

- Change to using long polling for remote acquisitions to lower the overhead further (as it could be an issue for simultaeneous acquisitions).