### PR TITLE
Make rule-based analysis work with different acquisition types

### DIFF
--- a/PYME/Acquire/Hardware/AndorNeo/AndorZyla.py
+++ b/PYME/Acquire/Hardware/AndorNeo/AndorZyla.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 
 class AndorBase(SDK3Camera, CameraMapMixin):
     numpy_frames=1
+    supports_software_trigger = True
     #MODE_CONTINUOUS = 1
     #MODE_SINGLE_SHOT = 0
 

--- a/PYME/Acquire/Hardware/Camera.py
+++ b/PYME/Acquire/Hardware/Camera.py
@@ -117,6 +117,11 @@ class Camera(object):
     MODE_HARDWARE_TRIGGER = 3
     MODE_HARDWARE_START_TRIGGER = 4
 
+    # Does this camera support a software trigger?
+    # Should be overridden in derived classes if the camera supports software triggering,
+    # and the derived class should also implement the FireSoftwareTrigger method
+    supports_software_trigger = False
+
 
     def __init__(self, *args, **kwargs):
         """

--- a/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
+++ b/PYME/Acquire/Hardware/HamamatsuDCAM/HamamatsuORCA.py
@@ -106,6 +106,7 @@ class DCAMZeroBufferedException(Exception):
 
 class HamamatsuORCA(HamamatsuDCAM, CameraMapMixin):
     numpy_frames = 1
+    supports_software_trigger = True
 
     def __init__(self, camNum):
         HamamatsuDCAM.__init__(self, camNum)

--- a/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
@@ -152,17 +152,22 @@ class PcoSdkCam(Camera):
                     if self._n_queued > 0:
                         _curr_buf = self._queued_buffers.get()
                         self._n_queued -= 1
+                        
                         # wait for the buffer
                         wait_status = k32_dll.WaitForSingleObject(self._buf_event[_curr_buf], self._timeout)
                         if wait_status:
-                            self._n_timeouts += 1
-                            if self._n_timeouts >= MAX_TIMEOUTS:
-                                raise TimeoutError(f"Waited too long for buffer ({self._timeout} ms).")
+                            logger.warning(f"Waited too long for buffer ({self._timeout} ms).") 
+                            
+                            #TODO: we currently continue as if we got the buffer - is this the right thing to do?
+                            # Presumably the status will be non-zero and we will drop the buffer?, but then what 
+                            # happens to those buffers? do they just dissapear?
+                        
                         k32_dll.ResetEvent(self._buf_event[_curr_buf])
                         # make sure this buffer is safe to use
                         status = self._buffer_status[_curr_buf]
                         if status:
                             logger.warning(f"Error {status} during check of buffer {_curr_buf}.")
+                            #DB: Do you see a lot of these warnings? IE - do we get one every time we have a timeout?
                             # drop this buffer
                         else:
                             # use it

--- a/PYME/Acquire/Scripts/init.py
+++ b/PYME/Acquire/Scripts/init.py
@@ -194,9 +194,9 @@ def action_manager(MainFrame, scope):
 
 @init_gui('Automated analysis')
 def chained_analysis(main_frame, scope):
-    from PYME.Acquire.htsms.rule_ui_v2 import SMLMChainedAnalysisPanel
+    from PYME.Acquire.htsms import rule_ui_v2
     
-    SMLMChainedAnalysisPanel.plug(main_frame, scope)
+    rule_ui_v2.plug(main_frame, scope)
 
 
 

--- a/PYME/Acquire/Scripts/init.py
+++ b/PYME/Acquire/Scripts/init.py
@@ -192,6 +192,13 @@ def action_manager(MainFrame, scope):
     ap = tile_panel.TilePanel(MainFrame, scope)
     MainFrame.aqPanels.append((ap, 'Tiling'))
 
+@init_gui('Automated analysis')
+def chained_analysis(main_frame, scope):
+    from PYME.Acquire.htsms.rule_ui_v2 import SMLMChainedAnalysisPanel
+    
+    SMLMChainedAnalysisPanel.plug(main_frame, scope)
+
+
 
 #must be here!!!
 joinBGInit() #wait for anyhting which was being done in a separate thread

--- a/PYME/Acquire/Scripts/init.py
+++ b/PYME/Acquire/Scripts/init.py
@@ -184,13 +184,24 @@ def action_manager(MainFrame, scope):
     ap = actionUI.ActionPanel(MainFrame, scope.actions, scope)
     MainFrame.AddPage(ap, caption='Queued Actions')
 
+@init_hardware('Tiling')
+def tiling(scope):
+    from PYME.Acquire.Utils import tiler
+    scope.spoolController.register_acquisition_type('Tiling', tiler.Tiler)
 
 @init_gui('Tiling')
-def action_manager(MainFrame, scope):
-    from PYME.Acquire.ui import tile_panel
+def tiling(MainFrame, scope):
+    from PYME.Acquire.ui import tilesettingsui
     
-    ap = tile_panel.TilePanel(MainFrame, scope)
-    MainFrame.aqPanels.append((ap, 'Tiling'))
+    ts = tilesettingsui.TileSettingsUI(MainFrame, scope)
+    MainFrame.register_acquisition_ui('Tiling', (ts, 'Tiling'))
+
+# @init_gui('Tiling')
+# def action_manager(MainFrame, scope):
+#     from PYME.Acquire.ui import tile_panel
+    
+#     ap = tile_panel.TilePanel(MainFrame, scope)
+#     MainFrame.aqPanels.append((ap, 'Tiling'))
 
 @init_gui('Automated analysis')
 def chained_analysis(main_frame, scope):

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -422,6 +422,10 @@ class SpoolController(object):
             self._status_changed_condition.notify_all()
             
         self.onSpoolProgress.send(self)
+
+    @property
+    def acquistion_cls(self):
+        return self.acquisition_types[self.acquisition_type]
         
     def _get_queue_name(self, fn, pcs=False, subdirectory=None):
         """ Get fully resolved uri to spool to
@@ -446,6 +450,9 @@ class SpoolController(object):
             ext = '.pcs'
         else:
             ext = '.h5'
+
+        # allow acquisition types (e.g. tiling) to specify their own extension
+        ext = getattr(self.acquistion_cls, 'FILE_EXTENSION', ext)
         
         return self._sep.join([self.get_dirname(subdirectory), fn + ext])
 
@@ -550,7 +557,7 @@ class SpoolController(object):
 
         
         try:
-            self.spooler = self.acquisition_types[acquisition_type].from_spool_settings(self.scope, settings, backend=backends[self.spoolType], backend_kwargs=backend_kwargs, series_name=self.queueName, spool_controller=self)
+            self.spooler = self.acquisition_cls.from_spool_settings(self.scope, settings, backend=backends[self.spoolType], backend_kwargs=backend_kwargs, series_name=self.queueName, spool_controller=self)
         except KeyError:
             raise RuntimeError('Unknown acquisition type %s' % acquisition_type)
         

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -642,6 +642,11 @@ class SpoolController(object):
         
         else:
             settings['acquisition_type'] = self.acquisition_type
+            
+            settings['analysis_mode'] = self.analysis_mode
+            settings['analysis_launch_mode'] = self.analysis_launch_mode
+            settings['analysis_rule_name'] = self.analysis_rule_name
+            
             settings.update(self.acquisition_types[self.acquisition_type].get_frozen_settings(self.scope, self)) 
             
             return settings
@@ -759,7 +764,7 @@ class SpoolController(object):
                         'seriesName': seriesName,
                         'inputs': {'input': seriesName}, # needed for recipes
                         'output_dir':  posixpath.split(seriesName)[0],
-                        'spooler': self.spooler, # for SpoolLocalLocalization rule completeness check
+                        'spooler': self.spooler.storage, # for SpoolLocalLocalization rule completeness check
                     }
 
                     rule =  rule_factory.get_rule(context=context)
@@ -781,8 +786,19 @@ class SpoolController(object):
                 if self._analysis_launchers.full():
                     self._analysis_launchers.get().join()
                 self._analysis_launchers.put(t)
+
+                self._rule_outputs = rule.output_files
         except:
             logger.exception('Error launching analysis')
+
+    def open_analysis(self):
+        """Open the currenly running analysis in PYMEVis"""
+        import subprocess
+        # get the URL
+        uri = self._rule_outputs['results'] + '?live'
+        subprocess.Popen('visgui %s' % uri, shell=True)
+
+
             
      
     # def launch_cluster_analysis(self):

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -373,12 +373,13 @@ class SpoolController(object):
             # special case for HTTP spooling.  Make sure 000\series.pcs -> 000/series.pcs
             pyme_cluster = self.dirname + '/' + fn.replace('\\', '/')
             logger.debug('Looking for %s (.pcs or .h5) on cluster' % pyme_cluster)
-            return HTTPSpooler.exists(pyme_cluster + '.pcs') or HTTPSpooler.exists(pyme_cluster + '.h5')
+            return HTTPSpooler.exists(pyme_cluster + '.pcs') or HTTPSpooler.exists(pyme_cluster + '.h5') or HTTPSpooler.exists(pyme_cluster + '.tiles')
             #return (fn + '.h5/') in HTTPSpooler.clusterIO.listdir(self.dirname)
         else:
-            local_h5 = os.sep.join([self.dirname, fn + '.h5'])
-            logger.debug('Looking for %s on local machine' % local_h5)
-            return os.path.exists(local_h5)
+            local_stub = os.sep.join([self.dirname, fn])
+            local_h5 = local_stub + '.h5'
+            logger.debug('Looking for %s on local machine' % local_stub)
+            return os.path.exists(local_h5) or os.path.exists(local_stub + '.pcs') or os.path.exists(local_stub + '.tiles')
         
     def get_free_space(self):
         """

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -569,11 +569,8 @@ class SpoolController(object):
         if extra_metadata is not None:
             self.spooler.md.mergeEntriesFrom(MetaDataHandler.DictMDHandler(extra_metadata))
 
-        # stop the frameWrangler before we start spooling
-        # this serves to ensure that a) we don't accidentally spool frames which were in the camera buffer when we hit start
-        # and b) we get a nice clean timestamp for when the actual frames start (after any protocol init tasks)
-        # it might also slightly improve performance.
-        self.scope.frameWrangler.stop()
+        # NOTE - stopping and starting the framewrangler has moved to the spooler .start() method
+        #self.scope.frameWrangler.stop()
         
         try:
             self.spooler.on_stop.connect(self.SpoolStopped)
@@ -583,8 +580,8 @@ class SpoolController(object):
             raise
 
         # restart frame wrangler
-        self.scope.frameWrangler.Prepare()
-        self.scope.frameWrangler.start()
+        #self.scope.frameWrangler.Prepare()
+        #self.scope.frameWrangler.start()
         
         self.onSpoolStart.send(self)
 

--- a/PYME/Acquire/Utils/pointScanner.py
+++ b/PYME/Acquire/Utils/pointScanner.py
@@ -125,7 +125,7 @@ class PointScanner(object):
         #self.scope.frameWrangler.WantFrameNotification.append(self.tick)
         self.scope.frameWrangler.onFrame.connect(self.on_frame, dispatch_uid=self._uuid)
 
-        if self.trigger:
+        if self.trigger and self.scope.frameWrangler.isRunning():
             self.scope.cam.FireSoftwareTrigger()
         
         #if self.sync:

--- a/PYME/Acquire/Utils/pointScanner.py
+++ b/PYME/Acquire/Utils/pointScanner.py
@@ -125,7 +125,7 @@ class PointScanner(object):
         #self.scope.frameWrangler.WantFrameNotification.append(self.tick)
         self.scope.frameWrangler.onFrame.connect(self.on_frame, dispatch_uid=self._uuid)
 
-        if self.trigger and self.scope.frameWrangler.isRunning():
+        if self.trigger: # and self.scope.frameWrangler.isRunning():
             self.scope.cam.FireSoftwareTrigger()
         
         #if self.sync:

--- a/PYME/Acquire/Utils/pointScanner.py
+++ b/PYME/Acquire/Utils/pointScanner.py
@@ -182,9 +182,12 @@ class PointScanner(object):
                 callN = int((self.callNum+1)/self.dwellTime)
                 new_x, new_y = self._position_for_index(callN)
 
+                if not cam_trigger:
+                    self.scope.frameWrangler.stop()
+                
                 self.scope.state.setItems({'Positioning.x' : new_x,
                                            'Positioning.y' : new_y
-                                           }, stopCamera = not cam_trigger)
+                                           })#, stopCamera = not cam_trigger)
 
                 #print 'SetP'
 
@@ -193,6 +196,9 @@ class PointScanner(object):
                     #eventLog.logEvent('ScannerYPos', '%3.6f' % self.yp[(callN % (self.imsize))/self.nx])
                     eventLog.logEvent('ScannerXPos', '%3.6f' % self.scope.state['Positioning.x'])
                     eventLog.logEvent('ScannerYPos', '%3.6f' % self.scope.state['Positioning.y'])
+
+                if not cam_trigger:
+                    self.scope.frameWrangler.start()
 
             if cam_trigger:
                 #logger.debug('Firing camera trigger')

--- a/PYME/Acquire/Utils/tiler.py
+++ b/PYME/Acquire/Utils/tiler.py
@@ -68,6 +68,16 @@ class Tiler(pointScanner.PointScanner, AcquisitionBase):
     @classmethod
     def get_frozen_settings(cls, scope, spool_controller=None):
         return {'tiling_settings': getattr(scope, 'tile_settings', {})}
+    
+    @classmethod
+    def get_tiled_area(cls, scope, settings):
+        fs = np.array(scope.frameWrangler.currentFrame.shape[:2])
+        #calculate tile spacing such that there is 20% overlap.
+        tile_spacing = settings.get(0.8*fs*np.array(scope.GetPixelSize()))
+
+        nx, ny = settings.get('n_tiles', (10, 10))
+        return nx * fs[0] * tile_spacing[0], ny * fs[1] * tile_spacing[1]
+
         
     def start(self):
         #self._weights =tile_pyramid.ImagePyramid.frame_weights(self.scope.frameWrangler.currentFrame.shape[:2]).squeeze()

--- a/PYME/Acquire/Utils/tiler.py
+++ b/PYME/Acquire/Utils/tiler.py
@@ -13,11 +13,14 @@ from PYME.IO import acquisition_backends
 
 class Tiler(pointScanner.PointScanner, AcquisitionBase):
     def __init__(self, scope, tile_dir, n_tiles = 10, tile_spacing=None, dwelltime = 1, background=0, evtLog=False,
-                 trigger=False, base_tile_size=256, return_to_start=True, backend='file'):
+                 trigger='auto', base_tile_size=256, return_to_start=True, backend='file'):
         """
         :param return_to_start: bool
             Flag to toggle returning home at the end of the scan. False leaves scope position as-is on scan completion.
         """
+        
+        if trigger == 'auto':
+            trigger = scope.cam.supports_software_trigger
         
         if tile_spacing is None:
             fs = np.array(scope.frameWrangler.currentFrame.shape[:2])
@@ -60,7 +63,7 @@ class Tiler(pointScanner.PointScanner, AcquisitionBase):
                     dwelltime=settings.get('dwelltime', 1),
                     background=settings.get('background', 0),
                     evtLog=settings.get('evtLog', False),
-                    trigger=settings.get('software_trigger', False),
+                    trigger=settings.get('software_trigger', 'auto'),
                     base_tile_size=settings.get('base_tile_size', 256),
                     return_to_start=settings.get('return_to_start', True),
                     backend=backend)

--- a/PYME/Acquire/Utils/tiler.py
+++ b/PYME/Acquire/Utils/tiler.py
@@ -204,6 +204,8 @@ class Tiler(pointScanner.PointScanner, AcquisitionBase):
                 f.write(self.P.mdh.to_JSON())
                 
         logger.info('Pyramid complete (dt = %3.2f)' % (time.time()-t_))
+
+        self.spool_complete = True
             
         self.on_stop.send(self)
         self.on_progress.send(self)

--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -263,6 +263,13 @@ class PYMEMainFrame(acquirebase.PYMEAcquireBase, AUIFrame):
             self.register_acquisition_ui('ZStackAcquisition', (self.seq_d, 'Z-Stack'))
             #self.AddAqTool(self.seq_d, 'Z-Stack', pinned=False)
             #self.seq_d.Show()
+
+        # TODO - this is done in the init script for now - should this be automatic?
+        # if 'x' in self.scope.positioning.keys() and 'y' in self.scope.positioning.keys():
+        #     # we can tile, register the tiling UI
+        #     from PYME.Acquire.ui import tilesettingsui
+        #     self.tileUI = tilesettingsui.TileSettingsUI(self, self.scope)
+        #     self.register_acquisition_ui('TileAcquisition', (self.tileUI, 'Tile Settings'))
         
         for t in self.toolPanels:
             #print(t)

--- a/PYME/Acquire/htsms/rule_ui.py
+++ b/PYME/Acquire/htsms/rule_ui.py
@@ -118,7 +118,7 @@ class ProtocolRules(OrderedDict):
         spooler = self._spool_controller.spooler
         try:
             spooler.getURL
-        except AtrributeError:
+        except AttributeError:
             logger.exception('Rule-based analysis chaining currently requires spooling to cluster, not to file')
             raise 
         prot_filename = spooler.protocol.filename

--- a/PYME/Acquire/htsms/rule_ui_v2.py
+++ b/PYME/Acquire/htsms/rule_ui_v2.py
@@ -1,0 +1,721 @@
+
+import wx
+# from  PYME.ui import manualFoldPanel
+from PYME.cluster.rules import LocalisationRuleFactory as LocalizationRuleFactory
+from PYME.cluster.rules import RecipeRuleFactory
+from collections import OrderedDict
+#import queue
+import os
+import posixpath
+import logging
+from PYME.contrib import dispatch, wxPlotPanel
+from PYME.recipes.traits import HasTraits, Enum, Float, CStr
+import textwrap
+import numpy as np
+import matplotlib.pyplot as plt
+import threading
+
+logger = logging.getLogger(__name__)
+
+POST_CHOICES = ['off', 'spool start', 'spool stop']
+
+class RuleTile(HasTraits):
+    task_timeout = Float(60 * 10)
+    rule_timeout = Float(60 * 10)
+
+    def get_params(self):
+        editable = self.class_editable_traits()
+        return editable 
+
+    @property
+    def default_view(self):
+        if wx.GetApp() is None:
+            return None
+        from traitsui.api import View, Item
+
+        return View([Item(tn) for tn in self.get_params()], buttons=['OK'])
+
+    def default_traits_view(self):
+        """ This is the traits stock method to specify the default view"""
+        return self.default_view
+
+def get_rule_tile(rule_factory_class):
+    class _RuleTile(RuleTile, rule_factory_class):
+        def __init__(self, **kwargs):
+            RuleTile.__init__(self)
+            rule_factory_class.__init__(self, **kwargs)
+    return _RuleTile
+
+
+class RuleChain(HasTraits):
+    post_on = Enum(POST_CHOICES)
+    protocol = CStr('')
+    
+    def __init__(self, rule_factories=None, *args, **kwargs):
+        if rule_factories is None:
+            rule_factories = list()
+        self.rule_factories = rule_factories
+        HasTraits.__init__(self, *args, **kwargs)
+
+
+class RuleDict(OrderedDict):
+    """
+    Container for associating sets of analysis rules with specific acquisition
+    protocols
+
+    Notes
+    -----
+    use ordered dict for reproducibility with listctrl displays
+    """
+    def __init__(self):
+        """
+        Parameters
+        ----------
+        posting_thread_queue_size : int, optional
+            sets the size of a queue to hold rule posting threads to ensure they
+            have time to execute, by default 5. .. seealso:: modules :py:mod:`PYME.cluster.rules`
+        """
+        import queue
+
+        OrderedDict.__init__(self)
+        self.active = True
+        #self._spool_controller = spool_controller
+        #self.posting_thread_queue = queue.Queue(posting_thread_queue_size)
+        self._updated = dispatch.Signal()
+        self._updated.connect(self.update)
+        
+        self['default'] = RuleChain()
+
+        #self._spool_controller.onSpoolStart.connect(self.on_spool_start)
+        #self._spool_controller.on_stop.connect(self.on_spool_stop)
+    
+    # def on_spool_start(self, **kwargs):
+    #     self.on_spool_event('spool start')
+    
+    # def on_spool_stop(self, **kwargs):
+    #     self.on_spool_event('spool stop')
+    
+    def on_spool_event(self, event):
+        """
+        pipe input series name into rule chain and post them all
+        
+        Parameters
+        ----------
+        kwargs: dict
+            present here to allow us to call this method through a dispatch.Signal.send
+        """
+        if not self.active:
+            logger.info('inactive, check "active" to turn on auto analysis')
+            return
+        spooler = self._spool_controller.spooler
+        try:
+            spooler.getURL
+        except AttributeError:
+            logger.exception('Rule-based analysis chaining currently requires spooling to cluster, not to file')
+            raise 
+        prot_filename = spooler.protocol.filename
+        prot_filename = '' if prot_filename is None else prot_filename
+        protocol_name = os.path.splitext(os.path.split(prot_filename)[-1])[0]
+        logger.info('protocol name : %s' % protocol_name)
+
+        try:
+            rule_factory_chain = self[protocol_name]
+        except KeyError:
+            rule_factory_chain = self['default']
+        
+        if rule_factory_chain.post_on != event:
+            # not the right trigger for this protocol
+            return
+        
+        if len(rule_factory_chain.rule_factories) == 0:
+            logger.info('no rules in chain')
+            return
+        
+        # set the context based on the input series
+        series_uri = spooler.getURL()
+        spool_dir, series_stub = posixpath.split(series_uri)
+        series_stub = posixpath.splitext(series_stub)[0]
+        context = {
+            'spool_dir': spool_dir,  # do we need this? or typo in rule docs
+            'series_stub': series_stub,  # do we need this? or typo in rule docs
+            'seriesName': series_uri,  # Localization
+            'inputs': {'input': [series_uri]},  # Recipe
+            'output_dir': posixpath.join(spool_dir, 'analysis'), # Recipe
+            'spooler': spooler}  # SpoolLocalLocalization
+
+        # rule chain is already linked, add context and push
+        rule = rule_factory_chain.rule_factories[0].get_rule(context=context)
+        t = threading.Thread(target=rule.push)
+        t.start()
+        if self.posting_thread_queue.full():
+            self.posting_thread_queue.get_nowait().join()
+        self.posting_thread_queue.put_nowait(t)
+        
+    
+    def update(self, *args, **kwargs):
+        for p in self.keys():
+            factories = self[p].rule_factories
+            for ind in range(len(factories) - 1):
+                factories[ind].chain(factories[ind + 1])
+
+
+
+class RulePlotPanel(wxPlotPanel.PlotPanel):
+    def __init__(self, parent, protocol_rules, **kwargs):
+        self.protocol_rules = protocol_rules
+        self.parent = parent
+        wxPlotPanel.PlotPanel.__init__(self, parent, **kwargs)
+        self.figure.canvas.mpl_connect('pick_event', self.parent.OnPick)
+
+    def draw(self):
+        if not self.IsShownOnScreen():
+            return
+            
+        if not hasattr( self, 'ax' ):
+            self.ax = self.figure.add_axes([0, 0, 1, 1])
+
+        self.ax.cla()
+
+        rule_factories = self.parent.rule_chain.rule_factories
+        if len(rule_factories) < 1:
+            self.canvas.draw()
+            return
+        width = 1  # size of tile to draw
+        height = 0.5
+        nodes_x = np.arange(0, len(rule_factories) * 1.5 * width, 1.5 * width)
+        nodes_y = np.ones_like(nodes_x)
+
+        
+        axis_width = self.ax.get_window_extent().width
+        n_cols = max([1] + nodes_x.tolist())
+        pix_per_col = axis_width / n_cols
+        
+        font_size = max(6, min(10, 10 * pix_per_col / 100))
+        
+        TW = textwrap.TextWrapper(width=max(int(1.8 * pix_per_col / font_size), 10),
+                                  subsequent_indent='  ')
+        TW2 = textwrap.TextWrapper(width=max(int(1.3 * pix_per_col / font_size), 10),
+                                   subsequent_indent='  ')
+    
+        cols = {}
+
+        # plot connecting lines
+        for ind in range(1, len(rule_factories)):
+            self.ax.plot([nodes_x[ind - 1] + width, nodes_x[ind]],
+                         [nodes_y[ind - 1] + 0.5 * height, 
+                          nodes_y[ind] + 0.5 * height], lw=2)
+                
+        #plot the boxes and the labels
+        for ind in range(len(rule_factories)):
+            # draw a box
+            s = rule_factories[ind]._type
+            fc = [.8,.8, 1]
+            
+            rect = plt.Rectangle([nodes_x[ind], nodes_y[ind]], width, height,
+                                 ec='k', lw=2, fc=fc, picker=True)
+            rect._data = rule_factories[ind]
+            self.ax.add_patch(rect)
+            
+            s = TW2.wrap(s)
+            if len(s) == 1:
+                self.ax.text(nodes_x[ind] + .05, nodes_y[ind] + .18 , s[0], size=font_size, weight='bold')
+            else:
+                self.ax.text(nodes_x[ind] + .05, nodes_y[ind] + .18 - .05*(len(s) - 1) , '\n'.join(s), size=font_size, weight='bold')
+        
+        self.ax.set_ylim(0, 2)
+        self.ax.set_xlim(-0.5 * width, nodes_x[-1] + 1.5 * width)
+        
+        self.ax.axis('off')
+        self.ax.grid()
+        
+        self.canvas.draw()
+
+class ChainedAnalysisPage(wx.Panel):
+    def __init__(self, parent, rules, recipe_manager, 
+                 localization_panel=None, default_pairings=None, localization_settings=None):
+        """
+
+        Parameters
+        ----------
+        parent : wx something
+        protocol_rules : dict
+            [description]
+        recipe_manager : PYME.recipes.recipeGui.RecipeManager
+            [description]
+        default_pairings : dict
+            protocol keys with lists of RuleFactorys as values to prepopulate
+            panel on start up
+        """
+        wx.Panel.__init__(self, parent, -1)
+        self._loaded_rules = rules
+        self._selected_rule = list(rules.keys())[0]
+        self._recipe_manager = recipe_manager
+        self._localization_panel = localization_panel
+
+        self._editor_panels = []
+
+        v_sizer = wx.BoxSizer(wx.VERTICAL)
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+
+        # associated protocol choicebox (default / others on top, then rest)
+        hsizer.Add(wx.StaticText(self, -1, 'Rule Chain:'), 0, 
+                   wx.LEFT|wx.RIGHT|wx.ALIGN_CENTER_VERTICAL, 5)
+        self.c_rule_selection = wx.Choice(self, -1, choices=list(self._loaded_rules.keys()))
+        self.c_rule_selection.SetSelection(0)
+        self.c_rule_selection.Bind(wx.EVT_CHOICE, self.OnRuleChoice)
+        hsizer.Add(self.c_rule_selection, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
+
+        hsizer.AddStretchSpacer()
+
+        self._b_add_rule_chain = wx.Button(self, -1, 'Add')
+        hsizer.Add(self._b_add_rule_chain, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
+        self._b_add_rule_chain.Bind(wx.EVT_BUTTON, self.OnAddRuleChain)
+
+        self._b_load_rule_chain = wx.Button(self, -1, 'Load')
+        hsizer.Add(self._b_load_rule_chain, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
+        self._b_load_rule_chain.Bind(wx.EVT_BUTTON, self.OnLoadRuleChain)
+
+        self._b_save_rule_chain = wx.Button(self, -1, 'Save')
+        hsizer.Add(self._b_save_rule_chain, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
+        self._b_save_rule_chain.Bind(wx.EVT_BUTTON, self.OnSaveRuleChain)
+
+        vsizer.Add(hsizer, 0, wx.TOP|wx.EXPAND, 5)
+
+        # rule plot
+        self.rule_plot = RulePlotPanel(self, self._loaded_rules, 
+                                       size=(-1, 100))
+        vsizer.Add(self.rule_plot, 1, wx.ALL|wx.EXPAND, 5)
+        
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        
+        self.b_clear = wx.Button(self, -1, 'Clear Chain')
+        hsizer.Add(self.b_clear, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
+        self.b_clear.Bind(wx.EVT_BUTTON, self.OnClear)
+        
+        self.b_add_localization = wx.Button(self, -1, 'Add Localization Task')
+        hsizer.Add(self.b_add_localization, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
+        self.b_add_localization.Bind(wx.EVT_BUTTON, self.OnAddLocalization)
+
+        self.b_add_recipe = wx.Button(self, -1, 'Add Recipe Task')
+        hsizer.Add(self.b_add_recipe, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
+        self.b_add_recipe.Bind(wx.EVT_BUTTON, self.OnAddRecipe)
+        
+        vsizer.Add(hsizer, 0, wx.EXPAND, 0)
+        v_sizer.Add(vsizer, 0, wx.EXPAND, 0)
+
+        if self._localization_panel is None and not localization_settings is None:
+            self._lpan = wx.Panel(self, -1)
+            self._localization_panel = LocalizationSettingsPanel(self._lpan,localization_settings, localization_settings.onMetadataChanged)
+            self._localization_panel.chained_analysis_page = self
+            sbsizer = wx.StaticBoxSizer(wx.StaticBox(self._lpan, -1, 'Localisation settings'), wx.HORIZONTAL)
+            sbsizer.Add(self._localization_panel, 1, wx.EXPAND, 0)
+            self._lpan.SetSizerAndFit(sbsizer)
+            v_sizer.Add(self._lpan, 1, wx.EXPAND|wx.ALL, 5)
+            self._lpan.Hide()
+            self._editor_panels.append(self._lpan)
+
+        self._rpan = wx.Panel(self, -1)
+        self._recipe_view = RuleRecipeView(self._rpan, self._recipe_manager)
+        sbsizer = wx.StaticBoxSizer(wx.StaticBox(self._rpan, -1, 'Recipe Editor'), wx.HORIZONTAL)
+        sbsizer.Add(self._recipe_view, 1, wx.EXPAND, 0)
+        self._rpan.SetSizerAndFit(sbsizer)
+        v_sizer.Add(self._rpan, 1, wx.EXPAND|wx.ALL, 5)
+        self._rpan.Hide()
+        self._editor_panels.append(self._rpan)
+
+
+        self.SetSizerAndFit(v_sizer)
+        self._loaded_rules._updated.connect(self.update)
+    
+    def OnClear(self, wx_event=None):
+        self._loaded_rules[self._selected_rule] = RuleChain()
+        self._loaded_rules._updated.send(self)
+
+    def OnAddRuleChain(self, wx_event=None):
+        # display a text enty dialog to get the name of the new rule chain
+        # then add it to the list of rule chains
+        from PYME import warnings
+
+        dlg = wx.TextEntryDialog(self, 'Enter name for new rule chain', 'New Rule Chain', '')
+        if dlg.ShowModal() == wx.ID_OK:
+            name = dlg.GetValue()
+
+            if name in self._loaded_rules.keys() or name == '':
+                dlg.Destroy()
+                warnings.warn('Name already in use or empty')
+                return
+            else:
+                self._loaded_rules[name] = RuleChain()
+                self._loaded_rules._updated.send(self) 
+
+                self.select_rule_chain(name)
+
+    def OnLoadRuleChain(self, wx_event=None):
+        # display a dialog to select a rule file to load
+        # then load it into the list of rule chains
+        from PYME import warnings
+
+        # TODO - specify the directory to start in
+        # TODO - will this be YAML?
+        dlg = wx.FileDialog(self, 'Choose a rule chain file', '', '', 'YAML files (*.yaml)|*.yaml', wx.FD_OPEN)
+        if dlg.ShowModal() == wx.ID_OK:
+            path = dlg.GetPath()
+            name = (os.path.split(path)[-1])
+            if name in self._loaded_rules.keys():
+                warnings.warn('Name already in use')
+                return
+            
+            with open(path, 'r') as f:
+                self._loaded_rules[name] = RuleChain.from_yaml(f.read())
+
+            self._loaded_rules._updated.send(self)
+            self.select_rule_chain(name)
+
+    def OnSaveRuleChain(self, wx_event=None):
+        # display a dialog to select a file to save the rule chain to
+        # then save it
+        from PYME import warnings
+
+        # TODO - specify the directory to start in
+        # TODO - will this be YAML?
+        dlg = wx.FileDialog(self, 'Choose a rule chain file', '', '', 'YAML files (*.yaml)|*.yaml', wx.FD_SAVE)
+        if dlg.ShowModal() == wx.ID_OK:
+            path = dlg.GetPath()
+            
+            with open(path, 'w') as f:
+                f.write(self._loaded_rules[self._selected_rule].to_yaml())
+
+    
+
+    def OnRuleChoice(self, wx_event=None):
+        self.select_rule_chain(self.c_rule_selection.GetStringSelection())
+    
+    def select_rule_chain(self, rule='default'):
+        if rule not in self._loaded_rules.keys():
+            self._loaded_rules[rule] = RuleChain()
+            self._loaded_rules._updated.send(self)
+        
+        self._selected_rule = rule
+
+        for e in self._editor_panels:
+            e.Hide()
+
+        # force a redraw, even though we might just have done so if we added
+        self.update()
+        
+        
+    def update(self, *args, **kwargs):
+        self.c_rule_selection.SetItems(list(self._loaded_rules.keys()))
+        self.c_rule_selection.SetStringSelection(self._selected_rule)
+        self.rule_plot.draw()
+        
+    
+    def edit_localisation_rule(self, rule):
+        for e in self._editor_panels:
+            e.Hide()
+
+        self._localization_panel.localization_settings.analysisMDH = rule._rule_kwargs['analysisMetadata']
+        self._localization_panel.localization_settings.onMetadataChanged.send_robust(self._localization_panel.localization_settings)
+        self._lpan.Show()
+        self.Layout()
+
+    def edit_recipe_rule(self, rule):
+        for e in self._editor_panels:
+            e.Hide()
+
+        self._recipe_view.edit_recipe_rule(rule)
+        self._rpan.Show()
+        self.Layout()
+
+    def OnPick(self, event):
+        k = event.artist._data
+        #logger.info('picked %s' % k)
+
+        if k.rule_type == 'localization':
+            self.edit_localisation_rule(k)
+        elif k.rule_type == 'recipe':
+            self.edit_recipe_rule(k)
+    
+    @property
+    def rule_chain(self):
+        return self._loaded_rules[self._selected_rule]
+
+    def add_tile(self, rule_tile):
+        self.rule_chain.rule_factories.append(rule_tile)
+        self._loaded_rules._updated.send(self)
+
+        # for e in self._editor_panels:
+        #     e.Hide()
+
+        self.Layout()
+
+    
+    
+    def OnAddLocalization(self, wx_event=None):
+        from PYME.IO.MetaDataHandler import DictMDHandler
+        from PYME.cluster.rules import SpoolLocalLocalizationRuleFactory
+        # copy the metadata handler so we don't accidentally over-ride the original
+        mdh = DictMDHandler(self._localization_panel.localization_settings.analysisMDH)
+        loc_rule = get_rule_tile(SpoolLocalLocalizationRuleFactory)(analysisMetadata=mdh)
+        self.add_tile(loc_rule)
+
+        self.edit_localisation_rule(loc_rule)
+
+    def OnAddRecipe(self, wx_event=None):
+        rec = get_rule_tile(RecipeRuleFactory)(recipe='')
+        self.add_tile(rec)
+        
+        self.edit_recipe_rule(rec)
+        
+
+from PYME.recipes.recipeGui import RecipeView, RecipeManager, RecipePlotPanel
+class RuleRecipeView(RecipeView):
+    _rule = None
+
+    def edit_recipe_rule(self, rule):
+        self._rule = rule
+        self.recipes.activeRecipe.update_from_yaml(rule._rule_kwargs['recipe'])
+
+    def update(self, *args, **kwargs):
+        if self._rule is not None:
+            self._rule._rule_kwargs['recipe'] = self.recipes.activeRecipe.toYAML()
+
+        return super().update(*args, **kwargs)
+
+
+class RuleRecipeManager(RecipeManager):
+    def __init__(self, chained_analysis_page=None):
+        RecipeManager.__init__(self)
+        self.chained_analysis_page = chained_analysis_page
+
+    def OnAddRecipeRule(self, wx_event=None):
+        from PYME.cluster.rules import RecipeRuleFactory
+        #from PYME.Acquire.htsms.rule_ui import get_rule_tile
+        if self.chained_analysis_page is None:
+            logger.error('chained_analysis_page attribute unset')
+
+        rec = get_rule_tile(RecipeRuleFactory)(recipe=self.activeRecipe.toYAML())
+        self.chained_analysis_page.add_tile(rec)
+
+class ChainedAnalysisPanel(wx.Panel):
+    def __init__(self, parent, protocol_rules, chained_analysis_page,
+                 default_pairings=None):
+        """
+
+        Parameters
+        ----------
+        parent : PYME.ui.AUIFrame.AUIFrame
+            should be the 'main frame'
+        protocol_rules : dict
+            [description]
+        recipe_manager : PYME.recipes.recipeGui.RecipeManager
+            [description]
+        default_pairings : dict
+            protocol keys with RuleChains as values to prepopulate
+            panel on start up
+        """
+        wx.Panel.__init__(self, parent, -1)
+        self.parent = parent
+        self._protocol_rules = protocol_rules
+        self._page = chained_analysis_page
+
+        v_sizer = wx.BoxSizer(wx.VERTICAL)
+        h_sizer = wx.BoxSizer(wx.HORIZONTAL)
+
+        self.checkbox_active = wx.CheckBox(self, -1, 'active')
+        self.checkbox_active.SetValue(True)
+        self.checkbox_active.Bind(wx.EVT_CHECKBOX, self.OnToggleActive)
+        h_sizer.Add(self.checkbox_active, 0, wx.ALL, 2)
+        v_sizer.Add(h_sizer, 0, wx.EXPAND|wx.TOP, 0)
+
+        h_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        self._protocol_rules_list = ProtocolRuleFactoryListCtrl(self._protocol_rules, self)
+        h_sizer.Add(self._protocol_rules_list)
+        v_sizer.Add(h_sizer, 0, wx.EXPAND|wx.TOP, 0)
+
+        h_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.button_del_chain = wx.Button(self, -1, 'Delete pair')
+        self.button_del_chain.Bind(wx.EVT_BUTTON, self.OnRemoveProtocolRule)
+        h_sizer.Add(self.button_del_chain, 0, wx.ALL, 2)
+
+        self.button_edit_chain = wx.Button(self, -1, 'Edit in tab')
+        self.button_edit_chain.Bind(wx.EVT_BUTTON, self.OnEditRuleChain)
+        h_sizer.Add(self.button_edit_chain, 0, wx.ALL, 2)
+        v_sizer.Add(h_sizer)
+
+        self.SetSizerAndFit(v_sizer)
+
+        if default_pairings is not None:
+            self._set_up_defaults(default_pairings)
+    
+    def _set_up_defaults(self, pairings):
+        for protocol_name, rule_chain in pairings.items():
+            # add them to the protocol rules dict
+            self._protocol_rules[protocol_name] = rule_chain
+        
+        self._protocol_rules._updated.send(self)
+
+    def OnRemoveProtocolRule(self, wx_event=None):
+        # make sure that we reset the chained analysis page just in case
+        # we deleted a rule which was active
+        self._page.c_protocol.SetStringSelection('default')
+        self._page.OnProtocolChoice()
+        self._protocol_rules_list.delete_rule_chains()
+    
+    def OnEditRuleChain(self, wx_event=None):
+        ind = self._protocol_rules_list.get_selected_items()[0]
+        protocol = self._protocol_rules_list.GetItemText(ind, col=0)
+        self._page.select_rule_chain(protocol)
+        self.parent._select_page_by_name('Chained Analysis')
+
+    def OnToggleActive(self, wx_event):
+        self._protocol_rules.active = self.checkbox_active.GetValue()
+
+    @staticmethod
+    def plug(main_frame, scope, default_pairings=None):
+        """
+        Adds a ChainedAnalysisPanel to a microscope gui during start-up
+        
+        Parameters
+        ----------
+        main_frame : PYME.Acquire.acquiremainframe.PYMEMainFrame
+            microscope gui application
+        scope : PYME.Acquire.microscope.Microscope
+            the microscope itself
+        default_pairings : dict
+            [optional] protocol keys with lists of RuleFactorys as values to
+            prepopulate panel on start up. By default, None
+        
+        """
+
+        scope.protocol_rules = ProtocolRules(scope.spoolController)
+        scope._recipe_manager = RuleRecipeManager()
+
+        main_frame.chained_analysis_page = ChainedAnalysisPage(main_frame, 
+                                                               scope.protocol_rules,
+                                                               scope._recipe_manager,
+                                                               default_pairings)
+        
+        scope._recipe_manager.chained_analysis_page = main_frame.chained_analysis_page
+        main_frame.recipe_view = RuleRecipeView(main_frame, scope._recipe_manager)
+
+        main_frame.AddPage(page=main_frame.recipe_view, select=False, caption='Recipe')
+        main_frame.AddPage(page=main_frame.chained_analysis_page, select=False,
+                           caption='Chained Analysis')
+
+        # add this panel
+        chained_analysis = ChainedAnalysisPanel(main_frame, 
+                                                scope.protocol_rules,
+                                                main_frame.chained_analysis_page,
+                                                default_pairings)
+        main_frame.anPanels.append((chained_analysis, 'Automatic Analysis', 
+                                    True))
+
+
+from PYME.Acquire.ui.AnalysisSettingsUI import AnalysisSettingsPanel, AnalysisDetailsPanel, manualFoldPanel
+class LocalizationSettingsPanel(wx.Panel):
+    def __init__(self, wx_parent, localization_settings,
+                 chained_analysis_page=None):
+        #from PYME.ui.autoFoldPanel import collapsingPane
+        #manualFoldPanel.foldingPane.__init__(self, wx_parent, caption='Localization Analysis')
+        wx.Panel.__init__(self, wx_parent)
+
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+
+        self.localization_settings = localization_settings
+        self.chained_analysis_page = chained_analysis_page
+        
+        #clp = collapsingPane(self, caption='settings ...')
+
+        asp = AnalysisSettingsPanel(self,self.localization_settings,self.localization_settings.onMetadataChanged, show_save_mdh=False)
+        vsizer.Add(asp, 0, wx.EXPAND|wx.ALL, 5)
+        adp = AnalysisDetailsPanel(self, self.localization_settings,self.localization_settings.onMetadataChanged)
+        vsizer.Add(adp, 1, wx.EXPAND|wx.ALL, 5)
+       
+        self.SetSizerAndFit(vsizer)
+
+        
+
+class SMLMChainedAnalysisPanel(ChainedAnalysisPanel):
+    def __init__(self, wx_parent, protocol_rules, chained_analysis_page,
+                 default_pairings=None):
+        """
+        Parameters
+        ----------
+        wx_parent
+        localization_settings: PYME.ui.AnalysisSettingsUI.AnalysisSettings
+        rule_list_ctrl: RuleChainListCtrl
+        default_pairings : dict
+            [optional] protocol keys with lists of RuleFactorys as values to
+            prepopulate panel on start up. By default, None
+        """
+        ChainedAnalysisPanel.__init__(self, wx_parent, protocol_rules, 
+                                      chained_analysis_page, default_pairings)
+
+    # def OnToggleLiveView(self, wx_event=None):
+    #     if self.checkbox_view_live.GetValue() and 0 in self._rule_list_ctrl.localization_rule_indices:
+    #         self._rule_list_ctrl._rule_chain.posted.connect(self._open_live_view)
+    #     else:
+    #         self._rule_list_ctrl._rule_chain.posted.disconnect(self._open_live_view)
+
+    def _open_live_view(self, **kwargs):
+        """
+        Open PYMEVisualize on a freshly spooled series which is being localized
+        
+        Parameters
+        ----------
+        kwargs: dict
+            present here to allow us to call this method through a dispatch.Signal.send
+        """
+        import subprocess
+        # get the URL
+        uri = self._rule_list_ctrl._rule_chain[self._rule_list_ctrl.localization_rule_indices[0]].outputs[0]['input'] + '/live'
+        subprocess.Popen('visgui %s' % uri, shell=True)
+
+    @staticmethod
+    def plug(main_frame, scope, default_pairings=None):
+        """
+        Adds a SMLMChainedAnalysisPanel to a microscope gui during start-up
+        
+        Parameters
+        ----------
+        main_frame : PYME.Acquire.acquiremainframe.PYMEMainFrame
+            microscope gui application
+        scope : PYME.Acquire.microscope.Microscope
+            the microscope itself
+        default_pairings : dict
+            [optional] protocol keys with RuleChains as values to
+            prepopulate panel on start up. By default, None
+        """
+        from PYME.Acquire.ui.AnalysisSettingsUI import AnalysisSettings
+
+        scope.analysis_rules = RuleDict()
+        scope._recipe_manager = RecipeManager()
+        scope._localization_settings = AnalysisSettings() #TODO - we should not need this to be global.
+
+        # localization_settings_pan = LocalizationSettingsPanel(main_frame,
+        #                                                              scope._localization_settings,
+        #                                                              scope._localization_settings.onMetadataChanged)
+
+        main_frame.chained_analysis_page = ChainedAnalysisPage(main_frame, 
+                                                                   scope.analysis_rules,
+                                                                   scope._recipe_manager,
+                                                                   None,
+                                                                   default_pairings, localization_settings=scope._localization_settings)
+        
+        #scope._recipe_manager.chained_analysis_page = main_frame.chained_analysis_page
+        #main_frame.recipe_view = RuleRecipeView(main_frame, scope._recipe_manager)
+        #main_frame.localization_settings.chained_analysis_page = main_frame.chained_analysis_page
+        #main_frame.AddPage(page=main_frame.recipe_view, select=False, caption='Recipe')
+        #main_frame.AddPage(page=main_frame.localization_settings, select=False, caption='Localization')
+        main_frame.AddPage(page=main_frame.chained_analysis_page, select=False,
+                           caption='Chained Analysis')
+        
+        # add this panel
+        # chained_analysis = SMLMChainedAnalysisPanel(main_frame, 
+        #                                             scope.protocol_rules,
+        #                                             main_frame.chained_analysis_page,
+        #                                             default_pairings)
+        # main_frame.anPanels.append((chained_analysis, 'Automatic Analysis', 
+        #                             False))

--- a/PYME/Acquire/htsms/rule_ui_v2.py
+++ b/PYME/Acquire/htsms/rule_ui_v2.py
@@ -108,6 +108,21 @@ class RuleDict(OrderedDict):
         # TODO - make the default rule chain a 2D Gaussian localization rule
         #mdh = DictMDHandler(self._localization_panel.localization_settings.analysisMDH)
         #loc_rule = get_rule_tile(SpoolLocalLocalizationRuleFactory)(analysisMetadata=mdh)
+
+
+    def load_from_config(self):
+        """
+        Load rule chains stored in the analysis_rules subfolder of the PYME config directory
+        (typically ~/.PYME/analysis_rules)
+
+        """
+        from PYME import config
+
+        chains = config.get_analysis_rulechains()
+
+        for k, fn in chains.items():
+            with open(fn, 'r') as f:
+                self[os.path.splitext(k)[0]] = RuleChain.from_yaml(f.read())
         
     
     def update(self, *args, **kwargs):
@@ -542,6 +557,7 @@ def plug(main_frame, scope, default_pairings=None):
     from PYME.Acquire.ui.AnalysisSettingsUI import AnalysisSettings
 
     scope.analysis_rules = RuleDict()
+    scope.analysis_rules.load_from_config()
     _recipe_manager = RecipeManager()
     _localization_settings = AnalysisSettings() #TODO - we should not need this to be global.
 

--- a/PYME/Acquire/microscope.py
+++ b/PYME/Acquire/microscope.py
@@ -142,6 +142,15 @@ class StateManager(object):
         #    raise KeyError('No handler registered for %s' % key)
         #    
         #return handler.setState(value)
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            if default is not None:
+                return default
+            else:
+                raise
         
     def setItem(self, key, value, stopCamera=False, force=False):
         """ Set the value of one of our hardware components

--- a/PYME/Acquire/protocol_acquisition.py
+++ b/PYME/Acquire/protocol_acquisition.py
@@ -108,7 +108,7 @@ class ProtocolAcquisition(AcquisitionBase):
             # TODO - make this softer and allow memory backend for fixed length protocol acquisitions???
             raise RuntimeError('Memory spooling not supported for protocol-based acquisitions')
         
-        protocol = spool_controller.protocol_settings.get_protocol_for_acquistion(settings=settings)
+        protocol = spool_controller.protocol_settings.get_protocol_for_acquisition(settings=settings)
         
         preflight_mode = settings.get('preflight_mode', 'interactive')
         if (preflight_mode != 'skip'):

--- a/PYME/Acquire/protocol_acquisition.py
+++ b/PYME/Acquire/protocol_acquisition.py
@@ -49,7 +49,7 @@ def getReducedFilename(filename):
 
 class ProtocolAcquisition(AcquisitionBase):
     """Spooler base class"""
-    def __init__(self, filename, frameSource, protocol = p.NullProtocol, 
+    def __init__(self, filename, frameSource, frame_wrangler, protocol = p.NullProtocol, 
                  fakeCamCycleTime=None, maxFrames = p.maxint, backend='hdf', backend_kwargs={}, **kwargs):
         """Create a new spooler.
         
@@ -63,6 +63,8 @@ class ProtocolAcquisition(AcquisitionBase):
             A source of frames we can subscribe to. It should implement a "connect"
             method allowing us to register a callback and then call the callback with
             the frame data in a "frameData" kwarg.
+        frame_wrangler : PYME.IO.FrameWrangler object
+            The frame wrangler object to use for spooling - used to stop and start while we update settings
         protocol : PYME.Acquire.protocol.TaskListProtocol object
             The acquisition protocol
         guiUpdateCallback : function
@@ -73,6 +75,7 @@ class ProtocolAcquisition(AcquisitionBase):
 
         self.filename=filename
         self.frameSource = frameSource
+        self._frame_wrangler = frame_wrangler
         self.seriesName = getReducedFilename(filename)
         
         self.protocol = protocol
@@ -126,6 +129,7 @@ class ProtocolAcquisition(AcquisitionBase):
         #logger.info('Creating spooler for %s' % series_name)
         return cls(filename=series_name,
                     frameSource=scope.frameWrangler.onFrame,
+                    frame_wrangler=scope.frameWrangler,
                     protocol=protocol,
                     fakeCamCycleTime=fakeCycleTime, 
                     maxFrames=settings.get('max_frames', sys.maxsize),
@@ -196,27 +200,32 @@ class ProtocolAcquisition(AcquisitionBase):
         """ Perform protocol 'frame -1' tasks, log start metadata, then connect
         to the frame source.
         """
-        self.watchingFrames = True
-        eventLog.register_event_handler(self._backend.event_logger)
+        with self._frame_wrangler.spooling_stopped():
+            # stop the frameWrangler before we start spooling
+            # this serves to ensure that a) we don't accidentally spool frames which were in the camera buffer when we hit start
+            # and b) we get a nice clean timestamp for when the actual frames start (after any protocol init tasks)
+            # it might also slightly improve performance.
+            self.watchingFrames = True
+            eventLog.register_event_handler(self._backend.event_logger)
 
-        self.frame_num = 0
-        
-        # set tStart here for simulator so that events in init phase get time stamps. Real start time is set below
-        # **after** protocol.Init() call
-        self.tStart = time.time()
+            self.frame_num = 0
+            
+            # set tStart here for simulator so that events in init phase get time stamps. Real start time is set below
+            # **after** protocol.Init() call
+            self.tStart = time.time()
 
-        self.protocol.Init(self)
-        
-        # record start time when we start receiving frames.
-        self.tStart = time.time()
-        self._collect_start_metadata()
-        self.frameSource.connect(self.on_frame, dispatch_uid=self._spooler_uuid)
-        
-        self.spoolOn = True
+            self.protocol.Init(self)
+            
+            # record start time when we start receiving frames.
+            self.tStart = time.time()
+            self._collect_start_metadata()
+            self.frameSource.connect(self.on_frame, dispatch_uid=self._spooler_uuid)
+            
+            self.spoolOn = True
 
-        logger.debug('Starting spooling: %s' %self.seriesName)
+            logger.debug('Starting spooling: %s' %self.seriesName)
 
-        self._backend.initialise()
+            self._backend.initialise()
        
     def stop(self):
         #try:

--- a/PYME/Acquire/ui/AnalysisSettingsUI.py
+++ b/PYME/Acquire/ui/AnalysisSettingsUI.py
@@ -16,11 +16,10 @@ from PYME.contrib import dispatch
 logger = logging.getLogger(__name__)
 
 class AnalysisSettingsPanel(wx.Panel):
-    def __init__(self, parent, analysisSettings, mdhChangedSignal=None):
+    def __init__(self, parent, analysisSettings, mdhChangedSignal=None, show_save_mdh=True):
         wx.Panel.__init__(self, parent, -1)
         
         self.analysisSettings = analysisSettings        
-        self.analysisMDH = analysisSettings.analysisMDH
         self.mdhChangedSignal = mdhChangedSignal
         
         self._inChange = False
@@ -39,16 +38,21 @@ class AnalysisSettingsPanel(wx.Panel):
         hsizer.Add(self.cFitType, 1, wx.ALIGN_CENTER_VERTICAL, 0)
         vsizer.Add(hsizer, 0, wx.EXPAND|wx.ALL, 4)
         
-        hsizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.cbLogSettings = wx.CheckBox(self, -1, 'Save analysis settings to metadata')
-        self.cbLogSettings.SetValue(False)
-        self.cbLogSettings.Bind(wx.EVT_CHECKBOX, lambda e : self.analysisSettings.SetPropagate(e.IsChecked()))
-        hsizer.Add(self.cbLogSettings, 1, wx.ALIGN_CENTER_VERTICAL, 0)
-        vsizer.Add(hsizer, 0, wx.EXPAND|wx.ALL, 4)
+        if show_save_mdh:
+            hsizer = wx.BoxSizer(wx.HORIZONTAL)
+            self.cbLogSettings = wx.CheckBox(self, -1, 'Save analysis settings to metadata')
+            self.cbLogSettings.SetValue(False)
+            self.cbLogSettings.Bind(wx.EVT_CHECKBOX, lambda e : self.analysisSettings.SetPropagate(e.IsChecked()))
+            hsizer.Add(self.cbLogSettings, 1, wx.ALIGN_CENTER_VERTICAL, 0)
+            vsizer.Add(hsizer, 0, wx.EXPAND|wx.ALL, 4)
         
         self.SetSizerAndFit(vsizer)
         
         self.update()
+
+    @property
+    def analysisMDH(self):
+        return self.analysisSettings.analysisMDH
         
     def OnFitModuleChanged(self, event):
         self._inChange = True
@@ -87,8 +91,8 @@ class AnalysisDetailsPanel(wx.Panel):
     def __init__(self, parent, analysisSettings, mdhChangedSignal=None):
         wx.Panel.__init__(self, parent, -1)
 
-        #self.analysisSettings = analysisSettings
-        self.analysisMDH = analysisSettings.analysisMDH
+        self.analysisSettings = analysisSettings
+        #self.analysisMDH = analysisSettings.analysisMDH
         self.mdhChangedSignal = mdhChangedSignal
         
         mdhChangedSignal.connect(self.OnMDChanged)
@@ -108,6 +112,10 @@ class AnalysisDetailsPanel(wx.Panel):
         self.SetSizerAndFit(vsizer)
     
 
+    @property
+    def analysisMDH(self):
+        return self.analysisSettings.analysisMDH
+    
     def _populateStdOptionsPanel(self, pan, vsizer):
         for param in self.DEFAULT_PARAMS:
             pg = param.createGUI(pan, self.analysisMDH, syncMdh=True, 

--- a/PYME/Acquire/ui/HDFSpoolFrame.py
+++ b/PYME/Acquire/ui/HDFSpoolFrame.py
@@ -248,7 +248,7 @@ class PanSpool(afp.foldingPane):
         self.stSpoolingTo = wx.StaticText(self.spoolProgPan, -1, 'Spooling to .....')
         spoolProgSizer.Add(self.stSpoolingTo, 0, wx.ALL, 0)
     
-        self.stNImages = wx.StaticText(self.spoolProgPan, -1, 'NNNNN images spooled in MM minutes')
+        self.stNImages = wx.StaticText(self.spoolProgPan, -1, 'NNN images spooled in MM mins')
         self.stSpoolingTo.SetForegroundColour(wx.TheColourDatabase.Find('GREY'))
         self.stNImages.SetForegroundColour(wx.TheColourDatabase.Find('GREY'))
     

--- a/PYME/Acquire/ui/actionUI.py
+++ b/PYME/Acquire/ui/actionUI.py
@@ -37,6 +37,9 @@ class ActionList(wx.ListCtrl):
         self.SetColumnWidth(3, 60)
         self.SetColumnWidth(4, 200)
 
+        self.Bind(wx.EVT_KEY_DOWN, self.OnKeyDown)
+
+
 
     def OnGetItemText(self, item, col):
         if item < len(self._queueItems):
@@ -55,6 +58,38 @@ class ActionList(wx.ListCtrl):
             return time.strftime('%H:%M:%S', time.localtime(val))
         else:
             return repr(val)
+    
+        
+    def OnKeyDown(self, event):
+        #logger.info('Key down %d' % event.GetKeyCode())
+        if event.GetKeyCode() in (wx.WXK_DELETE, wx.WXK_BACK):
+            self.delete_selected()
+        else:
+            event.Skip()
+
+    def delete_selected(self):
+        logger.info('Deleting selected actions')
+        to_remove = []
+        to_deselect = []
+
+        idx = self.GetFirstSelected()
+
+        while idx != -1:
+            if idx < len(self._queueItems):
+                a =self._queueItems[idx]
+            else:
+                idx -= len(self._queueItems)
+                a = self._scheduledItems[idx]
+            
+            to_remove.append(a)
+            to_deselect.append(idx)
+            idx = self.GetNextSelected(idx)
+
+        for idx in to_deselect:
+            self.Select(idx, on=0)
+        
+        if to_remove:
+            self.actionManager.remove_actions(to_remove)
         
     def update(self, **kwargs):
         self._queueItems = list(self.actionManager.actionQueue.queue)

--- a/PYME/Acquire/ui/actionUI.py
+++ b/PYME/Acquire/ui/actionUI.py
@@ -640,7 +640,7 @@ class ActionPanel(wx.Panel, cascading_layout.CascadingLayoutMixin):
         if delay > 0:
             execute_after = time.time() + delay
         else:
-            execute_after = 0
+            execute_after = time.time()
 
         #self.actionManager.QueueAction(functionName, args, nice, timeout,
         #                               max_duration, execute_after=execute_after)'

--- a/PYME/Acquire/ui/actionUI.py
+++ b/PYME/Acquire/ui/actionUI.py
@@ -557,12 +557,20 @@ class SpoolSeriesPanel(SingleActionPanel):
         hsizer.Add(self.tNumFrames, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 2)
         sizer.Add(hsizer, 0, wx.EXPAND, 0)
 
+        self._mf = self.GetTopLevelParent()
+        self._mf.time1.register_callback(self._update)
+
     def _get_action(self, idx=0):
         settings = self.scope.spoolController.get_settings()
         settings['max_frames']  = int(self.tNumFrames.GetValue())
         return actions.SpoolSeries(settings=settings, preflight_mode='warn', )  
 
     def _update(self, **kwargs):
+        if not self:
+            self._mf.time1.unregister_callback(self._update)
+            del self._mf # free the reference to the main frame
+            return
+
         aqType = self.scope.spoolController.acquisition_type
         if aqType == 'ProtocolAcquisition':
             self.stNumFramesLabel.Show()
@@ -571,9 +579,12 @@ class SpoolSeriesPanel(SingleActionPanel):
             self.stNumFramesLabel.Hide()
             self.tNumFrames.Hide()
 
-        self.stAqType.SetLabel(f'An {aqType} acquisition will be added with the following settings: {self.scope.spoolController.get_settings()}')
+        self.stAqType.SetLabel(f'{aqType} with the following settings:\n{self.scope.spoolController.get_settings()}')
+        self.stAqType.Wrap(self.GetSize()[0]-5)
 
         self.cascading_layout()
+
+    
 
 class RemoteSpoolSeriesPanel(SpoolSeriesPanel):
     supports_then = False
@@ -703,6 +714,8 @@ class ActionPanel(wx.Panel, cascading_layout.CascadingLayoutMixin):
         self._pan_action_sizer = wx.BoxSizer(wx.VERTICAL)
         self._pan_action_sizer.Add(self._pan_action, 0, wx.EXPAND, 0)
         self.add_single_sizer.Add(self._pan_action_sizer, 0, wx.EXPAND|wx.LEFT, 20)
+
+        vsizer.Add(wx.StaticLine(self, -1, style=wx.LI_HORIZONTAL), 0, wx.EXPAND|wx.ALL, 5)
         
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
         

--- a/PYME/Acquire/ui/spool_panel.py
+++ b/PYME/Acquire/ui/spool_panel.py
@@ -692,7 +692,9 @@ class SpoolingPane(afp.foldingPane):
             
     def OnSpoolingStarted(self, **kwargs):
         if self.spoolController.spoolType in ['Queue', 'Cluster']:
+            self.bAnalyse.SetLabel('Analyse')
             self.bAnalyse.Enable()
+            
 
         self.bStartSpool.Enable(False)
         #self.bStartStack.Enable(False)
@@ -736,7 +738,13 @@ class SpoolingPane(afp.foldingPane):
         #self.cascading_layout()
 
     def OnBAnalyse(self, event):
-        self.spoolController.LaunchAnalysis()
+        if self.bAnalyse.GetLabel() == 'Analyse':
+            self.spoolController.launch_analysis()
+            if self.spoolController.analysis_mode == 'rule-based':
+                self.bAnalyse.SetLabel('View')
+        else:
+            self.spoolController.open_analysis()
+
         
     
     def _tick(self, **kwargs):

--- a/PYME/Acquire/ui/spool_panel.py
+++ b/PYME/Acquire/ui/spool_panel.py
@@ -113,20 +113,10 @@ class ProtocolAcquisitionPane(cascading_layout.CascadingLayoutPanel):
             #self.AddNewElement(clp, priority=1)
             self.seq_pan = clp
 
-        #analysis settings
-        clp = afp.collapsingPane(self, caption='Real time analysis ...')
-
-        self.scope.analysisSettings = AnalysisSettingsUI.AnalysisSettings() #Move me???
-
-        clp.AddNewElement(AnalysisSettingsUI.AnalysisSettingsPanel(clp, self.scope.analysisSettings,
-                                                                   self.scope.analysisSettings.onMetadataChanged))
-        clp.AddNewElement(AnalysisSettingsUI.AnalysisDetailsPanel(clp, self.scope.analysisSettings,
-                                                                  self.scope.analysisSettings.onMetadataChanged))
-        #self.AddNewElement(clp)
-        vsizer.Add(clp, 0, wx.ALL | wx.EXPAND, 0)
+        
         self.SetSizerAndFit(vsizer)
         #end analysis settings
-        
+
 
     def __init__(self, parent, scope, **kwargs):
         """Initialise the spooling panel.
@@ -312,6 +302,118 @@ class SpoolingPane(afp.foldingPane):
         
         return pan
     
+    
+    def _analysis_pan(self):
+        pan = cascading_layout.CascadingLayoutPanel(parent=self, style=wx.TAB_TRAVERSAL)
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+    
+        ###Spool directory
+        sbAnalysis = wx.StaticBox(pan, -1, 'Analysis:')
+        analysisSizer = wx.StaticBoxSizer(sbAnalysis, wx.VERTICAL)
+
+        #analysis settings
+        if hasattr(self.scope, 'analysis_rules'):
+            # new style analysis rules
+            # analysis mode
+            hsizer = wx.BoxSizer(wx.HORIZONTAL)
+            #hsizer.Add(wx.StaticText(pan, -1, 'Analysis:'), 0, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, 5)
+            self.rbInteractiveAnalysis = wx.RadioButton(pan, -1, 'Interactive', style=wx.RB_GROUP)
+            self.rbInteractiveAnalysis.Bind(wx.EVT_RADIOBUTTON, self.OnToggleAnalysis)
+            self.rbInteractiveAnalysis.SetToolTip('Interactive analysis launches PYMEImage and allows you to test analysis parameters etc ... before running the analysis. It also shows a real-time update of localisations as they come in.')
+            hsizer.Add(self.rbInteractiveAnalysis, 1, wx.ALL | wx.EXPAND, 2)
+            self.rbAutomaticAnalysis = wx.RadioButton(pan, -1, 'Automatic')
+            self.rbAutomaticAnalysis.Bind(wx.EVT_RADIOBUTTON, self.OnToggleAnalysis)
+            self.rbAutomaticAnalysis.SetToolTip('Automatic analysis will runs analysis rules on the data with no user interaction. This is useful for high-throughput applications, but does not show progress updates.')
+            hsizer.Add(self.rbAutomaticAnalysis, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 2)
+            if self.spoolController.analysis_mode == 'interactive':
+                self.rbInteractiveAnalysis.SetValue(True)
+            else:
+                self.rbAutomaticAnalysis.SetValue(True)
+            analysisSizer.Add(hsizer, 0, wx.ALL | wx.EXPAND, 0)
+
+            
+            #analysis trigger
+            hsizer = wx.BoxSizer(wx.HORIZONTAL)
+            hsizer.Add(wx.StaticText(pan, -1, 'Start:'), 0, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, 5)
+            self.rbOnTrigger = wx.RadioButton(pan, -1, 'Trigger', style=wx.RB_GROUP)
+            self.rbOnTrigger.Bind(wx.EVT_RADIOBUTTON, self.OnToggleAnalysisTrigger)
+            self.rbOnTrigger.SetToolTip('Analysis is triggered by the protocol, or by manually clicking the `Analyse` button. Should be used if analysis should start before the series is complete.')
+            hsizer.Add(self.rbOnTrigger, 1, wx.ALL | wx.EXPAND, 2)
+            self.rbOnEnd = wx.RadioButton(pan, -1, 'Series end')
+            self.rbOnEnd.Bind(wx.EVT_RADIOBUTTON, self.OnToggleAnalysisTrigger)
+            self.rbOnEnd.SetToolTip('Analysis is triggered when the series is complete. Should be used if analysis should only start once all data is available.')
+            hsizer.Add(self.rbOnEnd, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 2)
+            if self.spoolController.analysis_launch_mode == 'triggered':
+                self.rbOnTrigger.SetValue(True)
+            else:
+                self.rbOnEnd.SetValue(True)
+            analysisSizer.Add(hsizer, 0, wx.ALL | wx.EXPAND, 0)
+
+            #analysis rule name
+            hsizer = wx.BoxSizer(wx.HORIZONTAL)
+            self.stRuleChain = wx.StaticText(pan, -1, 'Rule chain:')
+            hsizer.Add(self.stRuleChain, 0, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, 5)
+            choices = [r for r in self.scope.analysis_rules.keys()]
+            self.cRuleChain = wx.Choice(pan, -1, choices=choices)
+            self.cRuleChain.SetSelection(choices.index(self.spoolController.analysis_rule_name))
+            self.cRuleChain.Bind(wx.EVT_CHOICE, self.OnRuleChainChanged)
+            hsizer.Add(self.cRuleChain, 1, wx.ALL | wx.EXPAND, 2)
+            analysisSizer.Add(hsizer, 0, wx.ALL | wx.EXPAND, 0)
+
+            self._update_analysis_controls()
+
+            
+        else:
+            clp = afp.collapsingPane(self, caption='Real time analysis ...')
+
+            self.scope.analysisSettings = AnalysisSettingsUI.AnalysisSettings() #Move me???
+
+            clp.AddNewElement(AnalysisSettingsUI.AnalysisSettingsPanel(clp, self.scope.analysisSettings,
+                                                                    self.scope.analysisSettings.onMetadataChanged))
+            clp.AddNewElement(AnalysisSettingsUI.AnalysisDetailsPanel(clp, self.scope.analysisSettings,
+                                                                    self.scope.analysisSettings.onMetadataChanged))
+            #self.AddNewElement(clp)
+            analysisSizer.Add(clp, 0, wx.ALL | wx.EXPAND, 0)
+
+        vsizer.Add(analysisSizer, 0, wx.ALL | wx.EXPAND, 0)
+        pan.SetSizerAndFit(vsizer)
+        return pan
+        
+
+    def OnToggleAnalysis(self, event):
+        self.spoolController.analysis_mode = 'interactive' if self.rbInteractiveAnalysis.GetValue() else 'rule-based'
+        self._update_analysis_controls()
+
+    def OnToggleAnalysisTrigger(self, event):
+        self.spoolController.analysis_launch_mode = 'triggered' if self.rbOnTrigger.GetValue() else 'series-end'
+
+    def OnRuleChainChanged(self, event):
+        self.spoolController.analysis_rule_name = self.cRuleChain.GetStringSelection()
+
+    def _update_analysis_controls(self):
+        self.rbOnTrigger.SetValue(self.spoolController.analysis_launch_mode == 'triggered')
+        self.rbInteractiveAnalysis.SetValue(self.spoolController.analysis_mode == 'interactive')
+
+        if hasattr(self.scope, 'analysis_rules'):
+            choices = [r for r in self.scope.analysis_rules.keys()]
+            self.cRuleChain.SetItems(choices)
+            self.cRuleChain.SetSelection(choices.index(self.spoolController.analysis_rule_name))
+
+            if self.spoolController.analysis_mode == 'interactive':
+                #self.stRuleChain.Hide()
+                #self.cRuleChain.Hide()
+                self.cRuleChain.Disable()
+            else:
+                #self.stRuleChain.Show()
+                #self.cRuleChain.Show()
+                self.cRuleChain.Enable()
+
+        else:
+            self.cRuleChain.Disable()
+            #self.stRuleChain.Hide()
+            #self.cRuleChain.Hide()
+
+        #self.cascading_layout()
         
     def _spool_pan(self):
         pan = wx.Panel(parent=self, style=wx.TAB_TRAVERSAL)
@@ -427,6 +529,7 @@ class SpoolingPane(afp.foldingPane):
         self.AddNewElement(self._aq_settings_pan(), priority=1, foldable=False)
         self._pan_spool_to = self._spool_to_pan()
         self.AddNewElement(self._pan_spool_to)
+        self.AddNewElement(self._analysis_pan())
 
         self.AddNewElement(self._spool_pan())
 

--- a/PYME/Acquire/ui/spool_panel.py
+++ b/PYME/Acquire/ui/spool_panel.py
@@ -441,15 +441,20 @@ class SpoolingPane(afp.foldingPane):
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
 
         self.bStartSpool = wx.Button(self.spoolProgPan, -1, 'Start', style=wx.BU_EXACTFIT)
-        self.bStartSpool.Bind(wx.EVT_BUTTON, self.OnBStartSpoolButton)
+        self.bStartSpool.Bind(wx.EVT_BUTTON, self.OnStartStopButton)
         #self.bStartSpool.SetDefault()
         hsizer.Add(self.bStartSpool, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 2)
+
+        self.bView = wx.Button(self.spoolProgPan, -1, 'View', style=wx.BU_EXACTFIT)
+        self.bView.Bind(wx.EVT_BUTTON, self.OnViewButton)
+        hsizer.Add(self.bView, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 2)
+        self.bView.Enable(False)
     
-        self.bStopSpooling = wx.Button(self.spoolProgPan, -1, 'Stop', style=wx.BU_EXACTFIT)
-        self.bStopSpooling.Enable(False)
-        self.bStopSpooling.Bind(wx.EVT_BUTTON, self.OnBStopSpoolingButton)
+        # self.bStopSpooling = wx.Button(self.spoolProgPan, -1, 'Stop', style=wx.BU_EXACTFIT)
+        # self.bStopSpooling.Enable(False)
+        # self.bStopSpooling.Bind(wx.EVT_BUTTON, self.OnBStopSpoolingButton)
     
-        hsizer.Add(self.bStopSpooling, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        # hsizer.Add(self.bStopSpooling, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
     
         self.bAnalyse = wx.Button(self.spoolProgPan, -1, 'Analyse', style=wx.BU_EXACTFIT)
         self.bAnalyse.Enable(False)
@@ -686,10 +691,18 @@ class SpoolingPane(afp.foldingPane):
 
         try:
             self.spoolController.start_spooling(fn)
+            return True
         except IOError as e:
             logger.exception('IO error whilst spooling')
             ans = wx.MessageBox(str(e.strerror), 'Error', wx.OK)
             self.tcSpoolFile.SetValue(self.spoolController.seriesName)
+            return False
+
+    def OnStartStopButton(self, event=None):
+        if self.bStartSpool.GetLabel() == 'Start':
+            self.OnBStartSpoolButton(event)
+        else:
+            self.OnBStopSpoolingButton(event)
             
     def update_ui(self):
         self.cbCompress.SetValue(self.spoolController.hdf_compression_level > 0)
@@ -700,23 +713,21 @@ class SpoolingPane(afp.foldingPane):
         if self.spoolController.spoolType in ['Queue', 'Cluster']:
             self.bAnalyse.SetLabel('Analyse')
             self.bAnalyse.Enable()
+            self.bView.Enable() # todo - does this make sense for tiling?
+        else:
+            self.bView.Enable(False)
             
 
-        self.bStartSpool.Enable(False)
+        #self.bStartSpool.Enable(False)
         #self.bStartStack.Enable(False)
-        self.bStopSpooling.Enable(True)
+        #self.bStopSpooling.Enable(True)
+        self.bStartSpool.SetLabel('Stop')
         #self.stSpoolingTo.Enable(True)
         #self.stNImages.Enable(True)
         self.stSpoolingTo.SetForegroundColour(None)
         self.stNImages.SetForegroundColour(None)
         self.stSpoolingTo.SetLabel('Spooling to ' + self.spoolController.seriesName)
         self.stNImages.SetLabel('0 images spooled in 0 minutes')
-        
-        
-
-    def OnBStartStackButton(self, event=None):
-        """GUI callback to start spooling with z-stepping."""
-        self.OnBStartSpoolButton(stack=True)
         
 
     def OnBStopSpoolingButton(self, event):
@@ -725,9 +736,11 @@ class SpoolingPane(afp.foldingPane):
         #self.OnSpoolingStopped()
         
     def OnSpoolingStopped(self, **kwargs):
-        self.bStartSpool.Enable(True)
+        self.bStartSpool.SetLabel('Start')
+        self.bView.Enable(True)
+        #self.bStartSpool.Enable(True)
         #self.bStartStack.Enable(True)
-        self.bStopSpooling.Enable(False)
+        #self.bStopSpooling.Enable(False)
         #self.stSpoolingTo.Enable(False)
         #self.stNImages.Enable(False)
         self.stSpoolingTo.SetForegroundColour(wx.TheColourDatabase.Find('GREY'))
@@ -747,9 +760,12 @@ class SpoolingPane(afp.foldingPane):
         if self.bAnalyse.GetLabel() == 'Analyse':
             self.spoolController.launch_analysis()
             if self.spoolController.analysis_mode == 'rule-based':
-                self.bAnalyse.SetLabel('View')
+                self.bAnalyse.SetLabel('View Results')
         else:
             self.spoolController.open_analysis()
+
+    def OnViewButton(self, event):
+        self.spoolController.open_view()
 
         
     

--- a/PYME/Acquire/ui/spool_panel.py
+++ b/PYME/Acquire/ui/spool_panel.py
@@ -235,7 +235,7 @@ class SpoolingPane(afp.foldingPane):
         spoolDirSizer.Add(self.stDiskSpace, 0, wx.ALL | wx.EXPAND, 2)
 
         ### Compression etc
-        clp = afp.collapsingPane(pan, caption='Compression and quantization ...', padding=2)
+        clp = afp.collapsingPane(pan, caption='Compression ...', padding=2)
         clp.AddNewElement(self._comp_pan(clp))
         spoolDirSizer.Add(clp, 0, wx.ALL | wx.EXPAND, 2)
 
@@ -354,7 +354,7 @@ class SpoolingPane(afp.foldingPane):
             self.stRuleChain = wx.StaticText(pan, -1, 'Rule chain:')
             hsizer.Add(self.stRuleChain, 0, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, 5)
             choices = [r for r in self.scope.analysis_rules.keys()]
-            self.cRuleChain = wx.Choice(pan, -1, choices=choices)
+            self.cRuleChain = wx.Choice(pan, -1, choices=choices, size=(100, -1))
             self.cRuleChain.SetSelection(choices.index(self.spoolController.analysis_rule_name))
             self.cRuleChain.Bind(wx.EVT_CHOICE, self.OnRuleChainChanged)
             hsizer.Add(self.cRuleChain, 1, wx.ALL | wx.EXPAND, 2)
@@ -432,7 +432,7 @@ class SpoolingPane(afp.foldingPane):
         self.stSpoolingTo = wx.StaticText(self.spoolProgPan, -1, 'Spooling to .....')
         spoolProgSizer.Add(self.stSpoolingTo, 0, wx.ALL, 0)
     
-        self.stNImages = wx.StaticText(self.spoolProgPan, -1, 'NNNNN images spooled in MM minutes')
+        self.stNImages = wx.StaticText(self.spoolProgPan, -1, 'NNN images spooled in MM mins')
         self.stSpoolingTo.SetForegroundColour(wx.TheColourDatabase.Find('GREY'))
         self.stNImages.SetForegroundColour(wx.TheColourDatabase.Find('GREY'))
     

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -80,12 +80,7 @@ class TilePanel(wx.Panel):
         
         self.SetSizerAndFit(vsizer)
         
-    def OnGo(self, event=None):
-        # run a triggered tile acquisition if the camera is capable
-        # FIXME - the hasattr test becomes problematic once we add FireSoftwareTrigger to our base camera class (to
-        # document API)
-        trigger = hasattr(self.scope.cam, 'FireSoftwareTrigger')
-        
+    def OnGo(self, event=None):        
         backend = 'file'
         if self.rbSpoolCluster.GetValue():
             backend = 'cluster'
@@ -101,7 +96,7 @@ class TilePanel(wx.Panel):
         
         self.scope.tiler = tiler.Tiler(self.scope, tile_dir = tile_dir,
                                        n_tiles=(int(self.tXTiles.GetValue()), int(self.tYTiles.GetValue())),
-                                       trigger=trigger, backend=backend)
+                                       backend=backend)
         
         self.bStop.Enable()
         self.bGo.Disable()

--- a/PYME/Acquire/ui/tilesettingsui.py
+++ b/PYME/Acquire/ui/tilesettingsui.py
@@ -72,5 +72,5 @@ class TileSettingsUI(cascading_layout.CascadingLayoutPanel):
         sp = self.scope.tile_settings.get('tile_spacing', 0.8)
         fs = np.array(self.scope.frameWrangler.currentFrame.shape[:2])*np.array(self.scope.GetPixelSize())
         #print(((n-1) * sp * fs + fs))
-        self.stRegionSize.SetLabel('Region size: %3.1f x %3.1f um' % tuple((n-1) * sp * fs + fs))
+        self.stRegionSize.SetLabel('Region size: %3.1f x %3.1f um' % tuple(n * sp * fs + fs))
         

--- a/PYME/Acquire/ui/tilesettingsui.py
+++ b/PYME/Acquire/ui/tilesettingsui.py
@@ -1,0 +1,39 @@
+import wx
+from PYME.ui import cascading_layout
+
+
+class TileSettingsUI(cascading_layout.CascadingLayoutPanel):
+    def __init__(self, parent, scope, **kwargs):
+        cascading_layout.CascadingLayoutPanel.__init__(self, parent, **kwargs)
+        self.scope = scope
+        
+        if not hasattr(self.scope, 'tile_settings'):
+            self.scope.tile_settings = {'n_tiles': (10, 10)}   
+
+        vsizer = wx.BoxSizer(wx.VERTICAL)
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, label='# x steps'), 0, wx.ALIGN_CENTER_VERTICAL)
+        self.tXSteps = wx.TextCtrl(self, value='10')
+        self.tXSteps.Bind(wx.EVT_TEXT, self.update_settings)
+        hsizer.Add(self.tXSteps, 0, wx.ALIGN_CENTER_VERTICAL)
+        vsizer.Add(hsizer, 0, wx.EXPAND)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(wx.StaticText(self, label='# y steps'), 0, wx.ALIGN_CENTER_VERTICAL)
+        self.tYSteps = wx.TextCtrl(self, value='10')
+        self.tYSteps.Bind(wx.EVT_TEXT, self.update_settings)
+        hsizer.Add(self.tYSteps, 0, wx.ALIGN_CENTER_VERTICAL)
+        vsizer.Add(hsizer, 0, wx.EXPAND)
+
+        self.update_from_settings()
+
+        self.SetSizerAndFit(vsizer)
+
+    def update_from_settings(self):
+        xs, ys = self.scope.tile_settings.get('n_tiles', (10, 10))
+        self.tXSteps.SetValue(str(xs))
+        self.tYSteps.SetValue(str(ys))
+
+    def update_settings(self, event=None):
+        self.scope.tile_settings['n_tiles'] = (int(self.tXSteps.GetValue()), int(self.tYSteps.GetValue()))
+

--- a/PYME/Acquire/ui/tilesettingsui.py
+++ b/PYME/Acquire/ui/tilesettingsui.py
@@ -12,20 +12,44 @@ class TileSettingsUI(cascading_layout.CascadingLayoutPanel):
 
         vsizer = wx.BoxSizer(wx.VERTICAL)
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
-        hsizer.Add(wx.StaticText(self, label='# x steps'), 0, wx.ALIGN_CENTER_VERTICAL)
-        self.tXSteps = wx.TextCtrl(self, value='10')
+        hsizer.Add(wx.StaticText(self, label='# steps - x:'), 0, wx.ALIGN_CENTER_VERTICAL)
+        self.tXSteps = wx.TextCtrl(self, value='10', size=(40, -1))
         self.tXSteps.Bind(wx.EVT_TEXT, self.update_settings)
-        hsizer.Add(self.tXSteps, 0, wx.ALIGN_CENTER_VERTICAL)
+        hsizer.Add(self.tXSteps, 1, wx.ALIGN_CENTER_VERTICAL)
+        #vsizer.Add(hsizer, 0, wx.EXPAND)
+
+        #hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        #hsizer.Add(wx.StaticText(self, label='# y steps'), 0, wx.ALIGN_CENTER_VERTICAL)
+        hsizer.Add(wx.StaticText(self, label=', y:'), 0, wx.ALIGN_CENTER_VERTICAL)
+        self.tYSteps = wx.TextCtrl(self, value='10', size=(40, -1))
+        self.tYSteps.Bind(wx.EVT_TEXT, self.update_settings)
+        hsizer.Add(self.tYSteps, 1, wx.ALIGN_CENTER_VERTICAL)
         vsizer.Add(hsizer, 0, wx.EXPAND)
 
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
-        hsizer.Add(wx.StaticText(self, label='# y steps'), 0, wx.ALIGN_CENTER_VERTICAL)
-        self.tYSteps = wx.TextCtrl(self, value='10')
-        self.tYSteps.Bind(wx.EVT_TEXT, self.update_settings)
-        hsizer.Add(self.tYSteps, 0, wx.ALIGN_CENTER_VERTICAL)
-        vsizer.Add(hsizer, 0, wx.EXPAND)
+        hsizer.Add(wx.StaticText(self, label='Tile spacing:'), 0, wx.ALIGN_CENTER_VERTICAL)
+        self.tTileSpacing = wx.TextCtrl(self, value='0.8', size=(40, -1))
+        self.tTileSpacing.Bind(wx.EVT_TEXT, self.update_settings)
+        self.tTileSpacing.SetToolTip('Spacing between tiles as a fraction of the tile size')
+        hsizer.Add(self.tTileSpacing, 1, wx.ALIGN_CENTER_VERTICAL)
+        vsizer.Add(hsizer, 0, wx.EXPAND|wx.TOP, 2)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.stRegionSize = wx.StaticText(self, label='Region size: 0.0 x 0.0 um')
+        hsizer.Add(self.stRegionSize, 0, wx.ALIGN_CENTER_VERTICAL)
+        vsizer.Add(hsizer, 0, wx.EXPAND|wx.TOP, 5)
+
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        #hsizer.Add(wx.StaticText(self, label=''), 0, wx.ALIGN_CENTER_VERTICAL)
+        self.cbSaveRaw = wx.CheckBox(self, label='Save raw frames')
+        self.cbSaveRaw.SetValue(False)
+        self.cbSaveRaw.SetToolTip('Save raw frames in addition to the stitched image. Can be useful for debugging and/or high-precision alignment')
+        self.cbSaveRaw.Bind(wx.EVT_CHECKBOX, self.update_settings)
+        hsizer.Add(self.cbSaveRaw, 0, wx.ALIGN_CENTER_VERTICAL)
+        vsizer.Add(hsizer, 0, wx.EXPAND|wx.TOP, 5)
 
         self.update_from_settings()
+        self.update_region_size()
 
         self.SetSizerAndFit(vsizer)
 
@@ -33,7 +57,20 @@ class TileSettingsUI(cascading_layout.CascadingLayoutPanel):
         xs, ys = self.scope.tile_settings.get('n_tiles', (10, 10))
         self.tXSteps.SetValue(str(xs))
         self.tYSteps.SetValue(str(ys))
+        self.tTileSpacing.SetValue('%3.2f' %self.scope.tile_settings.get('tile_spacing', 0.8))
 
     def update_settings(self, event=None):
         self.scope.tile_settings['n_tiles'] = (int(self.tXSteps.GetValue()), int(self.tYSteps.GetValue()))
+        self.scope.tile_settings['tile_spacing'] = float(self.tTileSpacing.GetValue())
+        self.scope.tile_settings['save_raw'] = self.cbSaveRaw.GetValue()
 
+        self.update_region_size()
+
+    def update_region_size(self):
+        import numpy as np
+        n = np.array(self.scope.tile_settings.get('n_tiles', (10, 10)))
+        sp = self.scope.tile_settings.get('tile_spacing', 0.8)
+        fs = np.array(self.scope.frameWrangler.currentFrame.shape[:2])*np.array(self.scope.GetPixelSize())
+        #print(((n-1) * sp * fs + fs))
+        self.stRegionSize.SetLabel('Region size: %3.1f x %3.1f um' % tuple((n-1) * sp * fs + fs))
+        

--- a/PYME/Acquire/xyztc.py
+++ b/PYME/Acquire/xyztc.py
@@ -169,7 +169,7 @@ class XYZTCAcquisition(AcquisitionBase):
         self.scope.stackSettings.SetPrevPos(self.scope.stackSettings._CurPos())
 
         with self.scope.frameWrangler.spooling_stopped():
-            # avoid stopping both here and in the SpoolController
+            # stop frameWrangler wile we set things up
             #self.scope.frameWrangler.stop()
             if self._stack_settings:
                 self._stack_settings.SetPrevPos(self._stack_settings._CurPos())

--- a/PYME/Analysis/PSFEst/fit_psf_zernikes.py
+++ b/PYME/Analysis/PSFEst/fit_psf_zernikes.py
@@ -1,0 +1,186 @@
+"""Fits zernike polynomials to a PSF image (as an alternative to Gerchberg-Saxton pupil estimation)
+
+works by using the PSF simulation functions to generate as PSF image with a given set of zernike 
+coefficients and comparing to the measured PSF image.
+"""
+
+import numpy as np
+from PYME.Analysis.PSFGen import fourierHNA
+
+
+
+class ZernikePSFFitter(object):
+    def __init__(self, psf, voxelsize_nm, wavelength=700., n=1.51, NA=1.4, **kwargs):
+        self.psf = psf
+        self.voxelsize_nm = voxelsize_nm
+        self.wavelength = wavelength
+        self.n = n
+        self.NA = NA
+
+    def get_zernike_psf(self, zernike_coeffs=None):
+        """
+        Generate a PSF image with a given set of zernike coefficients
+
+        Parameters
+        ----------
+        zernike_coeffs : ndarray
+            array of zernike coefficients
+
+        Returns
+        -------
+        psf : ndarray
+            simulated PSF image
+        """
+
+        if zernike_coeffs is None:
+            zernike_coeffs = self.zernike_coefficients
+
+        zs = (np.arange(self.psf.shape[2]) - self.psf.shape[2]/2)*self.voxelsize_nm.z
+
+        ps = fourierHNA.GenZernikePSF(zs, zernike_coeffs, dx=self.voxelsize_nm.x, lamb=self.wavelength, n=self.n, NA=self.NA, output_shape=self.psf.shape)
+        
+        # TODO - improve normalisation of PSF - maybe build into residual calculation
+        return ps/ps.max()
+    
+    def zernike_residuals(self, zernike_coeffs):
+        """
+        Calculate the residuals between a measured PSF and a simulated PSF with a given set of zernike coefficients
+
+        Parameters
+        ----------
+        zernike_coeffs : ndarray
+            array of zernike coefficients
+
+        Returns
+        -------
+        residuals : ndarray
+            array of residuals between the measured and simulated PSFs
+        """
+
+        sim_psf = self.get_zernike_psf(zernike_coeffs)
+        residuals = sim_psf - self.psf
+
+        # TODO - change noise model???
+        return np.sum(residuals**2)
+
+    def refine_zernike(self, zernike_coeffs, zernike_order, delta=2.0):
+        """
+        Refine a single zernike coefficient, assuming a quadratic dependence on the residuals
+        """
+        coeffs = np.copy(zernike_coeffs)
+        
+        res0 = self.zernike_residuals(coeffs)
+
+        coeffs[zernike_order] += delta
+        res1 = self.zernike_residuals(coeffs)
+
+        coeffs[zernike_order] -= 2*delta
+        res2 = self.zernike_residuals(coeffs)
+
+        # fit a quadratic to the residuals
+        a = (res1 + res2 - 2*res0)/(2*delta**2)
+        b = (res1 - res2)/(2*delta)
+        c = res0
+
+        return (-b/(2*a))
+    
+    def refine_zernikes(self, zernike_coeffs, delta):
+        """
+        Refine all zernike coefficients
+        """
+        refined_coeffs = np.copy(zernike_coeffs)
+        for i in range(1, len(zernike_coeffs)): # skip the piston term
+            d_i = self.refine_zernike(refined_coeffs, i, delta)
+            refined_coeffs[i] += np.clip(d_i, -delta, delta) # limit the step size to the range we are searching
+        
+        return refined_coeffs
+    
+    def approximate_zernikes(self, num_zernike_orders, num_iterations=5, starting_zernikes={}, plot=True, **kwargs):
+        """
+        Approximate the zernike coefficients of a PSF image using a least squares fit
+        """
+        zernikes = np.zeros(num_zernike_orders)
+        for k,v in starting_zernikes.items():
+            zernikes[k] = v
+
+        delta = 2.0
+
+        self._residuals = [] 
+        self._deltas = []
+
+        for i in range(num_iterations):
+            z0 = zernikes
+            zernikes = self.refine_zernikes(zernikes, delta)
+            self._residuals.append(self.zernike_residuals(zernikes))
+            self._deltas.append(delta)
+            print(self._residuals[-1])
+
+            # if we made a large move on any of the coefficients, hold step size, otherwise reduce it.
+            max_change = np.max(np.abs(zernikes - z0))
+            delta = np.max([delta/ 2.0, max_change])
+        
+        self.zernike_coefficients = zernikes
+
+        if plot:
+            self.plot_results()
+        
+        return zernikes
+    
+
+    def get_misfit_map(self, zernike_coeffs):
+        """
+        Get a map of the residuals between the measured and simulated PSFs
+        as a 5x5 tiled image of z planes
+        """
+        sim_psf = self.get_zernike_psf(zernike_coeffs)
+        res =  sim_psf - self.psf
+
+        step = res.shape[2]//25
+        out = np.zeros([5*self.psf.shape[0], 5*self.psf.shape[1]])
+
+        for i in range(5):
+            for j in range(5):
+                out[i*self.psf.shape[0]:(i+1)*self.psf.shape[0], j*self.psf.shape[1]:(j+1)*self.psf.shape[1]] = res[:,:,(i*5+j)*step]
+
+        return out
+    
+    def plot_results(self):
+        """
+        Plot the results of the zernike fitting
+        """
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.imshow(100*self.get_misfit_map(self.zernike_coefficients), cmap=plt.cm.RdBu_r, clim=(-30, 30))
+        plt.colorbar()
+        plt.title('Fit residuals (% of max)')
+        plt.xticks([])
+        plt.yticks([])
+
+        plt.figure()
+        plt.subplot(311)
+        plt.plot(self._residuals)
+        plt.ylabel('Squared error')
+        plt.xlabel('Iteration')
+        plt.subplot(312)
+        plt.plot(self._deltas)
+        plt.ylabel('Step size')
+        plt.xlabel('Iteration')
+
+        plt.subplot(313)
+        b = plt.bar(np.arange(len(self.zernike_coefficients)), self.zernike_coefficients)
+        plt.bar_label(b, fmt='%.2f')
+        plt.ylabel('Zernike coefficient')
+        plt.xlabel('Zernike order')
+        plt.axhline(0, color='k', linestyle='--')
+
+        plt.show()
+
+
+
+
+
+
+
+    
+
+

--- a/PYME/Analysis/PSFGen/fourierHNA.py
+++ b/PYME/Analysis/PSFGen/fourierHNA.py
@@ -821,6 +821,8 @@ def GenZernikePSF(zs, zernikeCoeffs = [], **kwargs):
         
     pupil = F.astype('d')*np.exp(-1j*ang)
 
+    kwargs.pop('X', None)
+    kwargs.pop('Y', None)
     return PSF_from_pupil_and_propagator(X, Y, R, FP, u, v, pupil=pupil, zs=zs, **kwargs)
     
     

--- a/PYME/Analysis/deTile.py
+++ b/PYME/Analysis/deTile.py
@@ -112,8 +112,10 @@ def tile(ds, xm, ym, mdh, split=True, skipMoveFrames=True, shiftfield=None, mixm
         nchans = 1
 
     #x & y positions of each frame
-    xps = xm(np.arange(numFrames))
-    yps = ym(np.arange(numFrames))
+    # FIXME!! - work out why we need to subtract 2 from the range and fix it properly
+    # FIXME!! - is the -2 simulator specific?
+    xps = xm(np.arange(numFrames)-2)
+    yps = ym(np.arange(numFrames)-2)
 
     if mdh.getOrDefault('CameraOrientation.FlipX', False):
         xps = -xps
@@ -134,8 +136,8 @@ def tile(ds, xm, ym, mdh, split=True, skipMoveFrames=True, shiftfield=None, mixm
     #print (xps - xps.min()), mdh.getEntry('voxelsize.x')
 
     #work out how big our tiled image is going to be
-    imageSizeX = np.ceil(xdp.max() + frameSizeX + bufSize)
-    imageSizeY = np.ceil(ydp.max() + frameSizeY + bufSize)
+    imageSizeX = int(np.ceil(xdp.max() + frameSizeX + bufSize))
+    imageSizeY = int(np.ceil(ydp.max() + frameSizeY + bufSize))
 
     #print imageSizeX, imageSizeY
 
@@ -178,7 +180,7 @@ def tile(ds, xm, ym, mdh, split=True, skipMoveFrames=True, shiftfield=None, mixm
 #    yvs = list(set(ydp))
 #    yvs.sort()
 
-    for i in range(mdh.getEntry('Protocol.DataStartsAt'), numFrames):
+    for i in range(mdh.get('Protocol.DataStartsAt', 0), numFrames):
         if xdp[i - 1] == xdp[i] or not skipMoveFrames:
             d = ds[:,:,i].astype('f')
             if not dark is None:

--- a/PYME/Analysis/deTile.py
+++ b/PYME/Analysis/deTile.py
@@ -73,6 +73,7 @@ def calcCorrShift(im1, im2):
     y_ = np.arange(xct.shape[1]) - xct.shape[1]/2
 
     xc = xc - xc.min()
+    # TODO - subtract half max instead??
     xc = np.maximum(xc - xc.mean(), 0)
 
     s = xc.sum()
@@ -81,18 +82,6 @@ def calcCorrShift(im1, im2):
     dy = (xc*y_[None, :]).sum()/s
 
     return dx, dy, s
-
-    #figure(1)
-    #imshow(xct)
-
-    #dx, dy =  ndimage.measurements.center_of_mass(xct)
-
-    #print np.where(xct==xct.max())
-    #TODO - do COI based shift estimation, rather than just max
-
-    dx, dy = np.where(xct==xct.max())
-
-    return dx[0] - im1.shape[0]/2, dy[0] - im1.shape[1]/2, xct.max()
 
 def genDark(ds, mdh, blur=2):
     df = mdh.getEntry('Protocol.DarkFrameRange')

--- a/PYME/Analysis/distributed_pyramid.py
+++ b/PYME/Analysis/distributed_pyramid.py
@@ -208,13 +208,17 @@ class DistributedImagePyramid(ImagePyramid):
         self._spooler.put_stream(server_idx, fn,PZFFormat.dumps(data))
              
     
+    @property
+    def servers(self):
+        return self._spooler.servers
+    
     def finish_base_tiles(self):
         """
         Notifies all cluster servers that all frames have been processed on the
         microscope end. Blocks until the servers have finished constructing their partial pyramids
         """
         
-        for ts in self._spooler.servers:
+        for ts in self._spooler._streams:
             ts.finalize('__pyramid_finish/' + self.base_dir.lstrip('/'))
             
         # put this in a separate loop to the above as .close() joins the pushing threads, which

--- a/PYME/Analysis/distributed_pyramid.py
+++ b/PYME/Analysis/distributed_pyramid.py
@@ -245,7 +245,7 @@ class DistributedImagePyramid(ImagePyramid):
             logger.debug("Topmost level: {}".format(inputLevel + 1))
     
             self.pyramid_valid = True
-            self.depth = inputLevel
+            self.depth = inputLevel +1
             self._imgs.flush()
 
 

--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -733,9 +733,10 @@ class LMAnalyser2(Plugin):
                 self.ds = tabular.FitResultsSource(self.fitResults)
                 self.ds.mdh = self.resultsMdh
                 self.dsviewer.pipeline.OpenFile(ds=self.ds, imBounds=self.dsviewer.image.imgBounds)
-                self.dsviewer.pipeline.mdh = self.resultsMdh
+                #self.dsviewer.pipeline.mdh = self.resultsMdh
                 try:
                     self.dsviewer.LMDisplay.SetFit()
+                    self.dsviewer.LMDisplay._create_base_layer()
                 except:
                     pass
             else:

--- a/PYME/DSView/modules/tiling.py
+++ b/PYME/DSView/modules/tiling.py
@@ -35,11 +35,17 @@ class Tiler(Plugin):
         from PYME.Analysis import deTile
         from PYME.DSView import View3D
 
+        dlg = wx.TextEntryDialog(self.dsviewer, 'Please enter backlash correction parameters (x, y)', 'Backlash Correction Parameters', '0.0, 0.0')
+        if dlg.ShowModal():
+            x_corr, y_corr = [float(x) for x in dlg.GetValue().split(',')]
+        else:
+            return
+
         x0 = self.image.mdh.getEntry('Positioning.x')
-        xm = piecewiseMapping.GenerateBacklashCorrPMFromEventList(self.image.events, self.image.mdh, self.image.mdh.getEntry('StartTime'), x0, 'ScannerXPos', 0, .0055)
+        xm = piecewiseMapping.GenerateBacklashCorrPMFromEventList(self.image.events, self.image.mdh, self.image.mdh.getEntry('StartTime'), x0, b'ScannerXPos', 0, x_corr)
 
         y0 = self.image.mdh.getEntry('Positioning.y')
-        ym = piecewiseMapping.GenerateBacklashCorrPMFromEventList(self.image.events, self.image.mdh, self.image.mdh.getEntry('StartTime'), y0, 'ScannerYPos', 0, .0035)
+        ym = piecewiseMapping.GenerateBacklashCorrPMFromEventList(self.image.events, self.image.mdh, self.image.mdh.getEntry('StartTime'), y0, b'ScannerYPos', 0, y_corr)
 
         #dark = deTile.genDark(self.vp.do.ds, self.image.mdh)
         dark = self.image.mdh.getEntry('Camera.ADOffset')
@@ -69,12 +75,12 @@ class Tiler(Plugin):
         x0 = self.image.mdh.getEntry('Positioning.x')
         xm = piecewiseMapping.GenerateBacklashCorrPMFromEventList(self.image.events, self.image.mdh,
                                                                   self.image.mdh.getEntry('StartTime'), x0,
-                                                                  'ScannerXPos', 0, .0055)
+                                                                  b'ScannerXPos', 0, .0055)
 
         y0 = self.image.mdh.getEntry('Positioning.y')
         ym = piecewiseMapping.GenerateBacklashCorrPMFromEventList(self.image.events, self.image.mdh,
                                                                   self.image.mdh.getEntry('StartTime'), y0,
-                                                                  'ScannerYPos', 0, .0035)
+                                                                  b'ScannerYPos', 0, .0035)
 
         #dark = deTile.genDark(self.vp.do.ds, self.image.mdh)
         dark = self.image.mdh.getEntry('Camera.ADOffset')

--- a/PYME/DSView/modules/tiling.py
+++ b/PYME/DSView/modules/tiling.py
@@ -30,8 +30,9 @@ class Tiler(Plugin):
         Plugin.__init__(self, dsviewer)
 
         dsviewer.AddMenuItem('Processing', "&Tiling", self.OnTile)
+        dsviewer.AddMenuItem('Processing', "&Tiling (with cross-correlation)", lambda e: self.OnTile(correlate=True))
 
-    def OnTile(self, event):
+    def OnTile(self, event=None, correlate=False):
         from PYME.Analysis import deTile
         from PYME.DSView import View3D
 
@@ -58,7 +59,7 @@ class Tiler(Plugin):
 
         split = False
 
-        dt = deTile.tile(self.image.data, xm, ym, self.image.mdh, split=split, skipMoveFrames=False, dark=dark, flat=flat)#, mixmatrix = [[.3, .7], [.7, .3]])
+        dt = deTile.tile(self.image.data, xm, ym, self.image.mdh, split=split, skipMoveFrames=False, dark=dark, flat=flat, correlate=correlate)#, mixmatrix = [[.3, .7], [.7, .3]])
 
         mdh = MetaDataHandler.NestedClassMDHandler(self.image.mdh)        
         

--- a/PYME/IO/DataSources/TileDataSource.py
+++ b/PYME/IO/DataSources/TileDataSource.py
@@ -1,0 +1,91 @@
+from PYME.IO.FileUtils.nameUtils import getFullExistingFilename
+from PYME.IO import MetaDataHandler
+#from PYME.IO.FileUtils import readTiff
+#from PIL import Image
+import glob
+import os
+import numpy as np
+from .BaseDataSource import XYZTCDataSource
+#from PYME.misc import TiffImagePlugin #monkey patch PIL with improved tiff support from Priithon
+
+from urllib.parse import parse_qs
+#import numpy as np
+
+#from PYME.misc import tifffile
+
+import logging
+logger = logging.getLogger(__name__)
+
+class TileDataSource(XYZTCDataSource):
+    moduleName = 'TileDataSource'
+    def __init__(self, pyramid, level=0):
+        # NOTE: We cheat a bit here to allow this to be constructed from an existing pyramid - the cannonical module.DataSource(filename) instantiation 
+        # is handled in the function below
+        self.level = int(level)
+
+        self.mdh = MetaDataHandler.NestedClassMDHandler()
+        self.mdh.copyEntriesFrom(pyramid.mdh)
+        
+        voxelsize = self.mdh['Pyramid.PixelSize'] * (2 ** self.level)
+        self.mdh['voxelsize.x'], self.mdh['voxelsize.y'] = (voxelsize, voxelsize)
+
+        self._pyr = pyramid
+
+        self._nx = pyramid.n_tiles_x/(2**level)
+        self._ny = pyramid.n_tiles_y/(2**level)        
+        self.tile_size = pyramid.tile_size
+
+        self._levels = None
+
+        XYZTCDataSource.__init__(self)
+    
+
+    @classmethod
+    def from_filename(cls, filename):
+        from PYME.Analysis.tile_pyramid import ImagePyramid
+        p = ImagePyramid.load_existing(filename)
+        
+        return cls(p)
+    
+    @property
+    def levels(self):
+        if self._levels is None:
+            self._levels = [self.__class__(self._pyr, level) for level in range(self._pyr.depth + 1)]
+        
+        return self._levels
+        
+    
+    def getSlice(self, ind):
+        assert(ind == 0)
+        return self._pyr.layers[self.level][:,:].squeeze()
+    
+    def __getitem__(self, keys):
+        logger.debug(f'TileDataSource.__getitem__ called with level: {self.level}, keys: {keys}')
+        return self._pyr.layers[self.level].__getitem__(keys)
+    
+    @property
+    def dtype(self):
+        return self._pyr.layers[self.level].dtype
+    
+
+    def getSliceShape(self):
+        return self._pyr.layers[self.level].shape
+        #return self.im[0].shape[1:3]
+        #return self.data.shape[:2]
+
+    def getNumSlices(self):
+        return 1
+
+    def getEvents(self):
+        return []
+
+    def release(self):
+        #self.im.close()
+        pass
+
+    def reloadData(self):
+        pass
+    
+def DataSource(filename, taskQueue=None):
+    # cannonical DataSource constructor from filename (needed in order to be able to use this datasource as a task input)
+    return TileDataSource.from_filename(filename)

--- a/PYME/IO/acquisition_backends.py
+++ b/PYME/IO/acquisition_backends.py
@@ -220,6 +220,7 @@ class HDFBackend(Backend):
            
         self._complevel = complevel
         self._complib = complib
+        self.series_name = series_name
         
 
     def store_frame(self, n, frame_data):
@@ -248,3 +249,7 @@ class HDFBackend(Backend):
 
         self.h5File.flush()
         self.h5File.close()
+
+    def getURL(self):
+        '''Get URL for the series to pass to other processes so they can open it'''
+        return self.series_name

--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -642,18 +642,27 @@ class ImageStack(object):
 
         self.mode = 'default'
 
-    def _load_supertile(self, filename):
-        from PYME.IO.DataSources import SupertileDatasource
-        
+    def _load_supertile(self, filename):        
         #strip leading supertile schema
         if filename.upper().startswith('SUPERTILE:'):
             filename = filename[10:]
         
-        data = SupertileDatasource.DataSource(filename)
+        self._load_tiles(filename)
+
+    def _load_tiles(self, filename):
+        from PYME.IO.DataSources import TileDataSource
+
+        filename = filename.rstrip(os.path.sep)
+        
+        data = TileDataSource.DataSource(filename)
         self.SetData(data)
         self.mdh = data.mdh
         self.seriesName = filename
         self.mode = 'default'
+
+        # TODO - make this a property which refers to the datasource??
+        self.levels = data.levels
+
 
     def _load_concatenated(self, filename):
         from PYME.IO.DataSources import ConcatenatedDataSource
@@ -1299,6 +1308,8 @@ class ImageStack(object):
                 self._loadClusterPZF(filename)
             elif (filename.upper().startswith('SUPERTILE:')):
                 self._load_supertile(filename)
+            elif (filename.endswith('.tiles') or filename.endswith('.tiles/')):
+                self._load_tiles(filename)
             elif (filename.upper().startswith('CONCATENATED://')):
                 self._load_concatenated(filename)
             elif filename.endswith('.h5'):

--- a/PYME/IO/testClusterSpooling.py
+++ b/PYME/IO/testClusterSpooling.py
@@ -71,6 +71,15 @@ import numpy as np
 from PYME.util import fProfile
 
 # class DCIMGSpooler(object):
+
+
+from contextlib import contextmanager
+class DummyFramewrangler(object):
+    # Dummy class to provide the spooling_stopped context manager
+    @contextmanager
+    def spooling_stopped(self):
+        yield
+
 class TestSpooler:
     def __init__(self, testFrameSize = TEST_FRAME_SIZE, serverfilter=''):
         
@@ -95,19 +104,19 @@ class TestSpooler:
         if hdf_spooler:
             if compression:
                 #self.spooler = HDFSpooler.Spooler(filename, self.onFrame, frameShape = frameShape, complevel=0)
-                self.spooler = protocol_acquisition.ProtocolAcquisition(filename, self.onFrame, frameShape = frameShape, complevel=0,backend='hdf')
+                self.spooler = protocol_acquisition.ProtocolAcquisition(filename, self.onFrame, frameShape = frameShape, complevel=0,backend='hdf', frame_wrangler=DummyFramewrangler())
             else:
                 #self.spooler = HDFSpooler.Spooler(filename, self.onFrame,frameShape = frameShape, complevel=3)
-                self.spooler = protocol_acquisition.ProtocolAcquisition(filename, self.onFrame, frameShape = frameShape, complevel=3,backend='hdf')
+                self.spooler = protocol_acquisition.ProtocolAcquisition(filename, self.onFrame, frameShape = frameShape, complevel=3,backend='hdf', frame_wrangler=DummyFramewrangler())
         else:
             if compression:
-                self.spooler = protocol_acquisition.ProtocolAcquisition(filename, self.onFrame, frameShape = None, serverfilter=self.serverfilter, backend='cluster')
+                self.spooler = protocol_acquisition.ProtocolAcquisition(filename, self.onFrame, frameShape = None, serverfilter=self.serverfilter, backend='cluster', frame_wrangler=DummyFramewrangler())
 
             else:
                 self.spooler = protocol_acquisition.ProtocolAcquisition(filename, self.onFrame,
                                                    frameShape = None, serverfilter=self.serverfilter,
                                                    compressionSettings={'compression': PZFFormat.DATA_COMP_RAW,
-                                                                        'quantization':PZFFormat.DATA_QUANT_NONE}, backend='cluster')
+                                                                        'quantization':PZFFormat.DATA_QUANT_NONE}, backend='cluster', frame_wrangler=DummyFramewrangler())
                 
         
         

--- a/PYME/config.py
+++ b/PYME/config.py
@@ -50,6 +50,9 @@ overall template for a configuration directory is as follows: ::
       |     |- init_mymachine.py
       |     |- init_my_other_config.py
       |
+      |- chained_analyisis
+      |     |-analysis_rule_chain.yaml
+      |
       |- cameras
       |     |- bunch_of_cams.yaml
       |     |- single_cam.yaml
@@ -514,6 +517,18 @@ def get_custom_recipes():
         recip_glob = os.path.join(config_dir, 'customrecipes/[a-zA-Z]*.yaml')
         recipes.update({os.path.split(p)[-1] : p for p in glob.glob(recip_glob)})
     return recipes
+
+def get_analysis_rulechains():
+    """
+    Get a dictionary recording the locations of any custom analysis rule chains, as used by
+    PYMEAcquire chained analysis.
+    """
+    import glob
+    chains = {}
+    for config_dir in config_dirs:
+        chain_glob = os.path.join(config_dir, 'chained_analysis/*.yaml')
+        chains.update({os.path.split(p)[-1] : p for p in glob.glob(chain_glob)})
+    return chains
 
 def get_init_filename(filename, legacy_scripts_directory=None):
     """

--- a/PYME/contrib/listctrlMixins.py
+++ b/PYME/contrib/listctrlMixins.py
@@ -425,6 +425,8 @@ class ListCtrlSelectionManagerMix(object):
 #----------------------------------------------------------------------------
 from bisect import bisect
 
+from wx.lib.mixins import listctrl as listmix
+
 
 class TextEditMixin(object):
     """    
@@ -572,13 +574,16 @@ class TextEditMixin(object):
 
         # give the derived class a chance to Allow/Veto this edit.
         evt = wx.ListEvent(wx.wxEVT_COMMAND_LIST_BEGIN_LABEL_EDIT, self.GetId())
-        evt.m_itemIndex = row
-        evt.m_col = col
+        #evt.m_itemIndex = row
+        #evt.m_col = col
+        evt.SetIndex(row)
+        evt.SetColumn(col)
         item = self.GetItem(row, col)
-        evt.m_item.SetId(item.GetId()) 
-        evt.m_item.SetColumn(item.GetColumn()) 
-        evt.m_item.SetData(item.GetData()) 
-        evt.m_item.SetText(item.GetText()) 
+        evt.SetItem(item)
+        #evt.m_item.SetId(item.GetId()) 
+        #evt.m_item.SetColumn(item.GetColumn()) 
+        #evt.m_item.SetData(item.GetData()) 
+        #evt.m_item.SetText(item.GetText()) 
         ret = self.GetEventHandler().ProcessEvent(evt)
         #print ret, evt.IsAllowed()
         if ret and not evt.IsAllowed():

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -38,6 +38,10 @@ import yaml
 class MyDumper(yaml.SafeDumper):
             def represent_mapping(self, tag, value, flow_style=None):
                 return super(MyDumper, self).represent_mapping(tag, value, False)
+            
+# make sure we can dump metadata to yaml
+from PYME.IO import MetaDataHandler
+MyDumper.add_multi_representer(MetaDataHandler.MDHandlerBase, yaml.representer.SafeRepresenter.represent_dict)
 
 # TODO - move to recipe.py?
 all_modules = {}

--- a/PYME/ui/editList.py
+++ b/PYME/ui/editList.py
@@ -21,7 +21,8 @@
 ##################
 
 import wx
-import PYME.contrib.listctrlMixins  as  listmix
+#import PYME.contrib.listctrlMixins  as  listmix
+from wx.lib.mixins import listctrl as listmix
 
 class EditListCtrl(wx.ListCtrl,
                    listmix.ListCtrlAutoWidthMixin,

--- a/PYME/ui/mytimer.py
+++ b/PYME/ui/mytimer.py
@@ -26,6 +26,9 @@ import time
 
 from wx.core import TIMER_CONTINUOUS
 
+import logging
+logger = logging.getLogger(__name__)
+
 
 
 class MultiTargetTimer(wx.Timer):
@@ -41,7 +44,10 @@ class MultiTargetTimer(wx.Timer):
     def Notify(self):
         for a in self.WantNotification:
             ts = time.time()
-            a()
+            try:
+                a()
+            except:
+                logger.exception('Error in timer callback')
             
             if self.PROFILE:
                 te = time.time() - ts
@@ -53,6 +59,9 @@ class MultiTargetTimer(wx.Timer):
                 
     def register_callback(self, callback):
         self.WantNotification.append(callback)
+
+    def unregister_callback(self, callback):
+        self.WantNotification.remove(callback)
 
     def start(self, delay_ms, single_shot=False):
         if single_shot:


### PR DESCRIPTION
This is an attempt to expand the slightly special-case automated analysis we had for the HTSMS paper a bit more generic (i.e. not limited to protocol-driven acquisitions), and to make it a bit easier to navigate for people who are not already familiar with things. Main changes compared with HTSMS version / current status quo:

- Rule chains are no longer tied to a protocol name, but rather a text tag (or filename if the rule chain has been loaded from file).
- This means that you have to specify `analysis_rule_name` in the dictionary of settings when queueing an acquisition task. If you do this through the GUI, this will automatically be the currently selected analysis rule. If you queue through code or the REST endpoint, you are responsible for specifying it.
- The UI should hopefully be a little bit clearer (see below). The "save analysis settings to metadata" switch is gone, as is the analysis settings fold down in the spooling panel. Instead, there is a now a clear switch between 'Interactive' (which means launch PYMEImage, let you choose and test fit modules and settings there), and fully "automatic". For fully automatic, the settings now live in the "Chained Analysis" tab. 

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/77271458-5a27-4f39-a48d-aa296f697669">

- Within the "Chained Analysis" tab, there are a few subtle UI changes, the biggest of which is that you can now edit the blocks of an existing rule. Changes propagate instantaneously (no need to press apply, or similar), and "add localization rule" or "add recipe rule" now add the rule and edit it, rather than editing the settings then adding.

### TODOS

- wire up saving and loading of rule chains
- load rule chains stored in `.PYME/analysis_rules/` at startup. Potentially also provide a default *2D localisation* rule chain, and maybe a *localise and render* and/or *deconvolve* as examples.
- make a null rule an option (maybe the default)
- handle null / empty rule chains 
- make the spooler UI rule name dropdown choices update when a rule is added
- add a visual cue as to which rule within a chain is being edited
- add a visual cue about whether the rule chain you are editing is the currently selected / active rule chain

