### PR TITLE
set new imagebounds when loading a session

### DIFF
--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -799,6 +799,18 @@ class Pipeline(object):
 
         self.Rebuild()
 
+        # we need some way to calculate image bounds when loading a session
+        # - presumably this needs to happen after the Rebuild()?
+        # - there could also be an issue if the selectedDataSource only spans a subset of the image extent!
+        # - we therefore select 'FitResults' as datasource in the first attempt and fall back to the selected ds otherwise
+        if ('scanx' not in self.selectedDataSource.keys() or
+            'scany' not in self.selectedDataSource.keys()) and 'Camera.ROIWidth' in self.mdh.getEntryNames():
+            self.imageBounds = ImageBounds.extractFromMetadata(self.mdh)
+        elif 'FitResults' in self.dataSources.keys():
+            self.imageBounds = ImageBounds.estimateFromSource(self.dataSources['FitResults'])
+        else:
+            self.imageBounds = ImageBounds.estimateFromSource(self.selectedDataSource)
+
     def _create_default_recipe(self, pixel_size= 1.0, ds_keys = []):
         from PYME.recipes.localisations import ProcessColour, Pipelineify
         from PYME.recipes.tablefilters import FilterTable


### PR DESCRIPTION
Addresses issue that rendering is currently broken when a session was loaded in `PYMEVis`.

The issue seems to result from `pipeline.imageBounds` not set after loading a session (because we bypass `OpenFile` where this normally happens).

**Is this a bugfix or an enhancement?**
Bugfix.
 
**Proposed changes:**
The code uses some heuristics to estimate the image bounds, based on the code in `OpenFile` but slightly adapted to session loading.

The code needs brief checking if this all makes sense. My tests to date indicated it works with both PYME acquired data and external data (CSV, MINFLUX).
