### PR TITLE
without the missing wx import dh5view fails

### DIFF
--- a/PYME/DSView/modules/shell.py
+++ b/PYME/DSView/modules/shell.py
@@ -22,6 +22,7 @@
 
 import PYME.ui.shell
 from PYME import config
+import wx
 
 def Plug(dsviewer):
     sh = PYME.ui.shell.Shell(id=-1,


### PR DESCRIPTION
Addresses issue where `dh5view` fails to start because of missing `wx` import in `shell.py`.

**Is this a bugfix or an enhancement?**
Bugfix, but bug not separately reported.

**Proposed changes:**
Add missing import.

Hopefully reproducable on other systems, at least saw it on mine...
