### PR TITLE
Add a labels layer type for annotated tabular data

### DIFF
--- a/PYME/DSView/modules/psfTools.py
+++ b/PYME/DSView/modules/psfTools.py
@@ -23,13 +23,19 @@
 import wx
 import wx.html2
 import wx.grid
+import wx.lib.agw.aui as aui
+
 
 from jinja2 import Environment, PackageLoader
 env = Environment(loader=PackageLoader('PYME.DSView.modules', 'templates'))
 
 from PYME.recipes.traits import HasTraits, Float, Int, Bool, Enum
+import numpy as np
 
-from .graphViewPanel import *
+from matplotlib.figure import Figure
+from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
+
+#from .graphViewPanel import *
 from PYME.Analysis.PSFEst import psfQuality
 
 def remove_newlines(s):

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -112,6 +112,7 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
         ################################   
 
         self.MainWindow = self #so we can access from shell
+        self.pymevis = self # more memorable alias for the main window
         self.sh = wx.py.shell.Shell(id=-1,
                                     parent=self, size=wx.Size(-1, -1), style=0, locals=self.__dict__,
                                     startupScript=config.get('VisGUI-console-startup-file', None),
@@ -130,7 +131,9 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
 
         self.generatedImages = []
         
-        self.sh.Execute('from pylab import *')
+        #self.sh.Execute('from pylab import *')
+        self.sh.Execute('import numpy as np')
+        self.sh.Execute('import matplotlib.pyplot as plt')
         self.sh.Execute('from PYME.DSView.dsviewer import View3D')
         
         import os

--- a/PYME/LMVis/gl_render3D_shaders.py
+++ b/PYME/LMVis/gl_render3D_shaders.py
@@ -296,10 +296,7 @@ class LMGLShaderCanvas(GLCanvas):
         # TODO - do we need to do anything differnt on win?
         vmajor,vminor = wx.VERSION[:2]
 
-        if (vmajor >= 4) and (vminor >=1): # 4.1 or later 
-            sc = self.GetContentScaleFactor()
-        else:
-            sc = 1
+        sc = self.content_scale_factor
 
         #print('scale factor:', sc)
 
@@ -410,7 +407,7 @@ class LMGLShaderCanvas(GLCanvas):
                 
                 oit_layers = [] #layers which support order independent transparency - render these all together
                 for l in self.layers:
-                    if getattr(l.engine, 'use_oit', lambda l: False)(l) or getattr(l.engine, 'oit', False):
+                    if hasattr(l, 'engine') and (getattr(l.engine, 'use_oit', lambda l: False)(l) or getattr(l.engine, 'oit', False)):
                         #defer rendering
                         oit_layers.append(l)
                     else:
@@ -472,11 +469,7 @@ class LMGLShaderCanvas(GLCanvas):
         # fix scaling error
         # TODO - should this check be on wx, or OpenGL (or potentially python)
         # TODO - do we need to do anything differnt on win?
-        vmajor,vminor = wx.VERSION[:2]
-        if vmajor >= 4 and vminor >=1: # 4.1 or later 
-            sc = self.GetContentScaleFactor()
-        else:
-            sc = 1
+        sc = self.content_scale_factor
 
         #sc = 1
 
@@ -694,6 +687,16 @@ class LMGLShaderCanvas(GLCanvas):
     def pixelsize(self):
         return 2. / (self.view.scale * self.view_port_size[0])
     
+    @property
+    def content_scale_factor(self):
+        # version-safe way to get the content scale factor for high DPI screens
+        vmajor,vminor = wx.VERSION[:2]
+        if vmajor >= 4 and vminor >=1: # 4.1 or later 
+            sc = self.GetContentScaleFactor()
+        else:
+            sc = 1
+        return sc
+    
     def _view_changed(self):
         """Notify anyone who is synced to our view"""
         for callback in self.wantViewChangeNotification:
@@ -824,7 +827,7 @@ class LMGLShaderCanvas(GLCanvas):
 
     def _ScreenCoordinatesToNm(self, x, y):
         # FIXME!!!
-        sc = self.GetContentScaleFactor()
+        sc = self.content_scale_factor
         x_ = self.pixelsize * (x - 0.5 * float(self.view_port_size[0])) + self.view.translation[0]
         y_ = self.pixelsize * (y - 0.5 * float(self.view_port_size[1])) + self.view.translation[1]
         # print x_, y_
@@ -942,11 +945,7 @@ class LMGLShaderCanvas(GLCanvas):
         #     raise RuntimeError('{} is not a supported format.'.format(mode))
         # img.show()
         self.on_screen = False
-        vmajor, vminor = wx.VERSION[:2]
-        if (vmajor >= 4) and (vminor >= 1):
-            sc = self.GetContentScaleFactor()
-        else:
-            sc = 1
+        sc = self.content_scale_factor
         view_port_size = (int(self.view_port_size[0]*sc), int(self.view_port_size[1]*sc))
         off_screen_handler = OffScreenHandler(view_port_size, mode, self._num_antialias_samples)
         with off_screen_handler:

--- a/PYME/LMVis/gl_render3D_shaders.py
+++ b/PYME/LMVis/gl_render3D_shaders.py
@@ -384,6 +384,8 @@ class LMGLShaderCanvas(GLCanvas):
                 GL.glOrtho(-1, 1, ys, -ys, -1000, 1000)
 
             GL.glMatrixMode(GL.GL_MODELVIEW)
+
+            #stereo offset
             GL.glTranslatef(eye, 0.0, 0.0)
 
             # move our object to be centred at -10

--- a/PYME/LMVis/layers/LUTOverlayLayer.py
+++ b/PYME/LMVis/layers/LUTOverlayLayer.py
@@ -131,9 +131,12 @@ class LUTOverlayLayer(OverlayLayer):
                     tl.text = '%.3G' % cl
                     
                     xc = lb_ur_x - 0.5*lb_width
+
+                    _, hu, wu = tu.get_img_array(gl_canvas)
+                    _, hl, wl = tl.get_img_array(gl_canvas)
                     
-                    tu.pos = (xc - tu._w/2, lb_ur_y - tu._h)
-                    tl.pos = (xc - tl._w/2, lb_lr_y)
+                    tu.pos = (xc - wu/2, lb_ur_y - hu)
+                    tl.pos = (xc - wl/2, lb_lr_y)
                     
                     labels.extend([tl, tu])
                 

--- a/PYME/LMVis/layers/labels.py
+++ b/PYME/LMVis/layers/labels.py
@@ -25,7 +25,7 @@ class LabelLayer(SimpleLayer):
     _datasource_choices = List()
 
     textColour = CStr('', desc='Name of variable used to colour our text')
-    font_size = Float(12, desc='font size in points')
+    font_size = Float(10, desc='font size in points')
     cmap = Enum(*cm.cmapnames, default='gist_rainbow', desc='Name of colourmap used to colour text')
     clim = ListFloat([0, 1], desc='How our variable should be scaled prior to colour mapping')
 
@@ -52,10 +52,12 @@ class LabelLayer(SimpleLayer):
         # define responses to changes in various traits
         self.on_trait_change(self._update, 'textColour')
         self.on_trait_change(lambda: self.on_update.send(self), 'visible')
-        self.on_trait_change(self.update, 'cmap, clim, dsname, font_size')
+        self.on_trait_change(self.update, 'cmap, clim, dsname, font_size, format_string')
 
         # update any of our traits which were passed as command line arguments
         self.set(**kwargs)
+
+        self.update()
         
         # if we were given a pipeline, connect ourselves to the onRebuild signal so that we can automatically update
         # ourselves
@@ -101,7 +103,7 @@ class LabelLayer(SimpleLayer):
         return cm[self.cmap]
     
     def update_from_datasource(self, ds):
-        print('pointcloud.update_from_datasource() - dsname=%s' % self.dsname)
+        print('labels.update_from_datasource() - dsname=%s' % self.dsname)
         x, y = ds[self.x_key], ds[self.y_key]
         try:
             z = ds[self.z_key]

--- a/PYME/LMVis/layers/labels.py
+++ b/PYME/LMVis/layers/labels.py
@@ -1,0 +1,184 @@
+"""
+A layer which draws text labels at the positions of the points in a tabular datasource.
+"""
+
+from PYME.LMVis.layers.base import SimpleLayer
+
+from PYME.recipes.traits import CStr, Float, Enum, ListFloat, List, Bool
+# from pylab import cm
+from PYME.misc.colormaps import cm
+import numpy as np
+import string
+from PYME.contrib import dispatch
+from .text import Text
+
+import logging
+logger = logging.getLogger(__name__)
+
+class LabelLayer(SimpleLayer):
+    """
+    A layer which draws text labels at the positions of the points in a tabular datasource.
+    """
+
+    dsname = CStr('output', desc='Name of the datasource within the pipeline to use as a source of points')
+    _datasource_keys = List()
+    _datasource_choices = List()
+
+    textColour = CStr('', desc='Name of variable used to colour our text')
+    font_size = Float(12, desc='font size in points')
+    cmap = Enum(*cm.cmapnames, default='gist_rainbow', desc='Name of colourmap used to colour text')
+    clim = ListFloat([0, 1], desc='How our variable should be scaled prior to colour mapping')
+
+    format_string = CStr('P{idx}', desc='Format string for the text labels. This should be a python format string which can take column names (and the special idx name which is the index in the table)')
+
+    def __init__(self, pipeline, **kwargs):
+        SimpleLayer.__init__(self, **kwargs)
+        self._pipeline = pipeline
+        
+        self.x_key = 'x' #TODO - make these traits?
+        self.y_key = 'y'
+        self.z_key = 'z'
+
+        self._bbox = None
+        self._text_objects = []
+    
+        # define a signal so that people can be notified when we are updated (currently used to force a redraw when
+        # parameters change)
+        self.on_update = dispatch.Signal()
+
+        # signal for when the data is updated (used to, e.g., refresh histograms)
+        self.data_updated = dispatch.Signal()
+
+        # define responses to changes in various traits
+        self.on_trait_change(self._update, 'textColour')
+        self.on_trait_change(lambda: self.on_update.send(self), 'visible')
+        self.on_trait_change(self.update, 'cmap, clim, dsname, font_size')
+
+        # update any of our traits which were passed as command line arguments
+        self.set(**kwargs)
+        
+        # if we were given a pipeline, connect ourselves to the onRebuild signal so that we can automatically update
+        # ourselves
+        if not self._pipeline is None:
+            self._pipeline.onRebuild.connect(self.update)
+
+    @property
+    def datasource(self):
+        """
+        Return the datasource we are connected to (through our dsname property).
+        """
+        return self._pipeline.get_layer_data(self.dsname)
+    
+    def _get_cdata(self):
+        try:
+            cdata = self.datasource[self.textColour]
+        except KeyError:
+            cdata = np.array([0, 1])
+    
+        return cdata
+    
+    def _update(self, *args, **kwargs):
+        cdata = self._get_cdata()
+        self.clim = [float(np.nanmin(cdata)), float(np.nanmax(cdata))+1e-9]
+        #self.update(*args, **kwargs)
+
+    def update(self, *args, **kwargs):
+        #print('lw update')
+        self._datasource_choices = self._pipeline.layer_data_source_names
+        if not self.datasource is None:
+            self._datasource_keys = sorted(self.datasource.keys())
+            
+            self.update_from_datasource(self.datasource)
+            self.on_update.send(self)
+            
+
+    @property
+    def bbox(self):
+        return self._bbox
+    
+    @property
+    def colour_map(self):
+        return cm[self.cmap]
+    
+    def update_from_datasource(self, ds):
+        print('pointcloud.update_from_datasource() - dsname=%s' % self.dsname)
+        x, y = ds[self.x_key], ds[self.y_key]
+        try:
+            z = ds[self.z_key]
+        except (KeyError, ValueError):
+            z = 0*x
+        
+        if not self.textColour == '':
+            c = ds[self.textColour]
+        else:
+            c = 0*x
+
+        # find out what fields we need to format
+        format_field_names  = [f for _, f, _, _ in string.Formatter().parse(self.format_string) if f is not None]  
+        
+        data_columns = {k: ds[k] for k in format_field_names if not k == 'idx'}
+        data_columns['idx'] = np.arange(len(x))
+
+        labels = [self.format_string.format(**{k:v[i] for k, v in data_columns.items()}) for i in range(len(x))]
+
+        self.update_data(x, y, z, c, cmap=cm[self.cmap], clim=self.clim, labels=labels)
+
+        self.data_updated.send(self)
+    
+    
+    def update_data(self, x=None, y=None, z=None, colors=None, cmap=None, clim=None, labels=None, alpha=1.0):
+        self._text_objects = []
+        self._bbox = None
+
+        if clim is not None and colors is not None and clim is not None:
+            cs_ = ((colors - clim[0]) / (clim[1] - clim[0]))
+            cs = cmap(cs_)
+            cs[:, 3] = alpha
+            
+            cs = cs.ravel().reshape(len(colors), 4)
+        else:
+            if x is not None:
+                cs = np.ones((x.shape[0], 4), 'f')
+            else:
+                cs = None
+        
+        if x is not None and y is not None and z is not None and len(x) > 0:
+            self._text_objects = [Text(pos=(x[i], y[i], z[i]), text=labels[i], color=cs[i, :], font_size=self.font_size) for i in range(len(x))]
+            
+            self._bbox = np.array([x.min(), y.min(), z.min(), x.max(), y.max(), z.max()])
+        else:
+            
+            self._bbox = None
+
+    def render(self, gl_canvas):
+        if not self.visible:
+            return
+        
+        for to in self._text_objects:
+            to.render(gl_canvas)
+
+    @property
+    def default_view(self):
+        from traitsui.api import View, Item, Group, InstanceEditor, EnumEditor, TextEditor
+        from PYME.ui.custom_traits_editors import HistLimitsEditor, CBEditor
+
+        vis_when = 'cmap not in %s' % cm.solid_cmaps
+    
+        return View([Group([Item('dsname', label='Data', editor=EnumEditor(name='_datasource_choices')), ]),
+                     Item('textColour', editor=EnumEditor(name='_datasource_keys'), label='Colour', visible_when=vis_when),
+                     Group([Item('clim', editor=HistLimitsEditor(data=self._get_cdata, update_signal=self.data_updated), show_label=False), ], visible_when=vis_when),
+                     Group(Item('cmap', label='LUT'),
+                           #Item('alpha', visible_when="method in ['pointsprites', 'transparent_points']", editor=TextEditor(auto_set=False, enter_set=True, evaluate=float)),
+                           Item('font_size', label=u'Font\u00A0size', editor=TextEditor(auto_set=False, enter_set=True, evaluate=float)),
+                           Item('format_string', label='Format string', editor=TextEditor(auto_set=False, enter_set=True)),
+                           )])
+        #buttons=['OK', 'Cancel'])
+
+    def default_traits_view(self):
+        return self.default_view
+        
+        
+
+       
+    
+

--- a/PYME/LMVis/layers/labels.py
+++ b/PYME/LMVis/layers/labels.py
@@ -26,7 +26,7 @@ class LabelLayer(SimpleLayer):
 
     textColour = CStr('', desc='Name of variable used to colour our text')
     font_size = Float(10, desc='font size in points')
-    cmap = Enum(*cm.cmapnames, default='gist_rainbow', desc='Name of colourmap used to colour text')
+    cmap = Enum('SolidWhite', cm.cmapnames, desc='Name of colourmap used to colour text')
     clim = ListFloat([0, 1], desc='How our variable should be scaled prior to colour mapping')
 
     format_string = CStr('P{idx}', desc='Format string for the text labels. This should be a python format string which can take column names (and the special idx name which is the index in the table)')

--- a/PYME/LMVis/layers/text.py
+++ b/PYME/LMVis/layers/text.py
@@ -155,7 +155,11 @@ class Text(BaseEngine):
                 glDisable(GL_TEXTURE_GEN_R)
             
                 #glColor3f(1.,0.,0.)
-                glColor4f(1., 1., 1., 1.)
+                if self._color is not None:
+                    glColor4f(*self._color)
+                else:
+                    glColor4f(1., 1., 1., 1.)
+                    
                 glBegin(GL_QUADS)
                 glTexCoord2f(0., 0.) # lower left corner of image */
                 glVertex3f(x0, y0, 0.0)

--- a/PYME/LMVis/layers/text.py
+++ b/PYME/LMVis/layers/text.py
@@ -21,13 +21,14 @@ class Text(BaseEngine):
     TODO - Shader. My first instinct here would be to make the text values (as derived from the array) control transparency.
            This should give an attractive anti-aliasing/blending effect, but we'd need to try it out in practice.
     """
-    def __init__(self, text='', pos=(0,0), color=None, **kwargs):
+    def __init__(self, text='', pos=(0,0), color=None, font_size=10, **kwargs):
         BaseEngine.__init__(self)
         self.set_shader_program(TextShaderProgram)
         
         self._texture_id = None
         self._img = None
         self._color = color
+        self._font_size = font_size
 
         self._im_key = None
         self._im = None
@@ -74,11 +75,11 @@ class Text(BaseEngine):
         return im
         
     def get_img_array(self, gl_canvas):
-        im_key = (self.text, gl_canvas.content_scale_factor)
+        im_key = (self.text, self._font_size, gl_canvas.content_scale_factor)
 
         if im_key != self._im_key:
             self._im_key = im_key
-            self._im = np.ascontiguousarray(self.gen_text_image(self.text, dip_scale=gl_canvas.content_scale_factor)[:, :, 0]/255.)
+            self._im = np.ascontiguousarray(self.gen_text_image(self.text, size=self._font_size, dip_scale=gl_canvas.content_scale_factor)[:, :, 0]/255.)
 
         h, w = self._im.shape
         return self._im, h, w 

--- a/PYME/misc/colormaps.py
+++ b/PYME/misc/colormaps.py
@@ -139,6 +139,11 @@ def Yellow(data):
     z = np.ones_like(data)
     return np.stack([z, z, 0*z, z], -1)
 
+@cm.register_cmap('SolidWhite', solid=True)
+def White(data):
+    z = np.ones_like(data)
+    return np.stack([z, z, z, z], -1)
+
 @cm.register_cmap('labeled')
 def labeled(data):
     return (data > 0).reshape(list(data.shape) +  [1])*cm.gist_rainbow(data % 1)


### PR DESCRIPTION
Work in progress ... This has been on the TODO for a while, adds a layer for text annotations - @csoeller 

<img width="1231" alt="image" src="https://github.com/user-attachments/assets/0fcfe7a0-89be-45ae-962c-7375f5a97c9f">

Example test usage (within pymevis console):
```python
>>> from PYME.LMVis.layers.labels import LabelLayer
>>> from PYME.IO import tabular
>>> rs = tabular.RandomSource(xmax=10000, ymax=10000, nsamps=100)
>>> pipeline.addDataSource('foo', rs, False)
>>> ll = LabelLayer(pipeline, dsname='foo')
>>> pymevis.add_layer(ll)
>>> ll.update()
```

### Caveats and TODOs

- layer doesn't update properly when you change stuff in UI (need to call `.update()` on the layer manually, then resize window to force a repaint)
- Limited to relatively small datasets (you don't want to add a `LabelLayer` pointing to a standard localisation dataset)
- colour and font size settings are ignored
- should probably allow a programmable offset
