### PR TITLE
make scipy.stats.mode call compatible with scipy>=1.10

### DIFF
--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -2674,7 +2674,7 @@ class StatisticsByFrame(ModuleBase):
             var[si] = np.var(slice_data)
             mean[si] = np.mean(slice_data)
             median[si] = np.median(slice_data)
-            mode[si] = stats.mode(slice_data, axis=None).mode.item()
+            mode[si] = stats.mode(slice_data, axis=None)[0].squeeze()
 
         # package up and ship-out results
         return tabular.DictSource({'variance': var, 'mean': mean, 'median': median, 'mode': mode})

--- a/PYME/recipes/processing.py
+++ b/PYME/recipes/processing.py
@@ -2674,7 +2674,7 @@ class StatisticsByFrame(ModuleBase):
             var[si] = np.var(slice_data)
             mean[si] = np.mean(slice_data)
             median[si] = np.median(slice_data)
-            mode[si] = stats.mode(slice_data, axis=None)[0][0]
+            mode[si] = stats.mode(slice_data, axis=None).mode.item()
 
         # package up and ship-out results
         return tabular.DictSource({'variance': var, 'mean': mean, 'median': median, 'mode': mode})


### PR DESCRIPTION
Addresses issue [scipy.stats.mode output keepdims behavior change](https://github.com/scipy/scipy/issues/16418)


**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
make scipy.stats.mode calls (I only found one) compatible with scipy 1.10+

previously:
```
..\..\..\PYME\recipes\base.py:259: in execute
    ret = self.run(**inputs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <PYME.recipes.processing.StatisticsByFrame object at 0x000001A18913ADE0>, input_name = <PYME.IO.image.ImageStack object at 0x000001A188A4F3D0>
mask = <PYME.IO.DataSources.ArrayDataSource.ArrayDataSource object at 0x000001A188A4E800>

    def run(self, input_name, mask=None):
        from scipy import stats

        data = input_name.data
        if mask:
            # again, handle our mask being either 2D, 3D, or 4D. NB - no color (4D) handling implemented at this point
            mask = mask.data

        var = np.empty(data.shape[2], dtype=float)
        mean = np.empty_like(var)
        median = np.empty_like(var)
        mode = np.empty_like(var)

        for si in range(data.shape[2]):
            slice_data = data[:,:,si, 0]

            if mask is not None:
                if mask.shape[2] == 1:
                    slice_data = slice_data[mask[:,:,0,0].astype('bool')]
                elif mask.shape[2] == data.shape[2]:
                    slice_data = slice_data[mask[:,:,si,0].astype('bool')]
                else:
                    raise RuntimeError('Mask dimensions do not match data dimensions')

            var[si] = np.var(slice_data)
            mean[si] = np.mean(slice_data)
            median[si] = np.median(slice_data)
>           mode[si] = stats.mode(slice_data, axis=None)[0][0]
E           IndexError: invalid index to scalar variable.

..\..\..\PYME\recipes\processing.py:2677: IndexError
```


which passes with the PR'd change. 



**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
