### PR TITLE
make sure pytest calls setup and teardown functions in recipes/test_acquisition.py

### DIFF
--- a/tests/PYME/recipes/test_acquisition.py
+++ b/tests/PYME/recipes/test_acquisition.py
@@ -8,14 +8,14 @@ class fakescope(object):
 action_manager = None
 action_manager_server= None
 
-def setup():
+def setup_module():
     global action_manager, action_manager_server
     scope = fakescope()
     action_manager = ActionManager(scope)
     action_manager_server = ActionManagerServer(action_manager, 9393, '127.0.0.1')
     #return am, ams
     
-def teardown():
+def teardown_module():
     action_manager_server.shutdown()
     
 


### PR DESCRIPTION
Addresses issue


```
rootdir: C:\Userfiles\andrew\code\python-microscopy
collected 1 item

test_acquisition.py F                                                                                                                                 [100%]

========================================================================= FAILURES =========================================================================
_________________________________________________________________ test_queue_acquisitions __________________________________________________________________

    def test_queue_acquisitions():
        from PYME.IO.tabular import DictSource
        from PYME.recipes import Recipe
        import numpy as np
        import time

>       action_manager.paused = True
E       AttributeError: 'NoneType' object has no attribute 'paused'

test_acquisition.py:28: AttributeError
===================================================================== warnings summary =====================================================================
..\..\..\..\..\..\..\Users\aesb\AppData\Local\miniforge3\envs\pyme310\lib\site-packages\numexpr\expressions.py:21
..\..\..\..\..\..\..\Users\aesb\AppData\Local\miniforge3\envs\pyme310\lib\site-packages\numexpr\expressions.py:21
  C:\Users\aesb\AppData\Local\miniforge3\envs\pyme310\lib\site-packages\numexpr\expressions.py:21: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_forbids_neg_powint = LooseVersion(numpy.__version__) >= LooseVersion('1.12.0b1')

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================= short test summary info ==================================================================
FAILED test_acquisition.py::test_queue_acquisitions - AttributeError: 'NoneType' object has no attribute 'paused'
============================================================== 1 failed, 2 warnings in 3.63s ===============================================================

```



**Platform (please complete the following information - or copy-paste from error dialog if shown):**

<details> <summary> conda list </summary> 

```
(pyme310) C:\Userfiles\andrew\code\python-microscopy\tests\PYME\recipes>conda list
# packages in environment at C:\Users\aesb\AppData\Local\miniforge3\envs\pyme310:
#
# Name                    Version                   Build  Channel
_libavif_api              1.0.4                h57928b3_4    conda-forge
alabaster                 0.7.16             pyhd8ed1ab_0    conda-forge
aom                       3.9.0                he0c23c2_0    conda-forge
async-timeout             4.0.3              pyhd8ed1ab_0    conda-forge
babel                     2.14.0             pyhd8ed1ab_0    conda-forge
blosc                     1.21.5               hbd69f2e_1    conda-forge
brotli                    1.1.0                hcfcfb64_1    conda-forge
brotli-bin                1.1.0                hcfcfb64_1    conda-forge
brotli-python             1.1.0           py310h00ffb61_1    conda-forge
bzip2                     1.0.8                hcfcfb64_5    conda-forge
c-blosc2                  2.14.4               h183a6f4_1    conda-forge
ca-certificates           2024.6.2             h56e8100_0    conda-forge
certifi                   2024.2.2           pyhd8ed1ab_0    conda-forge
charls                    2.4.2                h1537add_0    conda-forge
charset-normalizer        3.3.2              pyhd8ed1ab_0    conda-forge
colorama                  0.4.6              pyhd8ed1ab_0    conda-forge
contourpy                 1.2.1           py310h232114e_0    conda-forge
cycler                    0.12.1             pyhd8ed1ab_0    conda-forge
cython                    3.0.10          py310h00ffb61_0    conda-forge
dav1d                     1.2.1                hcfcfb64_0    conda-forge
docutils                  0.21.2             pyhd8ed1ab_0    conda-forge
exceptiongroup            1.2.0              pyhd8ed1ab_2    conda-forge
fftw                      3.3.10          nompi_h38027f0_108    conda-forge
fonttools                 4.52.4          py310ha8f682b_0    conda-forge
freetype                  2.12.1               hdaf720e_2    conda-forge
giflib                    5.2.2                h64bf75a_0    conda-forge
glib                      2.80.2               h0df6a38_0    conda-forge
glib-tools                2.80.2               h2f9d560_0    conda-forge
gst-plugins-base          1.24.4               hba88be7_0    conda-forge
gstreamer                 1.24.4               h5006eae_0    conda-forge
hdf5                      1.14.3          nompi_h2b43c12_102    conda-forge
icu                       73.2                 h63175ca_0    conda-forge
idna                      3.7                pyhd8ed1ab_0    conda-forge
ifaddr                    0.2.0              pyhd8ed1ab_0    conda-forge
imagecodecs               2024.1.1        py310he9b5339_7    conda-forge
imageio                   2.34.1             pyh4b66e23_0    conda-forge
imagesize                 1.4.1              pyhd8ed1ab_0    conda-forge
importlib-metadata        7.1.0              pyha770c72_0    conda-forge
importlib_metadata        7.1.0                hd8ed1ab_0    conda-forge
importlib_resources       6.4.0              pyhd8ed1ab_0    conda-forge
iniconfig                 2.0.0              pyhd8ed1ab_0    conda-forge
intel-openmp              2024.1.0           h57928b3_966    conda-forge
jinja2                    3.1.4              pyhd8ed1ab_0    conda-forge
joblib                    1.4.2              pyhd8ed1ab_0    conda-forge
jxrlib                    1.1                  hcfcfb64_3    conda-forge
kiwisolver                1.4.5           py310h232114e_1    conda-forge
krb5                      1.21.2               heb0366b_0    conda-forge
lazy_loader               0.4                pyhd8ed1ab_0    conda-forge
lcms2                     2.16                 h67d730c_0    conda-forge
lerc                      4.0.0                h63175ca_0    conda-forge
libaec                    1.1.3                h63175ca_0    conda-forge
libavif16                 1.0.4                hac688ae_4    conda-forge
libblas                   3.9.0              22_win64_mkl    conda-forge
libbrotlicommon           1.1.0                hcfcfb64_1    conda-forge
libbrotlidec              1.1.0                hcfcfb64_1    conda-forge
libbrotlienc              1.1.0                hcfcfb64_1    conda-forge
libcblas                  3.9.0              22_win64_mkl    conda-forge
libclang13                18.1.6          default_hf64faad_0    conda-forge
libcurl                   8.8.0                hd5e4a3a_0    conda-forge
libdeflate                1.20                 hcfcfb64_0    conda-forge
libffi                    3.4.2                h8ffe710_5    conda-forge
libglib                   2.80.2               h0df6a38_0    conda-forge
libhwloc                  2.10.0          default_h8125262_1001    conda-forge
libiconv                  1.17                 hcfcfb64_2    conda-forge
libintl                   0.22.5               h5728263_2    conda-forge
libintl-devel             0.22.5               h5728263_2    conda-forge
libjpeg-turbo             3.0.0                hcfcfb64_1    conda-forge
liblapack                 3.9.0              22_win64_mkl    conda-forge
libogg                    1.3.4                h8ffe710_1    conda-forge
libpng                    1.6.43               h19919ed_0    conda-forge
libsqlite                 3.45.3               hcfcfb64_0    conda-forge
libssh2                   1.11.0               h7dfc565_0    conda-forge
libtiff                   4.6.0                hddb2be6_3    conda-forge
libvorbis                 1.3.7                h0e60522_0    conda-forge
libwebp-base              1.4.0                hcfcfb64_0    conda-forge
libxcb                    1.15                 hcd874cb_0    conda-forge
libxml2                   2.12.7               h283a6d9_0    conda-forge
libzlib                   1.2.13               h2466b09_6    conda-forge
libzopfli                 1.0.3                h0e60522_0    conda-forge
lz4-c                     1.9.4                hcfcfb64_0    conda-forge
m2w64-gcc-libgfortran     5.3.0                         6    conda-forge
m2w64-gcc-libs            5.3.0                         7    conda-forge
m2w64-gcc-libs-core       5.3.0                         7    conda-forge
m2w64-gmp                 6.1.0                         2    conda-forge
m2w64-libwinpthread-git   5.0.0.4634.697f757               2    conda-forge
markupsafe                2.1.5           py310h8d17308_0    conda-forge
matplotlib                3.6.0           py310h5588dad_0    conda-forge
matplotlib-base           3.6.0           py310h51140c5_0    conda-forge
mkl                       2024.1.0           h66d3029_692    conda-forge
msys2-conda-epoch         20160418                      1    conda-forge
munkres                   1.1.4              pyh9f0ad1d_0    conda-forge
networkx                  3.3                pyhd8ed1ab_1    conda-forge
numexpr                   2.7.3           py310hf5e1058_2    conda-forge
numpy                     1.26.4          py310hf667824_0    conda-forge
openjpeg                  2.5.2                h3d672ee_0    conda-forge
openssl                   3.3.0                h2466b09_3    conda-forge
packaging                 24.0               pyhd8ed1ab_0    conda-forge
pandas                    2.2.2           py310hb4db72f_1    conda-forge
pcre2                     10.43                h17e33f8_0    conda-forge
pillow                    10.3.0          py310hf5d6e66_0    conda-forge
pip                       24.0               pyhd8ed1ab_0    conda-forge
pluggy                    1.5.0              pyhd8ed1ab_0    conda-forge
ply                       3.11               pyhd8ed1ab_2    conda-forge
psutil                    5.9.8           py310h8d17308_0    conda-forge
pthread-stubs             0.4               hcd874cb_1001    conda-forge
pthreads-win32            2.9.1                hfa6e2cd_3    conda-forge
py-cpuinfo                9.0.0              pyhd8ed1ab_0    conda-forge
pybind11                  2.12.0          py310h232114e_0    conda-forge
pybind11-global           2.12.0          py310h232114e_0    conda-forge
pyface                    8.0.0              pyhd8ed1ab_0    conda-forge
pyfftw                    0.13.1          py310ha9ca8c9_0    conda-forge
pygments                  2.18.0             pyhd8ed1ab_0    conda-forge
pymecompress              0.3.6                   py310_0    david_baddeley
pyopengl                  3.1.6              pyhd8ed1ab_1    conda-forge
pyparsing                 3.1.2              pyhd8ed1ab_0    conda-forge
pyqt                      5.15.9          py310h1fd54f2_5    conda-forge
pyqt5-sip                 12.12.2         py310h00ffb61_5    conda-forge
pysocks                   1.7.1              pyh0701188_6    conda-forge
pytables                  3.9.2           py310h7bf2125_2    conda-forge
pytest                    8.2.1              pyhd8ed1ab_0    conda-forge
python                    3.10.14         h4de0772_0_cpython    conda-forge
python-dateutil           2.9.0              pyhd8ed1ab_0    conda-forge
python-microscopy         23.6.15.post0.dev0           dev_0    <develop>
python-tzdata             2024.1             pyhd8ed1ab_0    conda-forge
python_abi                3.10                    4_cp310    conda-forge
pytz                      2024.1             pyhd8ed1ab_0    conda-forge
pywavelets                1.4.1           py310h3e78b6c_1    conda-forge
pywin32                   306             py310h00ffb61_2    conda-forge
pyyaml                    6.0.1           py310h8d17308_1    conda-forge
qt-main                   5.15.8              hcef0176_21    conda-forge
rav1e                     0.6.6                h975169c_2    conda-forge
requests                  2.32.3             pyhd8ed1ab_0    conda-forge
scikit-image              0.22.0          py310hecd3228_2    conda-forge
scikit-learn              1.5.0           py310hf2a6c47_1    conda-forge
scipy                     1.13.1          py310h46043a1_0    conda-forge
setuptools                70.0.0             pyhd8ed1ab_0    conda-forge
sip                       6.7.12          py310h00ffb61_0    conda-forge
six                       1.16.0             pyh6c4a22f_0    conda-forge
snappy                    1.2.0                hfb803bf_1    conda-forge
snowballstemmer           2.2.0              pyhd8ed1ab_0    conda-forge
sphinx                    7.3.7              pyhd8ed1ab_0    conda-forge
sphinxcontrib-applehelp   1.0.8              pyhd8ed1ab_0    conda-forge
sphinxcontrib-devhelp     1.0.6              pyhd8ed1ab_0    conda-forge
sphinxcontrib-htmlhelp    2.0.5              pyhd8ed1ab_0    conda-forge
sphinxcontrib-jsmath      1.0.1              pyhd8ed1ab_0    conda-forge
sphinxcontrib-qthelp      1.0.7              pyhd8ed1ab_0    conda-forge
sphinxcontrib-serializinghtml 1.1.10             pyhd8ed1ab_0    conda-forge
svt-av1                   2.1.0                he0c23c2_0    conda-forge
tbb                       2021.12.0            hc790b64_1    conda-forge
threadpoolctl             3.5.0              pyhc1e730c_0    conda-forge
tifffile                  2024.5.22          pyhd8ed1ab_0    conda-forge
tk                        8.6.13               h5226925_1    conda-forge
toml                      0.10.2             pyhd8ed1ab_0    conda-forge
tomli                     2.0.1              pyhd8ed1ab_0    conda-forge
toposort                  1.10               pyhd8ed1ab_0    conda-forge
tornado                   6.4             py310h8d17308_0    conda-forge
traits                    6.4.3           py310h8d17308_0    conda-forge
traitsui                  8.0.0              pyhd8ed1ab_0    conda-forge
typing-extensions         4.11.0               hd8ed1ab_0    conda-forge
typing_extensions         4.11.0             pyha770c72_0    conda-forge
tzdata                    2024a                h0c530f3_0    conda-forge
ucrt                      10.0.22621.0         h57928b3_0    conda-forge
ujson                     5.10.0          py310h9e98ed7_0    conda-forge
unicodedata2              15.1.0          py310h8d17308_0    conda-forge
urllib3                   2.2.1              pyhd8ed1ab_0    conda-forge
vc                        14.3                ha32ba9b_20    conda-forge
vc14_runtime              14.38.33135         h835141b_20    conda-forge
vs2015_runtime            14.38.33135         h22015db_20    conda-forge
wheel                     0.43.0             pyhd8ed1ab_1    conda-forge
win_inet_pton             1.1.0              pyhd8ed1ab_6    conda-forge
wxpython                  4.2.1                    pypi_0    pypi
xorg-libxau               1.0.11               hcd874cb_0    conda-forge
xorg-libxdmcp             1.1.3                hcd874cb_0    conda-forge
xz                        5.2.6                h8d14728_0    conda-forge
yaml                      0.2.5                h8ffe710_2    conda-forge
zeroconf                  0.132.2            pyhd8ed1ab_0    conda-forge
zfp                       1.0.1                h63175ca_0    conda-forge
zipp                      3.17.0             pyhd8ed1ab_0    conda-forge
zlib-ng                   2.0.7                hcfcfb64_0    conda-forge
zstd                      1.5.6                h0ea2cb4_0    conda-forge
```

</details>


**Is this a bugfix or an enhancement?**

**Proposed changes:**
change setup and teardown functions to setup_module and reardown module so they get called by pytest





**Checklist:**

```
(pyme310) C:\Userfiles\andrew\code\python-microscopy\tests\PYME\recipes>pytest test_acquisition.py
=================================================================== test session starts ====================================================================
platform win32 -- Python 3.10.14, pytest-8.2.1, pluggy-1.5.0
rootdir: C:\Userfiles\andrew\code\python-microscopy
collected 1 item

test_acquisition.py .                                                                                                                                 [100%]

===================================================================== warnings summary =====================================================================
..\..\..\..\..\..\..\Users\aesb\AppData\Local\miniforge3\envs\pyme310\lib\site-packages\numexpr\expressions.py:21
..\..\..\..\..\..\..\Users\aesb\AppData\Local\miniforge3\envs\pyme310\lib\site-packages\numexpr\expressions.py:21
  C:\Users\aesb\AppData\Local\miniforge3\envs\pyme310\lib\site-packages\numexpr\expressions.py:21: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_forbids_neg_powint = LooseVersion(numpy.__version__) >= LooseVersion('1.12.0b1')

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================== 1 passed, 2 warnings in 5.11s ===============================================================

```