### PR TITLE
fix cropped im metadata so it is serializable

### DIFF
--- a/PYME/IO/DataSources/CropDataSource.py
+++ b/PYME/IO/DataSources/CropDataSource.py
@@ -201,25 +201,25 @@ def crop_image(image, xrange=None, yrange=None, zrange=None, trange=None):
     im.mdh['Origin.z'] = oz + vz*_offset(zrange)
 
     try:
-        im.mdh['cropping.xslice'] = _slice(xrange)
+        im.mdh['cropping.xslice'] = _slice(xrange).indices(image.data_xyztc.shape[0])
     except TypeError:
         #xrange is None
         pass
 
     try:
-        im.mdh['cropping.yslice'] = _slice(yrange)
+        im.mdh['cropping.yslice'] = _slice(yrange).indices(image.data_xyztc.shape[1])
     except TypeError:
         #yrange is None
         pass
 
     try:
-        im.mdh['cropping.zslice'] = _slice(zrange)
+        im.mdh['cropping.zslice'] = _slice(zrange).indices(image.data_xyztc.shape[2])
     except TypeError:
         #zrange is None
         pass
 
     try:
-        im.mdh['cropping.tslice'] = _slice(trange)
+        im.mdh['cropping.tslice'] = _slice(trange).indices(image.data_xyztc.shape[3])
     except TypeError:
         #trange is None
         pass


### PR DESCRIPTION
Addresses issue #1466 .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- following suggestion in #1466 to use the slice.indices method to convert the slice metadata to tuple for writing in metadata.

**Checklist:**
 - tested with colloborator while supporting them over zoom, sorry for lack of screenshots showing tests or so

**outstanding thoughts**
- the cropped datasource stuff could be cleaned up a bit
- `File > export` cropped does not save events, which might be kind of annoying for some folks