### PR TITLE
Olympus IX81 control code with command set - currently halogen lamp only

### DIFF
--- a/PYME/Acquire/Hardware/olympusix81.py
+++ b/PYME/Acquire/Hardware/olympusix81.py
@@ -1,3 +1,13 @@
+"""
+Control the halogen lamp (transmitted light) on an Olympus IX81 stand.
+
+Uses the serial command set described at https://madhadron.com/science/olympus_ix81_commands.html
+
+TODO - move logic to an IX81 class which also allows control of other stand features and support more of the command set.
+TODO - some form of error handling
+TODO - consider re-writing the query function to try and match responses to commands (these are not guaranteed to be synchronous) 
+
+"""
 import serial
 import time
 import threading

--- a/PYME/Acquire/Hardware/olympusix81.py
+++ b/PYME/Acquire/Hardware/olympusix81.py
@@ -1,0 +1,39 @@
+import serial
+import time
+import threading
+
+class halogenlamp:
+    def __init__(self, name, portname='COM17', **kwargs):
+        self.ser_port = serial.Serial(portname, 19200, parity='E',
+                                      timeout=2, writeTimeout=2)
+        self.lock = threading.Lock()
+        self.name= name
+        self.powerControlable = False
+        self.isOn=True
+        self.TurnOn()
+
+    def query(self, command, lines_expected=1):
+        with self.lock:
+            self.ser_port.reset_input_buffer()
+            self.ser_port.write(command)
+            reply = [self.ser_port.readline() for line in range(lines_expected)]
+            self.ser_port.reset_input_buffer()
+        return reply
+
+    def IsOn(self):
+        return self.isOn
+        
+    def TurnOn(self):
+        self.query(b'1LOG IN\r\n')
+        self.query(b'1LMPSW ON\r\n')
+        self.ser_port.flush()
+        self.isOn = True
+
+    def TurnOff(self):
+        self.query(b'1LMPSW OFF\r\n')
+        self.query(b'1LOG OUT\r\n')
+        self.ser_port.flush()
+        self.isOn = False
+
+    def GetName(self):
+        return self.name


### PR DESCRIPTION
Addresses issue # .

**This is an enhancement**

**Proposed changes:**
Control code for Olympus IX81 microscope stand - halogen lamp only for now.






**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
