### PR TITLE
Fix uc480 regression

### DIFF
--- a/PYME/Acquire/Hardware/uc480/uc480.py
+++ b/PYME/Acquire/Hardware/uc480/uc480.py
@@ -155,7 +155,7 @@ def loadLibrary(cameratype='uc480'):
                 # see https://stackoverflow.com/questions/59330863/cant-import-dll-module-in-python
                 # winmode=0 enforces windows default dll search mechanism including searching the path set
                 # necessary since python 3.8.x
-                libuc480 = ctypes.WinDLL('ueye_api_64',winmode=0))  
+                libuc480 = ctypes.WinDLL('ueye_api_64',winmode=0)  
                 print("loading ueye_api_64")
         else:
                 raise RuntimeError("unknown camera type")


### PR DESCRIPTION
PR #1470 broke uc480 cameras on non-windows platforms. This should fix it.

