### PR TITLE
Fix for TypeError when no Track Fiducials selected

### DIFF
--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -999,10 +999,11 @@ class LMAnalyser2(Plugin):
                     plt.yticks([])
                     plt.plot(res.results['fitResults']['x0']/vx, res.results['fitResults']['y0']/vy, '+b')
 
-                try:
-                    plt.plot(res.driftResults['fitResults']['x0']/vx, res.driftResults['fitResults']['y0']/vy, '*y', mew=2)
-                except AttributeError:
-                    pass
+                if ft.driftEst:
+                    try:
+                        plt.plot(res.driftResults['fitResults']['x0']/vx, res.driftResults['fitResults']['y0']/vy, '*y', mew=2)
+                    except AttributeError:
+                        pass
                     
                 #figure()
                 #imshow()


### PR DESCRIPTION
**This is a bugfix**

**Proposed changes:**
In `testFrame`, I made displaying `driftResults` only available when  `Track Fiducials` is selected when doing localization. It is because when `Track Fiducials` is not selected, `res.driftResults` will be an empty list instead of an array and it gives `TypeError: list indices must be integers or slices, not str`. However, this bug only exists in `testFrame` and does not affect the functionality of the full localization analysis.





**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [√] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
