### PR TITLE
Initial steps to move away from deprecated OpenGL functionality

### DIFF
--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -31,7 +31,7 @@ import time
 import PYME.ui.manualFoldPanel as afp
 import wx
 import wx.lib.agw.aui as aui
-import wx.py.shell
+import PYME.ui.shell
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -122,7 +122,7 @@ class PYMEMainFrame(acquirebase.PYMEAcquireBase, AUIFrame):
         self.splash.Show()
         
 
-        self.sh = wx.py.shell.Shell(id=-1,
+        self.sh = PYME.ui.shell.Shell(id=-1,
               parent=self, size=wx.Size(-1, -1), style=0, locals=self.__dict__,
               introText='PYMEAcquire - note that help, license, etc. below is for Python, not PYME\n\n')
         self.AddPage(self.sh, caption='Shell')

--- a/PYME/DSView/modules/annotation.py
+++ b/PYME/DSView/modules/annotation.py
@@ -458,7 +458,7 @@ class AnnotateBase(object):
     def render(self, gl_canvas):
         import  OpenGL.GL as gl
         
-        gl.glDisable(gl.GL_LIGHTING)
+        #gl.glDisable(gl.GL_LIGHTING)
         gl.glPolygonMode(gl.GL_FRONT_AND_BACK, gl.GL_LINE)
         gl.glDisable(gl.GL_DEPTH_TEST)
 

--- a/PYME/DSView/modules/psfTools.py
+++ b/PYME/DSView/modules/psfTools.py
@@ -23,13 +23,19 @@
 import wx
 import wx.html2
 import wx.grid
+import wx.lib.agw.aui as aui
+
 
 from jinja2 import Environment, PackageLoader
 env = Environment(loader=PackageLoader('PYME.DSView.modules', 'templates'))
 
 from PYME.recipes.traits import HasTraits, Float, Int, Bool, Enum
+import numpy as np
 
-from .graphViewPanel import *
+from matplotlib.figure import Figure
+from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
+
+#from .graphViewPanel import *
 from PYME.Analysis.PSFEst import psfQuality
 
 def remove_newlines(s):

--- a/PYME/DSView/modules/shell.py
+++ b/PYME/DSView/modules/shell.py
@@ -20,11 +20,11 @@
 #
 ##################
 
-import wx.py.shell
+import PYME.ui.shell
 from PYME import config
 
 def Plug(dsviewer):
-    sh = wx.py.shell.Shell(id=-1,
+    sh = PYME.ui.shell.Shell(id=-1,
                            parent=dsviewer, pos=wx.Point(0, 0), size=wx.Size(618, 451), style=0, locals=dsviewer.__dict__,
                            startupScript=config.get('dh5View-console-startup-file', None),
               introText='PYMEImage - note that help, license, etc. below is for Python, not PYME\n\n')

--- a/PYME/DSView/modules/visgui.py
+++ b/PYME/DSView/modules/visgui.py
@@ -29,7 +29,13 @@ import wx
 import os
 
 from PYME.DSView.arrayViewPanel import ArrayViewPanel
-from PYME.LMVis.gl_render3D_shaders import LMGLShaderCanvas
+
+import PYME.config
+
+if PYME.config.get('VisGUI-opengl-core-profile', False):
+    from PYME.LMVis.glcanvas_core import LMGLShaderCanvas
+else:
+    from PYME.LMVis.gl_render3D_shaders import LMGLShaderCanvas
 
 from six.moves import xrange
 

--- a/PYME/LMVis/Extras/annotation.py
+++ b/PYME/LMVis/Extras/annotation.py
@@ -26,8 +26,8 @@ class AnnotationOverlayLayer(OverlayLayer):
         if not self.visible:
             return
         
-        self._clear_shader_clipping(gl_canvas)
-        with self.get_shader_program(gl_canvas):
+        with self.get_shader_program(gl_canvas) as sp:
+            sp.clear_shader_clipping()
             self._annotator.render(gl_canvas)
 
 class Annotator(ann.AnnotateBase):

--- a/PYME/LMVis/Extras/extra_layers.py
+++ b/PYME/LMVis/Extras/extra_layers.py
@@ -165,6 +165,7 @@ def open_surface(visFr):
             raise ValueError('Invalid file extension .' + str(ext))
         layer = TriangleRenderLayer(visFr.pipeline, dsname=surf_name, method='shaded')
         visFr.add_layer(layer)
+        visFr.update_datasource_panel()
         
 def save_surface(visFr):
     import wx

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -112,6 +112,7 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
         ################################   
 
         self.MainWindow = self #so we can access from shell
+        self.pymevis = self # more memorable alias for the main window
         self.sh = wx.py.shell.Shell(id=-1,
                                     parent=self, size=wx.Size(-1, -1), style=0, locals=self.__dict__,
                                     startupScript=config.get('VisGUI-console-startup-file', None),
@@ -130,7 +131,9 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
 
         self.generatedImages = []
         
-        self.sh.Execute('from pylab import *')
+        #self.sh.Execute('from pylab import *')
+        self.sh.Execute('import numpy as np')
+        self.sh.Execute('import matplotlib.pyplot as plt')
         self.sh.Execute('from PYME.DSView.dsviewer import View3D')
         
         import os

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -468,6 +468,7 @@ def main():
     args = parse()
     
     PYME.config.config['VisGUI-new_layers'] = args.new_layers
+    PYME.config.config['VisGUI-opengl-core-profile'] = args.opengl_core_profile
     
     if wx.GetApp() is None: #check to see if there's already a wxApp instance (running from ipython -pylab or -wthread)
         main_(args.file, use_shaders=args.use_shaders, args=args)

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -459,7 +459,8 @@ def parse():
                         default=True, help='switch shaders off(default: off)')
     parser.add_argument('--new-layers', dest='new_layers', action='store_true', default=True)
     parser.add_argument('--no-layers', dest='new_layers', action='store_false', default=True)
-    parser.add_argument('--opengl-core-profile', dest='opengl_core_profile', action='store_true', default=False)
+    parser.add_argument('--opengl-core-profile', dest='opengl_core_profile', action='store_true', default=True)
+    parser.add_argument('--opengl-compatibility-profile', dest='opengl_core_profile', action='store_false', default=True)
     parser.add_argument('-l', '--load', nargs=2, action='append', default=[], dest='load', metavar=('KEY', 'FILENAME'), help='Load one (or more) additional files into the recipe namespace.')
     args = parser.parse_args()
     return args

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -27,7 +27,7 @@ os.environ['ETS_TOOLKIT'] = 'wx'
 import argparse
 
 import wx
-import wx.py.shell
+import PYME.ui.shell
 
 #hacked so py2exe works
 #from PYME.DSView.dsviewer import View3D
@@ -113,7 +113,7 @@ class VisGUIFrame(AUIFrame, visCore.VisGUICore):
 
         self.MainWindow = self #so we can access from shell
         self.pymevis = self # more memorable alias for the main window
-        self.sh = wx.py.shell.Shell(id=-1,
+        self.sh = PYME.ui.shell.Shell(id=-1,
                                     parent=self, size=wx.Size(-1, -1), style=0, locals=self.__dict__,
                                     startupScript=config.get('VisGUI-console-startup-file', None),
               introText='PYMEVisualize - note that help, license, etc. below is for Python, not PYME\n\n')

--- a/PYME/LMVis/VisGUI.py
+++ b/PYME/LMVis/VisGUI.py
@@ -455,6 +455,7 @@ def parse():
                         default=True, help='switch shaders off(default: off)')
     parser.add_argument('--new-layers', dest='new_layers', action='store_true', default=True)
     parser.add_argument('--no-layers', dest='new_layers', action='store_false', default=True)
+    parser.add_argument('--opengl-core-profile', dest='opengl_core_profile', action='store_true', default=False)
     args = parser.parse_args()
     return args
     

--- a/PYME/LMVis/gl_render3D_shaders.py
+++ b/PYME/LMVis/gl_render3D_shaders.py
@@ -296,10 +296,7 @@ class LMGLShaderCanvas(GLCanvas):
         # TODO - do we need to do anything differnt on win?
         vmajor,vminor = wx.VERSION[:2]
 
-        if (vmajor >= 4) and (vminor >=1): # 4.1 or later 
-            sc = self.GetContentScaleFactor()
-        else:
-            sc = 1
+        sc = self.content_scale_factor
 
         #print('scale factor:', sc)
 
@@ -410,7 +407,7 @@ class LMGLShaderCanvas(GLCanvas):
                 
                 oit_layers = [] #layers which support order independent transparency - render these all together
                 for l in self.layers:
-                    if getattr(l.engine, 'use_oit', lambda l: False)(l) or getattr(l.engine, 'oit', False):
+                    if hasattr(l, 'engine') and (getattr(l.engine, 'use_oit', lambda l: False)(l) or getattr(l.engine, 'oit', False)):
                         #defer rendering
                         oit_layers.append(l)
                     else:
@@ -472,11 +469,7 @@ class LMGLShaderCanvas(GLCanvas):
         # fix scaling error
         # TODO - should this check be on wx, or OpenGL (or potentially python)
         # TODO - do we need to do anything differnt on win?
-        vmajor,vminor = wx.VERSION[:2]
-        if vmajor >= 4 and vminor >=1: # 4.1 or later 
-            sc = self.GetContentScaleFactor()
-        else:
-            sc = 1
+        sc = self.content_scale_factor
 
         #sc = 1
 
@@ -694,6 +687,16 @@ class LMGLShaderCanvas(GLCanvas):
     def pixelsize(self):
         return 2. / (self.view.scale * self.view_port_size[0])
     
+    @property
+    def content_scale_factor(self):
+        # version-safe way to get the content scale factor for high DPI screens
+        vmajor,vminor = wx.VERSION[:2]
+        if vmajor >= 4 and vminor >=1: # 4.1 or later 
+            sc = self.GetContentScaleFactor()
+        else:
+            sc = 1
+        return sc
+    
     def _view_changed(self):
         """Notify anyone who is synced to our view"""
         for callback in self.wantViewChangeNotification:
@@ -824,7 +827,7 @@ class LMGLShaderCanvas(GLCanvas):
 
     def _ScreenCoordinatesToNm(self, x, y):
         # FIXME!!!
-        sc = self.GetContentScaleFactor()
+        sc = self.content_scale_factor
         x_ = self.pixelsize * (x - 0.5 * float(self.view_port_size[0])) + self.view.translation[0]
         y_ = self.pixelsize * (y - 0.5 * float(self.view_port_size[1])) + self.view.translation[1]
         # print x_, y_
@@ -942,11 +945,7 @@ class LMGLShaderCanvas(GLCanvas):
         #     raise RuntimeError('{} is not a supported format.'.format(mode))
         # img.show()
         self.on_screen = False
-        vmajor, vminor = wx.VERSION[:2]
-        if (vmajor >= 4) and (vminor >= 1):
-            sc = self.GetContentScaleFactor()
-        else:
-            sc = 1
+        sc = self.content_scale_factor
         view_port_size = (int(self.view_port_size[0]*sc), int(self.view_port_size[1]*sc))
         off_screen_handler = OffScreenHandler(view_port_size, mode, self._num_antialias_samples)
         with off_screen_handler:

--- a/PYME/LMVis/gl_render3D_shaders.py
+++ b/PYME/LMVis/gl_render3D_shaders.py
@@ -384,6 +384,8 @@ class LMGLShaderCanvas(GLCanvas):
                 GL.glOrtho(-1, 1, ys, -ys, -1000, 1000)
 
             GL.glMatrixMode(GL.GL_MODELVIEW)
+
+            #stereo offset
             GL.glTranslatef(eye, 0.0, 0.0)
 
             # move our object to be centred at -10

--- a/PYME/LMVis/gl_render3D_shaders.py
+++ b/PYME/LMVis/gl_render3D_shaders.py
@@ -21,6 +21,7 @@
 #
 ##################
 from math import floor
+import time
 
 import numpy
 import numpy as np
@@ -350,6 +351,7 @@ class LMGLShaderCanvas(GLCanvas):
             return ['centre']
     
     def OnDraw(self):
+        t0 = time.time()
         self.SetCurrent(self.gl_context)
         self.interlace_stencil()
         GL.glEnable(GL.GL_DEPTH_TEST)
@@ -441,6 +443,8 @@ class LMGLShaderCanvas(GLCanvas):
         GL.glFlush()
 
         self.SwapBuffers()
+        
+        logger.debug('Frame rendered in: %3.4fs' % (time.time() - t0))
 
     def init_oit(self):
         self._fb = GL.glGenFramebuffers(1)

--- a/PYME/LMVis/gl_render3D_shaders.py
+++ b/PYME/LMVis/gl_render3D_shaders.py
@@ -89,6 +89,8 @@ class LMGLShaderCanvas(GLCanvas):
     ScaleBoxOverlayLayer = None
     _is_initialized = False
 
+    core_profile = False #legacy fixed function OpenGL pipeline (see glcanvas_core.py for modern core profile implementation)
+
     def __init__(self, parent, show_lut=True, display_mode='2D', view=None):
         print("New Canvas")
         attribute_list = [wx.glcanvas.WX_GL_RGBA, wx.glcanvas.WX_GL_STENCIL_SIZE, 8, wx.glcanvas.WX_GL_DOUBLEBUFFER]

--- a/PYME/LMVis/glcanvas_core.py
+++ b/PYME/LMVis/glcanvas_core.py
@@ -293,6 +293,10 @@ class LMGLShaderCanvas(GLCanvas):
             
         self.layer_added.send(self)
 
+    def get_session_info(self):
+        return {'layers': [l.serialise() for l in self.layers],
+                'view': self.view.to_json()}
+
     def setOverlayMessage(self, message=''):
         # self.messageOverlay.set_message(message)
         # if self._is_initialized:

--- a/PYME/LMVis/glcanvas_core.py
+++ b/PYME/LMVis/glcanvas_core.py
@@ -27,7 +27,7 @@ import numpy
 import numpy as np
 import wx
 import wx.glcanvas
-import glm
+import PYME.LMVis.mv_math as mm
 from OpenGL import GL, GLU
 #from OpenGL import GLU
 
@@ -385,32 +385,32 @@ class LMGLShaderCanvas(GLCanvas):
             if self.displayMode == '3DPersp':
                 # our object will be be scaled to fit a 2x2x2 box at z=10 - see translate and scale calls below
                 #GL.glFrustum(-1 + eye, 1 + eye, ys, -ys, 8.5, 11.5)
-                proj = glm.frustum(-1 + eye, 1 + eye, ys, -ys, 8.5, 11.5)
+                proj = mm.frustum(-1 + eye, 1 + eye, ys, -ys, 8.5, 11.5)
             else:
-                proj = glm.ortho(-1, 1, ys, -ys, -1000, 1000)
+                proj = mm.ortho(-1, 1, ys, -ys, -1000, 1000)
                 #GL.glOrtho(-1, 1, ys, -ys, -1000, 1000)
 
             self.proj = proj
 
             #GL.glMatrixMode(GL.GL_MODELVIEW)
 
-            self.mv = glm.mat4(1.0)
+            self.mv = np.eye(4)#glm.mat4(1.0)
 
             #stereo offset
-            self.mv = glm.translate(self.mv, glm.vec3(eye, 0.0, 0.0))
+            self.mv = mm.translate(self.mv, eye, 0, 0) #glm.translate(self.mv, glm.vec3(eye, 0.0, 0.0))
             #GL.glTranslatef(eye, 0.0, 0.0)
 
             # move our object to be centred at -10
             if self.displayMode == '3DPersp':
                 #GL.glTranslatef(0, 0, -10)
-                self.mv = glm.translate(self.mv, glm.vec3(0, 0, -10))
+                self.mv = mm.translate(self.mv, 0, 0, -10)
 
             if not self.displayMode == '2D':
                 self.AxesOverlayLayer.render(self)
 
             # scale object to fit a 2x2x2 box
             #GL.glScalef(self.view.scale, self.view.scale, self.view.scale)
-            self.mv = glm.scale(self.mv, glm.vec3(self.view.scale, self.view.scale, self.view.scale))
+            self.mv = mm.scale(self.mv, self.view.scale, self.view.scale, self.view.scale)
 
             #GL.glPushMatrix()
             _mv = self.mv
@@ -418,11 +418,11 @@ class LMGLShaderCanvas(GLCanvas):
             try:
                 # rotate object
                 #GL.glMultMatrixf(self.object_rotation_matrix)
-                self.mv = self.mv * glm.mat4(self.object_rotation_matrix)
+                self.mv = np.dot(self.mv,  self.object_rotation_matrix)
                 #GL.glTranslatef(-self.view.translation[0], -self.view.translation[1], -self.view.translation[2])
-                self.mv = glm.translate(self.mv, glm.vec3(-self.view.translation))
+                self.mv = mm.translate(self.mv, *(-self.view.translation))
 
-                self.mvp = proj * self.mv
+                self.mvp = np.dot(proj, self.mv)
                 
                 for l in self.underlays:
                     l.render(self)
@@ -446,7 +446,7 @@ class LMGLShaderCanvas(GLCanvas):
                 self.mv = _mv
                 #GL.glPopMatrix()
 
-            self.mvp = proj * self.mv
+            self.mvp = np.dot(proj, self.mv)
             #scale bar gets drawn without the rotation
             self.ScaleBarOverlayLayer.render(self)
 
@@ -455,7 +455,7 @@ class LMGLShaderCanvas(GLCanvas):
                 #GL.glMatrixMode(GL.GL_PROJECTION)
                 #GL.glLoadIdentity()
                 #GL.glOrtho(0, self.Size[0], self.Size[1], 0, -1000, 1000)
-                proj = glm.ortho(0, self.Size[0], self.Size[1], 0, -1000, 1000)
+                proj = mm.ortho(0, self.Size[0], self.Size[1], 0, -1000, 1000)
                 self.mvp = proj
 
                 #GL.glMatrixMode(GL.GL_MODELVIEW)

--- a/PYME/LMVis/glcanvas_core.py
+++ b/PYME/LMVis/glcanvas_core.py
@@ -21,6 +21,7 @@
 #
 ##################
 from math import floor
+import time
 
 import numpy
 import numpy as np
@@ -351,6 +352,7 @@ class LMGLShaderCanvas(GLCanvas):
             return ['centre']
     
     def OnDraw(self):
+        t0 = time.time()
         self.SetCurrent(self.gl_context)
         #self.interlace_stencil()
         GL.glEnable(GL.GL_DEPTH_TEST)
@@ -464,6 +466,8 @@ class LMGLShaderCanvas(GLCanvas):
         GL.glFlush()
 
         self.SwapBuffers()
+
+        logger.debug('Frame rendered in: %3.4fs' % (time.time() - t0))
 
     @property
     def normal_matrix(self):

--- a/PYME/LMVis/glcanvas_core.py
+++ b/PYME/LMVis/glcanvas_core.py
@@ -467,7 +467,7 @@ class LMGLShaderCanvas(GLCanvas):
 
         self.SwapBuffers()
 
-        logger.debug('Frame rendered in: %3.4fs' % (time.time() - t0))
+        #logger.debug('Frame rendered in: %3.4fs' % (time.time() - t0))
 
     @property
     def normal_matrix(self):

--- a/PYME/LMVis/glcanvas_core.py
+++ b/PYME/LMVis/glcanvas_core.py
@@ -1,0 +1,1078 @@
+#!/usr/bin/python
+
+##################
+# gl_render3D.py
+#
+# Copyright David Baddeley, Michael Graff
+# graff@hm.edu
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##################
+from math import floor
+
+import numpy
+import numpy as np
+import wx
+import wx.glcanvas
+import glm
+from OpenGL import GL, GLU
+#from OpenGL import GLU
+
+from PYME.LMVis.layers import AxesOverlayLayer, LUTOverlayLayer, ScaleBarOverlayLayer, SelectionOverlayLayer
+    #QuadTreeRenderLayer, VertexRenderLayer, , ShadedPointRenderLayer, \
+    #TetrahedraRenderLayer
+
+from PYME.LMVis.gl_offScreenHandler import OffScreenHandler
+from wx.glcanvas import GLCanvas
+
+
+from PYME import config
+from PYME.LMVis.views import View
+
+try:
+    from PYME.Analysis.points.gen3DTriangs import gen3DTriangs, gen3DBlobs
+except:
+    pass
+
+try:
+    # location in Python 2.7 and 3.1
+    from weakref import WeakSet
+except ImportError:
+    # separately installed py 2.6 compatibility
+    from weakrefset import WeakSet
+
+# import time
+
+from warnings import warn
+import logging
+logger = logging.getLogger(__name__)
+
+import sys
+
+# if sys.platform == 'darwin':
+#     # osx gives us LOTS of scroll events
+#     # ajust the mag in smaller increments
+#     ZOOM_FACTOR = 1.1
+# else:
+#     ZOOM_FACTOR = 2.0
+ZOOM_FACTOR = config.get('pymevis-zoom-factor', 1.1)
+
+# import statusLog
+
+name = 'ball_glut'
+
+from . import views
+from PYME.contrib import dispatch
+from PYME.ui import selection
+
+class SelectionSettings(selection.Selection):
+    def __init__(self):
+        selection.Selection.__init__(self)
+        self.colour = [1, 1, 0]
+        self.show = False
+
+class LMGLShaderCanvas(GLCanvas):
+    LUTOverlayLayer = None
+    AxesOverlayLayer = None
+    ScaleBarOverlayLayer = None
+    ScaleBoxOverlayLayer = None
+    _is_initialized = False
+
+    def __init__(self, parent, show_lut=True, display_mode='2D', view=None):
+        print("New Canvas")
+        attribute_list = [wx.glcanvas.WX_GL_RGBA, wx.glcanvas.WX_GL_STENCIL_SIZE, 8, wx.glcanvas.WX_GL_DOUBLEBUFFER, wx.glcanvas.WX_GL_CORE_PROFILE]
+        self._num_antialias_samples = int(config.get('VisGUI-antialias_samples', 4))
+        if self._num_antialias_samples > 0:
+            attribute_list.extend([wx.glcanvas.WX_GL_SAMPLE_BUFFERS, 1, wx.glcanvas.WX_GL_SAMPLES, self._num_antialias_samples])
+        
+        GLCanvas.__init__(self, parent, -1, attribList=attribute_list)
+        self.Bind(wx.EVT_PAINT, self.OnPaint)
+        self.Bind(wx.EVT_SIZE, self.OnSize)
+        self.Bind(wx.EVT_MOUSEWHEEL, self.OnWheel)
+        self.Bind(wx.EVT_LEFT_DOWN, self.OnLeftDown)
+        self.Bind(wx.EVT_LEFT_UP, self.OnLeftUp)
+        self.Bind(wx.EVT_MIDDLE_DOWN, self.OnMiddleDown)
+        self.Bind(wx.EVT_MIDDLE_UP, self.OnMiddleUp)
+        self.Bind(wx.EVT_RIGHT_DOWN, self.OnMiddleDown)
+        self.Bind(wx.EVT_RIGHT_UP, self.OnMiddleUp)
+        self.Bind(wx.EVT_MOTION, self.OnMouseMove)
+        self.Bind(wx.EVT_KEY_DOWN, self.OnKeyPress)
+        # wx.EVT_MOVE(self, self.OnMove)
+        try:
+            self.gl_context = wx.glcanvas.GLContext(self)
+        except:
+            logger.exception('Error creating OpenGL context, try modifying the number of anti-aliasing samples using the "VisGUI-antialias_samples" config setting (0 to disable antialiasing)')
+            raise
+
+        self.displayMode = display_mode  # 3DPersp' #one of 3DPersp, 3DOrtho, 2D
+
+        self.parent = parent
+
+        self._scaleBarLength = 1000
+        self.clear_colour = [0,0,0,1.0]
+
+        self.LUTDraw = show_lut
+
+        self.zmin = -10
+        self.zmax = 10
+
+        self.angup = 0
+        self.angright = 0
+        
+        if view is None:
+            self.view = views.View()
+        else:
+            self.view = view
+
+        self.sx = 100
+        self.sy = 100
+
+        self.zc_o = 0
+
+        self.stereo = False
+
+        self.eye_dist = .01
+
+        self.dragging = False
+        self.panning = False
+
+        self.selectionSettings = SelectionSettings()
+        self.selectionDragging = False
+
+        self.layers = []
+        self.overlays = []
+        self.underlays = [] #draw these before data (assuming depth-testing is disabled)
+
+        self.wantViewChangeNotification = WeakSet()
+        self.pointSelectionCallbacks = []
+
+        self.on_screen = True
+        self.view_port_size = (self.Size[0], self.Size[1])
+        
+        self._old_bbox = None
+
+        self.layer_added = dispatch.Signal()
+    
+    @property
+    def xc(self):
+        warn('Use view.translation[0] instead', DeprecationWarning, stacklevel=2)
+        return self.view.translation[0]
+    
+    @property
+    def yc(self):
+        warn('Use view.translation[1] instead', DeprecationWarning, stacklevel=2)
+        return self.view.translation[1]
+
+    @property
+    def zc(self):
+        warn('Use view.translation[2] instead', DeprecationWarning, stacklevel=2)
+        return self.view.translation[2]
+
+    @property
+    def scale(self):
+        warn('Use view.scale instead', DeprecationWarning, stacklevel=2)
+        return self.view.scale
+    
+    @property
+    def bounds(self):
+        return self.view.clipping
+
+    @property
+    def scaleBarLength(self):
+        return self._scaleBarLength
+
+    @scaleBarLength.setter
+    def scaleBarLength(self, value):
+        self._scaleBarLength = value
+        self.ScaleBarOverlayLayer.set_scale_bar_length(value)
+
+    def OnPaint(self, events):
+        if not self.IsShown():
+            print('ns')
+            return
+        
+        #wx.PaintDC(self)
+        #self.gl_context.SetCurrent(self)
+        self.SetCurrent(self.gl_context)
+
+        if not self._is_initialized:
+            self.initialize()
+        else:
+            self.OnDraw()
+        return
+    
+    @property
+    def bbox(self):
+        """ Bounding box in format [x0,y0,z0, x1, y1, z1]
+        
+        Calculated as the spanning box of all visible layers
+        """
+        
+        bb = np.zeros(6)
+        bb[:3] = 1e12
+        bb[3:] = -1e12
+        
+        nLayers = 0
+        
+        for l in self.layers:
+            # if getattr(l, 'visible', True):
+            if True:
+                bbl = l.bbox
+                
+                if not bbl is None:
+                    bb[:3] = np.minimum(bb[:3], bbl[:3])
+                    bb[3:] = np.maximum(bb[3:], bbl[3:])
+                    nLayers += 1
+                
+        if nLayers > 0:
+            #print('bbox: %s' % bb)
+            if not self._old_bbox is None and not np.allclose(self._old_bbox, bb):
+                #bbox has changed - update our cliping region
+                self.bounds['x'] = [bb[0]-1, bb[3]+1]
+                self.bounds['y'] = [bb[1]-1, bb[4]+1]
+                self.bounds['z'] = [bb[2]-1, bb[5]+1]
+            self._old_bbox = bb
+            return bb
+        else:
+            return None
+        
+
+    def initialize(self):
+        from .layers.ScaleBoxOverlayLayer import ScaleBoxOverlayLayer
+        self.InitGL()
+        self.ScaleBarOverlayLayer = ScaleBarOverlayLayer()
+        self.ScaleBoxOverlayLayer = ScaleBoxOverlayLayer()
+
+        self.LUTOverlayLayer = LUTOverlayLayer()
+        self.AxesOverlayLayer = AxesOverlayLayer()
+        
+        #self.overlays.append(SelectionOverlayLayer(self.selectionSettings,))
+        self.underlays.append(self.ScaleBoxOverlayLayer)
+
+        self._is_initialized = True
+
+    def OnSize(self, event):
+        self.view_port_size = (self.Size[0], self.Size[1])
+        if self._is_initialized:
+            self.OnDraw()
+        self.Refresh()
+
+        # self.interlace_stencil()
+
+    def OnMove(self, event):
+        self.Refresh()
+        
+    def add_layer(self, layer, connect=True):
+        self.layers.append(layer)
+        if connect:
+            layer.on_update.connect(self.refresh)
+            
+        self.layer_added.send(self)
+
+    def setOverlayMessage(self, message=''):
+        # self.messageOverlay.set_message(message)
+        # if self._is_initialized:
+        #     self.Refresh()
+        pass
+
+    def interlace_stencil(self):
+        window_width = self.view_port_size[0]
+        window_height = self.view_port_size[1]
+
+        #high dpi screens
+        # fix scaling error
+        # TODO - should this check be on wx, or OpenGL (or potentially python)
+        # TODO - do we need to do anything differnt on win?
+        vmajor,vminor = wx.VERSION[:2]
+
+        sc = self.content_scale_factor
+
+        #print('scale factor:', sc)
+
+        # setting screen-corresponding geometry
+        GL.glViewport(0, 0, int(sc*window_width), int(sc*window_height))
+        GL.glMatrixMode(GL.GL_MODELVIEW)
+        GL.glLoadIdentity()
+        GL.glMatrixMode(GL.GL_PROJECTION)
+        GL.glLoadIdentity()
+        GLU.gluOrtho2D(0.0, window_width - 1, 0.0, window_height - 1)
+        GL.glMatrixMode(GL.GL_MODELVIEW)
+        GL.glLoadIdentity()
+
+        # clearing and configuring stencil drawing
+        if self.on_screen:
+            GL.glDrawBuffer(GL.GL_BACK)
+        GL.glEnable(GL.GL_STENCIL_TEST)
+        GL.glClearStencil(0)
+        GL.glClear(GL.GL_STENCIL_BUFFER_BIT)
+        GL.glStencilOp(GL.GL_REPLACE, GL.GL_REPLACE, GL.GL_REPLACE)  # colorbuffer is copied to stencil
+        GL.glDisable(GL.GL_DEPTH_TEST)
+        GL.glStencilFunc(GL.GL_ALWAYS, 1, 1)  # to avoid interaction with stencil content
+
+        # drawing stencil pattern
+        GL.glColor4f(1, 1, 1, 0)  # alfa is 0 not to interfere with alpha tests
+
+        start = self.ScreenPosition[1] % 2
+        # print start
+
+        for y in range(start, window_height, 2):
+            GL.glLineWidth(1)
+            GL.glBegin(GL.GL_LINES)
+            GL.glVertex2f(0, y)
+            GL.glVertex2f(window_width, y)
+            GL.glEnd()
+
+        GL.glStencilOp(GL.GL_KEEP, GL.GL_KEEP, GL.GL_KEEP)  # // disabling changes in stencil buffer
+        GL.glFlush()
+
+        # print 'is'
+
+    @property
+    def _stereo_views(self):
+        if self.displayMode == '2D':
+            return ['2D']
+        elif self.stereo:
+            return ['left', 'right']
+        else:
+            return ['centre']
+    
+    def OnDraw(self):
+        self.SetCurrent(self.gl_context)
+        #self.interlace_stencil()
+        GL.glEnable(GL.GL_DEPTH_TEST)
+        
+        GL.glClearColor(*self.clear_colour)
+        GL.glClear(GL.GL_COLOR_BUFFER_BIT)
+
+        #aspect ratio of window
+        ys = float(self.view_port_size[1]) / float(self.view_port_size[0])
+
+        for stereo_view in self._stereo_views:
+            if stereo_view == 'left':
+                eye = -self.eye_dist
+                GL.glStencilFunc(GL.GL_NOTEQUAL, 1, 1)
+            elif stereo_view == 'right':
+                eye = +self.eye_dist
+                GL.glStencilFunc(GL.GL_EQUAL, 1, 1)
+            else:
+                eye = 0
+
+            GL.glClear(GL.GL_DEPTH_BUFFER_BIT)
+
+            
+            #proj = glm.mat4(1.0)
+            # GL.glMatrixMode(GL.GL_MODELVIEW)
+            # GL.glLoadIdentity()
+            # GL.glMatrixMode(GL.GL_PROJECTION)
+            # GL.glLoadIdentity()
+
+            if self.displayMode == '3DPersp':
+                # our object will be be scaled to fit a 2x2x2 box at z=10 - see translate and scale calls below
+                #GL.glFrustum(-1 + eye, 1 + eye, ys, -ys, 8.5, 11.5)
+                proj = glm.frustum(-1 + eye, 1 + eye, ys, -ys, 8.5, 11.5)
+            else:
+                proj = glm.ortho(-1, 1, ys, -ys, -1000, 1000)
+                #GL.glOrtho(-1, 1, ys, -ys, -1000, 1000)
+
+            #GL.glMatrixMode(GL.GL_MODELVIEW)
+
+            mv = glm.mat4(1.0)
+
+            #stereo offset
+            mv = glm.translate(mv, glm.vec3(eye, 0.0, 0.0))
+            #GL.glTranslatef(eye, 0.0, 0.0)
+
+            # move our object to be centred at -10
+            if self.displayMode == '3DPersp':
+                #GL.glTranslatef(0, 0, -10)
+                mv = glm.translate(mv, glm.vec3(0, 0, -10))
+
+            if False:#not self.displayMode == '2D':
+                self.AxesOverlayLayer.render(self)
+
+            # scale object to fit a 2x2x2 box
+            #GL.glScalef(self.view.scale, self.view.scale, self.view.scale)
+            mv = glm.scale(mv, glm.vec3(self.view.scale, self.view.scale, self.view.scale))
+
+            _mv = mv
+
+            try:
+                #GL.glPushMatrix()
+                # rotate object
+                #GL.glMultMatrixf(self.object_rotation_matrix)
+                mv = mv * glm.mat4(self.object_rotation_matrix)
+                #GL.glTranslatef(-self.view.translation[0], -self.view.translation[1], -self.view.translation[2])
+                mv = glm.translate(mv, glm.vec3(-self.view.translation))
+
+                self.mvp = proj * mv
+                
+                for l in self.underlays:
+                    l.render(self)
+    
+                
+                oit_layers = [] #layers which support order independent transparency - render these all together
+                for l in self.layers:
+                    if hasattr(l, 'engine') and (getattr(l.engine, 'use_oit', lambda l: False)(l) or getattr(l.engine, 'oit', False)):
+                        #defer rendering
+                        oit_layers.append(l)
+                    else:
+                        l.render(self)
+                        
+                if len(oit_layers) > 0:
+                    self.render_oit_layers(oit_layers)
+                    
+    
+                for o in self.overlays:
+                    o.render(self)
+            finally:
+                mv = _mv
+                #GL.glPopMatrix()
+
+            self.mvp = proj * mv
+            #scale bar gets drawn without the rotation
+            #self.ScaleBarOverlayLayer.render(self)
+
+            if False:#self.LUTDraw:
+                # set us up to draw in pixel coordinates
+                #GL.glMatrixMode(GL.GL_PROJECTION)
+                #GL.glLoadIdentity()
+                #GL.glOrtho(0, self.Size[0], self.Size[1], 0, -1000, 1000)
+                proj = glm.ortho(0, self.Size[0], self.Size[1], 0, -1000, 1000)
+                self.mvp = proj
+
+                #GL.glMatrixMode(GL.GL_MODELVIEW)
+                #GL.glLoadIdentity()
+                
+                self.LUTOverlayLayer.render(self)
+
+        GL.glFlush()
+
+        self.SwapBuffers()
+
+    def init_oit(self):
+        self._fb = GL.glGenFramebuffers(1)
+        GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, self._fb)
+    
+        self._accumT = GL.glGenTextures(1)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, self._accumT)
+    
+        self._revealT = GL.glGenTextures(1)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, self._revealT)
+    
+        self._db = GL.glGenRenderbuffers(1)
+        GL.glBindRenderbuffer(GL.GL_RENDERBUFFER, self._db)
+    
+        GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, 0)
+
+    def cleanup_oit(self):
+        GL.glDeleteFramebuffers(1, self._fb)
+        GL.glDeleteTextures(1, self._accumT)
+        GL.glDeleteTextures(1, self._revealT)
+        GL.glDeleteRenderbuffers(1, self._db)
+    
+    def resize_gl_oit(self, w, h):
+        #print('resize_gl')
+        self._oit_w = w
+        self._oit_h = h
+
+        # fix scaling error
+        # TODO - should this check be on wx, or OpenGL (or potentially python)
+        # TODO - do we need to do anything differnt on win?
+        sc = self.content_scale_factor
+
+        #sc = 1
+
+        w = int(sc*w)
+        h = int(sc*h)
+             
+        GL.glViewport(0, 0, w, h)
+        #self._accumdata = np.zeros([4,w,h], 'f')
+    
+        #print('bind fb')
+        GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, self._fb)
+    
+        #print('bind accum texture')
+        GL.glBindTexture(GL.GL_TEXTURE_2D, self._accumT)
+        GL.glTexImage2D(GL.GL_TEXTURE_2D, 0, GL.GL_RGBA32F, w, h, 0, GL.GL_RGBA, GL.GL_FLOAT, None)
+    
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S, GL.GL_CLAMP_TO_EDGE)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_T, GL.GL_CLAMP_TO_EDGE)
+    
+        #print('framebuffer texture')
+        GL.glFramebufferTexture2D(GL.GL_FRAMEBUFFER, GL.GL_COLOR_ATTACHMENT0, GL.GL_TEXTURE_2D, self._accumT, 0)
+    
+        #print('bind reveal texture')
+        GL.glBindTexture(GL.GL_TEXTURE_2D, self._revealT)
+        GL.glTexImage2D(GL.GL_TEXTURE_2D, 0, GL.GL_R32F, w, h, 0, GL.GL_RED, GL.GL_FLOAT, None)
+    
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S, GL.GL_CLAMP_TO_EDGE)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_T, GL.GL_CLAMP_TO_EDGE)
+    
+        GL.glFramebufferTexture2D(GL.GL_FRAMEBUFFER, GL.GL_COLOR_ATTACHMENT1, GL.GL_TEXTURE_2D, self._revealT, 0)
+    
+        GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+    
+        #print('bind render buffer')
+        GL.glBindRenderbuffer(GL.GL_RENDERBUFFER, self._db)
+        GL.glRenderbufferStorage(GL.GL_RENDERBUFFER, GL.GL_DEPTH_COMPONENT, w, h)
+        GL.glFramebufferRenderbuffer(GL.GL_FRAMEBUFFER, GL.GL_DEPTH_ATTACHMENT, GL.GL_RENDERBUFFER, self._db)
+        GL.glBindRenderbuffer(GL.GL_RENDERBUFFER, 0)
+    
+        GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, 0)
+    
+    def render_oit_layers(self, layers):
+        # initialise OIT if not already done
+        if not hasattr(self, '_fb'):
+            self.init_oit()
+            
+        # reallocate OIT textures if window has changed size
+        w, h = self.view_port_size
+        if not ((getattr(self, '_oit_w', None) == w) and (getattr(self,'_oit_h', None) == h)):
+            self.resize_gl_oit(w, h)
+    
+    
+        # draw to an offscreen framebuffer
+        current_fb = GL.glGetIntegerv(GL.GL_DRAW_FRAMEBUFFER_BINDING) #keep a reference to the current framebuffer so we can restore after we're done
+        GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, self._fb) #bind our offscreen framebuffer
+    
+        #clear the offscreen framebuffer
+    
+        #glClearBufferfv(GL.GL_COLOR, 0, (0., 0., 0., 1.))
+        #glClearBufferfv(GL.GL_COLOR, 1, (1., 0., 0., 0.))
+        GL.glClearColor(0.0, 0.0, 0.0, 1.0)
+        GL.glClearDepth(1.0)
+        GL.glClear(GL.GL_COLOR_BUFFER_BIT | GL.GL_DEPTH_BUFFER_BIT)
+    
+        #Copy depth buffer from opaque stuff rendered previously
+        GL.glBindFramebuffer(GL.GL_DRAW_FRAMEBUFFER, self._fb)
+        GL.glBindFramebuffer(GL.GL_READ_FRAMEBUFFER, 0)
+        GL.glBlitFramebuffer(0, 0, self._oit_w, self._oit_h,
+                          0, 0, self._oit_w, self._oit_h,
+                          GL.GL_DEPTH_BUFFER_BIT, GL.GL_NEAREST)
+        GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, self._fb)
+    
+        #glDrawBuffer(GL.GL_COLOR_ATTACHMENT0)
+        #glClear(GL.GL_COLOR_BUFFER_BIT) #| GL.GL_DEPTH_BUFFER_BIT)
+    
+        #clear the second colour attachment buffer
+        GL.glDrawBuffers(1, [GL.GL_COLOR_ATTACHMENT1, ])
+        GL.glClearColor(1.0, 0.0, 0.0, 1.0)
+        GL.glClear(GL.GL_COLOR_BUFFER_BIT)
+    
+        GL.glDrawBuffers(2, [GL.GL_COLOR_ATTACHMENT0, GL.GL_COLOR_ATTACHMENT1])
+        
+        #draw the OIT layers
+        for l in layers:
+            l.render(self)
+
+        # set the framebuffer back
+        GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, current_fb)
+
+        #now do the compositing pass
+        with self.composite_shader as c:
+            # bind our pre-rendered textures
+
+            GL.glActiveTexture(GL.GL_TEXTURE0)
+            GL.glEnable(GL.GL_TEXTURE_2D)
+            GL.glBindTexture(GL.GL_TEXTURE_2D, self._accumT)
+            self._acc_buf = GL.glGetTexImage(GL.GL_TEXTURE_2D, 0, GL.GL_RGBA, GL.GL_FLOAT)
+            GL.glUniform1i(c.get_uniform_location('accum_t'), 0)
+
+            GL.glActiveTexture(GL.GL_TEXTURE1)
+            GL.glEnable(GL.GL_TEXTURE_2D)
+            GL.glBindTexture(GL.GL_TEXTURE_2D, self._revealT)
+            self._reveal_buf = GL.glGetTexImage(GL.GL_TEXTURE_2D, 0, GL.GL_RED, GL.GL_FLOAT)
+            GL.glUniform1i(c.get_uniform_location('reveal_t'), 1)
+
+            GL.glEnable(GL.GL_BLEND)
+            GL.glBlendFunc(GL.GL_ONE_MINUS_SRC_ALPHA, GL.GL_SRC_ALPHA)
+
+            # Draw triangles to display texture on
+            GL.glColor4f(1., 1., 1., 1.)
+            GL.glBegin(GL.GL_QUADS)
+            GL.glTexCoord2f(0., 0.) # lower left corner of image */
+            GL.glVertex3f(-1, -1, 0.0)
+            GL.glTexCoord2f(1., 0.) # lower right corner of image */
+            GL.glVertex3f(1, -1, 0.0)
+            GL.glTexCoord2f(1.0, 1.0) # upper right corner of image */
+            GL.glVertex3f(1, 1, 0.0)
+            GL.glTexCoord2f(0.0, 1.0) # upper left corner of image */
+            GL.glVertex3f(-1, 1, 0.0)
+            GL.glEnd()
+
+            #unbind our textures
+            GL.glActiveTexture(GL.GL_TEXTURE0)
+            GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+            GL.glDisable(GL.GL_TEXTURE_2D)
+
+            GL.glActiveTexture(GL.GL_TEXTURE1)
+            GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+            GL.glDisable(GL.GL_TEXTURE_2D)
+                
+    @property
+    def composite_shader(self):
+        from PYME.LMVis.shader_programs.ShaderProgramFactory import ShaderProgramFactory
+        from PYME.LMVis.shader_programs.oit_compositor import OITCompositorProgram
+        if not hasattr(self, '_composite_shader'):
+            self._composite_shader = ShaderProgramFactory.get_program(OITCompositorProgram, self.gl_context, self)
+            
+        return self._composite_shader
+
+    @property
+    def object_rotation_matrix(self):
+        """
+        The transformation matrix used to map coordinates in real space to our 3D view space. Currently implements
+        rotation, defined by 3 vectors (up, right, and back). Does not include scaling or projection.
+        
+        Returns
+        -------
+        a 4x4 matrix describing the rotation of the points within our 3D world
+        
+        """
+        if not self.displayMode == '2D':
+            return numpy.array(
+                [numpy.hstack((self.view.vec_right, 0)), numpy.hstack((self.view.vec_up, 0)), numpy.hstack((self.view.vec_back, 0)),
+                 [0, 0, 0, 1]], 'f')
+        else:
+            return numpy.eye(4, dtype='f')
+
+    def InitGL(self):
+        print('OpenGL - Version: {}'.format(GL.glGetString(GL.GL_VERSION)))
+        self.glsl_version = GL.glGetString(GL.GL_SHADING_LANGUAGE_VERSION).decode().replace('.', '')
+        print('Shader - Version: {}'.format(self.glsl_version))
+
+        #supported_glsl_versions = [GL.glGetStringi(GL.GL_SHADING_LANGUAGE_VERSION, i) for i in range(GL.glGetIntegerv(GL.GL_NUM_SHADING_LANGUAGE_VERSIONS))]
+        #print('Supported GLSL versions: {}'.format(supported_glsl_versions))
+        
+        max_samples = GL.glGetInteger(GL.GL_MAX_SAMPLES)
+        n_samples = GL.glGetInteger(GL.GL_SAMPLES)
+        print('GL.GL_MAX_SAMPLES: %d, GL.GL_SAMPLES: %d' % (max_samples, n_samples))
+        
+        if (max_samples >= 4) and (n_samples < 4):
+            logger.info('Your machine supports OpenGL antialiasing, but antialiasing disabled - enable by setting the "VisGUI-antialias_samples" PYME config setting to 4 or higher')
+            
+        GL.glEnable(GL.GL_DEPTH_TEST)
+        #GL.glEnable(GL.GL_NORMALIZE)
+        GL.glEnable(GL.GL_MULTISAMPLE)
+
+        #GL.glLoadIdentity()
+        #GL.glOrtho(self.xmin, self.xmax, self.ymin, self.ymax, self.zmin, self.zmax)
+        GL.glClearColor(0.0, 0.0, 0.0, 1.0)
+        GL.glClearDepth(1.0)
+
+        #GL.glEnableClientState(GL.GL_VERTEX_ARRAY)
+        #GL.glEnableClientState(GL.GL_COLOR_ARRAY)
+        #GL.glEnableClientState(GL.GL_NORMAL_ARRAY)
+        GL.glEnable(GL.GL_BLEND)
+        GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
+        #GL.glEnable(GL.GL_POINT_SMOOTH)
+
+        self.ResetView()
+
+    def ResetView(self):
+        self.view.vec_up = numpy.array([0, 1, 0])
+        self.view.vec_right = numpy.array([1, 0, 0])
+        self.view.vec_back = numpy.array([0, 0, 1])
+
+        self.Refresh()
+
+    @property
+    def xmin(self):
+        return self.view.translation[0] - 0.5 * self.pixelsize * self.view_port_size[0]
+
+    @property
+    def xmax(self):
+        return self.view.translation[0] + 0.5 * self.pixelsize * self.view_port_size[0]
+
+    @property
+    def ymin(self):
+        return self.view.translation[1] - 0.5 * self.pixelsize * self.view_port_size[1]
+
+    @property
+    def ymax(self):
+        return self.view.translation[1] + 0.5 * self.pixelsize * self.view_port_size[1]
+
+    @property
+    def pixelsize(self):
+        return 2. / (self.view.scale * self.view_port_size[0])
+    
+    @property
+    def content_scale_factor(self):
+        # version-safe way to get the content scale factor for high DPI screens
+        vmajor,vminor = wx.VERSION[:2]
+        if vmajor >= 4 and vminor >=1: # 4.1 or later 
+            sc = self.GetContentScaleFactor()
+        else:
+            sc = 1
+        return sc
+    
+    def _view_changed(self):
+        """Notify anyone who is synced to our view"""
+        for callback in self.wantViewChangeNotification:
+            if callback:
+                callback.Refresh()
+
+    def setView(self, xmin, xmax, ymin, ymax):
+
+        self.view.translation[0] = (xmin + xmax) / 2.0
+        self.view.translation[1] = (ymin + ymax) / 2.0
+        self.view.translation[2] = self.zc_o  # 0#z.mean()
+
+        self.view.scale = 2. / (xmax - xmin)
+
+        self.Refresh()
+        if 'OnGLViewChanged' in dir(self.parent):
+            self.parent.OnGLViewChanged()
+
+        self._view_changed()
+
+    def moveView(self, dx, dy, dz=0):
+        return self.pan(dx, dy, dz)
+
+    def pan(self, dx, dy, dz=0):
+        self.view.translation[0] += dx
+        self.view.translation[1] += dy
+        self.view.translation[2] += dz
+
+        self.Refresh()
+        self._view_changed()
+
+    def OnWheel(self, event):
+        rot = event.GetWheelRotation()
+        xp, yp = self._ScreenCoordinatesToNm(event.GetX(), event.GetY())
+
+        dx, dy = (xp - self.view.translation[0]), (yp - self.view.translation[1])
+        dx_, dy_, dz_, c_ = numpy.dot(self.object_rotation_matrix, [dx, dy, 0, 0])
+        xp_, yp_, zp_ = (self.view.translation[0] + dx_), (self.view.translation[1] + dy_), (self.view.translation[2] + dz_)
+
+        if event.MiddleIsDown():
+            self.WheelFocus(rot, xp_, yp_, zp_)
+        else:
+            self.WheelZoom(rot, xp_, yp_, zp_)
+
+    def WheelZoom(self, rot, xp, yp, zp=0):
+        dx = xp - self.view.translation[0]
+        dy = yp - self.view.translation[1]
+        dz = zp - self.view.translation[2]
+
+        if rot > 0:
+            # zoom out
+            self.view.scale *= ZOOM_FACTOR
+
+            self.view.translation[0] += dx * (1. - 1. / ZOOM_FACTOR)
+            self.view.translation[1] += dy * (1. - 1. / ZOOM_FACTOR)
+            self.view.translation[2] += dz * (1. - 1. / ZOOM_FACTOR)
+
+        if rot < 0:
+            # zoom in
+            self.view.scale /= ZOOM_FACTOR
+
+            self.view.translation[0] += dx * (1. - ZOOM_FACTOR)
+            self.view.translation[1] += dy * (1. - ZOOM_FACTOR)
+            self.view.translation[2] += dz * (1. - ZOOM_FACTOR)
+
+        self.Refresh()
+        self._view_changed()
+
+    def WheelFocus(self, rot, xp, yp, zp=0):
+        if rot > 0:
+            self.view.translation[2] -= 1.
+
+        if rot < 0:
+            self.view.translation[2] += 1.
+
+        self.Refresh()
+        self._view_changed()
+
+    def OnLeftDown(self, event):
+        if not self.displayMode == '2D':
+            # dragging the mouse rotates the object
+            self.xDragStart = event.GetX()
+            self.yDragStart = event.GetY()
+
+            self.angyst = self.angup
+            self.angxst = self.angright
+
+            self.dragging = True
+        else:  # 2D
+            # dragging the mouse sets an ROI
+            xp, yp = self._ScreenCoordinatesToNm(event.GetX(), event.GetY())
+
+            self.selectionDragging = True
+            self.selectionSettings.show = True
+
+            self.selectionSettings.start = (xp, yp, None)
+            self.selectionSettings.finish = (xp, yp, None)
+            self.selectionSettings.trace.clear()
+            self.selectionSettings.trace.append((xp, yp))
+
+        event.Skip()
+
+    def OnLeftUp(self, event):
+        self.dragging = False
+
+        if self.selectionDragging:
+            xp, yp = self._ScreenCoordinatesToNm(event.GetX(), event.GetY())
+
+            self.selectionSettings.finish = (xp, yp, None)
+            self.selectionSettings.trace.append((xp, yp))
+            self.selectionDragging = False
+
+            self.Refresh()
+            self.Update()
+
+        event.Skip()
+
+    def OnMiddleDown(self, event):
+        self.xDragStart = event.GetX()
+        self.yDragStart = event.GetY()
+
+        self.panning = True
+        event.Skip()
+
+    def OnMiddleUp(self, event):
+        self.panning = False
+        event.Skip()
+
+    def _ScreenCoordinatesToNm(self, x, y):
+        # FIXME!!!
+        sc = self.content_scale_factor
+        x_ = self.pixelsize * (x - 0.5 * float(self.view_port_size[0])) + self.view.translation[0]
+        y_ = self.pixelsize * (y - 0.5 * float(self.view_port_size[1])) + self.view.translation[1]
+        # print x_, y_
+        return x_, y_
+
+    def OnMouseMove(self, event):
+        x = event.GetX()
+        y = event.GetY()
+
+        if self.selectionDragging:
+            sx, sy = self._ScreenCoordinatesToNm(x, y)
+            self.selectionSettings.finish = (sx, sy, None)
+            self.selectionSettings.trace.append((sx, sy))
+            self.Refresh()
+            event.Skip()
+
+        elif self.dragging:
+            angx = numpy.pi * (x - self.xDragStart) / 180
+            angy = numpy.pi * (y - self.yDragStart) / 180
+
+            r_mat1 = numpy.matrix(
+                [[numpy.cos(angx), 0, numpy.sin(angx)], [0, 1, 0], [-numpy.sin(angx), 0, numpy.cos(angx)]])
+            r_mat = r_mat1 * numpy.matrix(
+                [[1, 0, 0], [0, numpy.cos(angy), numpy.sin(angy)], [0, -numpy.sin(angy), numpy.cos(angy)]])
+
+            vec_right_n = numpy.array(r_mat * numpy.matrix(self.view.vec_right).T).squeeze()
+            vec_up_n = numpy.array(r_mat * numpy.matrix(self.view.vec_up).T).squeeze()
+            vec_back_n = numpy.array(r_mat * numpy.matrix(self.view.vec_back).T).squeeze()
+
+            self.view.vec_right = vec_right_n
+
+            self.view.vec_up = vec_up_n
+            self.view.vec_back = vec_back_n
+
+            self.xDragStart = x
+            self.yDragStart = y
+
+            self.Refresh()
+            event.Skip()
+
+        elif self.panning:
+            dx = self.pixelsize * (x - self.xDragStart)
+            dy = self.pixelsize * (y - self.yDragStart)
+
+            dx_, dy_, dz_, c_ = numpy.dot(self.object_rotation_matrix, [dx, dy, 0, 0])
+
+            self.xDragStart = x
+            self.yDragStart = y
+
+            self.pan(-dx_, -dy_, -dz_)
+
+            event.Skip()
+
+    def OnKeyPress(self, event):
+        # print event.GetKeyCode()
+        if event.GetKeyCode() == 83:  # S - toggle stereo
+            self.stereo = not self.stereo
+            self.Refresh()
+        elif event.GetKeyCode() == 67:  # C - centre
+            self.recenter_bbox()
+            self.Refresh()
+
+        elif event.GetKeyCode() == 91:  # [ decrease eye separation
+            self.eye_dist /= 1.5
+            self.Refresh()
+
+        elif event.GetKeyCode() == 93:  # ] increase eye separation
+            self.eye_dist *= 1.5
+            self.Refresh()
+
+        elif event.GetKeyCode() == 82:  # R reset view
+            self.ResetView()
+            self.Refresh()
+
+        elif event.GetKeyCode() == 314:  # left
+            pos = numpy.array([self.view.translation[0], self.view.translation[1], self.view.translation[2]], 'f')
+            pos -= 300 * self.view.vec_right
+            self.view.translation[0], self.view.translation[1], self.view.translation[2] = pos
+            # print 'l'
+            self.Refresh()
+
+        elif event.GetKeyCode() == 315:  # up
+            pos = numpy.array([self.view.translation[0], self.view.translation[1], self.view.translation[2]])
+            pos -= 300 * self.view.vec_back
+            self.view.translation[0], self.view.translation[1], self.view.translation[2] = pos
+            self.Refresh()
+
+        elif event.GetKeyCode() == 316:  # right
+            pos = numpy.array([self.view.translation[0], self.view.translation[1], self.view.translation[2]])
+            pos += 300 * self.view.vec_right
+            self.view.translation[0], self.view.translation[1], self.view.translation[2] = pos
+            self.Refresh()
+
+        elif event.GetKeyCode() == 317:  # down
+            pos = numpy.array([self.view.translation[0], self.view.translation[1], self.view.translation[2]])
+            pos += 300 * self.view.vec_back
+            self.view.translation[0], self.view.translation[1], self.view.translation[2] = pos
+            self.Refresh()
+
+        else:
+            event.Skip()
+
+    def getSnapshot(self, mode=GL.GL_RGB):
+        # GL.glBindFramebuffer(GL.GL_READ_FRAMEBUFFER, 0)
+        # width, height = self.view_port_size[0], self.view_port_size[1]
+        # snap = GL.glReadPixelsf(0, 0, width, height, mode)
+        # snap = snap.ravel().reshape(width, height, -1, order='F')
+        #
+        # if mode == GL.GL_LUMINANCE:
+        #     # snap.strides = (4, 4 * snap.shape[0])
+        #     pass
+        # elif mode == GL.GL_RGB:
+        #     snap.strides = (12, 12 * snap.shape[0], 4)
+        # else:
+        #     raise RuntimeError('{} is not a supported format.'.format(mode))
+        # img.show()
+        self.on_screen = False
+        sc = self.content_scale_factor
+        view_port_size = (int(self.view_port_size[0]*sc), int(self.view_port_size[1]*sc))
+        off_screen_handler = OffScreenHandler(view_port_size, mode, self._num_antialias_samples)
+        with off_screen_handler:
+            self.OnDraw()
+        snap = off_screen_handler.get_snap()
+        self.on_screen = True
+        return  (255*np.asarray(snap)).astype('uint8')
+
+    def getIm(self, pixel_size=None, mode=GL.GL_RGB, image_bounds=None):
+        if ((pixel_size is None) or (abs(1 - pixel_size) < 0.001) and image_bounds is None):  # use current pixel size
+            return self.getSnapshot(mode=mode)
+        else:
+            # set size before moving the view, since self.setView includes a self.Refresh() call
+            old_view = self.get_view()
+            old_size = self.view_port_size
+
+            try:
+                if image_bounds is None:
+                    # for snapshots, just scale the viewport by the ratio of desired and current pixel sizes
+                    # as this works well with 3D rotated (and perspective) views
+                    # NOTE: rounding to the nearest pixel causes the pixel size to be inexact, and images produced this way should NOT
+                    # be used for quantification.
+                    sc = pixel_size/self.pixelsize
+                    self.view_port_size = (int(old_size[0]/sc), int(old_size[1]/sc))
+
+                else:
+                    # legacy fallback for CurrentRenderer
+                    # NOTE - does not work for 3D views - strictly 2D only
+                    x0, y0, x1, y1, z0, z1 = image_bounds.bounds 
+
+            
+                    self.view_port_size = (int((x1 - x0) / pixel_size),
+                                    int((y1 - y0) / pixel_size))
+                    logging.debug('viewport size %s' % (self.view_port_size,))
+                
+                    self.setView(x0, x0 + self.view_port_size[0]*pixel_size,
+                            y0, y0 + self.view_port_size[1]*pixel_size)
+                    
+                    #enforce top-down view (2D)
+                    self.view.top()
+
+                    print(pixel_size, self.pixelsize)
+                    assert(self.pixelsize == pixel_size)
+                
+                snap = self.getSnapshot(mode=mode)
+
+            finally:
+                self.view_port_size = old_size
+                self.set_view(old_view)
+            return snap
+
+    def recenter(self, x, y):
+        self.view.translation[0] = x.mean()
+        self.view.translation[1] = y.mean()
+        self.view.translation[2] = 0  # z.mean()
+
+        self.sx = x.max() - x.min()
+        self.sy = y.max() - y.min()
+        self.sz = 0  # z.max() - z.min()
+
+        self.view.scale = 2. / (max(self.sx, self.sy))
+        
+    def recenter_bbox(self):
+        bb = self.bbox
+        if bb is None:
+            return
+        
+        centre = 0.5*(bb[:3] + bb[3:])
+        
+        self.view.translation[0], self.view.translation[1], self.view.translation[2] = centre
+        
+    def fit_bbox(self):
+        bb = self.bbox
+        if bb is None:
+            return
+    
+        sz = (bb[3:] - bb[:3])
+    
+        self.view.scale = 1.5/max(np.abs(sz))
+        self.recenter_bbox()
+
+    def set_view(self, view):
+        self.view=view
+        self.Refresh()
+
+    def get_view(self, view_id='id'):
+        view = View.copy(self.view)
+        view.view_id = view_id
+        return view
+    
+    def refresh(self, *args, **kwargs):
+        bb = self.bbox #force an update of our bounding box
+        self.Refresh()
+
+    
+
+
+def showGLFrame():
+    f = wx.Frame(None, size=(800, 800))
+    #sizer = wx.BoxSizer(wx.VERTICAL)
+    c = LMGLShaderCanvas(f)
+    #sizer.Add(c, 1, wx.EXPAND, 0)
+    #f.SetSizer(sizer)
+    f.Show()
+    return c

--- a/PYME/LMVis/layers/AxesOverlayLayer.py
+++ b/PYME/LMVis/layers/AxesOverlayLayer.py
@@ -81,7 +81,7 @@ class AxesOverlayLayer(OverlayLayer):
                                [.5, 1, .5, 1], [.5, 1, .5, 1], 
                                [.5, .5, 1, 1], [.5, .5, 1, 1]], 'f')
             
-            self._bind_data('axes', verts, 0*verts, colors)
+            self._bind_data('axes', verts, 0*verts, colors, core_profile=gl_canvas.core_profile)
             
             lw = min(3.0, glGetFloatv(GL_LINE_WIDTH_RANGE)[1])
             glLineWidth(lw)

--- a/PYME/LMVis/layers/AxesOverlayLayer.py
+++ b/PYME/LMVis/layers/AxesOverlayLayer.py
@@ -27,7 +27,7 @@ class AxesOverlayLayer(OverlayLayer):
     This OverlayLayer produces axes and displays the orientation of the model.
     """
 
-    def __init__(self, offset=None, size=1, **kwargs):
+    def __init__(self, offset=None, size=0.1, **kwargs):
         if not offset:
             offset = [10, 10]
         super(AxesOverlayLayer, self).__init__(offset, **kwargs)
@@ -58,17 +58,17 @@ class AxesOverlayLayer(OverlayLayer):
             #glDisable(GL_LIGHTING)
             if gl_canvas.core_profile:
                 import PYME.LMVis.mv_math as mm
-                mv = mm.scale(mm.translate(gl_canvas.mv, .9, -.9*view_ratio, 0), 0.1, 0.1, 0.1)
+                mv = mm.translate(gl_canvas.mv, .88, .88*view_ratio, -0.5)
                 mv = np.dot(mv, gl_canvas.object_rotation_matrix)
 
-                mvp = np.dot(mv,gl_canvas.proj)
+                mvp = np.dot(gl_canvas.proj, mv)
 
                 sp.set_modelviewprojectionmatrix(np.array(mvp))
 
             else:
                 glPushMatrix()
-                glTranslatef(.9, .9*view_ratio, 0)
-                glScalef(.1, .1, .1)
+                glTranslatef(.9, .9*view_ratio,0)
+                #glScalef(.1, .1, .1)
                 
                 glMultMatrixf(gl_canvas.object_rotation_matrix)
 

--- a/PYME/LMVis/layers/AxesOverlayLayer.py
+++ b/PYME/LMVis/layers/AxesOverlayLayer.py
@@ -49,8 +49,13 @@ class AxesOverlayLayer(OverlayLayer):
         if not self.visible:
             return
         
-        self._clear_shader_clipping(gl_canvas)
+        if gl_canvas.core_profile:
+            sp = self.get
+
+
         with self.get_shader_program(gl_canvas) as sp:
+            sp.clear_shader_clipping()
+
             view_ratio = float(gl_canvas.Size[1])/float(gl_canvas.Size[0])
 
             glEnable(GL_LINE_SMOOTH)

--- a/PYME/LMVis/layers/AxesOverlayLayer.py
+++ b/PYME/LMVis/layers/AxesOverlayLayer.py
@@ -81,7 +81,7 @@ class AxesOverlayLayer(OverlayLayer):
                                [.5, 1, .5, 1], [.5, 1, .5, 1], 
                                [.5, .5, 1, 1], [.5, .5, 1, 1]], 'f')
             
-            self._bind_data('axes', verts, 0*verts, colors, core_profile=gl_canvas.core_profile)
+            self._bind_data('axes', verts, 0*verts, colors, sp, core_profile=gl_canvas.core_profile)
             
             lw = min(3.0, glGetFloatv(GL_LINE_WIDTH_RANGE)[1])
             glLineWidth(lw)

--- a/PYME/LMVis/layers/AxesOverlayLayer.py
+++ b/PYME/LMVis/layers/AxesOverlayLayer.py
@@ -57,12 +57,11 @@ class AxesOverlayLayer(OverlayLayer):
 
             #glDisable(GL_LIGHTING)
             if gl_canvas.core_profile:
-                import glm
-                mv = glm.translate(gl_canvas.mv, glm.vec3(.9, -.9*view_ratio, 0))
-                mv = glm.scale(mv, glm.vec3(.1, .1, .1))
-                mv = mv*glm.mat4(gl_canvas.object_rotation_matrix)
+                import PYME.LMVis.mv_math as mm
+                mv = mm.scale(mm.translate(gl_canvas.mv, .9, -.9*view_ratio, 0), 0.1, 0.1, 0.1)
+                mv = np.dot(mv, gl_canvas.object_rotation_matrix)
 
-                mvp = mv*gl_canvas.proj
+                mvp = np.dot(mv,gl_canvas.proj)
 
                 sp.set_modelviewprojectionmatrix(np.array(mvp))
 

--- a/PYME/LMVis/layers/LUTOverlayLayer.py
+++ b/PYME/LMVis/layers/LUTOverlayLayer.py
@@ -131,9 +131,12 @@ class LUTOverlayLayer(OverlayLayer):
                     tl.text = '%.3G' % cl
                     
                     xc = lb_ur_x - 0.5*lb_width
+
+                    _, hu, wu = tu.get_img_array(gl_canvas)
+                    _, hl, wl = tl.get_img_array(gl_canvas)
                     
-                    tu.pos = (xc - tu._w/2, lb_ur_y - tu._h)
-                    tl.pos = (xc - tl._w/2, lb_lr_y)
+                    tu.pos = (xc - wu/2, lb_ur_y - hu)
+                    tl.pos = (xc - wl/2, lb_lr_y)
                     
                     labels.extend([tl, tu])
                 

--- a/PYME/LMVis/layers/LUTOverlayLayer.py
+++ b/PYME/LMVis/layers/LUTOverlayLayer.py
@@ -19,16 +19,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import numpy
+import numpy as np
 # import pylab
 
 from PYME.recipes.traits import Bool
 
 from PYME.LMVis.layers.OverlayLayer import OverlayLayer
 from OpenGL.GL import *
-from PYME.LMVis.shader_programs.DefaultShaderProgram import DefaultShaderProgram
+from PYME.LMVis.shader_programs.DefaultShaderProgram import DefaultShaderProgram, ImageShaderProgram
 
 
-class LUTOverlayLayer(OverlayLayer):
+class _LUTOverlayLayer(OverlayLayer):
     """
     This OverlayLayer produces a bar that indicates the given color map.
     """
@@ -143,3 +144,200 @@ class LUTOverlayLayer(OverlayLayer):
         for l in labels:
             l.render(gl_canvas)
                 
+class LUTOverlayLayer(OverlayLayer):
+    """
+    This OverlayLayer produces a bar that indicates the given color map.
+    """
+
+    show_bounds = Bool(False)
+    
+    def __init__(self, offset=None, **kwargs):
+        """
+
+        Parameters
+        ----------
+
+        offset      offset of the canvas origin where it should be drawn.
+                    Currently only offset[0] is used
+        """
+        if not offset:
+            offset = [10, 10]
+            
+        OverlayLayer.__init__(self, offset, **kwargs)
+
+        self.set_offset(offset)
+
+        self._lut_width_px = 10.0
+        self._border_colour = [.5, .5, 0]
+        self.set_shader_program(ImageShaderProgram)
+        
+        self._labels = {}
+
+        self._texture_id = None
+        self._lut_id = None
+        #self._lut_key = None
+        
+    def _get_label(self, layer):
+        from . import text
+        try:
+            return self._labels[layer]
+        except KeyError:
+            self._labels[layer] = [text.Text(), text.Text()]
+
+            return self._labels[layer]
+        
+    def set_texture(self):
+        if self._texture_id is None:
+            self._texture_id = glGenTextures(1)
+    
+            image = np.linspace(0, 1, 255).reshape([1, 255]).astype('f')# image.T.reshape(*image.shape) #get our byte order right
+    
+            glActiveTexture(GL_TEXTURE0)
+            glBindTexture(GL_TEXTURE_2D, self._texture_id)
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
+            #glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
+            #glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
+            #glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE)
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, image.shape[0], image.shape[1], 0, GL_RED, GL_FLOAT, image.astype('f4'))
+
+    def set_lut(self, cmap):
+        if self._lut_id is None:
+            self._lut_id = glGenTextures(1)
+    
+        lut_array = cmap(np.linspace(0, 1.0, 255))
+        
+        glActiveTexture(GL_TEXTURE1)
+        glBindTexture(GL_TEXTURE_1D, self._lut_id)
+
+
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
+        glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
+        #glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_T, GL_CLAMP)
+        #glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
+        glTexParameteri (GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
+        #glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
+        glTexParameteri (GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
+        #glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE)
+        glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, lut_array.shape[0], 0, GL_RGBA, GL_FLOAT,
+                    lut_array.astype('f4'))
+
+
+    def render(self, gl_canvas):
+        if not self.visible:
+            return
+        
+        self._clear_shader_clipping(gl_canvas)
+        labels = []
+        
+        with self.get_shader_program(gl_canvas) as sp:
+            glDisable(GL_DEPTH_TEST)
+            #glDisable(GL_LIGHTING)
+            glDisable(GL_BLEND)
+
+            glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
+            
+            #view_size_x = gl_canvas.xmax - gl_canvas.xmin
+            #view_size_y = gl_canvas.ymax - gl_canvas.ymin
+            
+            view_size_x, view_size_y = gl_canvas.Size
+
+            # upper right y
+            lb_ur_y = .1 * view_size_y
+            # lower right y
+            lb_lr_y = 0.9 * view_size_y
+
+            lb_len =lb_lr_y -  lb_ur_y
+            
+            lb_width = self._lut_width_px #* view_size_x / gl_canvas.Size[0]
+            
+            visible_layers = [l for l in gl_canvas.layers if (getattr(l, 'visible', True) and getattr(l, 'show_lut', True))]
+            
+            self.set_texture()
+            glUniform1i(sp.get_uniform_location('im_sampler'), 0)
+
+            if gl_canvas.core_profile:
+                sp.set_modelviewprojectionmatrix(np.array(gl_canvas.mvp, 'f'))
+            
+            for j, l in enumerate(visible_layers):
+                cmap = l.colour_map
+                self.set_lut(cmap)
+                glUniform1i(sp.get_uniform_location('lut'), 1)
+                glUniform2f(sp.get_uniform_location('clim'), 0, 1)
+                
+                # upper right x
+                lb_ur_x = view_size_x - self.get_offset()[0] - j*1.5*lb_width
+                
+                # upper left x
+                lb_ul_x = lb_ur_x - lb_width
+                
+                #print(lb_ur_x, lb_ur_y, lb_lr_y, lb_ul_x, lb_width, lb_len, view_size_x, view_size_y)
+
+                verts = self._gen_rect_triangles(lb_ul_x, lb_ur_y, lb_width , lb_len)
+                tex_coords = self._gen_rect_texture_coords()
+                
+                # glBegin(GL_QUAD_STRIP)
+    
+                # for i in numpy.arange(0, 1.01, .01):
+                #     glColor3fv(cmap(i)[:3])
+                #     glVertex2f(lb_ul_x, lb_ur_y + (1.- i) * lb_len)
+                #     glVertex2f(lb_ur_x, lb_ur_y + (1.- i) * lb_len)
+    
+                # glEnd()
+
+                if gl_canvas.core_profile:
+                    vao = glGenVertexArrays(1)
+                    vbo = glGenBuffers(2)
+
+                    glBindVertexArray(vao)
+                    glBindBuffer(GL_ARRAY_BUFFER, vbo[0])
+                    glBufferData(GL_ARRAY_BUFFER, verts, GL_STATIC_DRAW)
+                    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, None)
+                    glEnableVertexAttribArray(0)
+                    glBindBuffer(GL_ARRAY_BUFFER, vbo[1])
+                    glBufferData(GL_ARRAY_BUFFER, tex_coords, GL_STATIC_DRAW)
+                    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, None)
+                    glEnableVertexAttribArray(1)
+                else:
+                    glVertexPointerf(verts)
+                    glEnableClientState(GL_TEXTURE_COORD_ARRAY)
+                    glTexCoordPointerf(tex_coords)
+                
+                glDrawArrays(GL_TRIANGLES, 0, 6)
+
+                if gl_canvas.core_profile:
+                    glBindVertexArray(0)
+                    glDeleteVertexArrays(1, vao)
+                    glDeleteBuffers(1, vbo)
+                else:
+                    glDisableClientState(GL_TEXTURE_COORD_ARRAY)
+    
+                # glBegin(GL_LINE_LOOP)
+                # glColor3fv(self._border_colour)
+                # glVertex2f(lb_ul_x, lb_lr_y)
+                # glVertex2f(lb_ur_x, lb_lr_y)
+                # glVertex2f(lb_ur_x, lb_ur_y)
+                # glVertex2f(lb_ul_x, lb_ur_y)
+                # glEnd()
+                
+                if hasattr(l, 'clim') and self.show_bounds:
+                    tl, tu = self._get_label(l)
+                    cl, cu = l.clim
+                    tu.text = '%.3G' % cu
+                    tl.text = '%.3G' % cl
+                    
+                    xc = lb_ur_x - 0.5*lb_width
+
+                    _, hu, wu = tu.get_img_array(gl_canvas)
+                    _, hl, wl = tl.get_img_array(gl_canvas)
+                    
+                    tu.pos = (xc - wu/2, lb_ur_y - hu)
+                    tl.pos = (xc - wl/2, lb_lr_y)
+                    
+                    labels.extend([tl, tu])
+                
+        for l in labels:
+            l.render(gl_canvas)

--- a/PYME/LMVis/layers/LUTOverlayLayer.py
+++ b/PYME/LMVis/layers/LUTOverlayLayer.py
@@ -313,7 +313,7 @@ class LUTOverlayLayer(OverlayLayer):
 
                 if gl_canvas.core_profile:
                     glBindVertexArray(0)
-                    glDeleteVertexArrays(1, vao)
+                    glDeleteVertexArrays(1, [vao,])
                     glDeleteBuffers(1, vbo)
                 else:
                     glDisableClientState(GL_TEXTURE_COORD_ARRAY)

--- a/PYME/LMVis/layers/LUTOverlayLayer.py
+++ b/PYME/LMVis/layers/LUTOverlayLayer.py
@@ -72,10 +72,10 @@ class _LUTOverlayLayer(OverlayLayer):
         if not self.visible:
             return
         
-        self._clear_shader_clipping(gl_canvas)
         labels = []
         
-        with self.get_shader_program(gl_canvas):
+        with self.get_shader_program(gl_canvas) as sp:
+            sp.clear_shader_clipping()
             glDisable(GL_DEPTH_TEST)
             glDisable(GL_LIGHTING)
             glDisable(GL_BLEND)
@@ -233,10 +233,10 @@ class LUTOverlayLayer(OverlayLayer):
         if not self.visible:
             return
         
-        self._clear_shader_clipping(gl_canvas)
         labels = []
         
         with self.get_shader_program(gl_canvas) as sp:
+            sp.clear_shader_clipping()
             glDisable(GL_DEPTH_TEST)
             #glDisable(GL_LIGHTING)
             glDisable(GL_BLEND)

--- a/PYME/LMVis/layers/LUTOverlayLayer.py
+++ b/PYME/LMVis/layers/LUTOverlayLayer.py
@@ -203,6 +203,9 @@ class LUTOverlayLayer(OverlayLayer):
             #glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
             #glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE)
             glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, image.shape[0], image.shape[1], 0, GL_RED, GL_FLOAT, image.astype('f4'))
+        else:
+            glActiveTexture(GL_TEXTURE0)
+            glBindTexture(GL_TEXTURE_2D, self._texture_id)
 
     def set_lut(self, cmap):
         if self._lut_id is None:

--- a/PYME/LMVis/layers/OverlayLayer.py
+++ b/PYME/LMVis/layers/OverlayLayer.py
@@ -20,14 +20,15 @@
 #
 import abc
 
-from PYME.LMVis.layers.base import SimpleLayer
+from PYME.LMVis.layers.base import SimpleLayer, BindMixin
 from PYME.LMVis.shader_programs.DefaultShaderProgram import DefaultShaderProgram
 
 
-class OverlayLayer(SimpleLayer):
-
+class OverlayLayer(SimpleLayer, BindMixin):
     def __init__(self, offset, **kwargs):
-        super(OverlayLayer, self).__init__(**kwargs)
+        SimpleLayer.__init__(self, **kwargs)
+        BindMixin.__init__(self)
+
         if offset:
             self._offset = offset
         else:

--- a/PYME/LMVis/layers/ScaleBarOverlayLayer.py
+++ b/PYME/LMVis/layers/ScaleBarOverlayLayer.py
@@ -90,7 +90,7 @@ class ScaleBarOverlayLayer(OverlayLayer):
                 if core_profile:
                     sp.set_modelviewprojectionmatrix(np.array(gl_canvas.mvp))
 
-                self._bind_data('scalebar', self._verts, 0*self._verts, self._cols, core_profile=core_profile)
+                self._bind_data('scalebar', self._verts, 0*self._verts, self._cols, sp, core_profile=core_profile)
 
                 glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
                 glDrawArrays(GL_TRIANGLES, 0, 6)

--- a/PYME/LMVis/layers/ScaleBarOverlayLayer.py
+++ b/PYME/LMVis/layers/ScaleBarOverlayLayer.py
@@ -85,7 +85,7 @@ class ScaleBarOverlayLayer(OverlayLayer):
                 #print(self._verts.shape, self._verts.dtype)
                 col = np.ones(4, 'f')
                 col[:3] = self._color
-                self._cols =np.repeat(col[None, :], 6, axis=0)
+                self._cols =np.tile(col, 6)
 
                 if core_profile:
                     sp.set_modelviewprojectionmatrix(np.array(gl_canvas.mvp))

--- a/PYME/LMVis/layers/ScaleBarOverlayLayer.py
+++ b/PYME/LMVis/layers/ScaleBarOverlayLayer.py
@@ -21,6 +21,7 @@
 from PYME.LMVis.layers.OverlayLayer import OverlayLayer
 from OpenGL.GL import *
 from PYME.LMVis.shader_programs.DefaultShaderProgram import DefaultShaderProgram
+import numpy as np
 
 
 class ScaleBarOverlayLayer(OverlayLayer):
@@ -43,6 +44,7 @@ class ScaleBarOverlayLayer(OverlayLayer):
     def set_scale_bar_depth(self, depth):
         self._scale_bar_depth = depth
 
+
     def render(self, gl_canvas):
         """
 
@@ -61,8 +63,10 @@ class ScaleBarOverlayLayer(OverlayLayer):
         if not self.visible:
             return
         
+        core_profile = gl_canvas.core_profile
+        
         self._clear_shader_clipping(gl_canvas)
-        with self.get_shader_program(gl_canvas):
+        with self.get_shader_program(gl_canvas) as sp:
             if self._scale_bar_length:
                 view_size_x = gl_canvas.xmax - gl_canvas.xmin
                 view_size_y = gl_canvas.ymax - gl_canvas.ymin
@@ -72,12 +76,22 @@ class ScaleBarOverlayLayer(OverlayLayer):
                 sb_ur_y = -gl_canvas.view.translation[1] + gl_canvas.ymin + self.get_offset()[1] * view_size_y / gl_canvas.Size[1]
                 sb_depth = self._scale_bar_depth * view_size_y / gl_canvas.Size[1]
 
-                glDisable(GL_LIGHTING)
+                #glDisable(GL_LIGHTING)
 
-                glColor3fv(self._color)
-                glBegin(GL_POLYGON)
-                glVertex3f(sb_ur_x, sb_ur_y, 0)
-                glVertex3f(sb_ur_x, sb_ur_y + sb_depth, 0)
-                glVertex3f(sb_ur_x - self._scale_bar_length, sb_ur_y + sb_depth, 0)
-                glVertex3f(sb_ur_x - self._scale_bar_length, sb_ur_y, 0)
-                glEnd()
+                self._verts = self._gen_rect_triangles(sb_ur_x - self._scale_bar_length, sb_ur_y, self._scale_bar_length, sb_depth)
+
+                #v = np.hstack([self._verts, np.ones((6, 1), 'f')])
+                #print(self._verts, np.dot(np.array(gl_canvas.mvp), v.T))
+                #print(self._verts.shape, self._verts.dtype)
+                col = np.ones(4, 'f')
+                col[:3] = self._color
+                self._cols =np.repeat(col[None, :], 6, axis=0)
+
+                if core_profile:
+                    sp.set_modelviewprojectionmatrix(np.array(gl_canvas.mvp))
+
+                self._bind_data('scalebar', self._verts, 0*self._verts, self._cols, core_profile=core_profile)
+
+                glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
+                glDrawArrays(GL_TRIANGLES, 0, 6)
+

--- a/PYME/LMVis/layers/ScaleBarOverlayLayer.py
+++ b/PYME/LMVis/layers/ScaleBarOverlayLayer.py
@@ -65,8 +65,8 @@ class ScaleBarOverlayLayer(OverlayLayer):
         
         core_profile = gl_canvas.core_profile
         
-        self._clear_shader_clipping(gl_canvas)
         with self.get_shader_program(gl_canvas) as sp:
+            sp.clear_shader_clipping()
             if self._scale_bar_length:
                 view_size_x = gl_canvas.xmax - gl_canvas.xmin
                 view_size_y = gl_canvas.ymax - gl_canvas.ymin

--- a/PYME/LMVis/layers/ScaleBoxOverlayLayer.py
+++ b/PYME/LMVis/layers/ScaleBoxOverlayLayer.py
@@ -132,8 +132,8 @@ class ScaleBoxOverlayLayer(OverlayLayer):
             if bbox is None:
                 return
             
-            self._clear_shader_clipping(gl_canvas)
-            with self.get_shader_program(gl_canvas):
+            with self.get_shader_program(gl_canvas) as sp:
+                sp.clear_shader_clipping()
                 glDisable(GL_LIGHTING)
                 glColor4fv(self._color)
                 

--- a/PYME/LMVis/layers/ScaleBoxOverlayLayer.py
+++ b/PYME/LMVis/layers/ScaleBoxOverlayLayer.py
@@ -132,134 +132,50 @@ class ScaleBoxOverlayLayer(OverlayLayer):
             if bbox is None:
                 return
             
+            
             with self.get_shader_program(gl_canvas) as sp:
                 sp.clear_shader_clipping()
-                glDisable(GL_LIGHTING)
-                glColor4fv(self._color)
+
+                if gl_canvas.core_profile:
+                    sp.set_modelviewprojectionmatrix(gl_canvas.mvp)
                 
-               
-                
-                bb_0 = bbox[:3]
-                bb_1 = bbox[3:]
 
-                original_starts = np.copy(bb_0)
-                
-                bb_dims = bb_1 - bb_0
-                
-                delta_x, delta_y, delta_z = bb_dims
+                glLineWidth(1.0)
 
-                for i in np.arange(len(self._flips)):
-                    if self._flips[i]:
-                        original_starts[i] += bb_dims[i]
+                x0, y0, z0, x1, y1, z1 = bbox                  
+                delta_x, delta_y, delta_z = bbox[3:] - bbox[:3]
 
-                [start_x, start_y, start_z] = original_starts
-                [direction_x, direction_y, direction_z] = (np.array(self._flips) - 0.5) * -2
 
-                amount_of_lines_x = int(floor(delta_x / self._tick_distance)) + 1
-                amount_of_lines_y = int(floor(delta_y / self._tick_distance)) + 1
-                amount_of_lines_z = int(floor(delta_z / self._tick_distance)) + 1
+                n_lines_x = int(floor(delta_x / self._tick_distance)) + 1
+                n_lines_y = int(floor(delta_y / self._tick_distance)) + 1
+                n_lines_z = int(floor(delta_z / self._tick_distance)) + 1
 
-                # wall xy
-                glBegin(GL_LINES)
-                # top
-                glVertex(start_x + amount_of_lines_x * self._tick_distance * direction_x,
-                         start_y,
-                         start_z)
-                glVertex(start_x + amount_of_lines_x * self._tick_distance * direction_x,
-                         start_y + amount_of_lines_y * self._tick_distance * direction_y,
-                         start_z)
-                # ticks
-                for step in np.arange(amount_of_lines_y + 1):
-                    glVertex(start_x,
-                             start_y + step * self._tick_distance * direction_y,
-                             start_z)
-                    glVertex(start_x + amount_of_lines_x * self._tick_distance * direction_x,
-                             start_y + step * self._tick_distance * direction_y,
-                             start_z)
+                #xy wall
+                zp = z0 if self._flips[2] else z1
+                #verticals
+                vertices = [(x0 + j*self._tick_distance, y0, zp, x0 + j*self._tick_distance, y1, zp) for j in range(n_lines_x)]
+                #horizontals
+                vertices += [(x0, y0 + j*self._tick_distance, zp, x1, y0 + j*self._tick_distance, zp) for j in range(n_lines_y)]
 
-                for step in np.arange(amount_of_lines_x + 1):
-                    glVertex(start_x + step * self._tick_distance * direction_x,
-                             start_y,
-                             start_z)
-                    glVertex(start_x + step * self._tick_distance * direction_x,
-                             start_y + amount_of_lines_y * self._tick_distance * direction_y,
-                             start_z)
+                #xz wall
+                yp = y0 if self._flips[1] else y1
+                #verticals
+                vertices += [(x0 + j*self._tick_distance, yp, z0, x0 + j*self._tick_distance, yp, z1) for j in range(n_lines_x)]
+                #horizontals
+                vertices += [(x0, yp, z0 + j*self._tick_distance, x1, yp, z0 + j*self._tick_distance) for j in range(n_lines_z)]
 
-                # bottom
-                glVertex(start_x,
-                         start_y,
-                         start_z)
-                glVertex(start_x,
-                         start_y + amount_of_lines_y * self._tick_distance * direction_y,
-                         start_z)
-                glEnd()
+                #yz wall
+                xp = x0 if self._flips[1] else x1
+                #verticals
+                vertices += [(xp, y0 + j*self._tick_distance, z0, xp, y0 + j*self._tick_distance, z1) for j in range(n_lines_y)]
+                #horizontals
+                vertices += [(xp, y0, z0 + j*self._tick_distance, xp, y1, z0 + j*self._tick_distance) for j in range(n_lines_z)]
 
-                # wall xz
-                glBegin(GL_LINES)
-                # top
-                glVertex(start_x + amount_of_lines_x * self._tick_distance * direction_x,
-                         start_y,
-                         start_z)
-                glVertex(start_x + amount_of_lines_x * self._tick_distance * direction_x,
-                         start_y,
-                         start_z + amount_of_lines_z * self._tick_distance * direction_z)
-                # ticks
-                for step in np.arange(amount_of_lines_z + 1):
-                    glVertex(start_x,
-                             start_y,
-                             start_z + step * self._tick_distance * direction_z)
-                    glVertex(start_x + amount_of_lines_x * self._tick_distance * direction_x,
-                             start_y,
-                             start_z + step * self._tick_distance * direction_z)
+                vertices = np.hstack(vertices).astype('f')
+                cols = np.tile(self._color, len(vertices)//3)
 
-                for step in np.arange(amount_of_lines_x + 1):
-                    glVertex(start_x + step * self._tick_distance * direction_x,
-                             start_y,
-                             start_z)
-                    glVertex(start_x + step * self._tick_distance * direction_x,
-                             start_y,
-                             start_z + amount_of_lines_z * self._tick_distance * direction_z)
+                #print('vertices.shape: ', vertices.shape, ', n_lines:', n_lines_x, n_lines_y, n_lines_z)
 
-                # bottom
-                glVertex(start_x,
-                         start_y,
-                         start_z)
-                glVertex(start_x,
-                         start_y,
-                         start_z + amount_of_lines_z * self._tick_distance * direction_z)
-                glEnd()
+                self._bind_data('scalebox', vertices, 0*vertices, cols, sp, core_profile=gl_canvas.core_profile)
 
-                # wall yz
-                glBegin(GL_LINES)
-                # top
-                glVertex(start_x,
-                         start_y + amount_of_lines_y * self._tick_distance * direction_y,
-                         start_z)
-                glVertex(start_x,
-                         start_y + amount_of_lines_y * self._tick_distance * direction_y,
-                         start_z + amount_of_lines_z * self._tick_distance * direction_z)
-                # ticks
-                for step in np.arange(amount_of_lines_z + 1):
-                    glVertex(start_x,
-                             start_y,
-                             start_z + step * self._tick_distance * direction_z)
-                    glVertex(start_x,
-                             start_y + amount_of_lines_y * self._tick_distance * direction_y,
-                             start_z + step * self._tick_distance * direction_z)
-
-                for step in np.arange(amount_of_lines_y + 1):
-                    glVertex(start_x,
-                             start_y + step * self._tick_distance * direction_y,
-                             start_z)
-                    glVertex(start_x,
-                             start_y + step * self._tick_distance * direction_y,
-                             start_z + amount_of_lines_z * self._tick_distance * direction_z)
-
-                # bottom
-                glVertex(start_x,
-                         start_y,
-                         start_z)
-                glVertex(start_x,
-                         start_y,
-                         start_z + amount_of_lines_z * self._tick_distance * direction_z)
-                glEnd()
+                glDrawArrays(GL_LINES, 0, len(vertices))

--- a/PYME/LMVis/layers/SelectionOverlayLayer.py
+++ b/PYME/LMVis/layers/SelectionOverlayLayer.py
@@ -66,7 +66,7 @@ class SelectionOverlayLayer(OverlayLayer):
                     glLineWidth(1)
 
                     verts = np.array([[x0, y0, zc], [x1, y0, zc], [x1, y1, zc], [x0, y1, zc]], 'f')
-                    cols = np.repeat(np.hstack([self._selection_settings.colour, 1.0])[None,:], 4, axis=0)
+                    cols = np.tile(np.hstack([self._selection_settings.colour, 1.0]), 4)
 
                     self._bind_data('selection', verts, 0*verts, cols, sp, core_profile=gl_canvas.core_profile)
                     glDrawArrays(GL_LINE_LOOP, 0, 4)
@@ -88,7 +88,7 @@ class SelectionOverlayLayer(OverlayLayer):
                     glLineWidth(self._selection_settings.width)
 
                     verts = np.array([[x0, y0, zc], [x1, y1, zc]], 'f')
-                    cols = np.repeat(np.hstack([self._selection_settings.colour, 1.0])[None, :], 2, axis=0)
+                    cols = np.tile(np.hstack([self._selection_settings.colour, 1.0]), 2)
                     self._bind_data('selection', verts, 0*verts, cols, sp, core_profile=gl_canvas.core_profile)
                     glDrawArrays(GL_LINES, 0, 2)
 

--- a/PYME/LMVis/layers/SelectionOverlayLayer.py
+++ b/PYME/LMVis/layers/SelectionOverlayLayer.py
@@ -47,8 +47,9 @@ class SelectionOverlayLayer(OverlayLayer):
         if not self.visible:
             return
         
-        self._clear_shader_clipping(gl_canvas)
         with self.get_shader_program(gl_canvas) as sp:
+            sp.clear_shader_clipping()
+
             if gl_canvas.core_profile:
                 sp.set_modelviewprojectionmatrix(np.array(gl_canvas.mvp))
 

--- a/PYME/LMVis/layers/SelectionOverlayLayer.py
+++ b/PYME/LMVis/layers/SelectionOverlayLayer.py
@@ -48,9 +48,14 @@ class SelectionOverlayLayer(OverlayLayer):
             return
         
         self._clear_shader_clipping(gl_canvas)
-        with self.get_shader_program(gl_canvas):
+        with self.get_shader_program(gl_canvas) as sp:
+            if gl_canvas.core_profile:
+                sp.set_modelviewprojectionmatrix(np.array(gl_canvas.mvp))
+
+            #print('SelectionOverlayLayer.render() called')
+            
             if self._selection_settings.show:
-                glDisable(GL_LIGHTING)
+                #glDisable(GL_LIGHTING)
                 if self._selection_settings.mode == selection.SELECTION_RECTANGLE: 
                     x0, y0, _ = self._selection_settings.start
                     x1, y1, _ = self._selection_settings.finish
@@ -58,13 +63,20 @@ class SelectionOverlayLayer(OverlayLayer):
                     zc = gl_canvas.view.translation[2]
 
                     glLineWidth(1)
-                    glColor3fv(self._selection_settings.colour)
-                    glBegin(GL_LINE_LOOP)
-                    glVertex3f(x0, y0, zc)
-                    glVertex3f(x1, y0, zc)
-                    glVertex3f(x1, y1, zc)
-                    glVertex3f(x0, y1, zc)
-                    glEnd()
+
+                    verts = np.array([[x0, y0, zc], [x1, y0, zc], [x1, y1, zc], [x0, y1, zc]], 'f')
+                    cols = np.repeat(np.hstack([self._selection_settings.colour, 1.0])[None,:], 4, axis=0)
+
+                    self._bind_data('selection', verts, 0*verts, cols, core_profile=gl_canvas.core_profile)
+                    glDrawArrays(GL_LINE_LOOP, 0, 4)
+
+                    # glColor3fv(self._selection_settings.colour)
+                    # glBegin(GL_LINE_LOOP)
+                    # glVertex3f(x0, y0, zc)
+                    # glVertex3f(x1, y0, zc)
+                    # glVertex3f(x1, y1, zc)
+                    # glVertex3f(x0, y1, zc)
+                    # glEnd()
 
                 elif self._selection_settings.mode == selection.SELECTION_LINE:
                     x0, y0, _ = self._selection_settings.start
@@ -73,11 +85,17 @@ class SelectionOverlayLayer(OverlayLayer):
                     zc = gl_canvas.view.translation[2]
 
                     glLineWidth(self._selection_settings.width)
-                    glColor3fv(self._selection_settings.colour)
-                    glBegin(GL_LINES)
-                    glVertex3f(x0, y0, zc)
-                    glVertex3f(x1, y1, zc)
-                    glEnd()
+
+                    verts = np.array([[x0, y0, zc], [x1, y1, zc]], 'f')
+                    cols = np.repeat(np.hstack([self._selection_settings.colour, 1.0])[None, :], 2, axis=0)
+                    self._bind_data('selection', verts, 0*verts, cols, core_profile=gl_canvas.core_profile)
+                    glDrawArrays(GL_LINES, 0, 2)
+
+                    # glColor3fv(self._selection_settings.colour)
+                    # glBegin(GL_LINES)
+                    # glVertex3f(x0, y0, zc)
+                    # glVertex3f(x1, y1, zc)
+                    # glEnd()
 
                 elif self._selection_settings.mode == selection.SELECTION_SQUIGGLE:
                     if len(self._selection_settings.trace) == 0:
@@ -86,19 +104,20 @@ class SelectionOverlayLayer(OverlayLayer):
                     x, y = np.array(self._selection_settings.trace).T
                     z = np.ones_like(x)*gl_canvas.view.translation[2]
 
-                    vertices = np.vstack((x.ravel(), y.ravel(), z.ravel()))
+                    vertices = np.vstack((x.ravel(), y.ravel(), z.ravel())).astype('f')
                     vertices = vertices.T.ravel().reshape(len(x.ravel()), 3)
                     normals = -0.69 * np.ones(vertices.shape)
                     c = np.ones(len(x))[:,None]*np.hstack([self._selection_settings.colour, 1.0])[None,:]
                     
-                    glDisable(GL_LIGHTING)
+                    #glDisable(GL_LIGHTING)
                     glPolygonMode(GL_FRONT_AND_BACK, GL_LINE)
                     glDisable(GL_DEPTH_TEST)
                     glLineWidth(self._selection_settings.width)
                     #glColor3fv(self._selection_settings.colour)
 
-                    glVertexPointerf(vertices)
-                    glNormalPointerf(normals)
-                    glColorPointerf(c)
+                    # glVertexPointerf(vertices)
+                    # glNormalPointerf(normals)
+                    # glColorPointerf(c)
+                    self._bind_data('selection', vertices, normals, c, core_profile=gl_canvas.core_profile)
                     glDrawArrays(GL_LINE_STRIP, 0, len(x))
 

--- a/PYME/LMVis/layers/SelectionOverlayLayer.py
+++ b/PYME/LMVis/layers/SelectionOverlayLayer.py
@@ -67,7 +67,7 @@ class SelectionOverlayLayer(OverlayLayer):
                     verts = np.array([[x0, y0, zc], [x1, y0, zc], [x1, y1, zc], [x0, y1, zc]], 'f')
                     cols = np.repeat(np.hstack([self._selection_settings.colour, 1.0])[None,:], 4, axis=0)
 
-                    self._bind_data('selection', verts, 0*verts, cols, core_profile=gl_canvas.core_profile)
+                    self._bind_data('selection', verts, 0*verts, cols, sp, core_profile=gl_canvas.core_profile)
                     glDrawArrays(GL_LINE_LOOP, 0, 4)
 
                     # glColor3fv(self._selection_settings.colour)
@@ -88,7 +88,7 @@ class SelectionOverlayLayer(OverlayLayer):
 
                     verts = np.array([[x0, y0, zc], [x1, y1, zc]], 'f')
                     cols = np.repeat(np.hstack([self._selection_settings.colour, 1.0])[None, :], 2, axis=0)
-                    self._bind_data('selection', verts, 0*verts, cols, core_profile=gl_canvas.core_profile)
+                    self._bind_data('selection', verts, 0*verts, cols, sp, core_profile=gl_canvas.core_profile)
                     glDrawArrays(GL_LINES, 0, 2)
 
                     # glColor3fv(self._selection_settings.colour)
@@ -118,6 +118,6 @@ class SelectionOverlayLayer(OverlayLayer):
                     # glVertexPointerf(vertices)
                     # glNormalPointerf(normals)
                     # glColorPointerf(c)
-                    self._bind_data('selection', vertices, normals, c, core_profile=gl_canvas.core_profile)
+                    self._bind_data('selection', vertices, normals, c, csp, ore_profile=gl_canvas.core_profile)
                     glDrawArrays(GL_LINE_STRIP, 0, len(x))
 

--- a/PYME/LMVis/layers/__init__.py
+++ b/PYME/LMVis/layers/__init__.py
@@ -31,13 +31,16 @@ from .SelectionOverlayLayer import SelectionOverlayLayer
 #from .TetrahedraRenderLayer import TetrahedraRenderLayer
 from .base import BaseLayer
 
-from . import pointcloud, mesh, tracks, image_layer
+from . import pointcloud, mesh, tracks, image_layer, labels, quiver, octree
 
 layer_types = {
     'PointCloudRenderLayer' : pointcloud.PointCloudRenderLayer,
     'TriangleRenderLayer' : mesh.TriangleRenderLayer,
     'TrackRenderLayer' : tracks.TrackRenderLayer,
     'ImageRenderLayer' : image_layer.ImageRenderLayer,
+    'LabelLayer' : labels.LabelLayer,
+    'QuiverRenderLayer' : quiver.QuiverRenderLayer,
+    'OctreeRenderLayer' : octree.OctreeRenderLayer,
 }
 
 def layer_from_session_info(pipeline, layer_info):

--- a/PYME/LMVis/layers/base.py
+++ b/PYME/LMVis/layers/base.py
@@ -52,7 +52,7 @@ class BindMixin(object):
     def __del__(self):
         for vao, vbo, sig in self._bound_data.values():
             from OpenGL.GL import glDeleteVertexArrays, glDeleteBuffers
-            glDeleteVertexArrays(1, vao)
+            glDeleteVertexArrays(1, [vao,])
             glDeleteBuffers(3, vbo)
 
     def _bind_data_core(self, name, vertices, normals, colors, sp):
@@ -74,7 +74,7 @@ class BindMixin(object):
         elif old_vao is not None:
             glBindVertexArray(0) # unbind the old vao
             glBindBuffer(GL_ARRAY_BUFFER, 0) # unbind the old vbo
-            glDeleteVertexArrays(1, old_vao)
+            glDeleteVertexArrays(1, [old_vao,])
             glDeleteBuffers(3, old_vbo)
         
         vertices = np.ascontiguousarray(vertices, 'f')

--- a/PYME/LMVis/layers/base.py
+++ b/PYME/LMVis/layers/base.py
@@ -110,6 +110,18 @@ class BindMixin(object):
         normals = np.ascontiguousarray(normals, 'f')
         colors = np.ascontiguousarray(colors, 'f')
 
+        #glVertexPointer expects an Nx3 array
+        #glNormalPointer expects an Nx3 array
+        #glColorPointer expects an Nx4 array
+        if vertices.ndim == 1:
+            vertices = vertices.reshape([-1, 3])
+
+        if colors.ndim == 1:
+            colors = colors.reshape([-1,4])
+
+        if normals.ndim == 1:
+            normals = normals.reshape([-1,3])
+
         n_vertices = vertices.shape[0]
 
         glVertexPointerf(vertices)

--- a/PYME/LMVis/layers/image_layer.py
+++ b/PYME/LMVis/layers/image_layer.py
@@ -39,13 +39,13 @@ class ImageEngine(BaseEngine):
             glActiveTexture(GL_TEXTURE0)
             glBindTexture(GL_TEXTURE_2D, self._texture_id)
             glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP)
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
             #glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
             #glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
-            glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE)
+            #glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE)
             glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, image.shape[0], image.shape[1], 0, GL_RED, GL_FLOAT, image.astype('f4'))
 
     def set_lut(self, lut):
@@ -71,15 +71,18 @@ class ImageEngine(BaseEngine):
             glTexParameteri (GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
             #glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
             glTexParameteri (GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
-            glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE)
+            #glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE)
             glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, lut_array.shape[0], 0, GL_RGBA, GL_FLOAT,
                          lut_array.astype('f4'))
 
-
+    
     def render(self, gl_canvas, layer):
         self._set_shader_clipping(gl_canvas)
 
         with self.get_shader_program(gl_canvas) as sp:
+            if gl_canvas.core_profile:
+                sp.set_modelviewprojectionmatrix(gl_canvas.mvp)
+
             self.set_lut(layer.colour_map)
             glActiveTexture(GL_TEXTURE1)
             glBindTexture(GL_TEXTURE_1D, self._lut_id) # bind to our texture, has id of 1 */
@@ -88,31 +91,58 @@ class ImageEngine(BaseEngine):
             self.set_texture(layer._im)
             glUniform2f(sp.get_uniform_location("clim"), *layer.get_color_limit())
             
-            glEnable(GL_TEXTURE_2D) # enable texture mapping */
+            if not gl_canvas.core_profile:
+                glEnable(GL_TEXTURE_2D) # enable texture mapping */
+
             glActiveTexture(GL_TEXTURE0)
             glBindTexture(GL_TEXTURE_2D, self._texture_id) # bind to our texture, has id of 1 */
             glUniform1i(sp.get_uniform_location("im_sampler"), 0)
             
             x0, y0, x1, y1 = layer._bounds
 
-            glDisable(GL_TEXTURE_GEN_S)
-            glDisable(GL_TEXTURE_GEN_T)
-            glDisable(GL_TEXTURE_GEN_R)
+            if not gl_canvas.core_profile:
+                glDisable(GL_TEXTURE_GEN_S)
+                glDisable(GL_TEXTURE_GEN_T)
+                glDisable(GL_TEXTURE_GEN_R)
+
+            if gl_canvas.core_profile:
+                verts = self._gen_rect_triangles(x0, y0, x1-x0, y1-y0, z=layer.z_nm)
+                tex_coords = self._gen_rect_texture_coords()
+
+                vao = glGenVertexArrays(1)
+                vbo = glGenBuffers(2)
+                glBindVertexArray(vao)
+                glBindBuffer(GL_ARRAY_BUFFER, vbo[0])
+                glBufferData(GL_ARRAY_BUFFER, verts.nbytes, verts, GL_STATIC_DRAW)
+                glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, None)
+                glEnableVertexAttribArray(0)
+                glBindBuffer(GL_ARRAY_BUFFER, vbo[1])
+                glBufferData(GL_ARRAY_BUFFER, tex_coords.nbytes, tex_coords, GL_STATIC_DRAW)
+                glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, None)
+                glEnableVertexAttribArray(1)
+
+                glDrawArrays(GL_TRIANGLES, 0, len(verts))
+                glBindBuffer(GL_ARRAY_BUFFER, 0)
+                glBindVertexArray(0)
+                glDeleteVertexArrays(1, vao)
+                glDeleteBuffers(2, vbo)
+
+            else:
+                #glColor3f(1.,0.,0.)
+                glColor4f(1., 1., 1., 1.)
+                glBegin(GL_QUADS)
+                glTexCoord2f(0., 0.) # lower left corner of image */
+                glVertex3f(x0, y0, layer.z_nm)
+                glTexCoord2f(1., 0.) # lower right corner of image */
+                glVertex3f(x1, y0, layer.z_nm)
+                glTexCoord2f(1.0, 1.0) # upper right corner of image */
+                glVertex3f(x1, y1, layer.z_nm)
+                glTexCoord2f(0.0, 1.0) # upper left corner of image */
+                glVertex3f(x0, y1, layer.z_nm)
+                glEnd()
     
-            #glColor3f(1.,0.,0.)
-            glColor4f(1., 1., 1., 1.)
-            glBegin(GL_QUADS)
-            glTexCoord2f(0., 0.) # lower left corner of image */
-            glVertex3f(x0, y0, layer.z_nm)
-            glTexCoord2f(1., 0.) # lower right corner of image */
-            glVertex3f(x1, y0, layer.z_nm)
-            glTexCoord2f(1.0, 1.0) # upper right corner of image */
-            glVertex3f(x1, y1, layer.z_nm)
-            glTexCoord2f(0.0, 1.0) # upper left corner of image */
-            glVertex3f(x0, y1, layer.z_nm)
-            glEnd()
-    
-            glDisable(GL_TEXTURE_2D)
+            if not gl_canvas.core_profile:
+                glDisable(GL_TEXTURE_2D)
                 
 
 

--- a/PYME/LMVis/layers/image_layer.py
+++ b/PYME/LMVis/layers/image_layer.py
@@ -77,9 +77,9 @@ class ImageEngine(BaseEngine):
 
     
     def render(self, gl_canvas, layer):
-        self._set_shader_clipping(gl_canvas)
-
         with self.get_shader_program(gl_canvas) as sp:
+            sp.set_clipping(gl_canvas.view.clipping.squeeze(), gl_canvas.view.clip_plane_matrix)
+            
             if gl_canvas.core_profile:
                 sp.set_modelviewprojectionmatrix(gl_canvas.mvp)
 

--- a/PYME/LMVis/layers/image_layer.py
+++ b/PYME/LMVis/layers/image_layer.py
@@ -124,7 +124,7 @@ class ImageEngine(BaseEngine):
                 glDrawArrays(GL_TRIANGLES, 0, len(verts))
                 glBindBuffer(GL_ARRAY_BUFFER, 0)
                 glBindVertexArray(0)
-                glDeleteVertexArrays(1, vao)
+                glDeleteVertexArrays(1, [vao, ])
                 glDeleteBuffers(2, vbo)
 
             else:

--- a/PYME/LMVis/layers/labels.py
+++ b/PYME/LMVis/layers/labels.py
@@ -25,7 +25,7 @@ class LabelLayer(SimpleLayer):
     _datasource_choices = List()
 
     textColour = CStr('', desc='Name of variable used to colour our text')
-    font_size = Float(12, desc='font size in points')
+    font_size = Float(10, desc='font size in points')
     cmap = Enum(*cm.cmapnames, default='gist_rainbow', desc='Name of colourmap used to colour text')
     clim = ListFloat([0, 1], desc='How our variable should be scaled prior to colour mapping')
 
@@ -52,10 +52,12 @@ class LabelLayer(SimpleLayer):
         # define responses to changes in various traits
         self.on_trait_change(self._update, 'textColour')
         self.on_trait_change(lambda: self.on_update.send(self), 'visible')
-        self.on_trait_change(self.update, 'cmap, clim, dsname, font_size')
+        self.on_trait_change(self.update, 'cmap, clim, dsname, font_size, format_string')
 
         # update any of our traits which were passed as command line arguments
         self.set(**kwargs)
+
+        self.update()
         
         # if we were given a pipeline, connect ourselves to the onRebuild signal so that we can automatically update
         # ourselves
@@ -101,7 +103,7 @@ class LabelLayer(SimpleLayer):
         return cm[self.cmap]
     
     def update_from_datasource(self, ds):
-        print('pointcloud.update_from_datasource() - dsname=%s' % self.dsname)
+        print('labels.update_from_datasource() - dsname=%s' % self.dsname)
         x, y = ds[self.x_key], ds[self.y_key]
         try:
             z = ds[self.z_key]

--- a/PYME/LMVis/layers/labels.py
+++ b/PYME/LMVis/layers/labels.py
@@ -1,0 +1,184 @@
+"""
+A layer which draws text labels at the positions of the points in a tabular datasource.
+"""
+
+from PYME.LMVis.layers.base import SimpleLayer
+
+from PYME.recipes.traits import CStr, Float, Enum, ListFloat, List, Bool
+# from pylab import cm
+from PYME.misc.colormaps import cm
+import numpy as np
+import string
+from PYME.contrib import dispatch
+from .text import Text
+
+import logging
+logger = logging.getLogger(__name__)
+
+class LabelLayer(SimpleLayer):
+    """
+    A layer which draws text labels at the positions of the points in a tabular datasource.
+    """
+
+    dsname = CStr('output', desc='Name of the datasource within the pipeline to use as a source of points')
+    _datasource_keys = List()
+    _datasource_choices = List()
+
+    textColour = CStr('', desc='Name of variable used to colour our text')
+    font_size = Float(12, desc='font size in points')
+    cmap = Enum(*cm.cmapnames, default='gist_rainbow', desc='Name of colourmap used to colour text')
+    clim = ListFloat([0, 1], desc='How our variable should be scaled prior to colour mapping')
+
+    format_string = CStr('P{idx}', desc='Format string for the text labels. This should be a python format string which can take column names (and the special idx name which is the index in the table)')
+
+    def __init__(self, pipeline, **kwargs):
+        SimpleLayer.__init__(self, **kwargs)
+        self._pipeline = pipeline
+        
+        self.x_key = 'x' #TODO - make these traits?
+        self.y_key = 'y'
+        self.z_key = 'z'
+
+        self._bbox = None
+        self._text_objects = []
+    
+        # define a signal so that people can be notified when we are updated (currently used to force a redraw when
+        # parameters change)
+        self.on_update = dispatch.Signal()
+
+        # signal for when the data is updated (used to, e.g., refresh histograms)
+        self.data_updated = dispatch.Signal()
+
+        # define responses to changes in various traits
+        self.on_trait_change(self._update, 'textColour')
+        self.on_trait_change(lambda: self.on_update.send(self), 'visible')
+        self.on_trait_change(self.update, 'cmap, clim, dsname, font_size')
+
+        # update any of our traits which were passed as command line arguments
+        self.set(**kwargs)
+        
+        # if we were given a pipeline, connect ourselves to the onRebuild signal so that we can automatically update
+        # ourselves
+        if not self._pipeline is None:
+            self._pipeline.onRebuild.connect(self.update)
+
+    @property
+    def datasource(self):
+        """
+        Return the datasource we are connected to (through our dsname property).
+        """
+        return self._pipeline.get_layer_data(self.dsname)
+    
+    def _get_cdata(self):
+        try:
+            cdata = self.datasource[self.textColour]
+        except KeyError:
+            cdata = np.array([0, 1])
+    
+        return cdata
+    
+    def _update(self, *args, **kwargs):
+        cdata = self._get_cdata()
+        self.clim = [float(np.nanmin(cdata)), float(np.nanmax(cdata))+1e-9]
+        #self.update(*args, **kwargs)
+
+    def update(self, *args, **kwargs):
+        #print('lw update')
+        self._datasource_choices = self._pipeline.layer_data_source_names
+        if not self.datasource is None:
+            self._datasource_keys = sorted(self.datasource.keys())
+            
+            self.update_from_datasource(self.datasource)
+            self.on_update.send(self)
+            
+
+    @property
+    def bbox(self):
+        return self._bbox
+    
+    @property
+    def colour_map(self):
+        return cm[self.cmap]
+    
+    def update_from_datasource(self, ds):
+        print('pointcloud.update_from_datasource() - dsname=%s' % self.dsname)
+        x, y = ds[self.x_key], ds[self.y_key]
+        try:
+            z = ds[self.z_key]
+        except (KeyError, ValueError):
+            z = 0*x
+        
+        if not self.textColour == '':
+            c = ds[self.textColour]
+        else:
+            c = 0*x
+
+        # find out what fields we need to format
+        format_field_names  = [f for _, f, _, _ in string.Formatter().parse(self.format_string) if f is not None]  
+        
+        data_columns = {k: ds[k] for k in format_field_names if not k == 'idx'}
+        data_columns['idx'] = np.arange(len(x))
+
+        labels = [self.format_string.format(**{k:v[i] for k, v in data_columns.items()}) for i in range(len(x))]
+
+        self.update_data(x, y, z, c, cmap=cm[self.cmap], clim=self.clim, labels=labels)
+
+        self.data_updated.send(self)
+    
+    
+    def update_data(self, x=None, y=None, z=None, colors=None, cmap=None, clim=None, labels=None, alpha=1.0):
+        self._text_objects = []
+        self._bbox = None
+
+        if clim is not None and colors is not None and clim is not None:
+            cs_ = ((colors - clim[0]) / (clim[1] - clim[0]))
+            cs = cmap(cs_)
+            cs[:, 3] = alpha
+            
+            cs = cs.ravel().reshape(len(colors), 4)
+        else:
+            if x is not None:
+                cs = np.ones((x.shape[0], 4), 'f')
+            else:
+                cs = None
+        
+        if x is not None and y is not None and z is not None and len(x) > 0:
+            self._text_objects = [Text(pos=(x[i], y[i], z[i]), text=labels[i], color=cs[i, :], font_size=self.font_size) for i in range(len(x))]
+            
+            self._bbox = np.array([x.min(), y.min(), z.min(), x.max(), y.max(), z.max()])
+        else:
+            
+            self._bbox = None
+
+    def render(self, gl_canvas):
+        if not self.visible:
+            return
+        
+        for to in self._text_objects:
+            to.render(gl_canvas)
+
+    @property
+    def default_view(self):
+        from traitsui.api import View, Item, Group, InstanceEditor, EnumEditor, TextEditor
+        from PYME.ui.custom_traits_editors import HistLimitsEditor, CBEditor
+
+        vis_when = 'cmap not in %s' % cm.solid_cmaps
+    
+        return View([Group([Item('dsname', label='Data', editor=EnumEditor(name='_datasource_choices')), ]),
+                     Item('textColour', editor=EnumEditor(name='_datasource_keys'), label='Colour', visible_when=vis_when),
+                     Group([Item('clim', editor=HistLimitsEditor(data=self._get_cdata, update_signal=self.data_updated), show_label=False), ], visible_when=vis_when),
+                     Group(Item('cmap', label='LUT'),
+                           #Item('alpha', visible_when="method in ['pointsprites', 'transparent_points']", editor=TextEditor(auto_set=False, enter_set=True, evaluate=float)),
+                           Item('font_size', label=u'Font\u00A0size', editor=TextEditor(auto_set=False, enter_set=True, evaluate=float)),
+                           Item('format_string', label='Format string', editor=TextEditor(auto_set=False, enter_set=True)),
+                           )])
+        #buttons=['OK', 'Cancel'])
+
+    def default_traits_view(self):
+        return self.default_view
+        
+        
+
+       
+    
+

--- a/PYME/LMVis/layers/labels.py
+++ b/PYME/LMVis/layers/labels.py
@@ -26,7 +26,7 @@ class LabelLayer(SimpleLayer):
 
     textColour = CStr('', desc='Name of variable used to colour our text')
     font_size = Float(10, desc='font size in points')
-    cmap = Enum(*cm.cmapnames, default='gist_rainbow', desc='Name of colourmap used to colour text')
+    cmap = Enum('SolidWhite', cm.cmapnames, desc='Name of colourmap used to colour text')
     clim = ListFloat([0, 1], desc='How our variable should be scaled prior to colour mapping')
 
     format_string = CStr('P{idx}', desc='Format string for the text labels. This should be a python format string which can take column names (and the special idx name which is the index in the table)')

--- a/PYME/LMVis/layers/mesh.py
+++ b/PYME/LMVis/layers/mesh.py
@@ -26,7 +26,6 @@ class WireframeEngine(BaseEngine):
     
     def render(self, gl_canvas, layer):
         core_profile = gl_canvas.core_profile
-        self._set_shader_clipping(gl_canvas)
 
         vertices = layer.get_vertices()
         n_vertices = vertices.shape[0]
@@ -39,6 +38,8 @@ class WireframeEngine(BaseEngine):
         colors = layer.get_colors()
 
         with self.get_shader_program(gl_canvas) as sp:
+            sp.set_clipping(gl_canvas.view.clipping.squeeze(), gl_canvas.view.clip_plane_matrix)
+            
             self._bind_data('mesh', vertices, normals, colors, sp, core_profile=core_profile)
             
             if core_profile:        

--- a/PYME/LMVis/layers/mesh.py
+++ b/PYME/LMVis/layers/mesh.py
@@ -39,7 +39,7 @@ class WireframeEngine(BaseEngine):
         colors = layer.get_colors()
 
         with self.get_shader_program(gl_canvas) as sp:
-            self._bind_data('mesh', vertices, normals, colors, core_profile=core_profile)
+            self._bind_data('mesh', vertices, normals, colors, sp, core_profile=core_profile)
             
             if core_profile:        
                 sp.set_modelviewprojectionmatrix(np.array(gl_canvas.mvp))
@@ -54,7 +54,7 @@ class WireframeEngine(BaseEngine):
                 # TODO - move this to a shader uniform to avoid duplicating the data
                 sc = np.array([0.5, 0.5, 0.5, 1])
 
-                self._bind_data('outline', vertices, normals, sc*colors, core_profile=core_profile)
+                self._bind_data('outline', vertices, normals, sc*colors, sp, core_profile=core_profile)
 
                 glPolygonMode(GL_FRONT_AND_BACK, GL_LINE)
                 glDrawArrays(GL_TRIANGLES, 0, n_vertices)
@@ -76,7 +76,7 @@ class WireframeEngine(BaseEngine):
                 cols = (np.ones((normal_buffer.shape[0],4),dtype=colors.dtype)*sc[None,:])  # white normals
                 norms = (np.ones((normal_buffer.shape[0],3),dtype=normals.dtype))
 
-                self._bind_data('normals', normal_buffer, norms, cols, core_profile=core_profile)
+                self._bind_data('normals', normal_buffer, norms, cols, sp, core_profile=core_profile)
                 
                 glLineWidth(3)  # slightly thick
                 glDrawArrays(GL_LINES, 0, 2*n_vertices)

--- a/PYME/LMVis/layers/mesh.py
+++ b/PYME/LMVis/layers/mesh.py
@@ -1,7 +1,7 @@
 from .base import BaseEngine, EngineLayer
 from PYME.LMVis.shader_programs.DefaultShaderProgram import DefaultShaderProgram
 from PYME.LMVis.shader_programs.WireFrameShaderProgram import WireFrameShaderProgram
-from PYME.LMVis.shader_programs.GouraudShaderProgram import GouraudShaderProgram, OITGouraudShaderProgram #, OITCompositorProgram
+from PYME.LMVis.shader_programs.GouraudShaderProgram import GouraudShaderProgram, OITGouraudShaderProgram, PhongShaderProgram #, OITCompositorProgram,
 from PYME.LMVis.shader_programs.TesselShaderProgram import TesselShaderProgram
 
 from PYME.recipes.traits import CStr, Float, Enum, ListFloat, List, Bool
@@ -98,7 +98,8 @@ class ShadedFaceEngine(WireframeEngine):
         BaseEngine.__init__(self)
 
     def render(self, gl_canvas, layer):
-        self.set_shader_program(GouraudShaderProgram)
+        #self.set_shader_program(GouraudShaderProgram)
+        self.set_shader_program(PhongShaderProgram)
         WireframeEngine.render(self, gl_canvas, layer)
         
 class OITShadedFaceEngine(WireframeEngine):
@@ -132,7 +133,7 @@ class TesselEngine(WireframeEngine):
 ENGINES = {
     'wireframe' : WireframeEngine,
     'flat' : FlatFaceEngine,
-    #'shaded' : ShadedFaceEngine,
+    'phong' : ShadedFaceEngine,
     'tessel' : TesselEngine,
     'shaded' : OITShadedFaceEngine,
 }

--- a/PYME/LMVis/layers/mesh.py
+++ b/PYME/LMVis/layers/mesh.py
@@ -23,7 +23,9 @@ class WireframeEngine(BaseEngine):
         self.set_shader_program(WireFrameShaderProgram)
 
 
+    
     def render(self, gl_canvas, layer):
+        core_profile = gl_canvas.core_profile
         self._set_shader_clipping(gl_canvas)
 
         vertices = layer.get_vertices()
@@ -36,20 +38,29 @@ class WireframeEngine(BaseEngine):
         normals = layer.get_normals()
         colors = layer.get_colors()
 
-        with self.get_shader_program(gl_canvas):
-            glVertexPointerf(vertices)
-            glNormalPointerf(normals)
-            glColorPointerf(colors)
+        with self.get_shader_program(gl_canvas) as sp:
+            self._bind_data('mesh', vertices, normals, colors, core_profile=core_profile)
+            
+            if core_profile:        
+                sp.set_modelviewprojectionmatrix(np.array(gl_canvas.mvp))
+                sp.set_modelviewmatrix(np.array(gl_canvas.mv))
+                sp.set_normalmatrix(np.array(gl_canvas.normal_matrix))
+                #glBindVertexArray(self._bound_data['mesh'][0])
+            
 
             glDrawArrays(GL_TRIANGLES, 0, n_vertices)
             
             if self._outlines:
+                # TODO - move this to a shader uniform to avoid duplicating the data
                 sc = np.array([0.5, 0.5, 0.5, 1])
-                glColorPointerf(colors*sc[None,:])
+
+                self._bind_data('outline', vertices, normals, sc*colors, core_profile=core_profile)
+
                 glPolygonMode(GL_FRONT_AND_BACK, GL_LINE)
                 glDrawArrays(GL_TRIANGLES, 0, n_vertices)
 
             if layer.display_normals:
+                # TODO - do this using a geometry shader???
                 normal_buffer = np.empty((vertices.shape[0]+normals.shape[0],3), dtype=vertices.dtype)
                 if layer.normal_mode == 'Per vertex':
                     normal_buffer[0::2,:] = vertices
@@ -61,10 +72,12 @@ class WireframeEngine(BaseEngine):
                 assert(np.allclose(np.linalg.norm(normals,axis=1),1))
                 normal_buffer[1::2,:] += layer.normal_scaling*normals
                 
-                glVertexPointerf(normal_buffer)
                 sc = np.array([1, 1, 1, 1])
-                glColorPointerf(np.ones((normal_buffer.shape[0],4),dtype=colors.dtype)*sc[None,:])  # white normals
-                glNormalPointerf(np.ones((normal_buffer.shape[0],3),dtype=normals.dtype))
+                cols = (np.ones((normal_buffer.shape[0],4),dtype=colors.dtype)*sc[None,:])  # white normals
+                norms = (np.ones((normal_buffer.shape[0],3),dtype=normals.dtype))
+
+                self._bind_data('normals', normal_buffer, norms, cols, core_profile=core_profile)
+                
                 glLineWidth(3)  # slightly thick
                 glDrawArrays(GL_LINES, 0, 2*n_vertices)
 

--- a/PYME/LMVis/layers/pointcloud.py
+++ b/PYME/LMVis/layers/pointcloud.py
@@ -1,7 +1,7 @@
 from .base import BaseEngine, EngineLayer
 from PYME.LMVis.shader_programs.DefaultShaderProgram import DefaultShaderProgram, OpaquePointShaderProgram, BigOpaquePointShaderProgram
-from PYME.LMVis.shader_programs.PointSpriteShaderProgram import PointSpriteShaderProgram
-from PYME.LMVis.shader_programs.GouraudShaderProgram import GouraudShaderProgram, GouraudSphereShaderProgram
+from PYME.LMVis.shader_programs.PointSpriteShaderProgram import PointSpriteShaderProgram, BigPointSpriteShaderProgram
+from PYME.LMVis.shader_programs.GouraudShaderProgram import GouraudShaderProgram, GouraudSphereShaderProgram, BigGouraudSphereShaderProgram
 
 from PYME.recipes.traits import CStr, Float, Enum, ListFloat, List, Bool
 # from pylab import cm
@@ -43,12 +43,11 @@ class Points3DEngine(BaseEngine):
         point_size = self.point_size_px(gl_canvas, layer, sp)
 
         bigpoints = False
-        
+
         if (point_size > max_ps) and core_profile:
-            logger.debug(f'Point size ({point_size}) larger than OpenGL maximum ({max_ps}), size scaling might not work as expected')
+            #logger.debug(f'Point size ({point_size}) larger than OpenGL maximum ({max_ps}), size scaling might not work as expected')
             try:
                 sp = self.get_specific_shader_program(gl_canvas, self._big_point_shader_cls)
-
                 bigpoints = True
             except AttributeError:
                 logger.debug('No big point shader class defined, using default shader - points will appear smaller than expected')
@@ -109,6 +108,7 @@ class PointSpritesEngine(Points3DEngine):
     def __init__(self, *args, **kwargs):
         BaseEngine.__init__(self, *args, **kwargs)
         self.set_shader_program(PointSpriteShaderProgram)
+        self._big_point_shader_cls = BigPointSpriteShaderProgram
         self.point_scale_correction = 1.0
         
 class ShadedPointsEngine(Points3DEngine):
@@ -127,6 +127,7 @@ class SpheresEngine(Points3DEngine):
     def __init__(self, *args, **kwargs):
         BaseEngine.__init__(self, *args, **kwargs)
         self.set_shader_program(GouraudSphereShaderProgram)
+        self._big_point_shader_cls = BigGouraudSphereShaderProgram
         self.point_scale_correction = 1.0
         
 

--- a/PYME/LMVis/layers/pointcloud.py
+++ b/PYME/LMVis/layers/pointcloud.py
@@ -42,8 +42,16 @@ class Points3DEngine(BaseEngine):
                     point_size = (layer.point_size*point_scale_correction / gl_canvas.pixelsize)
             else:
                 point_size(layer.point_size*point_scale_correction) 
+
+            point_size = point_size*gl_canvas.content_scale_factor # scale for high DPI displays
             
-            print(f'point size = {point_size}')
+            #print(f'point size = {point_size}')
+            #print('max point size', glGetFloatv(GL_POINT_SIZE_MAX))
+            #print('Point distance attenuation', glGetFloatv(GL_POINT_DISTANCE_ATTENUATION))
+
+            max_ps = glGetFloatv(GL_POINT_SIZE_RANGE)[1]
+            if point_size > max_ps:
+                logger.debug(f'Point size ({point_size}) larger than OpenGL maximum ({max_ps}), size scaling might not work as expected')
             
             self._bind_data('points', vertices, normals, colors, core_profile=core_profile)
             if core_profile:

--- a/PYME/LMVis/layers/pointcloud.py
+++ b/PYME/LMVis/layers/pointcloud.py
@@ -40,8 +40,8 @@ class Points3DEngine(BaseEngine):
         max_ps = glGetFloatv(GL_POINT_SIZE_RANGE)[1]
 
         sp = self.get_shader_program(gl_canvas)
+        
         point_size = self.point_size_px(gl_canvas, layer, sp)
-
         bigpoints = False
 
         if (point_size > max_ps) and core_profile:
@@ -52,8 +52,6 @@ class Points3DEngine(BaseEngine):
             except AttributeError:
                 logger.debug('No big point shader class defined, using default shader - points will appear smaller than expected')
 
-        self._set_sp_shader_clipping(sp, gl_canvas)
-
         vertices = layer.get_vertices()
         n_vertices = vertices.shape[0]
         if n_vertices == 0:
@@ -62,7 +60,9 @@ class Points3DEngine(BaseEngine):
         normals = layer.get_normals()
         colors = layer.get_colors()    
     
-        with sp:            
+        with sp:
+            sp.set_clipping(gl_canvas.view.clipping.squeeze(), gl_canvas.view.clip_plane_matrix)
+
             self._bind_data('points', vertices, normals, colors, sp, core_profile=core_profile)
             if core_profile:
                 sp.set_modelviewprojectionmatrix(np.array(gl_canvas.mvp))

--- a/PYME/LMVis/layers/pointcloud.py
+++ b/PYME/LMVis/layers/pointcloud.py
@@ -1,7 +1,7 @@
 from .base import BaseEngine, EngineLayer
-from PYME.LMVis.shader_programs.DefaultShaderProgram import DefaultShaderProgram, OpaquePointShaderProgram, BigOpaquePointShaderProgram
+from PYME.LMVis.shader_programs.DefaultShaderProgram import DefaultShaderProgram, OpaquePointShaderProgram, BigOpaquePointShaderProgram, TransparentPointShaderProgram, BigTransparentPointShaderProgram
 from PYME.LMVis.shader_programs.PointSpriteShaderProgram import PointSpriteShaderProgram, BigPointSpriteShaderProgram
-from PYME.LMVis.shader_programs.GouraudShaderProgram import GouraudShaderProgram, GouraudSphereShaderProgram, BigGouraudSphereShaderProgram
+from PYME.LMVis.shader_programs.GouraudShaderProgram import GouraudShaderProgram, GouraudSphereShaderProgram, BigGouraudSphereShaderProgram, GouraudFlatpointsShaderProgram, BigGouraudFlatpointsShaderProgram
 
 from PYME.recipes.traits import CStr, Float, Enum, ListFloat, List, Bool
 # from pylab import cm
@@ -114,13 +114,15 @@ class PointSpritesEngine(Points3DEngine):
 class ShadedPointsEngine(Points3DEngine):
     def __init__(self, *args, **kwargs):
         BaseEngine.__init__(self, *args, **kwargs)
-        self.set_shader_program(GouraudShaderProgram)
+        self.set_shader_program(GouraudFlatpointsShaderProgram)
+        self._big_point_shader_cls = BigGouraudFlatpointsShaderProgram
         self.point_scale_correction = 1.0
         
 class TransparentPointsEngine(Points3DEngine):
     def __init__(self, *args, **kwargs):
         BaseEngine.__init__(self, *args, **kwargs)
-        self.set_shader_program(DefaultShaderProgram)
+        self.set_shader_program(TransparentPointShaderProgram)
+        self._big_point_shader_cls = BigTransparentPointShaderProgram
         self.point_scale_correction = 1.0
         
 class SpheresEngine(Points3DEngine):

--- a/PYME/LMVis/layers/pointcloud.py
+++ b/PYME/LMVis/layers/pointcloud.py
@@ -70,8 +70,10 @@ class Points3DEngine(BaseEngine):
                 #glBindVertexArray(self._bound_data['points'][0])
 
                 if bigpoints:
-                    sx = glGetIntegerv(GL_VIEWPORT)[2]
+                    vp = glGetIntegerv(GL_VIEWPORT)
+                    sx = vp[2]
                     glUniform1f(sp.get_uniform_location('point_size_vp'), 2.0*point_size/float(sx))
+                    glUniform2f(sp.get_uniform_location('viewport_size'), vp[2], vp[3])
 
             else:
                 glPointSize(point_size)

--- a/PYME/LMVis/layers/pointcloud.py
+++ b/PYME/LMVis/layers/pointcloud.py
@@ -1,5 +1,5 @@
 from .base import BaseEngine, EngineLayer
-from PYME.LMVis.shader_programs.DefaultShaderProgram import DefaultShaderProgram, OpaquePointShaderProgram
+from PYME.LMVis.shader_programs.DefaultShaderProgram import DefaultShaderProgram, OpaquePointShaderProgram, BigOpaquePointShaderProgram
 from PYME.LMVis.shader_programs.PointSpriteShaderProgram import PointSpriteShaderProgram
 from PYME.LMVis.shader_programs.GouraudShaderProgram import GouraudShaderProgram, GouraudSphereShaderProgram
 
@@ -20,9 +20,40 @@ class Points3DEngine(BaseEngine):
         self.set_shader_program(OpaquePointShaderProgram)
         self.point_scale_correction = 1.0
 
+    def point_size_px(self, gl_canvas, layer, sp):
+        point_scale_correction = self.point_scale_correction*getattr(sp, 'size_factor', 1.0)
+        
+        if gl_canvas:
+            if layer.point_size == 0:
+                point_size = (1 / gl_canvas.pixelsize)
+            else:
+                point_size = (layer.point_size*point_scale_correction / gl_canvas.pixelsize)
+        else:
+            point_size(layer.point_size*point_scale_correction) 
+
+        point_size = point_size*gl_canvas.content_scale_factor # scale for high DPI displays
+        
+        return point_size
+    
     def render(self, gl_canvas, layer):
         core_profile = gl_canvas.core_profile
-        self._set_shader_clipping(gl_canvas)
+        max_ps = glGetFloatv(GL_POINT_SIZE_RANGE)[1]
+
+        sp = self.get_shader_program(gl_canvas)
+        point_size = self.point_size_px(gl_canvas, layer, sp)
+
+        bigpoints = False
+        
+        if (point_size > max_ps) and core_profile:
+            logger.debug(f'Point size ({point_size}) larger than OpenGL maximum ({max_ps}), size scaling might not work as expected')
+            try:
+                sp = self.get_specific_shader_program(gl_canvas, self._big_point_shader_cls)
+
+                bigpoints = True
+            except AttributeError:
+                logger.debug('No big point shader class defined, using default shader - points will appear smaller than expected')
+
+        self._set_sp_shader_clipping(sp, gl_canvas)
 
         vertices = layer.get_vertices()
         n_vertices = vertices.shape[0]
@@ -30,34 +61,18 @@ class Points3DEngine(BaseEngine):
             return False
         
         normals = layer.get_normals()
-        colors = layer.get_colors()
+        colors = layer.get_colors()    
     
-        with self.get_shader_program(gl_canvas) as sp:
-            point_scale_correction = self.point_scale_correction*getattr(sp, 'size_factor', 1.0)
-        
-            if gl_canvas:
-                if layer.point_size == 0:
-                    point_size = (1 / gl_canvas.pixelsize)
-                else:
-                    point_size = (layer.point_size*point_scale_correction / gl_canvas.pixelsize)
-            else:
-                point_size(layer.point_size*point_scale_correction) 
-
-            point_size = point_size*gl_canvas.content_scale_factor # scale for high DPI displays
-            
-            #print(f'point size = {point_size}')
-            #print('max point size', glGetFloatv(GL_POINT_SIZE_MAX))
-            #print('Point distance attenuation', glGetFloatv(GL_POINT_DISTANCE_ATTENUATION))
-
-            max_ps = glGetFloatv(GL_POINT_SIZE_RANGE)[1]
-            if point_size > max_ps:
-                logger.debug(f'Point size ({point_size}) larger than OpenGL maximum ({max_ps}), size scaling might not work as expected')
-            
-            self._bind_data('points', vertices, normals, colors, core_profile=core_profile)
+        with sp:            
+            self._bind_data('points', vertices, normals, colors, sp, core_profile=core_profile)
             if core_profile:
                 sp.set_modelviewprojectionmatrix(np.array(gl_canvas.mvp))
                 sp.set_point_size(point_size)
                 #glBindVertexArray(self._bound_data['points'][0])
+
+                if bigpoints:
+                    sx = glGetIntegerv(GL_VIEWPORT)[2]
+                    glUniform1f(sp.get_uniform_location('point_size_vp'), 2.0*point_size/float(sx))
 
             else:
                 glPointSize(point_size)
@@ -77,12 +92,18 @@ class Points3DEngine(BaseEngine):
                 cols = (np.ones((normal_buffer.shape[0],4),dtype=colors.dtype)*sc[None,:])  # white normals
                 norms = (np.ones((normal_buffer.shape[0],3),dtype=normals.dtype))
                 
-                self._bind_data('normals', normal_buffer, norms, cols, core_profile=core_profile)
+                self._bind_data('normals', normal_buffer, norms, cols, sp, core_profile=core_profile)
 
                 glLineWidth(3)  # slightly thick
                 glDrawArrays(GL_LINES, 0, 2*n_vertices)
             
 
+class OpaquePointsEngine(Points3DEngine):
+    def __init__(self, *args, **kwargs):
+        BaseEngine.__init__(self, *args, **kwargs)
+        self.set_shader_program(OpaquePointShaderProgram)
+        self._big_point_shader_cls = BigOpaquePointShaderProgram
+        self.point_scale_correction = 1.0
 
 class PointSpritesEngine(Points3DEngine):
     def __init__(self, *args, **kwargs):
@@ -110,7 +131,7 @@ class SpheresEngine(Points3DEngine):
         
 
 ENGINES = {
-    'points' : Points3DEngine,
+    'points' : OpaquePointsEngine,
     'transparent_points' : TransparentPointsEngine,
     'pointsprites' : PointSpritesEngine,
     'shaded_points' : ShadedPointsEngine,

--- a/PYME/LMVis/layers/quiver.py
+++ b/PYME/LMVis/layers/quiver.py
@@ -22,9 +22,8 @@ class QuiverEngine(BaseEngine):
 
 
     def render(self, gl_canvas, layer):
-        self._set_shader_clipping(gl_canvas)
-
-        with self.get_shader_program(gl_canvas) as sp:            
+        with self.get_shader_program(gl_canvas) as sp: 
+            sp.set_clipping(gl_canvas.view.clipping.squeeze(), gl_canvas.view.clip_plane_matrix)           
             vertices = layer.get_vertices()
             n_vertices = vertices.shape[0]
             vecs = layer.get_vecs()

--- a/PYME/LMVis/layers/quiver.py
+++ b/PYME/LMVis/layers/quiver.py
@@ -24,7 +24,7 @@ class QuiverEngine(BaseEngine):
     def render(self, gl_canvas, layer):
         self._set_shader_clipping(gl_canvas)
 
-        with self.get_shader_program(gl_canvas):            
+        with self.get_shader_program(gl_canvas) as sp:            
             vertices = layer.get_vertices()
             n_vertices = vertices.shape[0]
             vecs = layer.get_vecs()
@@ -34,12 +34,21 @@ class QuiverEngine(BaseEngine):
             vec_buffer[1::2,:] = vertices
             
             vec_buffer[1::2,:] += layer.scaling*vecs
-            
-            glVertexPointerf(vec_buffer)
+
             sc = np.array([1, 1, 1, 1])
-            glColorPointerf(np.ones((vec_buffer.shape[0],4),dtype='f4')*sc[None,:])  # white normals
-            glNormalPointerf(np.ones((vec_buffer.shape[0],3),dtype='f4'))
+            cols = np.ones((vec_buffer.shape[0],4),dtype='f4')*sc[None,:]
+
+            # glVertexPointerf(vec_buffer)           
+            # glColorPointerf(cols)  # white normals
+            # glNormalPointerf(np.ones((vec_buffer.shape[0],3),dtype='f4'))
+
+            if gl_canvas.core_profile:
+                sp.set_modelviewprojection_matrix(gl_canvas.mvp)
+
+            self._bind_data('quiver', vec_buffer, cols, np.ones((vec_buffer.shape[0],3),dtype='f4'), sp, core_profile=gl_canvas.core_profile)
+            
             glLineWidth(3)  # slightly thick
+            
             glDrawArrays(GL_LINES, 0, 2*n_vertices)
 
 

--- a/PYME/LMVis/layers/text.py
+++ b/PYME/LMVis/layers/text.py
@@ -170,7 +170,7 @@ class Text(BaseEngine):
                 glDrawArrays(GL_TRIANGLES, 0, 6)
 
                 glBindVertexArray(0)
-                glDeleteVertexArrays(1, vao)
+                glDeleteVertexArrays(1, [vao,])
                 glDeleteBuffers(3, vbo)
 
             else:

--- a/PYME/LMVis/layers/text.py
+++ b/PYME/LMVis/layers/text.py
@@ -155,7 +155,11 @@ class Text(BaseEngine):
                 glDisable(GL_TEXTURE_GEN_R)
             
                 #glColor3f(1.,0.,0.)
-                glColor4f(1., 1., 1., 1.)
+                if self._color is not None:
+                    glColor4f(*self._color)
+                else:
+                    glColor4f(1., 1., 1., 1.)
+                    
                 glBegin(GL_QUADS)
                 glTexCoord2f(0., 0.) # lower left corner of image */
                 glVertex3f(x0, y0, 0.0)

--- a/PYME/LMVis/layers/text.py
+++ b/PYME/LMVis/layers/text.py
@@ -115,14 +115,15 @@ class Text(BaseEngine):
             self.set_texture(im)
             
             if gl_canvas.core_profile:
-                import glm
+                from PYME.LMVis import mv_math as mm
                 # find the on-screen position of our text
                 vp = glGetIntegerv(GL_VIEWPORT)
                 #print('vp:', vp)
 
-                pos = np.zeros(3)
+                pos = np.zeros(4)
                 pos[:len(self.pos)] = self.pos
-                x0, y0, _, _ = gl_canvas.mvp*glm.vec4(*pos, 1)
+                pos[3] = 1.0
+                x0, y0, _, _ = np.dot(gl_canvas.mvp, pos)
 
                 #print('textPos:', x0, y0)
                 # convert to screen pixel coordinates
@@ -140,7 +141,7 @@ class Text(BaseEngine):
                 else:
                     cols = np.repeat(self._color, 6, axis=0)
 
-                proj = glm.ortho(0, vp[2], 0, vp[3], -1000, 1000)
+                proj = mm.ortho(0, vp[2], 0, vp[3], -1000, 1000)
                 #print('proj:', proj)
                 sp.set_modelviewprojectionmatrix(np.array(proj))
 

--- a/PYME/LMVis/layers/text.py
+++ b/PYME/LMVis/layers/text.py
@@ -139,7 +139,8 @@ class Text(BaseEngine):
                 if self._color is None:
                     cols = np.ones([6, 4], dtype='f4')
                 else:
-                    cols = np.repeat(self._color, 6, axis=0)
+                    cols = np.tile(self._color, 6).astype('f')
+                    #print(f'text cols: {cols}')
 
                 proj = mm.ortho(0, vp[2], 0, vp[3], -1000, 1000)
                 #print('proj:', proj)

--- a/PYME/LMVis/layers/text.py
+++ b/PYME/LMVis/layers/text.py
@@ -21,13 +21,14 @@ class Text(BaseEngine):
     TODO - Shader. My first instinct here would be to make the text values (as derived from the array) control transparency.
            This should give an attractive anti-aliasing/blending effect, but we'd need to try it out in practice.
     """
-    def __init__(self, text='', pos=(0,0), color=None, **kwargs):
+    def __init__(self, text='', pos=(0,0), color=None, font_size=10, **kwargs):
         BaseEngine.__init__(self)
         self.set_shader_program(TextShaderProgram)
         
         self._texture_id = None
         self._img = None
         self._color = color
+        self._font_size = font_size
 
         self._im_key = None
         self._im = None
@@ -74,11 +75,11 @@ class Text(BaseEngine):
         return im
         
     def get_img_array(self, gl_canvas):
-        im_key = (self.text, gl_canvas.content_scale_factor)
+        im_key = (self.text, self._font_size, gl_canvas.content_scale_factor)
 
         if im_key != self._im_key:
             self._im_key = im_key
-            self._im = np.ascontiguousarray(self.gen_text_image(self.text, dip_scale=gl_canvas.content_scale_factor)[:, :, 0]/255.)
+            self._im = np.ascontiguousarray(self.gen_text_image(self.text, size=self._font_size, dip_scale=gl_canvas.content_scale_factor)[:, :, 0]/255.)
 
         h, w = self._im.shape
         return self._im, h, w 

--- a/PYME/LMVis/layers/text.py
+++ b/PYME/LMVis/layers/text.py
@@ -99,13 +99,13 @@ class Text(BaseEngine):
             glActiveTexture(GL_TEXTURE0)
             glBindTexture(GL_TEXTURE_2D, self._texture_id)
             glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP)
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
             #glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
             #glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
-            glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE)
+            #glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE)
             glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, image.shape[1], image.shape[0], 0, GL_RED, GL_FLOAT,
                          image.astype('f4'))
     
@@ -113,67 +113,136 @@ class Text(BaseEngine):
         im, h, w = self.get_img_array(gl_canvas)
         with self.get_shader_program(gl_canvas) as sp:
             self.set_texture(im)
+            
+            if gl_canvas.core_profile:
+                import glm
+                # find the on-screen position of our text
+                vp = glGetIntegerv(GL_VIEWPORT)
+                #print('vp:', vp)
 
-            mv = glGetDoublev(GL_MODELVIEW_MATRIX)
-            p = glGetDoublev(GL_PROJECTION_MATRIX)
-            vp = glGetIntegerv(GL_VIEWPORT)
+                pos = np.zeros(3)
+                pos[:len(self.pos)] = self.pos
+                x0, y0, _, _ = gl_canvas.mvp*glm.vec4(*pos, 1)
 
-            #print(mv, p, vp)
+                #print('textPos:', x0, y0)
+                # convert to screen pixel coordinates
 
-            # calculate on-screen pixel coordinates for our text (perform model-view transformation)
-            pos = np.zeros(3)
-            pos[:len(self.pos)] = self.pos
-            x0, y0, _ = GLU.gluProject(pos[0], pos[1], pos[2], mv, p, vp)
+                x0  = (x0 + 1.) * vp[2] / 2.
+                y0 = (y0 + 1.) * vp[3] / 2.
 
-            #print('textPos:', x0, y0)
+                #print('textPos (px):', x0, y0)
 
-            try:
-                # set model-view so that we are drawing in screen pixel coordinates
-                glMatrixMode(GL_PROJECTION)
-                glPushMatrix()
-                glLoadIdentity()
-                glOrtho(0, vp[2], 0, vp[3], -1000, 1000)
+                verts = self._gen_rect_triangles(x0, y0, w, -h)
+                tex_coords = self._gen_rect_texture_coords()
 
-                glMatrixMode(GL_MODELVIEW)
-                glPushMatrix()
-                glLoadIdentity()
+                if self._color is None:
+                    cols = np.ones([6, 4], dtype='f4')
+                else:
+                    cols = np.repeat(self._color, 6, axis=0)
 
-        
-                glEnable(GL_TEXTURE_2D) # enable texture mapping */
+                proj = glm.ortho(0, vp[2], 0, vp[3], -1000, 1000)
+                #print('proj:', proj)
+                sp.set_modelviewprojectionmatrix(np.array(proj))
+
                 glActiveTexture(GL_TEXTURE0)
                 glBindTexture(GL_TEXTURE_2D, self._texture_id) # bind to our texture, has id of 1 */
                 glUniform1i(sp.get_uniform_location("im_sampler"), 0)
-            
-                # FIXME - choose appropriately for current viewport - want to make it so that the text renders real size
-                # (i.e. unwind any model-view / and projection stuff).
-                #x0, y0 = self.pos
-                x1 = x0 + w#*gl_canvas.content_scale_factor
-                y1 = y0 - h#*gl_canvas.content_scale_factor
-            
-                glDisable(GL_TEXTURE_GEN_S)
-                glDisable(GL_TEXTURE_GEN_T)
-                glDisable(GL_TEXTURE_GEN_R)
-            
-                #glColor3f(1.,0.,0.)
-                if self._color is not None:
-                    glColor4f(*self._color)
-                else:
-                    glColor4f(1., 1., 1., 1.)
+
+                vao = glGenVertexArrays(1)
+                vbo = glGenBuffers(3)
+                glBindVertexArray(vao)
+                glBindBuffer(GL_ARRAY_BUFFER, vbo[0])
+                glBufferData(GL_ARRAY_BUFFER, verts, GL_STATIC_DRAW)
+                glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, None)
+                glEnableVertexAttribArray(0)
+                glBindBuffer(GL_ARRAY_BUFFER, vbo[1])
+                glBufferData(GL_ARRAY_BUFFER, tex_coords, GL_STATIC_DRAW)
+                glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, None)
+                glEnableVertexAttribArray(1)
+                glBindBuffer(GL_ARRAY_BUFFER, vbo[2])
+                glBufferData(GL_ARRAY_BUFFER, cols, GL_STATIC_DRAW)
+                glVertexAttribPointer(2, 4, GL_FLOAT, GL_FALSE, 0, None)
+                glEnableVertexAttribArray(2)
+
+                glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
+                glDrawArrays(GL_TRIANGLES, 0, 6)
+
+                glBindVertexArray(0)
+                glDeleteVertexArrays(1, vao)
+                glDeleteBuffers(3, vbo)
+
+            else:
+                #legacy mode
+                mv = glGetDoublev(GL_MODELVIEW_MATRIX)
+                p = glGetDoublev(GL_PROJECTION_MATRIX)
+                
+
+                #print(mv, p, vp)
+
+                # calculate on-screen pixel coordinates for our text (perform model-view transformation)
+                pos = np.zeros(3)
+                pos[:len(self.pos)] = self.pos
+                x0, y0, _ = GLU.gluProject(pos[0], pos[1], pos[2], mv, p, vp)
+
+                #print('textPos:', x0, y0)
+
+                try:
+                    # set model-view so that we are drawing in screen pixel coordinates
                     
-                glBegin(GL_QUADS)
-                glTexCoord2f(0., 0.) # lower left corner of image */
-                glVertex3f(x0, y0, 0.0)
-                glTexCoord2f(1., 0.) # lower right corner of image */
-                glVertex3f(x1, y0, 0.0)
-                glTexCoord2f(1.0, 1.0) # upper right corner of image */
-                glVertex3f(x1, y1, 0.0)
-                glTexCoord2f(0.0, 1.0) # upper left corner of image */
-                glVertex3f(x0, y1, 0.0)
-                glEnd()
+                    glMatrixMode(GL_PROJECTION)
+                    glPushMatrix()
+                    glLoadIdentity()
+                    glOrtho(0, vp[2], 0, vp[3], -1000, 1000)
+
+                    glMatrixMode(GL_MODELVIEW)
+                    glPushMatrix()
+                    glLoadIdentity()
+
             
-                glDisable(GL_TEXTURE_2D)
-            finally:
-                glMatrixMode(GL_PROJECTION)
-                glPopMatrix()
-                glMatrixMode(GL_MODELVIEW)
-                glPopMatrix()
+                    glEnable(GL_TEXTURE_2D) # enable texture mapping */
+                    glActiveTexture(GL_TEXTURE0)
+                    glBindTexture(GL_TEXTURE_2D, self._texture_id) # bind to our texture, has id of 1 */
+                    glUniform1i(sp.get_uniform_location("im_sampler"), 0)
+                
+                    # FIXME - choose appropriately for current viewport - want to make it so that the text renders real size
+                    # (i.e. unwind any model-view / and projection stuff).
+                    #x0, y0 = self.pos
+                    x1 = x0 + w#*gl_canvas.content_scale_factor
+                    y1 = y0 - h#*gl_canvas.content_scale_factor
+                
+                    glDisable(GL_TEXTURE_GEN_S)
+                    glDisable(GL_TEXTURE_GEN_T)
+                    glDisable(GL_TEXTURE_GEN_R)
+                
+                    #glColor3f(1.,0.,0.)
+                    if self._color is not None:
+                        glColor4f(*self._color)
+                    else:
+                        glColor4f(1., 1., 1., 1.)
+
+                    #vertex_data = np.array([[x0, y0, 0.0], 
+                    #                        [x1, y0, 0.0], 
+                    #                        [x1, y1, 0.0], 
+                    #                        [x0, y1, 0.0]], dtype='f4') 
+
+                    #_vbo = glGenBuffers(1)
+                    #glBindBuffer(GL_ARRAY_BUFFER, _vbo)
+                    #glBufferData(GL_ARRAY_BUFFER, vertex_data, GL_STATIC_DRAW)   
+
+                    glBegin(GL_QUADS)
+                    glTexCoord2f(0., 0.) # lower left corner of image */
+                    glVertex3f(x0, y0, 0.0)
+                    glTexCoord2f(1., 0.) # lower right corner of image */
+                    glVertex3f(x1, y0, 0.0)
+                    glTexCoord2f(1.0, 1.0) # upper right corner of image */
+                    glVertex3f(x1, y1, 0.0)
+                    glTexCoord2f(0.0, 1.0) # upper left corner of image */
+                    glVertex3f(x0, y1, 0.0)
+                    glEnd()
+                
+                    glDisable(GL_TEXTURE_2D)
+                finally:
+                    glMatrixMode(GL_PROJECTION)
+                    glPopMatrix()
+                    glMatrixMode(GL_MODELVIEW)
+                    glPopMatrix()

--- a/PYME/LMVis/layers/tracks.py
+++ b/PYME/LMVis/layers/tracks.py
@@ -23,18 +23,22 @@ class Track3DEngine(BaseEngine):
     def render(self, gl_canvas, layer):
         self._set_shader_clipping(gl_canvas)
         
-        with self.get_shader_program(gl_canvas):
-            glDisable(GL_LIGHTING)
+        with self.get_shader_program(gl_canvas) as sp:
+            #glDisable(GL_LIGHTING)
             glPolygonMode(GL_FRONT_AND_BACK, GL_LINE)
             glDisable(GL_DEPTH_TEST)
             
             vertices = layer.get_vertices()
             #n_vertices = vertices.shape[0]
-            
-            glVertexPointerf(vertices)
-            glNormalPointerf(layer.get_normals())
-            glColorPointerf(layer.get_colors())
 
+            self._bind_data('tracks', vertices, layer.get_normals(), layer.get_colors(), sp, core_profile=gl_canvas.core_profile)
+            
+            # glVertexPointerf(vertices)
+            # glNormalPointerf(layer.get_normals())
+            # glColorPointerf(layer.get_colors())
+            if gl_canvas.core_profile:
+                sp.set_modelviewprojectionmatrix(gl_canvas.mvp)
+                
             glLineWidth(layer.line_width)
 
             for i, cl in enumerate(layer.clumpSizes):

--- a/PYME/LMVis/layers/tracks.py
+++ b/PYME/LMVis/layers/tracks.py
@@ -4,7 +4,7 @@ logger = logging.getLogger(__name__)
 from OpenGL.GL import *
 
 from .base import BaseEngine, EngineLayer
-from PYME.LMVis.shader_programs.DefaultShaderProgram import DefaultShaderProgram
+from PYME.LMVis.shader_programs.DefaultShaderProgram import DefaultShaderProgram, FatLineShaderProgram
 
 from PYME.recipes.traits import CStr, Float, Enum, ListFloat, List
 # from pylab import cm
@@ -21,10 +21,17 @@ class Track3DEngine(BaseEngine):
         self.set_shader_program(DefaultShaderProgram)
     
     def render(self, gl_canvas, layer):
-        with self.get_shader_program(gl_canvas) as sp:
+        if gl_canvas.core_profile:
+            sp = self.get_specific_shader_program(gl_canvas, FatLineShaderProgram)
+        else:
+            sp = self.get_specific_shader_program(gl_canvas, DefaultShaderProgram)
+
+
+        with sp:
             sp.set_clipping(gl_canvas.view.clipping.squeeze(), gl_canvas.view.clip_plane_matrix)
+
             #glDisable(GL_LIGHTING)
-            glPolygonMode(GL_FRONT_AND_BACK, GL_LINE)
+            glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
             glDisable(GL_DEPTH_TEST)
             
             vertices = layer.get_vertices()
@@ -37,8 +44,13 @@ class Track3DEngine(BaseEngine):
             # glColorPointerf(layer.get_colors())
             if gl_canvas.core_profile:
                 sp.set_modelviewprojectionmatrix(gl_canvas.mvp)
+
+                glUniform1f(sp.get_uniform_location('line_width_px'), layer.line_width)
+                vp = glGetIntegerv(GL_VIEWPORT)
+                glUniform2f(sp.get_uniform_location('viewport_size'), vp[2], vp[3])
+
                 
-            glLineWidth(layer.line_width)
+            glLineWidth(min(layer.line_width, glGetFloatv(GL_LINE_WIDTH_RANGE)[1]))
 
             for i, cl in enumerate(layer.clumpSizes):
                 if cl > 0:

--- a/PYME/LMVis/layers/tracks.py
+++ b/PYME/LMVis/layers/tracks.py
@@ -21,9 +21,8 @@ class Track3DEngine(BaseEngine):
         self.set_shader_program(DefaultShaderProgram)
     
     def render(self, gl_canvas, layer):
-        self._set_shader_clipping(gl_canvas)
-        
         with self.get_shader_program(gl_canvas) as sp:
+            sp.set_clipping(gl_canvas.view.clipping.squeeze(), gl_canvas.view.clip_plane_matrix)
             #glDisable(GL_LIGHTING)
             glPolygonMode(GL_FRONT_AND_BACK, GL_LINE)
             glDisable(GL_DEPTH_TEST)

--- a/PYME/LMVis/mv_math.py
+++ b/PYME/LMVis/mv_math.py
@@ -7,7 +7,10 @@ def ortho(left, right, bottom, top, near, far):
 
         m = np.eye(4)
         m[0, 0] = 2.0 / (right - left)
+        m[0, 3] = -(right + left) / (right - left)
         m[1, 1] = 2.0 / (top - bottom)
+        m[1, 3] = -(top + bottom) / (top - bottom)
+        
         m[2, 2] = -2.0 / (far - near)
 
         m[2, 3] = -(far + near) / (far - near)

--- a/PYME/LMVis/mv_math.py
+++ b/PYME/LMVis/mv_math.py
@@ -1,0 +1,75 @@
+"""Simple replacements for deprecated OpenGL projection and modelview functions
+"""
+import numpy as np
+
+def ortho(left, right, bottom, top, near, far):
+        """Create an orthographic projection matrix (replace glOrtho and remove glm dependency)"""
+
+        m = np.eye(4)
+        m[0, 0] = 2.0 / (right - left)
+        m[1, 1] = 2.0 / (top - bottom)
+        m[2, 2] = -2.0 / (far - near)
+
+        m[2, 3] = -(far + near) / (far - near)
+
+        return m
+
+def frustrum(left, right, bottom, top, near, far):
+    """Create a frustum projection matrix (replace glFrustum and remove glm dependency)"""
+
+    m = np.zeros((4, 4))
+
+    m[0, 0] = 2.0 * near / (right - left)
+    m[1, 1] = 2.0 * near / (top - bottom)
+    m[0, 2] = (right + left) / (right - left)
+    m[1, 2] = (top + bottom) / (top - bottom)
+    m[2, 2] = -(far + near) / (far - near)
+    m[3, 2] = -1.0
+    m[2, 3] = -2.0 * far * near / (far - near)
+
+    return m
+
+
+def translate_m(x, y, z):
+    """Create a translation matrix (replace glTranslate and remove glm dependency)"""
+
+    m = np.eye(4)
+    m[0, 3] = x
+    m[1, 3] = y
+    m[2, 3] = z
+
+    return m
+
+def translate(m, x, y, z):
+    """Translate a matrix (replace glTranslate and remove glm dependency)"""
+
+    return np.dot(m, translate_m(x, y, z))
+
+def scale_m(x, y, z):
+    """Create a scaling matrix (replace glScale and remove glm dependency)"""
+
+    m = np.eye(4)
+    m[0, 0] = x
+    m[1, 1] = y
+    m[2, 2] = z
+
+    return m
+
+def scale(m, x, y, z):
+    """Scale a matrix (replace glScale and remove glm dependency)"""
+
+    return np.dot(m, scale_m(x, y, z))
+
+def mat3_to_mat4(m):
+    """Convert a 3x3 matrix to a 4x4 matrix"""
+
+    m4 = np.eye(4)
+    m4[:3, :3] = m
+
+    return m4
+
+
+def vec3_to_vec4(v):
+    """Convert a 3-element vector to a 4-element vector"""
+
+    return np.array([v[0], v[1], v[2], 1.0])

--- a/PYME/LMVis/shader_programs/DefaultShaderProgram.py
+++ b/PYME/LMVis/shader_programs/DefaultShaderProgram.py
@@ -26,7 +26,7 @@ from OpenGL.GL import  GL_VERTEX_SHADER, GL_FRAGMENT_SHADER, glUseProgram, \
     glPolygonMode, GL_FILL, GL_FRONT_AND_BACK, glEnable, GL_BLEND, GL_SRC_ALPHA, GL_DST_ALPHA, glBlendFunc, \
     glBlendEquation, GL_FUNC_ADD, GL_DEPTH_TEST, glDepthFunc, GL_LEQUAL, GL_POINT_SMOOTH, GL_ONE_MINUS_SRC_ALPHA, GL_PROGRAM_POINT_SIZE,\
     GL_TRUE, glDepthMask, glClearDepth, glClear, GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, glDisable, GL_ONE, GL_ZERO, \
-    glUniform4f, glUniform1f, glUniformMatrix4fv, GL_CURRENT_PROGRAM, glGetInteger
+    glUniform4f, glUniform1f, glUniformMatrix4fv, GL_CURRENT_PROGRAM, glGetInteger, GL_POINT_SPRITE
 
 from PYME.LMVis.shader_programs.shader_program import ShaderProgram
 
@@ -74,10 +74,13 @@ class OpaquePointShaderProgram(DefaultShaderProgram):
         glDepthMask(GL_TRUE)
         glEnable(GL_DEPTH_TEST)
 
+
         glEnable(GL_PROGRAM_POINT_SIZE)
+        
         #glDepthFunc(GL_LEQUAL)
         try:
             glEnable(GL_POINT_SMOOTH)
+            glEnable(GL_POINT_SPRITE)
         except:
             # not supported in core profile
             pass
@@ -96,6 +99,12 @@ class BigOpaquePointShaderProgram(DefaultShaderProgram):
         glDisable(GL_BLEND)
         glDepthMask(GL_TRUE)
         glEnable(GL_DEPTH_TEST)
+
+        try:
+            glEnable(GL_POINT_SPRITE)
+        except:
+            # not supported in core profile
+            pass
 
         self.get_shader_program().use()
         self.set_clipping_uniforms()

--- a/PYME/LMVis/shader_programs/DefaultShaderProgram.py
+++ b/PYME/LMVis/shader_programs/DefaultShaderProgram.py
@@ -24,7 +24,7 @@ import numpy as np
 from PYME.LMVis.shader_programs.GLProgram import GLProgram
 from OpenGL.GL import  GL_VERTEX_SHADER, GL_FRAGMENT_SHADER, glUseProgram, \
     glPolygonMode, GL_FILL, GL_FRONT_AND_BACK, glEnable, GL_BLEND, GL_SRC_ALPHA, GL_DST_ALPHA, glBlendFunc, \
-    glBlendEquation, GL_FUNC_ADD, GL_DEPTH_TEST, glDepthFunc, GL_LEQUAL, GL_POINT_SMOOTH, GL_ONE_MINUS_SRC_ALPHA, \
+    glBlendEquation, GL_FUNC_ADD, GL_DEPTH_TEST, glDepthFunc, GL_LEQUAL, GL_POINT_SMOOTH, GL_ONE_MINUS_SRC_ALPHA, GL_PROGRAM_POINT_SIZE,\
     GL_TRUE, glDepthMask, glClearDepth, glClear, GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, glDisable, GL_ONE, GL_ZERO, \
     glUniform4f, glUniform1f, glUniformMatrix4fv, GL_CURRENT_PROGRAM, glGetInteger
 
@@ -32,10 +32,10 @@ from PYME.LMVis.shader_programs.shader_program import ShaderProgram
 
 
 class DefaultShaderProgram(GLProgram):
-    def __init__(self, clipping={'x':[-1e6, 1e6], 'y' : [-1e6, 1e6], 'z': [-1e6, 1e6], 'v' : [-1e6, 1e6]}):
-        GLProgram.__init__(self)
+    def __init__(self, clipping={'x':[-1e6, 1e6], 'y' : [-1e6, 1e6], 'z': [-1e6, 1e6], 'v' : [-1e6, 1e6]}, max_glsl_version='120'):
+        GLProgram.__init__(self, max_glsl_version=max_glsl_version)
         shader_path = os.path.join(os.path.dirname(__file__), "shaders")
-        _shader_program = ShaderProgram(shader_path)
+        _shader_program = ShaderProgram(shader_path, max_glsl_version)
         _shader_program.add_shader("default_vs.glsl", GL_VERTEX_SHADER)
         _shader_program.add_shader("default_fs.glsl", GL_FRAGMENT_SHADER)
         _shader_program.link()
@@ -57,7 +57,11 @@ class DefaultShaderProgram(GLProgram):
         glDepthMask(GL_TRUE)
         glDisable(GL_DEPTH_TEST)
         #glDepthFunc(GL_LEQUAL)
-        glEnable(GL_POINT_SMOOTH)
+        try:
+            glEnable(GL_POINT_SMOOTH)
+        except:
+            # not supported in core profile
+            pass
         
         self._old_prog = glGetInteger(GL_CURRENT_PROGRAM)
         
@@ -80,8 +84,14 @@ class OpaquePointShaderProgram(DefaultShaderProgram):
         glDisable(GL_BLEND)
         glDepthMask(GL_TRUE)
         glEnable(GL_DEPTH_TEST)
+
+        glEnable(GL_PROGRAM_POINT_SIZE)
         #glDepthFunc(GL_LEQUAL)
-        glEnable(GL_POINT_SMOOTH)
+        try:
+            glEnable(GL_POINT_SMOOTH)
+        except:
+            # not supported in core profile
+            pass
         self.get_shader_program().use()
         self.set_clipping_uniforms()
         glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
@@ -90,20 +100,20 @@ class OpaquePointShaderProgram(DefaultShaderProgram):
 
 
 class ImageShaderProgram(DefaultShaderProgram):
-    def __init__(self):
-        GLProgram.__init__(self)
+    def __init__(self, max_glsl_version='120'):
+        GLProgram.__init__(self, max_glsl_version=max_glsl_version)
         shader_path = os.path.join(os.path.dirname(__file__), "shaders")
-        _shader_program = ShaderProgram(shader_path)
+        _shader_program = ShaderProgram(shader_path, max_glsl_version=max_glsl_version)
         _shader_program.add_shader("image_vs.glsl", GL_VERTEX_SHADER)
         _shader_program.add_shader("image_fs.glsl", GL_FRAGMENT_SHADER)
         _shader_program.link()
         self.set_shader_program(_shader_program)
         
 class TextShaderProgram(DefaultShaderProgram):
-    def __init__(self):
-        GLProgram.__init__(self)
+    def __init__(self, max_glsl_version='120'):
+        GLProgram.__init__(self, max_glsl_version=max_glsl_version)
         shader_path = os.path.join(os.path.dirname(__file__), "shaders")
-        _shader_program = ShaderProgram(shader_path)
+        _shader_program = ShaderProgram(shader_path, max_glsl_version=max_glsl_version)
         _shader_program.add_shader("text_vs.glsl", GL_VERTEX_SHADER)
         _shader_program.add_shader("text_fs.glsl", GL_FRAGMENT_SHADER)
         _shader_program.link()

--- a/PYME/LMVis/shader_programs/DefaultShaderProgram.py
+++ b/PYME/LMVis/shader_programs/DefaultShaderProgram.py
@@ -32,22 +32,8 @@ from PYME.LMVis.shader_programs.shader_program import ShaderProgram
 
 
 class DefaultShaderProgram(GLProgram):
-    def __init__(self, clipping={'x':[-1e6, 1e6], 'y' : [-1e6, 1e6], 'z': [-1e6, 1e6], 'v' : [-1e6, 1e6]}, max_glsl_version='120'):
-        GLProgram.__init__(self, max_glsl_version=max_glsl_version)
-        shader_path = os.path.join(os.path.dirname(__file__), "shaders")
-        _shader_program = ShaderProgram(shader_path, max_glsl_version)
-        _shader_program.add_shader("default_vs.glsl", GL_VERTEX_SHADER)
-        _shader_program.add_shader("default_fs.glsl", GL_FRAGMENT_SHADER)
-        _shader_program.link()
-        self.set_shader_program(_shader_program)
-        self._old_prog = 0
-        
-        
-        self.xmin, self.xmax = clipping['x']
-        self.ymin, self.ymax = clipping['y']
-        self.zmin, self.zmax = clipping['z']
-        self.vmin, self.vmax = clipping['v']
-        
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, vs_filename = 'default_vs.glsl', fs_filename='default_fs.glsl', **kwargs)  
 
     def __enter__(self):
         #glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
@@ -79,6 +65,9 @@ class DefaultShaderProgram(GLProgram):
 
 
 class OpaquePointShaderProgram(DefaultShaderProgram):
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, vs_filename='default_vs.glsl', fs_filename='flatpoints_fs.glsl', **kwargs)
+
     def __enter__(self):
         glBlendFunc(GL_SRC_ALPHA, GL_ONE)
         glDisable(GL_BLEND)
@@ -100,21 +89,9 @@ class OpaquePointShaderProgram(DefaultShaderProgram):
 
 
 class ImageShaderProgram(DefaultShaderProgram):
-    def __init__(self, max_glsl_version='120'):
-        GLProgram.__init__(self, max_glsl_version=max_glsl_version)
-        shader_path = os.path.join(os.path.dirname(__file__), "shaders")
-        _shader_program = ShaderProgram(shader_path, max_glsl_version=max_glsl_version)
-        _shader_program.add_shader("image_vs.glsl", GL_VERTEX_SHADER)
-        _shader_program.add_shader("image_fs.glsl", GL_FRAGMENT_SHADER)
-        _shader_program.link()
-        self.set_shader_program(_shader_program)
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, vs_filename='image_vs.glsl', fs_filename='image_fs.glsl', **kwargs)
         
 class TextShaderProgram(DefaultShaderProgram):
-    def __init__(self, max_glsl_version='120'):
-        GLProgram.__init__(self, max_glsl_version=max_glsl_version)
-        shader_path = os.path.join(os.path.dirname(__file__), "shaders")
-        _shader_program = ShaderProgram(shader_path, max_glsl_version=max_glsl_version)
-        _shader_program.add_shader("text_vs.glsl", GL_VERTEX_SHADER)
-        _shader_program.add_shader("text_fs.glsl", GL_FRAGMENT_SHADER)
-        _shader_program.link()
-        self.set_shader_program(_shader_program)
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, vs_filename='text_vs.glsl', fs_filename='text_fs.glsl', **kwargs)

--- a/PYME/LMVis/shader_programs/DefaultShaderProgram.py
+++ b/PYME/LMVis/shader_programs/DefaultShaderProgram.py
@@ -87,6 +87,21 @@ class OpaquePointShaderProgram(DefaultShaderProgram):
 
         return self
 
+class BigOpaquePointShaderProgram(DefaultShaderProgram):
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, vs_filename='default_vs.glsl', fs_filename='bigflatpoints_fs.glsl', gs_filename='bigpoints_gs.glsl', **kwargs)
+
+    def __enter__(self):
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE)
+        glDisable(GL_BLEND)
+        glDepthMask(GL_TRUE)
+        glEnable(GL_DEPTH_TEST)
+
+        self.get_shader_program().use()
+        self.set_clipping_uniforms()
+        glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
+
+        return self
 
 class ImageShaderProgram(DefaultShaderProgram):
     def __init__(self, **kwargs):

--- a/PYME/LMVis/shader_programs/DefaultShaderProgram.py
+++ b/PYME/LMVis/shader_programs/DefaultShaderProgram.py
@@ -110,3 +110,14 @@ class ImageShaderProgram(DefaultShaderProgram):
 class TextShaderProgram(DefaultShaderProgram):
     def __init__(self, **kwargs):
         GLProgram.__init__(self, vs_filename='text_vs.glsl', fs_filename='text_fs.glsl', **kwargs)
+
+class FatLineShaderProgram(DefaultShaderProgram):
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, vs_filename='widelines_vs.glsl', fs_filename='widelines_fs.glsl', gs_filename='widelines_gs.glsl', **kwargs)
+
+    def __enter__(self):
+        self.get_shader_program().use()
+        self.set_clipping_uniforms()
+        glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
+
+        return self

--- a/PYME/LMVis/shader_programs/DefaultShaderProgram.py
+++ b/PYME/LMVis/shader_programs/DefaultShaderProgram.py
@@ -89,6 +89,15 @@ class OpaquePointShaderProgram(DefaultShaderProgram):
         glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
 
         return self
+    
+class TransparentPointShaderProgram(OpaquePointShaderProgram):
+    def __enter__(self):
+        super().__enter__()
+        glEnable(GL_BLEND)
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+        glEnable(GL_DEPTH_TEST)
+        return self
+    
 
 class BigOpaquePointShaderProgram(DefaultShaderProgram):
     def __init__(self, **kwargs):
@@ -110,6 +119,14 @@ class BigOpaquePointShaderProgram(DefaultShaderProgram):
         self.set_clipping_uniforms()
         glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
 
+        return self
+    
+class BigTransparentPointShaderProgram(BigOpaquePointShaderProgram):
+    def __enter__(self):
+        super().__enter__()
+        glEnable(GL_BLEND)
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+        glEnable(GL_DEPTH_TEST)
         return self
 
 class ImageShaderProgram(DefaultShaderProgram):

--- a/PYME/LMVis/shader_programs/GLProgram.py
+++ b/PYME/LMVis/shader_programs/GLProgram.py
@@ -27,7 +27,7 @@ import os
 
 class GLProgram(object):
 
-    def __init__(self, vs_filename=None, fs_filename=None, max_glsl_version='120', clipping={'x':[-1e6, 1e6], 'y' : [-1e6, 1e6], 'z': [-1e6, 1e6], 'v' : [-1e6, 1e6]}):
+    def __init__(self, vs_filename=None, fs_filename=None, gs_filename=None, max_glsl_version='120', clipping={'x':[-1e6, 1e6], 'y' : [-1e6, 1e6], 'z': [-1e6, 1e6], 'v' : [-1e6, 1e6]}):
         self._shader_program = None
         self._max_glsl_version = max_glsl_version
 
@@ -35,11 +35,11 @@ class GLProgram(object):
         self.ymin, self.ymax = clipping['y']
         self.zmin, self.zmax = clipping['z']
         self.vmin, self.vmax = clipping['v']
-        
+
         self.v_matrix = np.eye(4, 4, dtype='f')
         
         if (vs_filename is not None) and (fs_filename is not None):
-            self.create_and_set_shader_program(vs_filename, fs_filename)
+            self.create_and_set_shader_program(vs_filename, fs_filename, gs_filename=gs_filename)
 
         self._old_prog = 0
         
@@ -53,11 +53,14 @@ class GLProgram(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         glUseProgram(self._old_prog)
 
-    def create_and_set_shader_program(self, vs_filename, fs_filename):
+    def create_and_set_shader_program(self, vs_filename, fs_filename, gs_filename=None):
         shader_path = os.path.join(os.path.dirname(__file__), "shaders")
         shader_program = ShaderProgram(shader_path, max_glsl_version=self._max_glsl_version)
         shader_program.add_shader(vs_filename, GL_VERTEX_SHADER)
         shader_program.add_shader(fs_filename, GL_FRAGMENT_SHADER)
+        if gs_filename is not None:
+            shader_program.add_shader(gs_filename, GL_GEOMETRY_SHADER)
+
         shader_program.link()
         self.set_shader_program(shader_program)
         

--- a/PYME/LMVis/shader_programs/GLProgram.py
+++ b/PYME/LMVis/shader_programs/GLProgram.py
@@ -27,14 +27,15 @@ import os
 
 class GLProgram(object):
 
-    def __init__(self, vs_filename=None, fs_filename=None, max_glsl_version='120'):
+    def __init__(self, vs_filename=None, fs_filename=None, max_glsl_version='120', clipping={'x':[-1e6, 1e6], 'y' : [-1e6, 1e6], 'z': [-1e6, 1e6], 'v' : [-1e6, 1e6]}):
         self._shader_program = None
         self._max_glsl_version = max_glsl_version
 
-        self.xmin, self.xmax = [-1e6, 1e6]
-        self.ymin, self.ymax = [-1e6, 1e6]
-        self.zmin, self.zmax = [-1e6, 1e6]
-        self.vmin, self.vmax = [-1e6, 1e6]
+        self.xmin, self.xmax = clipping['x']
+        self.ymin, self.ymax = clipping['y']
+        self.zmin, self.zmax = clipping['z']
+        self.vmin, self.vmax = clipping['v']
+        
         self.v_matrix = np.eye(4, 4, dtype='f')
         
         if (vs_filename is not None) and (fs_filename is not None):
@@ -72,6 +73,14 @@ class GLProgram(object):
     def set_modelviewprojectionmatrix(self, mvp):
         if self._shader_program._vs_glsl_version >= '140':
             glUniformMatrix4fv(self.get_uniform_location('ModelViewProjectionMatrix'), 1, GL_FALSE, np.array(mvp, 'f4').T)
+
+    def set_modelviewmatrix(self, mv):
+        if self._shader_program._vs_glsl_version >= '140':
+            glUniformMatrix4fv(self.get_uniform_location('ModelViewMatrix'), 1, GL_FALSE, np.array(mv, 'f4').T)
+
+    def set_normalmatrix(self, normal_matrix):
+        if self._shader_program._vs_glsl_version >= '140':
+            glUniformMatrix3fv(self.get_uniform_location('NormalMatrix'), 1, GL_FALSE, np.array(normal_matrix, 'f4').T)
 
     def set_point_size(self, point_size):
         if self._shader_program._vs_glsl_version >= '140':

--- a/PYME/LMVis/shader_programs/GLProgram.py
+++ b/PYME/LMVis/shader_programs/GLProgram.py
@@ -31,12 +31,7 @@ class GLProgram(object):
         self._shader_program = None
         self._max_glsl_version = max_glsl_version
 
-        self.xmin, self.xmax = clipping['x']
-        self.ymin, self.ymax = clipping['y']
-        self.zmin, self.zmax = clipping['z']
-        self.vmin, self.vmax = clipping['v']
-
-        self.v_matrix = np.eye(4, 4, dtype='f')
+        self.set_clipping(clipping, update_uniforms=False)
         
         if (vs_filename is not None) and (fs_filename is not None):
             self.create_and_set_shader_program(vs_filename, fs_filename, gs_filename=gs_filename)
@@ -100,3 +95,25 @@ class GLProgram(object):
         glUniform1f(self.get_uniform_location('v_min'), float(self.vmin))
         glUniform1f(self.get_uniform_location('v_max'), float(self.vmax))
         glUniformMatrix4fv(self.get_uniform_location('clip_rotation_matrix'), 1, GL_FALSE, self.v_matrix)
+
+    def clear_shader_clipping(self):
+        self.xmin, self.xmax = -1e6, 1e6
+        self.ymin, self.ymax = -1e6, 1e6
+        self.zmin, self.zmax = -1e6, 1e6
+        self.vmin, self.vmax = -1e6, 1e6
+
+        self.set_clipping_uniforms()
+
+    def set_clipping(self, clipping, view_matrix=None, update_uniforms=True):
+        self.xmin, self.xmax = clipping['x']
+        self.ymin, self.ymax = clipping['y']
+        self.zmin, self.zmax = clipping['z']
+        self.vmin, self.vmax = clipping['v']
+
+        if view_matrix is not None:
+            self.v_matrix[:,:] = view_matrix
+        else:
+            self.v_matrix = np.eye(4, 4, dtype='f')
+
+        if update_uniforms:
+            self.set_clipping_uniforms()

--- a/PYME/LMVis/shader_programs/GouraudShaderProgram.py
+++ b/PYME/LMVis/shader_programs/GouraudShaderProgram.py
@@ -105,7 +105,10 @@ class GouraudSphereShaderProgram(GouraudShaderProgram):
         except:
             pass
         glDisable(GL_PROGRAM_POINT_SIZE)
-        
+
+class BigGouraudSphereShaderProgram(GouraudShaderProgram):
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, "default_vs.glsl", "bigspheres_fs.glsl", gs_filename='bigpoints_gs.glsl', **kwargs)    
 
 class OITGouraudShaderProgram(GouraudShaderProgram):
     def __init__(self, **kwargs):

--- a/PYME/LMVis/shader_programs/GouraudShaderProgram.py
+++ b/PYME/LMVis/shader_programs/GouraudShaderProgram.py
@@ -80,6 +80,9 @@ class GouraudShaderProgram(GLProgram):
         except:
             pass
         
+class PhongShaderProgram(GouraudShaderProgram):
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, "phong_vs.glsl", "phong_fs.glsl", **kwargs)
         
         
 class GouraudSphereShaderProgram(GouraudShaderProgram):

--- a/PYME/LMVis/shader_programs/GouraudShaderProgram.py
+++ b/PYME/LMVis/shader_programs/GouraudShaderProgram.py
@@ -110,6 +110,27 @@ class BigGouraudSphereShaderProgram(GouraudShaderProgram):
     def __init__(self, **kwargs):
         GLProgram.__init__(self, "default_vs.glsl", "bigspheres_fs.glsl", gs_filename='bigpoints_gs.glsl', **kwargs)    
 
+class GouraudFlatpointsShaderProgram(GouraudShaderProgram):
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, "gouraud_vs.glsl", "flatpoints_fs.glsl", **kwargs)
+
+    def __enter__(self):
+        GouraudShaderProgram.__enter__(self)
+        self.get_shader_program().use()
+        
+        glEnable(GL_PROGRAM_POINT_SIZE)
+        try:
+            glEnable(GL_POINT_SPRITE)
+        except:
+            pass
+
+        return self
+    
+class BigGouraudFlatpointsShaderProgram(GouraudShaderProgram):
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, "gouraud_vs.glsl", "bigflatpoints_fs.glsl", gs_filename='bigpoints_gs.glsl', **kwargs)
+
+
 class OITGouraudShaderProgram(GouraudShaderProgram):
     def __init__(self, **kwargs):
         GLProgram.__init__(self, "gouraud_vs.glsl", "gouraud_oit_fs.glsl", **kwargs)

--- a/PYME/LMVis/shader_programs/GouraudShaderProgram.py
+++ b/PYME/LMVis/shader_programs/GouraudShaderProgram.py
@@ -51,14 +51,7 @@ class GouraudShaderProgram(GLProgram):
         location = self.get_uniform_location('view_vector')
         glUniform4f(location, *self.view_vector)
 
-        glUniform1f(self.get_uniform_location('x_min'), float(self.xmin))
-        glUniform1f(self.get_uniform_location('x_max'), float(self.xmax))
-        glUniform1f(self.get_uniform_location('y_min'), float(self.ymin))
-        glUniform1f(self.get_uniform_location('y_max'), float(self.ymax))
-        glUniform1f(self.get_uniform_location('z_min'), float(self.zmin))
-        glUniform1f(self.get_uniform_location('z_max'), float(self.zmax))
-        glUniform1f(self.get_uniform_location('v_min'), float(self.vmin))
-        glUniform1f(self.get_uniform_location('v_max'), float(self.vmax))
+        self.set_clipping_uniforms()
 
         #glUniformMatrix4fv(self.get_uniform_location('clip_rotation_matrix'), 1, GL_FALSE, self.v_matrix)
         
@@ -82,7 +75,10 @@ class GouraudShaderProgram(GLProgram):
     def __exit__(self, exc_type, exc_val, exc_tb):
         glUseProgram(self._old_prog)
         glDisable(GL_DEPTH_TEST)
-        glDisable(GL_POINT_SMOOTH)
+        try:
+            glDisable(GL_POINT_SMOOTH)
+        except:
+            pass
         
         
         

--- a/PYME/LMVis/shader_programs/GouraudShaderProgram.py
+++ b/PYME/LMVis/shader_programs/GouraudShaderProgram.py
@@ -36,8 +36,8 @@ class GouraudShaderProgram(GLProgram):
     
     shininess = 8
 
-    def __init__(self):
-        GLProgram.__init__(self, "gouraud_vs.glsl", "gouraud_fs.glsl")
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, "gouraud_vs.glsl", "gouraud_fs.glsl", **kwargs)
         
 
     def __enter__(self):
@@ -69,7 +69,10 @@ class GouraudShaderProgram(GLProgram):
         #glEnable(GL_CULL_FACE)
         #glCullFace(GL_BACK)
         
-        glDisable(GL_POINT_SMOOTH)
+        try:
+            glDisable(GL_POINT_SMOOTH)
+        except:
+            pass
         #glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
         #glBlendFunc(GL_SRC_ALPHA, GL_DST_ALPHA)
         #glEnable(GL_BLEND)
@@ -84,27 +87,33 @@ class GouraudShaderProgram(GLProgram):
         
         
 class GouraudSphereShaderProgram(GouraudShaderProgram):
-    def __init__(self):
-        GLProgram.__init__(self, "pointsprites_vs.glsl", "spheres_fs.glsl")
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, "pointsprites_vs.glsl", "spheres_fs.glsl", **kwargs)
 
     def __enter__(self):
         self.get_shader_program().use()
         GouraudShaderProgram.__enter__(self)
     
-        glEnable(GL_POINT_SPRITE)
+        try:
+            glEnable(GL_POINT_SPRITE)
+        except:
+            pass
         glEnable(GL_PROGRAM_POINT_SIZE)
 
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         glUseProgram(0)
-        glDisable(GL_POINT_SPRITE)
+        try:
+            glDisable(GL_POINT_SPRITE)
+        except:
+            pass
         glDisable(GL_PROGRAM_POINT_SIZE)
         
 
 class OITGouraudShaderProgram(GouraudShaderProgram):
-    def __init__(self):
-        GLProgram.__init__(self, "gouraud_vs.glsl", "gouraud_oit_fs.glsl")
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, "gouraud_vs.glsl", "gouraud_oit_fs.glsl", **kwargs)
     
     def __enter__(self):
         self.get_shader_program().use()

--- a/PYME/LMVis/shader_programs/PointSpriteShaderProgram.py
+++ b/PYME/LMVis/shader_programs/PointSpriteShaderProgram.py
@@ -102,23 +102,10 @@ class PointSpriteShaderProgram(GLProgram):
     #    This is the uniform location to pass to the fragment shader to locate the texture
     #_uniform_tex_2d_id = 0
 
-    def __init__(self, clipping={'x':[-1e6, 1e6], 'y' : [-1e6, 1e6], 'z': [-1e6, 1e6], 'v' : [-1e6, 1e6]}, **kwargs):
-        GLProgram.__init__(self, **kwargs)
-        shader_path = os.path.join(os.path.dirname(__file__), "shaders")
-        shader_program = ShaderProgram(shader_path, **kwargs)
-        #shader_program.add_shader("pointsprites_vs.glsl", GL_VERTEX_SHADER)
-        shader_program.add_shader("default_vs.glsl", GL_VERTEX_SHADER)
-        shader_program.add_shader("pointsprites_fs.glsl", GL_FRAGMENT_SHADER)
-        shader_program.link()
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, vs_filename='default_vs.glsl', fs_filename='default_fs.glsl', **kwargs)
         self._texture = GaussTexture()
         self.size_factor = self._texture.load_texture()
-        self.set_shader_program(shader_program)
-        #self._uniform_tex_2d_id = self.get_shader_program().get_uniform_location(b'tex2D')
-
-        self.xmin, self.xmax = clipping['x']
-        self.ymin, self.ymax = clipping['y']
-        self.zmin, self.zmax = clipping['z']
-        self.vmin, self.vmax = clipping['v']
         
 
     def get_size_factor(self):
@@ -128,15 +115,8 @@ class PointSpriteShaderProgram(GLProgram):
     def __enter__(self):
         self._old_prog = glGetInteger(GL_CURRENT_PROGRAM)
         self.get_shader_program().use()
-        glUniform1f(self.get_uniform_location('x_min'), float(self.xmin))
-        glUniform1f(self.get_uniform_location('x_max'), float(self.xmax))
-        glUniform1f(self.get_uniform_location('y_min'), float(self.ymin))
-        glUniform1f(self.get_uniform_location('y_max'), float(self.ymax))
-        glUniform1f(self.get_uniform_location('z_min'), float(self.zmin))
-        glUniform1f(self.get_uniform_location('z_max'), float(self.zmax))
-        glUniform1f(self.get_uniform_location('v_min'), float(self.vmin))
-        glUniform1f(self.get_uniform_location('v_max'), float(self.vmax))
-        glUniformMatrix4fv(self.get_uniform_location('clip_rotation_matrix'), 1, GL_FALSE, self.v_matrix)
+        self.set_clipping_uniforms()
+        
         try:
             glEnable(GL_POINT_SPRITE)
         except:

--- a/PYME/LMVis/shader_programs/PointSpriteShaderProgram.py
+++ b/PYME/LMVis/shader_programs/PointSpriteShaderProgram.py
@@ -146,3 +146,9 @@ class PointSpriteShaderProgram(GLProgram):
     def __del__(self):
         # self._texture.delete_texture()
         pass
+
+class BigPointSpriteShaderProgram(PointSpriteShaderProgram):
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, vs_filename='default_vs.glsl', fs_filename='bigpointsprites_fs.glsl', gs_filename='bigpoints_gs.glsl', **kwargs)
+        self._texture = GaussTexture()
+        self.size_factor = self._texture.load_texture()

--- a/PYME/LMVis/shader_programs/PointSpriteShaderProgram.py
+++ b/PYME/LMVis/shader_programs/PointSpriteShaderProgram.py
@@ -103,7 +103,7 @@ class PointSpriteShaderProgram(GLProgram):
     #_uniform_tex_2d_id = 0
 
     def __init__(self, **kwargs):
-        GLProgram.__init__(self, vs_filename='default_vs.glsl', fs_filename='default_fs.glsl', **kwargs)
+        GLProgram.__init__(self, vs_filename='pointsprites_vs.glsl', fs_filename='pointsprites_fs.glsl', **kwargs)
         self._texture = GaussTexture()
         self.size_factor = self._texture.load_texture()
         

--- a/PYME/LMVis/shader_programs/ShaderProgramFactory.py
+++ b/PYME/LMVis/shader_programs/ShaderProgramFactory.py
@@ -43,9 +43,12 @@ class ShaderProgramFactory(object):
         if existing_program:
             return existing_program
         else:
-            new_program = class_name()
             if context and window:
                 context.SetCurrent(window)
+            
+            #print("Creating new shader program - max glsl version: {}".format(window.glsl_version))
+            new_program = class_name(max_glsl_version=getattr(window,'glsl_version', '120'))
+            
             ShaderProgramFactory._programs[(class_name, context)] = new_program
             logger.debug("New shader program created: {}".format(class_name))
             return new_program

--- a/PYME/LMVis/shader_programs/TesselShaderProgram.py
+++ b/PYME/LMVis/shader_programs/TesselShaderProgram.py
@@ -46,10 +46,10 @@ class TesselShaderProgram(GLProgram):
 
         return self
 
-    def __init__(self):
-        GLProgram.__init__(self)
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, **kwargs)
         shader_path = os.path.join(os.path.dirname(__file__), "shaders")
-        _shader_program = ShaderProgram(shader_path)
+        _shader_program = ShaderProgram(shader_path, **kwargs)
         _shader_program.add_shader("tessel_vs.glsl", GL_VERTEX_SHADER)
         _shader_program.add_shader("tessel_fs.glsl", GL_FRAGMENT_SHADER)
         _shader_program.link()

--- a/PYME/LMVis/shader_programs/TesselShaderProgram.py
+++ b/PYME/LMVis/shader_programs/TesselShaderProgram.py
@@ -28,10 +28,6 @@ from PYME.LMVis.shader_programs.shader_program import ShaderProgram
 
 
 class TesselShaderProgram(GLProgram):
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        glUseProgram(self._old_prog)
-        pass
-
     def __enter__(self):
         self._old_prog = glGetInteger(GL_CURRENT_PROGRAM)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE)
@@ -47,10 +43,5 @@ class TesselShaderProgram(GLProgram):
         return self
 
     def __init__(self, **kwargs):
-        GLProgram.__init__(self, **kwargs)
-        shader_path = os.path.join(os.path.dirname(__file__), "shaders")
-        _shader_program = ShaderProgram(shader_path, **kwargs)
-        _shader_program.add_shader("tessel_vs.glsl", GL_VERTEX_SHADER)
-        _shader_program.add_shader("tessel_fs.glsl", GL_FRAGMENT_SHADER)
-        _shader_program.link()
-        self.set_shader_program(_shader_program)
+        GLProgram.__init__(self, vs_filename='default_vs.glsl', fs_filename='tessel_fs.glsl', **kwargs)
+        

--- a/PYME/LMVis/shader_programs/WireFrameShaderProgram.py
+++ b/PYME/LMVis/shader_programs/WireFrameShaderProgram.py
@@ -45,10 +45,10 @@ class WireFrameShaderProgram(GLProgram):
 
         return self
 
-    def __init__(self):
-        GLProgram.__init__(self)
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, **kwargs)
         shader_path = os.path.join(os.path.dirname(__file__), "shaders")
-        _shader_program = ShaderProgram(shader_path)
+        _shader_program = ShaderProgram(shader_path, **kwargs)
         _shader_program.add_shader("default_vs.glsl", GL_VERTEX_SHADER)
         _shader_program.add_shader("default_fs.glsl", GL_FRAGMENT_SHADER)
         _shader_program.link()

--- a/PYME/LMVis/shader_programs/WireFrameShaderProgram.py
+++ b/PYME/LMVis/shader_programs/WireFrameShaderProgram.py
@@ -46,10 +46,5 @@ class WireFrameShaderProgram(GLProgram):
         return self
 
     def __init__(self, **kwargs):
-        GLProgram.__init__(self, **kwargs)
-        shader_path = os.path.join(os.path.dirname(__file__), "shaders")
-        _shader_program = ShaderProgram(shader_path, **kwargs)
-        _shader_program.add_shader("default_vs.glsl", GL_VERTEX_SHADER)
-        _shader_program.add_shader("default_fs.glsl", GL_FRAGMENT_SHADER)
-        _shader_program.link()
-        self.set_shader_program(_shader_program)
+        GLProgram.__init__(self, vs_filename='default_vs.glsl', fs_filename='default_fs.glsl', **kwargs)
+        

--- a/PYME/LMVis/shader_programs/oit_compositor.py
+++ b/PYME/LMVis/shader_programs/oit_compositor.py
@@ -4,10 +4,10 @@ from OpenGL.GL import *
 from PYME.LMVis.shader_programs.shader_program import ShaderProgram
 
 class OITCompositorProgram(GLProgram):
-    def __init__(self):
-        GLProgram.__init__(self)
+    def __init__(self, **kwargs):
+        GLProgram.__init__(self, **kwargs)
         shader_path = os.path.join(os.path.dirname(__file__), "shaders")
-        shader_program = ShaderProgram(shader_path)
+        shader_program = ShaderProgram(shader_path, **kwargs)
         shader_program.add_shader("compose_vs.glsl", GL_VERTEX_SHADER)
         shader_program.add_shader("compose_fs.glsl", GL_FRAGMENT_SHADER)
         shader_program.link()

--- a/PYME/LMVis/shader_programs/shaders/bigflatpoints_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/bigflatpoints_fs.glsl
@@ -1,0 +1,16 @@
+#version 330 core
+// Like the flatpoints shader, but using texture coordinates rather than point coordinates
+in float visibility;
+in vec4 frontColor;
+in vec2 texCoord;
+
+layout(location = 0) out vec4 FragColor;
+
+void main() {
+    //gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
+    if (visibility < .5) discard;
+
+    vec2 circ_coord = 2.0 * texCoord - 1.0;
+    if (dot(circ_coord, circ_coord) > 1) discard;
+    FragColor = frontColor;
+}

--- a/PYME/LMVis/shader_programs/shaders/bigpoints_gs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/bigpoints_gs.glsl
@@ -1,0 +1,38 @@
+#version 330 core
+// convert points to quads by using a geometry shader
+
+uniform float point_size_vp;
+
+layout (points) in;
+layout (triangle_strip, max_vertices = 4) out;
+
+in vec4 FrontColor[];
+in float vis[];
+
+out vec4 frontColor;
+out vec2 texCoord;
+out float visibility;
+
+void main(){
+    float half_size = point_size_vp / 2.0;
+    vec4 position = gl_in[0].gl_Position;
+
+    // pass through colour and visibility
+    frontColor = FrontColor[0];
+    visibility = vis[0];
+
+    gl_Position = position + vec4(-half_size, -half_size, 0.0, 0.0);    // 1:bottom-left
+    texCoord = vec2(0.0, 0.0);
+    EmitVertex();   
+    gl_Position = position + vec4( half_size, -half_size, 0.0, 0.0);    // 2:bottom-right
+    texCoord = vec2(1.0, 0.0);
+    EmitVertex();
+    gl_Position = position + vec4(-half_size,  half_size, 0.0, 0.0);    // 3:top-left
+    texCoord = vec2(0.0, 1.0);
+    EmitVertex();
+    gl_Position = position + vec4( half_size,  half_size, 0.0, 0.0);    // 4:top-right
+    texCoord = vec2(1.0, 1.0);
+    EmitVertex();
+    EndPrimitive();
+
+}

--- a/PYME/LMVis/shader_programs/shaders/bigpoints_gs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/bigpoints_gs.glsl
@@ -2,6 +2,7 @@
 // convert points to quads by using a geometry shader
 
 uniform float point_size_vp;
+uniform vec2 viewport_size;
 
 layout (points) in;
 layout (triangle_strip, max_vertices = 4) out;
@@ -15,22 +16,23 @@ out float visibility;
 
 void main(){
     float half_size = point_size_vp / 2.0;
+    float aspect_ratio = viewport_size.x / viewport_size.y;
     vec4 position = gl_in[0].gl_Position;
 
     // pass through colour and visibility
     frontColor = FrontColor[0];
     visibility = vis[0];
 
-    gl_Position = position + vec4(-half_size, -half_size, 0.0, 0.0);    // 1:bottom-left
+    gl_Position = position + vec4(-half_size, -half_size*aspect_ratio, 0.0, 0.0);    // 1:bottom-left
     texCoord = vec2(0.0, 0.0);
     EmitVertex();   
-    gl_Position = position + vec4( half_size, -half_size, 0.0, 0.0);    // 2:bottom-right
+    gl_Position = position + vec4( half_size, -half_size*aspect_ratio, 0.0, 0.0);    // 2:bottom-right
     texCoord = vec2(1.0, 0.0);
     EmitVertex();
-    gl_Position = position + vec4(-half_size,  half_size, 0.0, 0.0);    // 3:top-left
+    gl_Position = position + vec4(-half_size,  half_size*aspect_ratio, 0.0, 0.0);    // 3:top-left
     texCoord = vec2(0.0, 1.0);
     EmitVertex();
-    gl_Position = position + vec4( half_size,  half_size, 0.0, 0.0);    // 4:top-right
+    gl_Position = position + vec4( half_size,  half_size*aspect_ratio, 0.0, 0.0);    // 4:top-right
     texCoord = vec2(1.0, 1.0);
     EmitVertex();
     EndPrimitive();

--- a/PYME/LMVis/shader_programs/shaders/bigpointsprites_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/bigpointsprites_fs.glsl
@@ -1,0 +1,20 @@
+#version 330
+
+// This fragmentshader takes the given color and displays it.
+// It's transparency is determined by a submitted texture. That way the brightness is decreasing with the distance to the \
+// center of the point.
+
+uniform sampler2D tex2D;
+
+in vec4 frontColor;
+in float visibility;
+in vec2 texCoord;
+
+layout (location = 0) out vec4 fragColor;
+
+void main()
+{
+    if (visibility <0.5) discard;
+    float alpha = frontColor.a * texture(tex2D, texCoord).x;
+    fragColor = vec4(frontColor.xyz, alpha);
+}

--- a/PYME/LMVis/shader_programs/shaders/bigspheres_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/bigspheres_fs.glsl
@@ -1,0 +1,53 @@
+#version 330
+
+// This fragmentshader takes the given color and displays it.
+// It's transparency is determined by a submitted texture. That way the brightness is decreasing with the distance to the \
+// center of the point.
+
+uniform vec4 light_ambient;
+uniform vec4 light_diffuse;
+uniform vec4 light_specular;
+uniform vec4 light_position;
+uniform float shininess;
+uniform vec4 view_vector;
+
+in float visibility;
+in vec4 frontColor;
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+void main()
+{
+    vec3 N;
+    float m;
+
+    if (visibility < 0.5) discard;
+
+    N.xy = texCoord.xy*2.0 -vec2(1.0);
+    m = dot(N.xy, N.xy);
+    if (m > 1.0) discard;
+    N.z = sqrt(1.0 - m);
+
+    vec4 inputColor = frontColor;
+    vec4 white = vec4(1.0, 1.0, 1.0, frontColor.a);
+    vec4 ambient = inputColor * light_ambient;
+    //direction to the lightsource
+    vec3 lightsource = normalize(vec3(light_position));
+
+    float diffuseLight = abs(dot(lightsource, N));//, 0.0);
+    vec4 diffuse = vec4(0.0, 0.0, 0.0, 1.0);
+    vec4 specular = vec4(0.0, 0.0, 0.0, 1.0);
+    //vec4 diff = vec4(0.0, 0.0, 0.0, 1.0);
+    if (diffuseLight > 0){
+        diffuse = diffuseLight * inputColor * light_diffuse;
+        vec3 H = normalize(light_position.xyz + view_vector.xyz);
+        float specLight = pow(abs(dot(H, N)), shininess);
+        vec4 spec = white * light_specular;
+        specular = specLight * spec;
+    }
+    fragColor = ambient + diffuse + specular;
+
+    //float alpha = gl_Color.a * texture2D(tex2D, gl_PointCoord).x;
+    //gl_FragColor = vec4(gl_Color.xyz, alpha);
+}

--- a/PYME/LMVis/shader_programs/shaders/compose_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/compose_fs.glsl
@@ -17,3 +17,25 @@ void main(void)
     gl_FragColor = vec4(accum.rgb / clamp(accum.a, 1e-4f, 5e4f), (alpha) );
     //gl_FragColor = vec4(1.0f, 1.0f, 1.0f, 1.0f);
 }
+
+#version 330
+
+uniform sampler2D accum_t; // sum(rgb * a, a)
+uniform sampler2D reveal_t; // prod(1 - a)
+
+in vec2 vTexcoord;
+
+out vec4 fragColor;
+
+void main(void)
+{
+    vec4 accum = texture(accum_t, vTexcoord);
+    float alpha = accum.a;
+    accum.a = texture(reveal_t, vTexcoord).r; // GL_RED
+    //if (alpha >= 1.0f) { // Save the blending and color texture fetch cost
+    //    discard;
+    //}
+    //gl_FragColor = vec4(accum.rgb / clamp(accum.a, 1e-4f, 5e4f), (1.0f - alpha) );
+    fragColor = vec4(accum.rgb / clamp(accum.a, 1e-4f, 5e4f), (alpha) );
+    //gl_FragColor = vec4(1.0f, 1.0f, 1.0f, 1.0f);
+}

--- a/PYME/LMVis/shader_programs/shaders/compose_vs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/compose_vs.glsl
@@ -10,3 +10,16 @@ void main(void)
 
     vTexcoord = (vPosition.xy+1.0)/2.0;
 }
+
+#version 330
+
+in vec3 vPosition;
+
+out vec2 vTexcoord;
+
+void main(void)
+{
+    gl_Position = vec4(vPosition,1.0);
+
+    vTexcoord = (vPosition.xy+1.0)/2.0;
+}

--- a/PYME/LMVis/shader_programs/shaders/default_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/default_fs.glsl
@@ -8,3 +8,20 @@ void main() {
     if (vis < .5) discard;
     gl_FragColor = gl_Color;
 }
+
+#version 330 core
+//This is a very simple shader. It simply forwards the given color to the fragment.
+//There's no shading involved.
+in float vis;
+in vec4 FrontColor;
+
+layout(location = 0) out vec4 FragColor;
+
+void main() {
+    //gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
+    if (vis < .5) discard;
+
+    vec2 circ_coord = 2.0 * gl_PointCoord - 1.0;
+    if (dot(circ_coord, circ_coord) > 1) discard;
+    FragColor = FrontColor;
+}

--- a/PYME/LMVis/shader_programs/shaders/default_vs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/default_vs.glsl
@@ -35,3 +35,53 @@ void main() {
 
     gl_FrontColor.a = gl_FrontColor.a*(float(visible));
 }
+
+#version 330 core
+//This is one of the simplest vertex shader possible.
+//It simply passes the given color to the fragment shader and
+//transforms the vertex into screen space.
+
+uniform float x_min;
+uniform float x_max;
+uniform float y_min;
+uniform float y_max;
+uniform float z_min;
+uniform float z_max;
+uniform float v_min;
+uniform float v_max;
+uniform mat4 clip_rotation_matrix;
+
+uniform mat4 ModelViewProjectionMatrix;
+uniform float point_size_px;
+layout (location = 0) in vec3 Vertex;
+layout (location = 1) in vec3 Normal;
+layout (location = 2) in vec4 Color;
+
+out float vis;
+out vec4 FrontColor;
+//out float PointSize;
+//out vec4 Position;
+
+
+void main() {
+    bool visible;
+    vec4 v_position;
+    vec4 poss;
+    //PointSize = gl_Point.size;
+    gl_PointSize = point_size_px;
+    FrontColor = Color;
+
+    visible = Vertex.x > x_min && Vertex.x < x_max;
+    visible = visible && Vertex.y > y_min && Vertex.y < y_max;
+    visible = visible && Vertex.z > z_min && Vertex.z < z_max;
+
+    poss = vec4(Vertex, 1.0);
+    v_position = clip_rotation_matrix*poss;
+    visible = visible && v_position.z > v_min && v_position.z < v_max;
+
+    gl_Position = ModelViewProjectionMatrix * poss;
+
+    vis = float(visible);
+
+    FrontColor.a = FrontColor.a*(float(visible));
+}

--- a/PYME/LMVis/shader_programs/shaders/default_vs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/default_vs.glsl
@@ -53,6 +53,7 @@ uniform mat4 clip_rotation_matrix;
 
 uniform mat4 ModelViewProjectionMatrix;
 uniform float point_size_px;
+
 layout (location = 0) in vec3 Vertex;
 layout (location = 1) in vec3 Normal;
 layout (location = 2) in vec4 Color;

--- a/PYME/LMVis/shader_programs/shaders/flatpoints_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/flatpoints_fs.glsl
@@ -21,7 +21,7 @@ void main() {
     //gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
     if (vis < .5) discard;
 
-    //vec2 circ_coord = 2.0 * gl_PointCoord - 1.0;
-    //if (dot(circ_coord, circ_coord) > 1) discard;
+    vec2 circ_coord = 2.0 * gl_PointCoord - 1.0;
+    if (dot(circ_coord, circ_coord) > 1) discard;
     FragColor = FrontColor;
 }

--- a/PYME/LMVis/shader_programs/shaders/gouraud_flatpoints_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/gouraud_flatpoints_fs.glsl
@@ -1,0 +1,30 @@
+#version 120
+
+varying vec4 vertexColor;
+varying float vis;
+
+void main(void)
+{
+   if (vis < .5) discard;
+
+   gl_FragColor = vertexColor;
+}
+
+
+#version 330
+
+in vec4 vertexColor;
+in float vis;
+
+out vec4 FragColor;
+
+void main(void)
+{
+   if (vis < .5) discard;
+
+   vec2 coord = gl_PointCoord.xy*2 - vec2(1.0);
+   float m = dot(coord, coord);
+   if (m > 1.0) discard;
+
+   FragColor = vertexColor;
+}

--- a/PYME/LMVis/shader_programs/shaders/gouraud_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/gouraud_fs.glsl
@@ -1,19 +1,19 @@
 #version 120
 
-varying vec4 vertexColor;
+varying vec4 FrontColor;
 varying float vis;
 
 void main(void)
 {
    if (vis < .5) discard;
 
-   gl_FragColor = vertexColor;
+   gl_FragColor = FrontColor;
 }
 
 
 #version 330
 
-in vec4 vertexColor;
+in vec4 FrontColor;
 in float vis;
 
 out vec4 FragColor;
@@ -22,5 +22,5 @@ void main(void)
 {
    if (vis < .5) discard;
 
-   FragColor = vertexColor;
+   FragColor = FrontColor;
 }

--- a/PYME/LMVis/shader_programs/shaders/gouraud_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/gouraud_fs.glsl
@@ -9,3 +9,18 @@ void main(void)
 
    gl_FragColor = vertexColor;
 }
+
+
+#version 330
+
+in vec4 vertexColor;
+in float vis;
+
+out vec4 FragColor;
+
+void main(void)
+{
+   if (vis < .5) discard;
+
+   FragColor = vertexColor;
+}

--- a/PYME/LMVis/shader_programs/shaders/gouraud_oit_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/gouraud_oit_fs.glsl
@@ -30,3 +30,39 @@ void main(void)
     // Make sure to use the red channel (and GL_RED target in your texture)
     gl_FragData[1].r = alpha * weight; // GL_COLOR_ATTACHMENT1
 }
+
+#version 330
+
+in vec4 vertexColor;
+in float depth;
+in float vis;
+
+layout(location=0) out vec4 accum;
+layout(location=1) out float revealage;
+
+void main(void)
+{
+    if (vis < .5) discard;
+
+    float alpha = vertexColor.a;
+
+    // the object lies between -40 and -60 z coordinates
+    //float weight = pow(alpha + 0.01f, 4.0f) + max(0.01f, min(3000.0f, 0.3f / (0.00001f + pow(abs(depth) / 200.0f, 4.0f))));
+
+    //float weight = pow(alpha + 0.01f, 4.0f) + max(0.01f, min(3000.0f, 0.3f / (0.00001f + pow(abs(10*depth-50) / 200.0f, 4.0f))));
+
+    //dz = ((znear*zfar/z -zfar)/(znear-zfar)
+    // znear = 8, zfar = 12
+
+    float dz = ((100.0f/(-12.0f + depth)) + 0.0f)/4.0f;
+    //float dz = ((1.0f/(depth)) - 1.0f)/2.0f;
+    float dz1 = 1.0f - dz;
+    float weight = alpha*max(0.01f, 3000.0f*dz1*dz1*dz1);
+
+    // RGBA32F texture (accumulation)
+    accum = vec4(vertexColor.rgb * alpha * weight, alpha); // GL_COLOR_ATTACHMENT0, synonym of gl_FragColor
+
+    // R32F texture (revealage)
+    // Make sure to use the red channel (and GL_RED target in your texture)
+    revealage = alpha * weight; // GL_COLOR_ATTACHMENT1
+}

--- a/PYME/LMVis/shader_programs/shaders/gouraud_oit_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/gouraud_oit_fs.glsl
@@ -1,6 +1,6 @@
 #version 120
 
-varying vec4 vertexColor;
+varying vec4 FrontColor;
 varying float depth;
 varying float vis;
 
@@ -8,7 +8,7 @@ void main(void)
 {
     if (vis < .5) discard;
 
-    float alpha = vertexColor.a;
+    float alpha = FrontColor.a;
 
     // the object lies between -40 and -60 z coordinates
     //float weight = pow(alpha + 0.01f, 4.0f) + max(0.01f, min(3000.0f, 0.3f / (0.00001f + pow(abs(depth) / 200.0f, 4.0f))));
@@ -24,7 +24,7 @@ void main(void)
     float weight = alpha*max(0.01f, 3000.0f*dz1*dz1*dz1);
 
     // RGBA32F texture (accumulation)
-    gl_FragData[0] = vec4(vertexColor.rgb * alpha * weight, alpha); // GL_COLOR_ATTACHMENT0, synonym of gl_FragColor
+    gl_FragData[0] = vec4(FrontColor.rgb * alpha * weight, alpha); // GL_COLOR_ATTACHMENT0, synonym of gl_FragColor
 
     // R32F texture (revealage)
     // Make sure to use the red channel (and GL_RED target in your texture)
@@ -33,7 +33,7 @@ void main(void)
 
 #version 330
 
-in vec4 vertexColor;
+in vec4 FrontColor;
 in float depth;
 in float vis;
 
@@ -44,7 +44,7 @@ void main(void)
 {
     if (vis < .5) discard;
 
-    float alpha = vertexColor.a;
+    float alpha = FrontColor.a;
 
     // the object lies between -40 and -60 z coordinates
     //float weight = pow(alpha + 0.01f, 4.0f) + max(0.01f, min(3000.0f, 0.3f / (0.00001f + pow(abs(depth) / 200.0f, 4.0f))));
@@ -60,7 +60,7 @@ void main(void)
     float weight = alpha*max(0.01f, 3000.0f*dz1*dz1*dz1);
 
     // RGBA32F texture (accumulation)
-    accum = vec4(vertexColor.rgb * alpha * weight, alpha); // GL_COLOR_ATTACHMENT0, synonym of gl_FragColor
+    accum = vec4(FrontColor.rgb * alpha * weight, alpha); // GL_COLOR_ATTACHMENT0, synonym of gl_FragColor
 
     // R32F texture (revealage)
     // Make sure to use the red channel (and GL_RED target in your texture)

--- a/PYME/LMVis/shader_programs/shaders/gouraud_vs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/gouraud_vs.glsl
@@ -60,3 +60,74 @@ void main(void){
     // depth n eye/camera space coordinates
     depth = (eye_frame.z);
 }
+
+#version 330
+
+uniform vec4 light_ambient;
+uniform vec4 light_diffuse;
+uniform vec4 light_specular;
+uniform vec4 light_position;
+uniform float shininess;
+uniform vec4 view_vector;
+
+
+uniform float x_min;
+uniform float x_max;
+uniform float y_min;
+uniform float y_max;
+uniform float z_min;
+uniform float z_max;
+uniform float v_min;
+uniform float v_max;
+
+uniform mat4 ModelViewProjectionMatrix;
+uniform mat4 ModelViewMatrix;
+uniform mat3 NormalMatrix;
+uniform float point_size_px;
+layout (location = 0) in vec3 Vertex;
+layout (location = 1) in vec3 Normal;
+layout (location = 2) in vec4 Color;
+
+out vec4 vertexColor;
+out float vis;
+out float depth;
+
+void main(void){
+    bool visible;
+
+    vec4 inputColor = Color;
+    vec4 white = vec4(1.0, 1.0, 1.0, Color.a);
+    vec4 ambient = inputColor * light_ambient;
+    //direction to the lightsource
+    vec3 lightsource = normalize(vec3(light_position));
+    //normal between object and eye space
+    vec3 normal = normalize(NormalMatrix*Normal);
+
+    float diffuseLight = abs(dot(lightsource, normal));//, 0.0);
+    vec4 diffuse = vec4(0.0, 0.0, 0.0, 1.0);
+    vec4 specular = vec4(0.0, 0.0, 0.0, 1.0);
+    //vec4 diff = vec4(0.0, 0.0, 0.0, 1.0);
+    if (diffuseLight > 0){
+        diffuse = diffuseLight * inputColor * light_diffuse;
+        vec3 H = normalize(light_position.xyz + view_vector.xyz);
+        float specLight = pow(abs(dot(H, normal)), shininess);
+        vec4 spec = white * light_specular;
+        specular = specLight * spec;
+    }
+    vertexColor = ambient + diffuse + specular;
+    vertexColor.a = inputColor.a;
+
+    visible = Vertex.x > x_min && Vertex.x < x_max;
+    visible = visible && Vertex.y > y_min && Vertex.y < y_max;
+    visible = visible && Vertex.z > z_min && Vertex.z < z_max;
+
+    gl_Position = ModelViewProjectionMatrix * vec4(Vertex, 1.0);
+
+    vec4 eye_frame = ModelViewMatrix*vec4(Vertex, 1.0); //just do model view part for OIT calcs
+
+    visible = visible && gl_Position.z > v_min && gl_Position.z < v_max;
+    vis = (float(visible));
+
+    // depth n eye/camera space coordinates
+    depth = (eye_frame.z);
+}

--- a/PYME/LMVis/shader_programs/shaders/gouraud_vs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/gouraud_vs.glsl
@@ -7,7 +7,7 @@ uniform vec4 light_position;
 uniform float shininess;
 uniform vec4 view_vector;
 
-varying vec4 vertexColor;
+varying vec4 FrontColor;
 
 varying float vis;
 varying float depth;
@@ -43,8 +43,8 @@ void main(void){
         vec4 spec = white * light_specular;
         specular = specLight * spec;
     }
-    vertexColor = ambient + diffuse + specular;
-    vertexColor.a = inputColor.a;
+    FrontColor = ambient + diffuse + specular;
+    FrontColor.a = inputColor.a;
 
     visible = gl_Vertex.x > x_min && gl_Vertex.x < x_max;
     visible = visible && gl_Vertex.y > y_min && gl_Vertex.y < y_max;
@@ -88,12 +88,14 @@ layout (location = 0) in vec3 Vertex;
 layout (location = 1) in vec3 Normal;
 layout (location = 2) in vec4 Color;
 
-out vec4 vertexColor;
+out vec4 FrontColor;
 out float vis;
 out float depth;
 
 void main(void){
     bool visible;
+
+    gl_PointSize = point_size_px;
 
     vec4 inputColor = Color;
     vec4 white = vec4(1.0, 1.0, 1.0, Color.a);
@@ -114,8 +116,8 @@ void main(void){
         vec4 spec = white * light_specular;
         specular = specLight * spec;
     }
-    vertexColor = ambient + diffuse + specular;
-    vertexColor.a = inputColor.a;
+    FrontColor = ambient + diffuse + specular;
+    FrontColor.a = inputColor.a;
 
     visible = Vertex.x > x_min && Vertex.x < x_max;
     visible = visible && Vertex.y > y_min && Vertex.y < y_max;

--- a/PYME/LMVis/shader_programs/shaders/image_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/image_fs.glsl
@@ -27,3 +27,34 @@ void main() {
 
     //gl_FragColor = vec4(I, I, I, 1.0);
 }
+
+#version 330
+
+in float vis;
+in vec2 tex_coords;
+
+uniform vec2 clim;
+
+uniform sampler2D im_sampler;
+uniform sampler1D lut;
+
+out vec4 fragColor;
+
+void main() {
+    //gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
+    //if (vis < .5) discard;
+
+    float I;
+    float a = clim.x;
+    float b = clim.y;
+    vec4 c;
+
+    I = texture(im_sampler, tex_coords).r;
+    I = clamp((I-a)/(b-a), 0.0, 1.0);
+
+    c = texture(lut, I);
+
+    fragColor = c;
+
+    //gl_FragColor = vec4(I, I, I, 1.0);
+}

--- a/PYME/LMVis/shader_programs/shaders/image_vs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/image_vs.glsl
@@ -36,3 +36,44 @@ void main() {
 
     //gl_FrontColor.a = gl_FrontColor.a*(float(visible));
 }
+
+#version 330
+
+uniform float x_min;
+uniform float x_max;
+uniform float y_min;
+uniform float y_max;
+uniform float z_min;
+uniform float z_max;
+uniform float v_min;
+uniform float v_max;
+uniform mat4 clip_rotation_matrix;
+
+uniform mat4 ModelViewProjectionMatrix;
+
+layout(location = 0) in vec3 Vertex;
+layout(location = 1) in vec2 aTexCoord;
+
+out float vis;
+out vec2 tex_coords;
+
+void main() {
+    bool visible;
+    vec4 v_position;
+    //gl_PointSize = gl_Point.size;
+    //gl_FrontColor = gl_Color;
+
+    visible = Vertex.x > x_min && Vertex.x < x_max;
+    visible = visible && Vertex.y > y_min && Vertex.y < y_max;
+    visible = visible && Vertex.z > z_min && Vertex.z < z_max;
+
+    //v_position = clip_rotation_matrix*gl_Vertex;
+    //visible = visible && v_position.z > v_min && v_position.z < v_max;
+
+    gl_Position = ModelViewProjectionMatrix * vec4(Vertex, 1.0);
+
+    vis = float(visible);
+    tex_coords = aTexCoord; //gl_MultiTexCoord0.xy;
+
+    //gl_FrontColor.a = gl_FrontColor.a*(float(visible));
+}

--- a/PYME/LMVis/shader_programs/shaders/phong_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/phong_fs.glsl
@@ -1,0 +1,43 @@
+#version 330
+
+uniform vec4 light_ambient;
+uniform vec4 light_diffuse;
+uniform vec4 light_specular;
+uniform vec4 light_position;
+uniform float shininess;
+uniform vec4 view_vector;
+
+in vec4 FrontColor;
+in vec3 normal;
+in float vis;
+in float depth;
+
+out vec4 FragColor;
+
+void main(void)
+{
+    if (vis < .5) discard;
+
+    vec4 inputColor = FrontColor;
+    vec4 white = vec4(1.0, 1.0, 1.0, FrontColor.a);
+    vec4 ambient = inputColor * light_ambient;
+    //direction to the lightsource
+    vec3 lightsource = normalize(vec3(light_position));
+    //normal between object and eye space
+    vec3 normal = normalize(normal);
+
+    float diffuseLight = abs(dot(lightsource, normal));//, 0.0);
+    vec4 diffuse = vec4(0.0, 0.0, 0.0, 1.0);
+    vec4 specular = vec4(0.0, 0.0, 0.0, 1.0);
+    //vec4 diff = vec4(0.0, 0.0, 0.0, 1.0);
+    if (diffuseLight > 0){
+        diffuse = diffuseLight * inputColor * light_diffuse;
+        vec3 H = normalize(light_position.xyz + view_vector.xyz);
+        float specLight = pow(abs(dot(H, normal)), shininess);
+        vec4 spec = white * light_specular;
+        specular = specLight * spec;
+    }
+
+    FragColor = ambient + diffuse + specular;
+    FragColor.a = inputColor.a;
+}

--- a/PYME/LMVis/shader_programs/shaders/phong_vs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/phong_vs.glsl
@@ -1,0 +1,45 @@
+#version 330
+
+uniform float x_min;
+uniform float x_max;
+uniform float y_min;
+uniform float y_max;
+uniform float z_min;
+uniform float z_max;
+uniform float v_min;
+uniform float v_max;
+
+uniform mat4 ModelViewProjectionMatrix;
+uniform mat4 ModelViewMatrix;
+uniform mat3 NormalMatrix;
+uniform float point_size_px;
+
+layout (location = 0) in vec3 Vertex;
+layout (location = 1) in vec3 Normal;
+layout (location = 2) in vec4 Color;
+
+out vec4 FrontColor;
+out vec3 normal;
+out float vis;
+out float depth;
+
+void main(void){
+    bool visible;
+
+    FrontColor = Color;
+    normal = normalize(NormalMatrix*Normal);
+
+    visible = Vertex.x > x_min && Vertex.x < x_max;
+    visible = visible && Vertex.y > y_min && Vertex.y < y_max;
+    visible = visible && Vertex.z > z_min && Vertex.z < z_max;
+
+    gl_Position = ModelViewProjectionMatrix * vec4(Vertex, 1.0);
+
+    vec4 eye_frame = ModelViewMatrix*vec4(Vertex, 1.0); //just do model view part for OIT calcs
+
+    visible = visible && gl_Position.z > v_min && gl_Position.z < v_max;
+    vis = (float(visible));
+
+    // depth n eye/camera space coordinates
+    depth = (eye_frame.z);
+}

--- a/PYME/LMVis/shader_programs/shaders/pointsprites_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/pointsprites_fs.glsl
@@ -20,7 +20,7 @@ void main()
 
 uniform sampler2D tex2D;
 
-in vec4 FrontColor;
+in vec4 frontColor;
 in float vis;
 
 layout (location = 0) out vec4 fragColor;
@@ -28,6 +28,6 @@ layout (location = 0) out vec4 fragColor;
 void main()
 {
     if (vis <0.5) discard;
-    float alpha = FrontColor.a * texture(tex2D, gl_PointCoord).x;
-    fragColor = vec4(FrontColor.xyz, alpha);
+    float alpha = frontColor.a * texture(tex2D, gl_PointCoord).x;
+    fragColor = vec4(frontColor.xyz, alpha);
 }

--- a/PYME/LMVis/shader_programs/shaders/pointsprites_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/pointsprites_fs.glsl
@@ -11,3 +11,23 @@ void main()
     float alpha = gl_Color.a * texture2D(tex2D, gl_PointCoord).x;
     gl_FragColor = vec4(gl_Color.xyz, alpha);
 }
+
+#version 330
+
+// This fragmentshader takes the given color and displays it.
+// It's transparency is determined by a submitted texture. That way the brightness is decreasing with the distance to the \
+// center of the point.
+
+uniform sampler2D tex2D;
+
+in vec4 FrontColor;
+in float vis;
+
+layout (location = 0) out vec4 fragColor;
+
+void main()
+{
+    if (vis <0.5) discard;
+    float alpha = FrontColor.a * texture(tex2D, gl_PointCoord).x;
+    fragColor = vec4(FrontColor.xyz, alpha);
+}

--- a/PYME/LMVis/shader_programs/shaders/pointsprites_vs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/pointsprites_vs.glsl
@@ -32,3 +32,46 @@ void main() {
 
     gl_FrontColor.a = gl_FrontColor.a*(vis);
 }
+
+
+#version 330
+//This vertex shader simply transforms the position in eye space and forwards it.
+//This is one of the simplest vertex shader possible.
+//It simply passes the given color to the fragment shader and
+//transforms the vertex into screen space.
+
+uniform float x_min;
+uniform float x_max;
+uniform float y_min;
+uniform float y_max;
+uniform float z_min;
+uniform float z_max;
+uniform float v_min;
+uniform float v_max;
+
+uniform mat4 ModelViewProjectionMatrix;
+uniform float point_size_px;
+layout (location = 0) in vec3 Vertex;
+layout (location = 1) in vec3 Normal;
+layout (location = 2) in vec4 Color;
+
+out float vis;
+out vec4 frontColor;
+
+void main() {
+    bool visible;
+    gl_PointSize = point_size_px;
+    frontColor = Color;
+
+    visible = Vertex.x > x_min && Vertex.x < x_max;
+    visible = visible && Vertex.y > y_min && Vertex.y < y_max;
+    visible = visible && Vertex.z > z_min && Vertex.z < z_max;
+
+    gl_Position = ModelViewProjectionMatrix * vec4(Vertex, 1.0);
+
+    visible = visible && gl_Position.z > v_min && gl_Position.z < v_max;
+
+    vis = float(visible);
+
+    frontColor.a = frontColor.a*(vis);
+}

--- a/PYME/LMVis/shader_programs/shaders/spheres_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/spheres_fs.glsl
@@ -47,3 +47,56 @@ void main()
     //float alpha = gl_Color.a * texture2D(tex2D, gl_PointCoord).x;
     //gl_FragColor = vec4(gl_Color.xyz, alpha);
 }
+
+#version 330
+
+// This fragmentshader takes the given color and displays it.
+// It's transparency is determined by a submitted texture. That way the brightness is decreasing with the distance to the \
+// center of the point.
+
+uniform vec4 light_ambient;
+uniform vec4 light_diffuse;
+uniform vec4 light_specular;
+uniform vec4 light_position;
+uniform float shininess;
+uniform vec4 view_vector;
+
+in float vis;
+in vec4 frontColor;
+
+out vec4 fragColor;
+
+void main()
+{
+    vec3 N;
+    float m;
+
+    if (vis < 0.5) discard;
+
+    N.xy = gl_PointCoord.xy*2.0 -vec2(1.0);
+    m = dot(N.xy, N.xy);
+    if (m > 1.0) discard;
+    N.z = sqrt(1.0 - m);
+
+    vec4 inputColor = frontColor;
+    vec4 white = vec4(1.0, 1.0, 1.0, frontColor.a);
+    vec4 ambient = inputColor * light_ambient;
+    //direction to the lightsource
+    vec3 lightsource = normalize(vec3(light_position));
+
+    float diffuseLight = abs(dot(lightsource, N));//, 0.0);
+    vec4 diffuse = vec4(0.0, 0.0, 0.0, 1.0);
+    vec4 specular = vec4(0.0, 0.0, 0.0, 1.0);
+    //vec4 diff = vec4(0.0, 0.0, 0.0, 1.0);
+    if (diffuseLight > 0){
+        diffuse = diffuseLight * inputColor * light_diffuse;
+        vec3 H = normalize(light_position.xyz + view_vector.xyz);
+        float specLight = pow(abs(dot(H, N)), shininess);
+        vec4 spec = white * light_specular;
+        specular = specLight * spec;
+    }
+    fragColor = ambient + diffuse + specular;
+
+    //float alpha = gl_Color.a * texture2D(tex2D, gl_PointCoord).x;
+    //gl_FragColor = vec4(gl_Color.xyz, alpha);
+}

--- a/PYME/LMVis/shader_programs/shaders/tessel_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/tessel_fs.glsl
@@ -8,3 +8,16 @@ void main() {
     if (vis < .5) discard;
     gl_FragColor = gl_Color*gl_Color*gl_Color;
 }
+
+#version 330 core
+
+in float vis;
+in vec4 FrontColor;
+
+layout(location = 0) out vec4 FragColor;
+
+void main() {
+    if (vis < .5) discard;
+
+    FragColor = FrontColor*FrontColor*FrontColor;
+}

--- a/PYME/LMVis/shader_programs/shaders/text_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/text_fs.glsl
@@ -17,3 +17,26 @@ void main() {
 
     gl_FragColor = vec4(gl_Color.xyz, I);
 }
+
+#version 330
+//This is a very simple shader. It simply forwards the given color to the fragment.
+//There's no shading involved.
+in float vis;
+in vec2 tex_coords;
+in vec4 frontColor;
+
+uniform sampler2D im_sampler;
+
+out vec4 fragColor;
+
+void main() {
+    //gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
+    //if (vis < .5) discard;
+
+    float I;
+
+    I = texture(im_sampler, tex_coords).r;
+    I = clamp(I, 0.0, 1.0);
+
+    fragColor = vec4(frontColor.xyz, I);
+}

--- a/PYME/LMVis/shader_programs/shaders/text_vs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/text_vs.glsl
@@ -36,3 +36,49 @@ void main() {
 
     //gl_FrontColor.a = gl_FrontColor.a*(float(visible));
 }
+
+#version 330
+//This is one of the simplest vertex shader possible.
+//It simply passes the given color to the fragment shader and
+//transforms the vertex into screen space.
+
+uniform float x_min;
+uniform float x_max;
+uniform float y_min;
+uniform float y_max;
+uniform float z_min;
+uniform float z_max;
+uniform float v_min;
+uniform float v_max;
+uniform mat4 clip_rotation_matrix;
+
+uniform mat4 ModelViewProjectionMatrix;
+
+layout(location = 0) in vec3 vertex;
+layout(location = 1) in vec2 tex_coord;
+layout(location = 2) in vec4 color;
+
+out float vis;
+out vec2 tex_coords;
+out vec4 frontColor;
+
+void main() {
+    bool visible;
+    vec4 v_position;
+    //gl_PointSize = gl_Point.size;
+    frontColor = color;
+
+    visible = vertex.x > x_min && vertex.x < x_max;
+    visible = visible && vertex.y > y_min && vertex.y < y_max;
+    visible = visible && vertex.z > z_min && vertex.z < z_max;
+
+    //v_position = clip_rotation_matrix*gl_Vertex;
+    //visible = visible && v_position.z > v_min && v_position.z < v_max;
+
+    gl_Position = ModelViewProjectionMatrix * vec4(vertex, 1.0);
+
+    vis = float(visible);
+    tex_coords = tex_coord; //gl_MultiTexCoord0.xy;
+
+    //gl_FrontColor.a = gl_FrontColor.a*(float(visible));
+}

--- a/PYME/LMVis/shader_programs/shaders/widelines_fs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/widelines_fs.glsl
@@ -1,0 +1,19 @@
+#version 330
+
+// This fragmentshader takes the given color and displays it, ignoring texture coordinates
+// TODO - use texture coordinates to render a 3D cylinder
+
+//uniform sampler2D tex2D;
+
+in vec4 frontColor;
+in float visibility;
+in vec2 texCoord;
+
+layout (location = 0) out vec4 fragColor;
+
+void main()
+{
+    if (visibility <0.5) discard;
+    //float alpha = frontColor.a * texture(tex2D, texCoord).x;
+    fragColor = frontColor;
+}

--- a/PYME/LMVis/shader_programs/shaders/widelines_gs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/widelines_gs.glsl
@@ -8,7 +8,7 @@ layout (lines) in;
 layout (triangle_strip, max_vertices = 4) out;
 
 in vec4 FrontColor[];
-in vec2 normal[]; // this is not atually the normal, but a vector which is the average of the line perpendiculars for the current and previous/next line segments.
+in vec3 normal[]; // this is not atually the normal, but a vector which is the average of the line perpendiculars for the current and previous/next line segments.
 in float vis[];
 
 out vec4 frontColor;
@@ -20,14 +20,20 @@ void main(){
     vec4 pos0 = gl_in[0].gl_Position;
     vec4 pos1 = gl_in[1].gl_Position;
 
-    float aspect = viewport_size.x / viewport_size.y;
+    float aspect = 1.0;//viewport_size.x / viewport_size.y;
 
     vec2 dir = normalize(pos1.xy - pos0.xy);
 
     vec2 ortho = vec2(-dir.y, dir.x*aspect);
 
-    vec2 offset0 = normal[0] * half_size / dot(normal[0], ortho);
-    vec2 offset1 = normal[1] * half_size / dot(normal[1], ortho);
+    //vec2 norm0 = normalize(normal[0].xy);
+    //vec2 norm1 = normalize(normal[1].xy);
+
+    vec2 norm0 = ortho;
+    vec2 norm1 = ortho;
+
+    vec2 offset0 = norm0 * half_size;// / dot(norm0, ortho);
+    vec2 offset1 = norm1 * half_size;// / dot(norm1, ortho);
 
     // pass through colour and visibility
     frontColor = FrontColor[0];

--- a/PYME/LMVis/shader_programs/shaders/widelines_gs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/widelines_gs.glsl
@@ -1,0 +1,50 @@
+#version 330 core
+// convert points to quads by using a geometry shader
+
+uniform float line_width_px;
+uniform vec2 viewport_size;
+
+layout (lines) in;
+layout (triangle_strip, max_vertices = 4) out;
+
+in vec4 FrontColor[];
+in vec2 normal[]; // this is not atually the normal, but a vector which is the average of the line perpendiculars for the current and previous/next line segments.
+in float vis[];
+
+out vec4 frontColor;
+out vec2 texCoord;
+out float visibility;
+
+void main(){
+    float half_size =  line_width_px/ (2.0*viewport_size.x);
+    vec4 pos0 = gl_in[0].gl_Position;
+    vec4 pos1 = gl_in[1].gl_Position;
+
+    float aspect = viewport_size.x / viewport_size.y;
+
+    vec2 dir = normalize(pos1.xy - pos0.xy);
+
+    vec2 ortho = vec2(-dir.y, dir.x*aspect);
+
+    vec2 offset0 = normal[0] * half_size / dot(normal[0], ortho);
+    vec2 offset1 = normal[1] * half_size / dot(normal[1], ortho);
+
+    // pass through colour and visibility
+    frontColor = FrontColor[0];
+    visibility = vis[0];
+
+    gl_Position = pos0 - vec4(offset0, 0, 0);    // 1:bottom-left
+    texCoord = vec2(0.0, 0.0);
+    EmitVertex();   
+    gl_Position = pos1 - vec4(offset1, 0.0, 0.0);    // 2:bottom-right
+    texCoord = vec2(1.0, 0.0);
+    EmitVertex();
+    gl_Position = pos0 + vec4(offset0, 0.0, 0.0);    // 3:top-left
+    texCoord = vec2(0.0, 1.0);
+    EmitVertex();
+    gl_Position = pos1 + vec4(offset1, 0.0, 0.0);    // 4:top-right
+    texCoord = vec2(1.0, 1.0);
+    EmitVertex();
+    EndPrimitive();
+
+}

--- a/PYME/LMVis/shader_programs/shaders/widelines_vs.glsl
+++ b/PYME/LMVis/shader_programs/shaders/widelines_vs.glsl
@@ -1,0 +1,51 @@
+#version 330 core
+//This is one of the simplest vertex shader possible.
+//It simply passes the given color to the fragment shader and
+//transforms the vertex into screen space.
+
+uniform float x_min;
+uniform float x_max;
+uniform float y_min;
+uniform float y_max;
+uniform float z_min;
+uniform float z_max;
+uniform float v_min;
+uniform float v_max;
+uniform mat4 clip_rotation_matrix;
+
+uniform mat4 ModelViewProjectionMatrix;
+uniform mat3 NormalMatrix;
+
+layout (location = 0) in vec3 Vertex;
+layout (location = 1) in vec3 Normal;
+layout (location = 2) in vec4 Color;
+
+out float vis;
+out vec4 FrontColor;
+out vec3 normal;
+//out float PointSize;
+//out vec4 Position;
+
+
+void main() {
+    bool visible;
+    vec4 v_position;
+    vec4 poss;
+    //PointSize = gl_Point.size;
+    FrontColor = Color;
+
+    visible = Vertex.x > x_min && Vertex.x < x_max;
+    visible = visible && Vertex.y > y_min && Vertex.y < y_max;
+    visible = visible && Vertex.z > z_min && Vertex.z < z_max;
+
+    poss = vec4(Vertex, 1.0);
+    v_position = clip_rotation_matrix*poss;
+    visible = visible && v_position.z > v_min && v_position.z < v_max;
+
+    gl_Position = ModelViewProjectionMatrix * poss;
+
+    vis = float(visible);
+    normal = NormalMatrix * Normal;
+
+    FrontColor.a = FrontColor.a*(float(visible));
+}

--- a/PYME/LMVis/views.py
+++ b/PYME/LMVis/views.py
@@ -207,7 +207,16 @@ class View(object):
         """ set the view to right view"""
         self.vec_up = np.array([1, 0, 0])
         self.vec_back = np.array([0, -1,0])
-        self.vec_right = np.array([0,0,1])    
+        self.vec_right = np.array([0,0,1])  
+
+    @property
+    def clip_plane_matrix(self):
+        v_matrix = np.eye(4, dtype='f')  
+        if HAVE_QUATERNION:
+            v_matrix[:3,:3] = quaternion.as_rotation_matrix(self.clip_plane_orientation)
+            v_matrix[3, :3] = -self.clip_plane_position
+        
+        return v_matrix
 
 
 

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -101,9 +101,10 @@ class VisGUICore(object):
             from PYME.LMVis.gl_render3D_shaders import LegacyGLCanvas
 
             try:
-                if self.cmd_args.opengl_core_profile:
+                if PYME.config.get('VisGUI-opengl-core-profile', False):
                     from PYME.LMVis.glcanvas_core import LMGLShaderCanvas
                 else:
+                    logger.debug('Using legacy GLCanvas')
                     from PYME.LMVis.gl_render3D_shaders import LMGLShaderCanvas
             except AttributeError:
                 from PYME.LMVis.gl_render3D_shaders import LMGLShaderCanvas

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -18,6 +18,14 @@ import wx.lib.agw.aui as aui
 from PYME.IO.FileUtils import nameUtils
 
 import os
+import sys
+
+# hack for wayland on linux
+# TODO - we seem to need the egl platform on ubuntu 20.04 and 22.04 even when XDG_SESSION_TYPE is x11
+# This needs a bit more investigation - in the meantime, just use `export PYOPENGL_PLATFORM='egl'` 
+# in the terminal before trying to run PYMEVis`
+#if ('linux' in sys.platform) and ('wayland' in os.environ.get('XDG_SESSION_TYPE', '')):
+#    os.environ['PYOPENGL_PLATFORM'] = 'egl'
 
 #from PYME.LMVis import colourPanel
 from PYME.LMVis import renderers
@@ -869,6 +877,11 @@ class VisGUICore(object):
             self.SetTitle('PYME Visualise - ' + filename)
             self._removeOldTabs()
             self._createNewTabs()
+
+            # hack for linux as the select=False logic when adding tabs doesn't seem to work
+            # TODO - find a cleaner solution
+            if sys.platform == 'linux':
+                wx.CallAfter(self._mgr.GetNotebooks()[0].SetSelection, 0)
             
             #self.CreateFoldPanel()
             logger.debug('Gui stuff done')

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -5,7 +5,7 @@ Created on Sat May 14 14:54:52 2016
 @author: david
 """
 import wx
-import wx.py.shell
+
 
 #import PYME.ui.autoFoldPanel as afp
 import PYME.ui.manualFoldPanel as afp

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -97,7 +97,17 @@ class VisGUICore(object):
             from PYME.LMVis import gl_render3D
             self.glCanvas = gl_render3D.LMGLCanvas(gl_pan)
         else:
-            from PYME.LMVis.gl_render3D_shaders import LMGLShaderCanvas, LegacyGLCanvas
+            #from PYME.LMVis.gl_render3D_shaders import LMGLShaderCanvas, LegacyGLCanvas
+            from PYME.LMVis.gl_render3D_shaders import LegacyGLCanvas
+
+            try:
+                if self.cmd_args.opengl_core_profile:
+                    from PYME.LMVis.glcanvas_core import LMGLShaderCanvas
+                else:
+                    from PYME.LMVis.gl_render3D_shaders import LMGLShaderCanvas
+            except AttributeError:
+                from PYME.LMVis.gl_render3D_shaders import LMGLShaderCanvas
+            
             if self._new_layers:
                 #use stripped down version
                 self.glCanvas = LMGLShaderCanvas(gl_pan)

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -91,14 +91,11 @@ class VisGUICore(object):
         gl_pan = wx.Panel(self._win)
         sizer = wx.BoxSizer(wx.VERTICAL)
 
-
-        
         if not use_shaders:
             from PYME.LMVis import gl_render3D
             self.glCanvas = gl_render3D.LMGLCanvas(gl_pan)
         else:
-            #from PYME.LMVis.gl_render3D_shaders import LMGLShaderCanvas, LegacyGLCanvas
-            from PYME.LMVis.gl_render3D_shaders import LegacyGLCanvas
+            #from PYME.LMVis.gl_render3D_shaders import LMGLShaderCanvas, LegacyGLCanvas        
 
             try:
                 if PYME.config.get('VisGUI-opengl-core-profile', False):
@@ -113,6 +110,7 @@ class VisGUICore(object):
                 #use stripped down version
                 self.glCanvas = LMGLShaderCanvas(gl_pan)
             else:
+                from PYME.LMVis.gl_render3D_shaders import LegacyGLCanvas
                 self.glCanvas = LegacyGLCanvas(gl_pan)
 
         sizer.Add(self.create_tool_bar(gl_pan), 0, wx.EXPAND, 0)

--- a/PYME/misc/colormaps.py
+++ b/PYME/misc/colormaps.py
@@ -139,6 +139,11 @@ def Yellow(data):
     z = np.ones_like(data)
     return np.stack([z, z, 0*z, z], -1)
 
+@cm.register_cmap('SolidWhite', solid=True)
+def White(data):
+    z = np.ones_like(data)
+    return np.stack([z, z, z, z], -1)
+
 @cm.register_cmap('labeled')
 def labeled(data):
     return (data > 0).reshape(list(data.shape) +  [1])*cm.gist_rainbow(data % 1)

--- a/PYME/ui/shell.py
+++ b/PYME/ui/shell.py
@@ -1,0 +1,37 @@
+'''An over-ridden version of wx.py.shell.Shell that supports pasting of unicode-encoded text.'''
+
+import wx.py.shell
+import sys
+import os
+
+class Shell(wx.py.shell.Shell):
+    def Paste(self):
+        """Replace selection with clipboard contents."""
+        if self.CanPaste() and wx.TheClipboard.Open():
+            ps2 = str(sys.ps2)
+            if wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_TEXT)) or wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_UNICODETEXT)):
+                data = wx.TextDataObject()
+                if wx.TheClipboard.GetData(data):
+                    self.ReplaceSelection('')
+                    command = data.GetText()
+                    command = command.rstrip()
+                    command = self.fixLineEndings(command)
+                    command = self.lstripPrompt(text=command)
+                    command = command.replace(os.linesep + ps2, '\n')
+                    command = command.replace(os.linesep, '\n')
+                    command = command.replace('\n', os.linesep + ps2)
+                    self.write(command)
+            wx.TheClipboard.Close()
+
+
+    def PasteAndRun(self):
+        """Replace selection with clipboard contents, run commands."""
+        text = ''
+        if wx.TheClipboard.Open():
+            if wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_TEXT)) or wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_UNICODETEXT)):
+                data = wx.TextDataObject()
+                if wx.TheClipboard.GetData(data):
+                    text = data.GetText()
+            wx.TheClipboard.Close()
+        if text:
+            self.Execute(text)

--- a/PYME/util/fProfile/convertProfile.py
+++ b/PYME/util/fProfile/convertProfile.py
@@ -20,6 +20,7 @@ def build_call_tree_threads(df):
     """
     out = []
 
+
     gb = df.groupby('thread')
 
     #threadNames = gb.groups.keys()
@@ -102,6 +103,10 @@ def convert(infile='prof_spool.txt', outfile='prof_spool.json'):
     #except:
     #    df = pd.read_csv(infile, '\t', names=['time', 'thread', 'file', 'function', 'event'])
 
+    #catch absolute rather than relative times
+    if df['time'][0] > 10:
+        df['time'] = df['time']  - df['time'][0]
+    
     callstack = build_call_tree_threads(df)
 
     with open(outfile, 'w') as f:


### PR DESCRIPTION
PYMEVis has been using the old, deprecated, compatibility profile within OpenGL. This is a first step towards getting stuff working on the more modern "core" profile. To some extent this is an exercise in learning modern OpenGL, as a prelude for doing some WebGL stuff, but should also be good for PYMEVis in the long term.

The main advantages are:

- hopefully better platform support 
- possible (small) speed increases
- future proofing
- making a hypothetical webgl port easier

Still very much a **work in progress**, but points, spheres, and pointsprites work (modulo potential point scaling changes). Pretty much all the other layers don't work yet (surfaces, overlays, scalebars etc ...).

To run, use `PYMEVis --opengl-core-profile`