### PR TITLE
Fix cluster analysis regression

### DIFF
--- a/PYME/Acquire/acquisition_base.py
+++ b/PYME/Acquire/acquisition_base.py
@@ -10,6 +10,8 @@ from PYME.contrib import dispatch
 
 
 class AcquisitionBase(abc.ABC):
+    _backend=None
+
     @abc.abstractmethod
     def __init__(self, *args, **kwargs):
         '''Create an Acquisition object'''
@@ -128,8 +130,19 @@ class AcquisitionBase(abc.ABC):
         '''
         pass
 
+    @property
+    def storage(self):
+        '''Return the storage object for the acquisition
+        
+        '''
+        return self._backend
+    
+    @storage.setter
+    def storage(self, storage):
+        '''Set the storage object for the acquisition
+        
+        '''
+        self._backend = storage
+
     def getURL(self):
-        # FIXME - _backend is only defined in protocol_acquisition and tiler
-        # but not in xyztc or this base class
-        # TODO - specify a common interface for the backend and implement across backends
-        return self._backend.getURL()
+        return self.storage.getURL()

--- a/PYME/Acquire/acquisition_base.py
+++ b/PYME/Acquire/acquisition_base.py
@@ -127,3 +127,9 @@ class AcquisitionBase(abc.ABC):
         
         '''
         pass
+
+    def getURL(self):
+        # FIXME - _backend is only defined in protocol_acquisition and tiler
+        # but not in xyztc or this base class
+        # TODO - specify a common interface for the backend and implement across backends
+        return self._backend.getURL()

--- a/PYME/DSView/modules/shell.py
+++ b/PYME/DSView/modules/shell.py
@@ -21,6 +21,7 @@
 ##################
 
 import PYME.ui.shell
+import wx
 from PYME import config
 
 def Plug(dsviewer):

--- a/PYME/IO/acquisition_backends.py
+++ b/PYME/IO/acquisition_backends.py
@@ -131,6 +131,7 @@ class ClusterBackend(Backend):
         Backend.__init__(self, dim_order, shape, evt_time_fcn=evt_time_fcn)
 
         self.series_name = series_name
+        self.serverfilter = serverfilter
         self._cluster_h5 = cluster_h5
 
         if cluster_h5:
@@ -183,7 +184,7 @@ class ClusterBackend(Backend):
         
     def getURL(self):
         '''Get URL for the series to pass to other processes so they can open it'''
-        return 'PYME-CLUSTER://%s/%s' % (self.clusterFilter, self.seriesName)
+        return 'PYME-CLUSTER://%s/%s' % (self.serverfilter, self.series_name)
     
     def store_frame(self, n, frame_data):
         fn = '/'.join([self._series_location, 'frame%05d.pzf' % n])

--- a/PYME/IO/acquisition_backends.py
+++ b/PYME/IO/acquisition_backends.py
@@ -77,6 +77,13 @@ class Backend(abc.ABC):
             self._sequence_id = self.gen_sequence_id()
 
         return self._sequence_id
+    
+    def getURL(self):
+        '''Get URL for the series to pass to other processes so they can open it
+        
+        Implement in derived classes if appropriate.
+        '''
+        raise NotImplementedError('getURL() not implemented - this might not be a cluster-aware backend')
 
 
 class MemoryBackend(Backend):
@@ -173,6 +180,10 @@ class ClusterBackend(Backend):
             return '__aggregate_h5/' + self.series_name
         else:
             return self.series_name
+        
+    def getURL(self):
+        '''Get URL for the series to pass to other processes so they can open it'''
+        return 'PYME-CLUSTER://%s/%s' % (self.clusterFilter, self.seriesName)
     
     def store_frame(self, n, frame_data):
         fn = '/'.join([self._series_location, 'frame%05d.pzf' % n])

--- a/PYME/IO/h5rFile.py
+++ b/PYME/IO/h5rFile.py
@@ -17,7 +17,7 @@ file_cache = {}
 logger=logging.getLogger(__name__)
 openLock = threading.Lock()
 
-def openH5R(filename, mode='r', keep_alive_timeout=20.0):
+def openH5R(filename, mode='r', keep_alive_timeout=None):
     """
     Open an H5R file in a threadsafe and optimised way. Looks to see if the file is already open in our cache and
     returns the open file if present, otherwise opens the file and adds to the cache. Files are kept open for ``keep_alive_timeout``
@@ -54,14 +54,15 @@ def openH5R(filename, mode='r', keep_alive_timeout=20.0):
 
 
 class H5RFile(object):
-    #KEEP_ALIVE_TIMEOUT = 20 #keep the file open for 20s after the last time it was used
+    KEEP_ALIVE_TIMEOUT = 20.0 #keep the file open for 20s after the last time it was used
     FLUSH_INTERVAL = config.get('h5r-flush_interval', 1)
     
-    def __init__(self, filename, mode='r', keep_alive_timeout = 20.0):
+    def __init__(self, filename, mode='r', keep_alive_timeout = None):
         self.filename = filename
         self.mode = mode
         
-        self.KEEP_ALIVE_TIMEOUT = keep_alive_timeout
+        if keep_alive_timeout is not None:
+            self.KEEP_ALIVE_TIMEOUT = keep_alive_timeout
 
         logger.debug('pytables open call: %s' % filename)
         with tablesLock:


### PR DESCRIPTION
Fixes regression noted in Imagesc thread (https://forum.image.sc/t/pymeacquire-setup-and-real-time-analysis/100050/4)
which was introduced in recent refactor to allow automatice spooling of non-blinking series types.

TODO - this should be enough to reinstate old functionality, but remains broken for new (xyztc) acquisition type(s).