### PR TITLE
make version string compilation a little more robust

### DIFF
--- a/PYME/version.py
+++ b/PYME/version.py
@@ -52,7 +52,10 @@ def detailed_version():
     if _detailed_version is None:
         from PYME.misc.check_for_updates import guess_install_type
 
-        fv = version + '[' + guess_install_type() + ']'
+        # the string interpolation below should be more robust than the previous string concatenation with `+`
+        # which fails when one of the variables/return values is None
+        # a None return can apparently happen for zip snapshots of the git repo downloaded from github
+        fv = "%s[%s]" % (version,guess_install_type())
         if changeset !=_release_changeset:
             # code has been modified since last release, append commit hash
             fv += changeset


### PR DESCRIPTION
Tries to make version string compilation a little more robust.

**Issue addressed:**

Previously a None type could trip up the string assembly for the version string; now uses a slightly more robust way of interpolating the string.

This was annoying as it messed up the PYME error reporting, e.g.

```
Traceback (most recent call last):
  File "c:\pyme-test-env\build-test-py3.10-mamba\python-microscopy-master\PYME\ui\progress.py", line 152, in func
    with ComputationInProgress(window, description):
  File "c:\pyme-test-env\build-test-py3.10-mamba\python-microscopy-master\PYME\ui\progress.py", line 138, in exit
    show_traceback_dialog(self.window, self.description, exc_type, exc_val, exc_tb)
  File "c:\pyme-test-env\build-test-py3.10-mamba\python-microscopy-master\PYME\ui\progress.py", line 112, in show_traceback_dialog
    dlg = TracebackDialog(parent, description, exc_type, exc_val, exc_tb)
  File "c:\pyme-test-env\build-test-py3.10-mamba\python-microscopy-master\PYME\ui\progress.py", line 53, in init
    self.err_text=wx.TextCtrl(self, value=error_msg.format(description=description, pkgversions=get_package_versions(), traceback=tb),
  File "c:\pyme-test-env\build-test-py3.10-mamba\python-microscopy-master\PYME\ui\progress.py", line 25, in get_package_versions
    return _package_info.format(pyme_version=PYME.version.detailed_version(),
  File "c:\pyme-test-env\build-test-py3.10-mamba\python-microscopy-master\PYME\version.py", line 55, in detailed_version
    fv = version + '[' + guess_install_type() + ']'
TypeError: can only concatenate str (not "NoneType") to str
```

