### PR TITLE
PYMEVis extra datasources

### DIFF
--- a/PYME/Acquire/Hardware/driftTracking.py
+++ b/PYME/Acquire/Hardware/driftTracking.py
@@ -103,19 +103,42 @@ class OIDICFrameSource(StandardFrameSource):
     """
 
     def __init__(self, frameWrangler, oidic_controller, oidic_orientation=0):
-        super().__init__(frameWrangler)
+        #super().__init__(frameWrangler)
+        self._fw = frameWrangler
+        self._on_frame = dispatch.Signal(['frameData'])
+        
+        # connect to onFrame rather than onFrameGroup so we get the
+        # current frame which as opposed to an older one.
+        # this is important as the OIDIC orientation is expected to change between frames.
+        # NOTE: we still assume that this connection happens before any of the acquisition
+        # classes connect to onFrame, so that we get the frame data (and microscope state)
+        # before the acquisition classes have had a chance to modify the state (e.g. by changing the DIC orientation).
+        # TODO: This should be pretty safe, as the FrameSource is usually created in the init script, 
+        # but can we make this robust agains the assumed ordering (execution of handlers in order of addition is an undocumented feature of dispatch)?
+        self._fw.onFrame.connect(self.tick)
 
         self._oidic = oidic_controller
+
+        self._last_tick_time = 0
+        # throttle to ensure 50 ms delay between completion of computation on one frame and start of computation on the next.
+        # the 50ms is emperical, but should (hopefully) be long enough to let anything else which is hooked to onFrame run. 
+        self._tick_throttle = 0.05 
         #self._target_orientation = oidic_orientation
 
-    def tick(self, *args, **kwargs):
-        # FIXME - check when onFrameGroup is emitted relative to when the OIDIC orientation is set.
-        # Is this predictable, or does it depend on the order in which OIDIC and drift tracking are
-        # registered with the frameWrangler?
+    def tick(self, frameData, **kwargs):
+        # Because we are connected to onFrame rather than onFrameGroup (which is inherently throttled by the GUI loop),
+        # we need to throttle the signal ourselves to avoid overwhelming things
+        # when the frameWrangler is running at high speed (i.e. drift computation time
+        # is slower than or on the order of the camera integration time). 
+        if (time.time() - self._last_tick_time) < self._tick_throttle:
+            return
+        
         #self._target_orientation = self._oidic.home_channel()
         #if self._oidic.current_channel == self._target_orientation:
         if self._oidic.current_channel == self._oidic.home_channel():
-            super().tick(*args, **kwargs)
+            # send with the frame data of the frame which triggered the signal, rather than frameWrangler.currentFrame, which lags.
+            self._on_frame.send(sender=self, frameData=frameData)
+            self._last_tick_time = time.time() 
         else:
             # clobber all frames coming from camera when not in the correct DIC orientation
             pass

--- a/PYME/IO/csv_flavours.py
+++ b/PYME/IO/csv_flavours.py
@@ -232,8 +232,8 @@ def guess_flavour(colNames, delim=None, ext=None):
 
     return fl
 
-
-
+text_extensions = ['.csv', '.txt'] + [e for e in [csv_flavours[flavour].get('ext',None) for flavour in csv_flavours] if e is not None]
+text_extensions = list(set(text_extensions))
 
 def gen_mdh(self): # generate some metaData that will be passed up the chain
                     # to record some bits of this import

--- a/PYME/IO/csv_flavours.py
+++ b/PYME/IO/csv_flavours.py
@@ -187,6 +187,9 @@ def guess_text_options(filename):
 
     return text_options
 
+def strict_options(text_options):
+    '''Remove all options from dictionary which aren't defined in our text_options definition'''
+    return {k: text_options[k] for k in text_options if k in ['columnnames', 'skiprows', 'delimiter', 'invalid_raise']}
 
 def check_required_names(self):
     reqNotDef = [name for name in self.requiredNames.keys() if not name in self.translatedNames]

--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -1356,6 +1356,10 @@ class ImageStack(object):
             self.saved = True
 
     def Save(self, filename=None, crop=False, roi=None, progressCallback=None):
+        warnings.warn(DeprecationWarning('The "Save" method is deprecated, please use "save" instead'))
+        self.save(filename=filename, crop=crop, roi=roi, progressCallback=progressCallback)
+
+    def save(self, filename=None, crop=False, roi=None, progressCallback=None):
         """
         Saves an image to file.
 

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -56,6 +56,13 @@ def deprecated_name(name):
 
 class TabularBase(object):
     def toDataFrame(self, keys=None):
+        warnings.warn('toDataFrame is deprecated, use to_pandas instead', DeprecationWarning)
+        self.to_pandas(keys)
+
+    def to_pandas(self, keys=None):
+        """
+        Convert tabular data to a pandas DataFrame
+        """
         import pandas as pd
         if keys is None:
             keys = self.keys()

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -190,15 +190,15 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
 
         if not filename is None:
             def _recipe_callback():
+                if len(cmd_args.load) > 0:
+                    self.pipeline.load_extra_datasources(**dict(cmd_args.load))
+
                 recipe = getattr(self.cmd_args, 'recipe', None)
                 print('Using recipe: %s' % recipe)
                 if recipe:
                     from PYME.recipes import modules
                     self.pipeline.recipe.update_from_yaml(recipe)
-                    #self.recipeView.SetRecipe(self.pipeline.recipe)
-                
-                if len(cmd_args.load) > 0:
-                    self.pipeline.load_extra_datasources(**dict(cmd_args.load))
+                    #self.recipeView.SetRecipe(self.pipeline.recipe)  
                 
                 self.update_datasource_panel()
 

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -196,7 +196,11 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
                     from PYME.recipes import modules
                     self.pipeline.recipe.update_from_yaml(recipe)
                     #self.recipeView.SetRecipe(self.pipeline.recipe)
-                    self.update_datasource_panel()
+                
+                if len(cmd_args.load) > 0:
+                    self.pipeline.load_extra_datasources(**dict(cmd_args.load))
+                
+                self.update_datasource_panel()
 
                 self._recipe_editor.update_recipe_text()
             
@@ -452,6 +456,7 @@ def parse():
                         default=True, help='switch shaders off(default: off)')
     parser.add_argument('--new-layers', dest='new_layers', action='store_true', default=True)
     parser.add_argument('--no-layers', dest='new_layers', action='store_false', default=True)
+    parser.add_argument('-l', '--load', nargs=2, action='append', default=[], dest='load', metavar=('KEY', 'FILENAME'), help='Load one (or more) additional files into the recipe namespace.')
     args = parser.parse_args()
     return args
     

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -189,11 +189,12 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
         self.AddMenuItem('Recipe', 'Reconstruct from image file', self.reconstruct_pipeline_from_image_file)
 
         if not filename is None:
+            recipe = getattr(self.cmd_args, 'recipe', None)
+
             def _recipe_callback():
                 if len(cmd_args.load) > 0:
                     self.pipeline.load_extra_datasources(**dict(cmd_args.load))
-
-                recipe = getattr(self.cmd_args, 'recipe', None)
+                
                 print('Using recipe: %s' % recipe)
                 if recipe:
                     from PYME.recipes import modules
@@ -201,10 +202,9 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
                     #self.recipeView.SetRecipe(self.pipeline.recipe)  
                 
                 self.update_datasource_panel()
-
                 self._recipe_editor.update_recipe_text()
             
-            wx.CallLater(50,self.OpenFile,filename, recipe_callback=_recipe_callback)
+            wx.CallLater(50,self.OpenFile,filename, recipe_callback=_recipe_callback, create_default_recipe=(not recipe))
             #self.refv = False
         
         wx.CallAfter(self.RefreshView)

--- a/PYME/LMVis/gl_render3D_shaders.py
+++ b/PYME/LMVis/gl_render3D_shaders.py
@@ -280,6 +280,10 @@ class LMGLShaderCanvas(GLCanvas):
             
         self.layer_added.send(self)
 
+    def get_session_info(self):
+        return {'layers': [l.serialise() for l in self.layers],
+                'view': self.view.to_json()}
+
     def setOverlayMessage(self, message=''):
         # self.messageOverlay.set_message(message)
         # if self._is_initialized:

--- a/PYME/LMVis/layers/__init__.py
+++ b/PYME/LMVis/layers/__init__.py
@@ -30,3 +30,21 @@ from .SelectionOverlayLayer import SelectionOverlayLayer
 #from .ShadedPointRenderLayer import ShadedPointRenderLayer
 #from .TetrahedraRenderLayer import TetrahedraRenderLayer
 from .base import BaseLayer
+
+from . import pointcloud, mesh, tracks, image_layer
+
+layer_types = {
+    'PointCloudRenderLayer' : pointcloud.PointCloudRenderLayer,
+    'TriangleRenderLayer' : mesh.TriangleRenderLayer,
+    'TrackRenderLayer' : tracks.TrackRenderLayer,
+    'ImageRenderLayer' : image_layer.ImageRenderLayer,
+}
+
+def layer_from_session_info(pipeline, layer_info):
+    '''Construct a layer from a dictionary of layer information. 
+    
+    Used for de-serialising PYMEVis sessions.
+    '''
+    layer_type = layer_info['type']
+    layer = layer_types[layer_type](pipeline, **layer_info['settings'])
+    return layer

--- a/PYME/LMVis/layers/base.py
+++ b/PYME/LMVis/layers/base.py
@@ -113,6 +113,23 @@ class BaseLayer(HasTraits):
 
         """
         pass
+
+    def settings_dict(self):
+        d =  self.get([n for n in self.class_trait_names() if not n.startswith('_')])
+        for k, v in d.items():
+            if isinstance(v, dict) and not type(v) == dict:
+                v = dict(v)
+            elif isinstance(v, list) and not type(v) == list:
+                v = list(v)
+            elif isinstance(v, set) and not type(v) == set:
+                v = set(v)
+
+            d[k] = v
+        return d
+    
+    def serialise(self):
+        return {'type': self.__class__.__name__,
+                'settings': self.settings_dict()}
     
 class EngineLayer(BaseLayer):
     """
@@ -124,6 +141,11 @@ class EngineLayer(BaseLayer):
     def render(self, gl_canvas):
         if self.visible:
             return self.engine.render(gl_canvas, self)
+        
+    def settings_dict(self):
+        r = BaseLayer.settings_dict(self)
+        r.pop('engine') # don't include the enginge in the dict represetation (this is set by `method`)
+        return r
         
     
     @abc.abstractmethod

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -817,7 +817,7 @@ class Pipeline(object):
         self.recipe.add_module(FilterTable(self.recipe, inputName='colour_mapped', outputName='filtered_localizations', filters={k:list(v) for k, v in self.filterKeys.items() if k in ds_keys}))
 
 
-    def OpenFile(self, filename= '', ds = None, clobber_recipe=True, **kwargs):
+    def OpenFile(self, filename= '', ds = None, clobber_recipe=True, create_default_recipe=None, **kwargs):
         """Open a file - accepts optional keyword arguments for use with files
         saved as .txt and .mat. These are:
             
@@ -852,7 +852,10 @@ class Pipeline(object):
                 self.filterKeys['fitError_dx'] = (0, 10)
                 self.filterKeys['fitError_dy'] = (0, 10)
 
-        if clobber_recipe:
+        if create_default_recipe is None:
+            create_default_recipe = clobber_recipe
+
+        if create_default_recipe:
             self._create_default_recipe(pixel_size=kwargs.get('PixelSize', 1.0), ds_keys = ds.keys())
         else:
             logger.warn('Opening file without clobbering recipe, filter and ratiometric colour settings might not be handled properly')

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -856,6 +856,20 @@ class Pipeline(object):
             self.imageBounds = ImageBounds.estimateFromSource(self.selectedDataSource)
         
         #self._process_colour()
+
+    def load_extra_datasources(self, **kwargs):
+        ''' Load additional input data files into the pipeline.
+        
+       Takes keyword arguments with the following format:
+       namespace_key=filename
+
+       e.g.
+       load_extra_datadources(fitResults='fitResults.mat', drift='drift.mat')        
+       '''
+        
+        for k, v in kwargs.items():
+            self.recipe.loadInput(filename=v, key=k)
+
         
     @property
     def colour_mapper(self):

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -502,6 +502,36 @@ class Pipeline(object):
             return name, count
             
         return name
+    
+    def _get_session_datasources(self):
+        """
+        Return a dictionary of datasources which are suitable for listing in a session file
+        
+        """
+        out = {}
+        for k in self.recipe.inferred_data:
+            ds = self.dataSources[k]
+
+            if hasattr(ds, 'filename'):
+                fn = ds.filename
+
+                q = getattr(ds, 'query', None)
+                if q:
+                    fn += '?' + q
+
+                out[k] = fn
+            else:
+                logger.error('Data source %s has no filename, skipping. Session will be incomplete.' % k)
+        
+        return out
+    
+    def get_session(self):
+        """
+        Return a dictionary of the current session
+        
+        """
+        return {'datasources': self._get_session_datasources(),
+                'recipe': self.recipe.get_cleaned_module_list()}
 
     def addColumn(self, name, values, default = 0):
         """

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -508,6 +508,7 @@ class Pipeline(object):
         Return a dictionary of datasources which are suitable for listing in a session file
         
         """
+        from PYME import warnings
         out = {}
         for k in self.recipe.inferred_data:
             ds = self.dataSources[k]
@@ -520,8 +521,10 @@ class Pipeline(object):
                     fn += '?' + q
 
                 out[k] = fn
-            else:
-                logger.error('Data source %s has no filename, skipping. Session will be incomplete.' % k)
+            else:           
+                #logger.error('Data source %s has no filename, skipping. Session will be incomplete.' % k)
+                if not warnings.warn('Data source %s has no filename, skipping. Session will be incomplete.' % k, allow_cancel=True):
+                    raise RuntimeError('Session save cancelled')
         
         return out
     

--- a/PYME/LMVis/views.py
+++ b/PYME/LMVis/views.py
@@ -166,13 +166,13 @@ class View(object):
         return array / numpy.linalg.norm(array)
 
     def to_json(self):
-        ordered_dict = OrderedDict()
+        ordered_dict = dict()# OrderedDict()
         ordered_dict['view_id'] = self.view_id
         ordered_dict['vec_up'] = self.vec_up.tolist()
         ordered_dict['vec_back'] = self.vec_back.tolist()
         ordered_dict['vec_right'] = self.vec_right.tolist()
         ordered_dict['translation'] = self.translation.tolist()
-        ordered_dict['scale'] = self.scale
+        ordered_dict['scale'] = float(self.scale)
         ordered_dict['clipping'] = self.clipping.view('8f4').squeeze().tolist()
         #ordered_dict['clip_plane_orientation'] = self.clip_plane_orientation.view('4f8').squeeze().tolist()
         ordered_dict['clip_plane_position'] = self.clip_plane_position.tolist()

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -864,7 +864,7 @@ class VisGUICore(object):
             #self.CreateFoldPanel()
             logger.debug('Gui stuff done')
     
-    def OpenFile(self, filename, recipe_callback=None):
+    def OpenFile(self, filename, recipe_callback=None, create_default_recipe=True):
         # get rid of any old layers
         while len(self.layers) > 0:
             self.layers.pop()
@@ -876,12 +876,13 @@ class VisGUICore(object):
         
         logger.debug('Creating Pipeline')
         if filename is None and not ds is None:
-            self.pipeline.OpenFile(ds=ds)
+            self.pipeline.OpenFile(ds=ds, create_default_recipe=create_default_recipe)
         else:
             args = self._populate_open_args(filename)
             if args is None:
                 return
-            self.pipeline.OpenFile(filename, **args)
+            
+            self.pipeline.OpenFile(filename, create_default_recipe=create_default_recipe, **args)
         logger.debug('Pipeline Created')
         
         #############################

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -842,10 +842,28 @@ class VisGUICore(object):
             self.glCanvas.set_view(views.View.decode_json(view))
     
     
+    def _update_title_and_tabs(self, filename):
+        self.recipeView.invalidate_layout()
+        self.update_datasource_panel()
+
+        if isinstance(self, wx.Frame):
+            #run this if only we are the main frame
+            self.SetTitle('PYME Visualise - ' + filename)
+            self._removeOldTabs()
+            self._createNewTabs()
+            
+            #self.CreateFoldPanel()
+            logger.debug('Gui stuff done')
+    
     def OpenFile(self, filename, recipe_callback=None):
         # get rid of any old layers
         while len(self.layers) > 0:
             self.layers.pop()
+
+        if filename.endswith('.pvs'):
+            self.load_session(filename)
+            self._update_title_and_tabs(filename)
+            return
         
         logger.debug('Creating Pipeline')
         if filename is None and not ds is None:
@@ -859,17 +877,9 @@ class VisGUICore(object):
         
         #############################
         #now do all the gui stuff
-        self.recipeView.invalidate_layout()
-        self.update_datasource_panel()
+
+        self._update_title_and_tabs(filename)
         
-        if isinstance(self, wx.Frame):
-            #run this if only we are the main frame
-            self.SetTitle('PYME Visualise - ' + filename)
-            self._removeOldTabs()
-            self._createNewTabs()
-            
-            #self.CreateFoldPanel()
-            logger.debug('Gui stuff done')
         
         try:
             if recipe_callback:

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -799,6 +799,17 @@ class VisGUICore(object):
             
         return args
 
+    def get_session(self):
+        import yaml
+        from PYME.recipes.base import MyDumper
+        session = {}
+        session.update(self.pipeline.get_session()) # get the pipeline session info (data sources, recipe, outputfilter?? etc)
+
+        # TODO - View and layer settings
+
+        return yaml.dump(session, Dumper=MyDumper)
+    
+    
     def OpenFile(self, filename, recipe_callback=None):
         # get rid of any old layers
         while len(self.layers) > 0:

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -266,6 +266,7 @@ class VisGUICore(object):
             self.AddMenuItem('File', "Open Extra &Channel", self.OnOpenChannel)
             
         self.AddMenuItem('File', 'Save filtered localizations', self.OnSave)
+        self.AddMenuItem('File', 'Save Session', self.OnSaveSession)
         
         if not subMenu:
             self.AddMenuItem('File', itemType='separator')
@@ -818,6 +819,14 @@ class VisGUICore(object):
     def save_session(self, filename):
         with open(filename, 'w') as f:
             f.write(self.get_session_yaml())
+
+    def OnSaveSession(self, event):
+        '''GUI callback to save session to a file, shows a file dialog'''
+        filename = wx.SaveFileSelector("Choose a file to save the session to", 
+                                   #nameUtils.genResultDirectoryPath(), 
+                                   extension='.pvs')
+        if not filename == '':
+            self.save_session(filename)
     
     def load_session(self, filename):
         import yaml

--- a/PYME/cluster/taskWorkerHTTP.py
+++ b/PYME/cluster/taskWorkerHTTP.py
@@ -431,15 +431,17 @@ class taskWorker(object):
                     
                     #load recipe inputs
                     logging.debug(taskDescr)
+                    recipe.load_inputs(taskDescr['inputs'])
+
                     for key, url in taskDescr['inputs'].items():
                         if key == '__sim':
                             # special case for no-input simulation recipes
                             # for now, essentially ignore `__sim` inputs, but propagate into context just in case
                             # TODO?? find a way of encoding simulation parameters?
                             context['sim_tag'] = url
-                        else:    
-                            logging.debug('RECIPE: loading %s as %s' % (url, key))
-                            recipe.loadInput(url, key)
+                        # else:    
+                        #     logging.debug('RECIPE: loading %s as %s' % (url, key))
+                        #     recipe.loadInput(url, key)
 
                     #print recipe.namespace
                     recipe.execute()

--- a/PYME/recipes/localisations.py
+++ b/PYME/recipes/localisations.py
@@ -171,6 +171,8 @@ class DensityMapping(ModuleBase):
                     ),
                 ]
 
+class DictWrapper(dict):
+    pass
 @register_module('AddPipelineDerivedVars')
 class Pipelineify(ModuleBase):
     """
@@ -210,6 +212,7 @@ class Pipelineify(ModuleBase):
     foreshortening = Float(1.0, desc='scaling factor to correct for foreshortening in z')
 
     outputLocalizations = Output('Localizations')
+    outputEventMaps = Output('event_maps')
     
     # def execute(self, namespace):
     #     from PYME.LMVis import pipeline
@@ -286,7 +289,7 @@ class Pipelineify(ModuleBase):
         if isinstance(events, tabular.TabularBase):
             events = events.to_recarray()
 
-        ev_maps, ev_charts = pipeline._processEvents(mapped_ds, events, mdh)
+        ev_maps = pipeline._processEvents(mapped_ds, events, mdh)
         pipeline._add_missing_ds_keys(mapped_ds, ev_maps)
         mapped_ds.set_variables(foreShort=self.foreshortening)
         
@@ -305,7 +308,7 @@ class Pipelineify(ModuleBase):
 
         mapped_ds.mdh = mdh
 
-        return mapped_ds
+        return {'outputLocalizations' : mapped_ds, 'outputEventMaps' : DictWrapper(ev_maps)}
         
 @register_module("ProcessColour")
 class ProcessColour(ModuleBase):

--- a/PYME/recipes/recipe.py
+++ b/PYME/recipes/recipe.py
@@ -3,6 +3,7 @@ from PYME.contrib import dispatch
 from .base import ModuleBase, OutputModule
 from PYME.recipes import base
 from PYME.IO.image import ImageStack
+from PYME.IO import tabular, csv_flavours
 import time
 
 import logging
@@ -728,9 +729,11 @@ class Recipe(HasTraits):
                 logger.exception('Error reading HDF file: %s' % filename)
                 raise IOError('Error reading %s' % filename)
         
-        elif extension == '.csv':
-            logger.error('loading .csv not supported yet')
-            raise NotImplementedError
+        elif extension in csv_flavours.text_extensions:
+            logger.info('Guess text file format ...')
+            text_options = csv_flavours.guess_text_options(filename)
+            ds = tabular.TextfileSource(filename, **text_options)
+            self.namespace[key] = ds
         elif extension in ['.xls', '.xlsx']:
             logger.error('loading .xls not supported yet')
             raise NotImplementedError

--- a/PYME/recipes/recipe.py
+++ b/PYME/recipes/recipe.py
@@ -831,6 +831,7 @@ class Recipe(HasTraits):
             from urllib.parse import parse_qs
             filename, query = filename.split('?')
             args.update(parse_qs(query))
+            args = {k: v if len(v)>1 else v[0] for k, v in args.items()}
         else:
             query=None
         

--- a/PYME/recipes/recipe.py
+++ b/PYME/recipes/recipe.py
@@ -849,7 +849,7 @@ class Recipe(HasTraits):
         elif extension in ['.xls', '.xlsx']:
             logger.error('loading .xls not supported yet')
             raise NotImplementedError
-        elif os.path.splitext(filename)[1] == '.mat': #matlab file
+        elif extension == '.mat': #matlab file
             with unifiedIO.local_or_temp_filename(filename) as fn:
                 if 'VarName' in args.keys():
                     #old style matlab import
@@ -874,12 +874,15 @@ class Recipe(HasTraits):
                             field_names.append('probe')  # don't forget to copy this field over
                         ds = tabular.MappingFilter(ds, **{new_field : old_field for new_field, old_field in zip(field_names, ds.keys())})
 
+            ds.filename = filename
             self.namespace[key] = ds
 
-        elif os.path.splitext(filename)[1] == '.h5ad':
+        elif extension == '.h5ad':
             with unifiedIO.local_or_temp_filename(filename) as fn:
                 ds = tabular.AnndataSource(filename)
-                self.namespace[key] = ds
+                
+            ds.filename = filename
+            self.namespace[key] = ds
 
         elif (not default_to_image) or (extension in csv_flavours.text_extensions):
             with unifiedIO.local_or_temp_filename(filename) as fn:
@@ -893,8 +896,11 @@ class Recipe(HasTraits):
                 ds = tabular.TextfileSource(filename, **text_options)
                 
                 from urllib.parse import urlencode
-                ds.query = urlencode(csv_flavours.strict_options(text_options), doseq=True)
-                self.namespace[key] = ds
+
+            ds.query = urlencode(csv_flavours.strict_options(text_options), doseq=True)    
+            ds.filename = filename
+            self.namespace[key] = ds
+
         else: # assume it's an image
             if query:
                 filename = filename + '?' + query #reconstruct the filename with the query string as this is processed by some imaghe types

--- a/PYME/recipes/recipe.py
+++ b/PYME/recipes/recipe.py
@@ -675,6 +675,9 @@ class Recipe(HasTraits):
                     logger.exception('Error reading HDF file: %s' % filename)
                     raise IOError('Error reading %s' % filename)
 
+            for o in output.values():
+                o.filename = filename
+
             cache[filename] = output
             return output
         

--- a/PYME/recipes/recipe.py
+++ b/PYME/recipes/recipe.py
@@ -798,7 +798,7 @@ class Recipe(HasTraits):
     def _inject_tables_from_hdf5(self, key, filename, extension, cache={}, h5f=None):
         key_prefix = '' if key in ['input', '', None] else key + '_'  # prefix for keys in the namespace
 
-        tables = self._get_tables_from_hdf5(filename, extension, cache, h5f=h5f)
+        tables = self._get_tables_from_hdf5(filename, extension=extension, cache=cache, h5f=h5f)
         self.namespace.update({key_prefix + k: v for k, v in tables.items()})
 
     

--- a/PYME/recipes/runRecipe.py
+++ b/PYME/recipes/runRecipe.py
@@ -91,8 +91,7 @@ def runRecipe(recipe, inputs, outputs, context={}, metadata_defaults={}):
         recipe.namespace.clear()
 
         #load any necessary inputs and populate the recipes namespace
-        for key, filename in inputs.items():
-            recipe.loadInput(filename, key, metadata_defaults)
+        recipe.load_inputs(inputs, metadata_defaults=metadata_defaults)
 
         ### Run the recipe ###
         res = recipe.execute()

--- a/PYME/util/fProfile/html/index.html
+++ b/PYME/util/fProfile/html/index.html
@@ -40,7 +40,7 @@
 
             <form>
                 <p>Please specify the .json formatted profile file to use</p>
-                <input type="file" name="datafile" size="200" id="file_upload" onchange="OnFileUpload()">
+                <input type="file" name="datafile" size="200" id="file_upload" accept=".json" onchange="OnFileUpload()">
                 <div id="load_status"></div>
             </form>
 


### PR DESCRIPTION
First steps towards a solution for #1521 

You can now load additional files into the PYMEVis recipe namespace on the command line e.g.

`PYMEVis myfile.h5r -l raw myfile_raw.h5`

or 

`PYMEVis myfile.h5r --load raw myfile_raw.h5`

Also includes some first steps towards #1465 and allowing .csv as input to bakeshop etc ... (note, this needs a `with unifiedIO.local_or_temp_filename(filename) as fn` before it will work on the cluster).
