### PR TITLE
Piezo-go-home enhancement and enabling drift tracking in both 4-frame and 6-frame OIDIC mode

### DIFF
--- a/PYME/Acquire/Hardware/driftTracking.py
+++ b/PYME/Acquire/Hardware/driftTracking.py
@@ -106,12 +106,13 @@ class OIDICFrameSource(StandardFrameSource):
         super().__init__(frameWrangler)
 
         self._oidic = oidic_controller
-        self._target_orientation = oidic_orientation
+        #self._target_orientation = oidic_orientation
 
     def tick(self, *args, **kwargs):
         # FIXME - check when onFrameGroup is emitted relative to when the OIDIC orientation is set.
         # Is this predictable, or does it depend on the order in which OIDIC and drift tracking are
         # registered with the frameWrangler?
+        self._target_orientation = self._oidic.home_channel()
         if self._oidic.current_channel == self._target_orientation:
             super().tick(*args, **kwargs)
         else:

--- a/PYME/Acquire/Hardware/driftTracking.py
+++ b/PYME/Acquire/Hardware/driftTracking.py
@@ -112,8 +112,9 @@ class OIDICFrameSource(StandardFrameSource):
         # FIXME - check when onFrameGroup is emitted relative to when the OIDIC orientation is set.
         # Is this predictable, or does it depend on the order in which OIDIC and drift tracking are
         # registered with the frameWrangler?
-        self._target_orientation = self._oidic.home_channel()
-        if self._oidic.current_channel == self._target_orientation:
+        #self._target_orientation = self._oidic.home_channel()
+        #if self._oidic.current_channel == self._target_orientation:
+        if self._oidic.current_channel == self._oidic.home_channel():
             super().tick(*args, **kwargs)
         else:
             # clobber all frames coming from camera when not in the correct DIC orientation

--- a/PYME/Acquire/xyztc.py
+++ b/PYME/Acquire/xyztc.py
@@ -171,6 +171,9 @@ class XYZTCAcquisition(AcquisitionBase):
         with self.scope.frameWrangler.spooling_stopped():
             # avoid stopping both here and in the SpoolController
             #self.scope.frameWrangler.stop()
+            if self._stack_settings:
+                self._stack_settings.SetPrevPos(self._stack_settings._CurPos())
+            
             self.frame_num = 0
             
             z_idx, c_idx, t_idx = self._zct_indices(self.frame_num)
@@ -187,9 +190,6 @@ class XYZTCAcquisition(AcquisitionBase):
             self.storage.initialise()
 
             self._running = True
-
-            if self._stack_settings:
-                self._stack_settings.SetPrevPos(self._stack_settings._CurPos())
 
             self.dtStart = datetime.datetime.now() #for spooler compatibility - FIXME
             #self.scope.frameWrangler.start()


### PR DESCRIPTION
Here is the enhancement for two:

The first one is for piezo-go-home. To make the piezo returning result consistent with fluorescence z-stack acquisition, some code sequence is adjusted.

The second one is for the drift tracking. I revisited this and realize the reason it is not working when changing the mode is that the `self._target_orientation` is only defined when `OIDICFrameSource` is initiating, and manually changing the `self._target_orientation` by accessing `oidic_fs` when changing the mode solves the issue in a not-clean way. Here I try to solve the issue cleaner by defining a `home_channel()` and compare it to the current channel whenever doing a focus lock. The definition of the `home_channel()` code could be found in another PR in the other repo (pyme-oidic).