### PR TITLE
Session paths handling

### DIFF
--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -509,12 +509,13 @@ class Pipeline(object):
         
         """
         from PYME import warnings
+        from pathlib import Path
         out = {}
         for k in self.recipe.inferred_data:
             ds = self.dataSources[k]
 
             if hasattr(ds, 'filename'):
-                fn = ds.filename
+                fn = str(Path(ds.filename).resolve()) # ensure we return an absolute path!
 
                 q = getattr(ds, 'query', None)
                 if q:

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -508,14 +508,13 @@ class Pipeline(object):
         Return a dictionary of datasources which are suitable for listing in a session file
         
         """
-        from PYME import warnings
-        from pathlib import Path
+        from PYME import warning
         out = {}
         for k in self.recipe.inferred_data:
             ds = self.dataSources[k]
 
             if hasattr(ds, 'filename'):
-                fn = str(Path(ds.filename).resolve()) # ensure we return an absolute path!
+                fn = ds.filename
 
                 q = getattr(ds, 'query', None)
                 if q:

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -508,7 +508,7 @@ class Pipeline(object):
         Return a dictionary of datasources which are suitable for listing in a session file
         
         """
-        from PYME import warning
+        from PYME import warnings
         out = {}
         for k in self.recipe.inferred_data:
             ds = self.dataSources[k]

--- a/PYME/LMVis/sessionpaths.py
+++ b/PYME/LMVis/sessionpaths.py
@@ -1,19 +1,25 @@
 from pathlib import Path
 
-# in future we could check all traits of type File?
+# the idea of this module is to provide two functions to make paths either relative or absolute in session objects
+# typically this will be relative to the '.pvs' session file path
+# it also provides a method register_path_modulechecks to allow the user/module coder to request path
+# translation for some recipe module arguments
+
+# a dict of recipe module names with arguments to check
 checkmodules = {}
 
-# it seems currently best to reauest this directly from the files in which the modules are defined
+# it seems best to request this directly in the python files in which the modules are defined
 # example:     register_modulecheck('PYMEcs.MBMcorrection','mbmfile','mbmsettings')
+# can this possibly be autoregistered by modifying the Traits.File object suitably?
 def register_path_modulechecks(module,*entries):
     checkmodules[module] = entries
 
-# split finename?query type string in fname and query parts
+# split filename?query type string in fname and query parts
 def parse_fnq(dsfnstr):
     parts = dsfnstr.split('?')
     parts0 = parts[0]
     if len(parts) > 1:
-        parts1 = parts[1] # we assume there are no ?s in the query string
+        parts1 = parts[1] # we assume there are no further '?'s in the query string
     else:
         parts1 = None
     return (parts0,parts1)
@@ -46,14 +52,17 @@ def get_session_dirP(sessionpath):
     abspath = sessionpathp.resolve()
     sessiondir = abspath.parent # get the directory part of this absolute path
 
-    return sessiondir # return sessiondir as path object
+    return sessiondir # return sessiondir as Path object
     
-def make_session_relative(session,sessionpath):
+# note that we do not touch any paths that are already relative
+# this means we can repeatedly call this on session objects without doing any damage
+def make_session_paths_relative(session,sessionpath):
     sessionrel = session.copy()
     sessiondir = get_session_dirP(sessionpath)
     for ds in session['datasources']:
         fname,query = parse_fnq(session['datasources'][ds])
         sessionrel['datasources'][ds] = fnq_string(fnstring_relative(fname,sessiondir),query)
+    # users can request certain recipe module arguments to be also "path-translated" by registering the module/arguments
     for checkmod in checkmodules:
         for module in sessionrel['recipe']:
             if checkmod in module:
@@ -63,12 +72,15 @@ def make_session_relative(session,sessionpath):
                         module[checkmod][field] = fnstring_relative(module[checkmod][field],sessiondir)
     return sessionrel
 
-def make_session_absolute(session,sessionpath):
+# note that we do not touch any paths that are already absolute
+# this means we can repeatedly call this on session objects without doing any damage
+def make_session_paths_absolute(session,sessionpath):
     sessionabs = session.copy()
     sessiondir = get_session_dirP(sessionpath)
     for ds in session['datasources']:
         fname,query = parse_fnq(session['datasources'][ds])
         sessionabs['datasources'][ds] = fnq_string(fnstring_absolute(fname,sessiondir),query)
+    # users can request certain recipe module arguments to be also "path-translated" by registering the module/arguments
     for checkmod in checkmodules:
         for module in sessionabs['recipe']:
             if checkmod in module:

--- a/PYME/LMVis/sessionpaths.py
+++ b/PYME/LMVis/sessionpaths.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+# in future we could check all traits of type File?
+checkmodules = {}
+
+# it seems currently best to reauest this directly from the files in which the modules are defined
+# example:     register_modulecheck('PYMEcs.MBMcorrection','mbmfile','mbmsettings')
+def register_path_modulechecks(module,*entries):
+    checkmodules[module] = entries
+
+# split finename?query type string in fname and query parts
+def parse_fnq(dsfnstr):
+    parts = dsfnstr.split('?')
+    parts0 = parts[0]
+    if len(parts) > 1:
+        parts1 = parts[1] # we assume there are no ?s in the query string
+    else:
+        parts1 = None
+    return (parts0,parts1)
+
+# join filename and query to form the expected string for session loading
+def fnq_string(fn,query):
+    if query is None:
+        return fn
+    else:
+        return fn + '?' + query
+
+def fnstring_relative(fnstring,sessiondir):
+    fnamep = Path(fnstring)
+    if fnamep.is_absolute():
+        fnamerel = str(fnamep.relative_to(sessiondir)) # now make the filenames relative to the session dir path
+    else:
+        fnamerel = fnstring
+    return fnamerel
+
+def fnstring_absolute(fnstring,sessiondir):
+    fnamep = Path(fnstring)
+    if fnamep.is_absolute():
+        fnameabs = fnstring
+    else:
+        fnameabs = str(sessiondir / fnamep) # now make the filenames relative to the session dir path
+    return fnameabs
+
+def get_session_dirP(sessionpath):
+    sessionpathp = Path(sessionpath)
+    abspath = sessionpathp.resolve()
+    sessiondir = abspath.parent # get the directory part of this absolute path
+
+    return sessiondir # return sessiondir as path object
+    
+def make_session_relative(session,sessionpath):
+    sessionrel = session.copy()
+    sessiondir = get_session_dirP(sessionpath)
+    for ds in session['datasources']:
+        fname,query = parse_fnq(session['datasources'][ds])
+        sessionrel['datasources'][ds] = fnq_string(fnstring_relative(fname,sessiondir),query)
+    for checkmod in checkmodules:
+        for module in sessionrel['recipe']:
+            if checkmod in module:
+                # print("PYMEcs.MBMcorrection in module")
+                for field in checkmodules[checkmod]:    
+                    if field in module[checkmod]:
+                        module[checkmod][field] = fnstring_relative(module[checkmod][field],sessiondir)
+    return sessionrel
+
+def make_session_absolute(session,sessionpath):
+    sessionabs = session.copy()
+    sessiondir = get_session_dirP(sessionpath)
+    for ds in session['datasources']:
+        fname,query = parse_fnq(session['datasources'][ds])
+        sessionabs['datasources'][ds] = fnq_string(fnstring_absolute(fname,sessiondir),query)
+    for checkmod in checkmodules:
+        for module in sessionabs['recipe']:
+            if checkmod in module:
+                # print("PYMEcs.MBMcorrection in module")
+                for field in checkmodules[checkmod]:    
+                    if field in module[checkmod]:
+                        module[checkmod][field] = fnstring_absolute(module[checkmod][field],sessiondir)
+    return sessionabs

--- a/PYME/LMVis/sessionpaths.py
+++ b/PYME/LMVis/sessionpaths.py
@@ -1,94 +1,11 @@
 from pathlib import Path
 import os
-from traits.trait_errors import TraitError
-
-# this module provides a function 'check_session_paths' to check session paths in session dictionaries
-# enabling using paths relative to a session directory (where the .pvs resides)
-# this is done IF and ONLY IF all datasource paths are below that session directory
-# in doing so it also carries out these path checks for traits parameters of the FileOrURI type in recipes
+from PYME.recipes import base
 
 import logging
 logger = logging.getLogger(__name__)
 
-# a dict of recipe module names with recipe parameters to check, contents populated at runtime
-checkmodules = {}
-failedmodules = [] # list of modules we cannot instantiate, just for interest
-
-fou_modules_registered = False
-
-# it seems best to request this directly in the python files in which the modules are defined
-# example:     register_modulecheck('PYMEcs.MBMcorrection','mbmfile','mbmsettings')
-# NOTE: manual addition should not be required anymore as we now check all known modules for FileOrURI traits automatically
-def register_path_modulechecks(module,*entries):
-    checkmodules[module] = entries
-
-def register_fou_modules():
-    from PYME.recipes.traits import FileOrURI
-    from PYME.recipes.base import all_modules
-
-    for modname in all_modules:
-        try:
-            mod = all_modules[modname]()
-        except TraitError:
-            failedmodules.append(modname)
-            continue # skip modules we cannot load
-        fou_traits = []
-        class_traits = mod.class_traits()
-        for trait in class_traits:
-            if isinstance(class_traits[trait].trait_type,FileOrURI):
-                fou_traits.append(trait)
-        if len(fou_traits) > 0:
-            checkmodules[modname] = fou_traits
-
-    fou_modules_registered = True
-
-def chk_fou_modules_registered():
-    if not fou_modules_registered:
-        register_fou_modules()
-    
 SESSIONDIR_TOKEN = '$session_dir$'
-
-####
-#### BEGIN BLOCK remaining functions for compatibility reading - REMOVE EVENTUALLY
-####
-def fnstring_absolute(fnstring,sessiondir):
-    fnamep = Path(fnstring)
-    if fnamep.is_absolute():
-        fnameabs = fnstring
-    else:
-        fnameabs = str(sessiondir / fnamep) # now make the filenames relative to the session dir path
-    return fnameabs
-
-def get_session_dirP(sessionpath):
-    sessionpathp = Path(sessionpath)
-    abspath = sessionpathp.resolve()
-    sessiondir = abspath.parent # get the directory part of this absolute path
-
-    return sessiondir # return sessiondir as Path object
-    
-
-# note that we do not touch any paths that are already absolute
-# this means we can repeatedly call this on session objects without doing any damage
-# this function only briefly kept for compatibility until all pvs rewritten
-def make_session_paths_absolute_compat(session,sessionpath):
-    chk_fou_modules_registered()
-    sessionabs = session.copy()
-    sessiondir = get_session_dirP(sessionpath)
-    for ds in session['datasources']:
-        fname,query = parse_fnq(session['datasources'][ds])
-        sessionabs['datasources'][ds] = fnq_string(fnstring_absolute(fname,sessiondir),query)
-    # users can request certain recipe module arguments to be also "path-translated" by registering the module/arguments
-    for checkmod in checkmodules:
-        for module in sessionabs['recipe']:
-            if checkmod in module:
-                for field in checkmodules[checkmod]:    
-                    if field in module[checkmod]:
-                        module[checkmod][field] = fnstring_absolute(module[checkmod][field],sessiondir)
-    return sessionabs
-
-####
-#### END BLOCK remaining functions for compatibility reading - REMOVE EVENTUALLY
-####
 
 # split filename?query type string in fname and query parts
 def parse_fnq(dsfnstr):
@@ -119,24 +36,27 @@ def fnstring_relative(fnstring,sessiondir):
     return fnamerel
 
 def allpaths_relative_to(session,sessiondir):
-    # currently we only check data sources, NOT recipe FileOrURI entries
     for ds in session['datasources']:
         fname,query = parse_fnq(session['datasources'][ds])
         if not Path(fname).is_relative_to(sessiondir):
             return False
+    for module in session['recipe']:
+        [(mn, mod_dict)] = module.items()
+        for k in base.all_modules[mn].file_or_uri_traits():
+            if k in mod_dict:
+                if is_cluster_uri(mod_dict[k]) or not Path(mod_dict[k]).is_relative_to(sessiondir):
+                    return False
     return True
 
 # now a little nicer
 def process_recipe_paths(recipe,sessiondir):
-    chk_fou_modules_registered()
-    # users can request certain recipe module arguments to be "path-translated" by registering the module/arguments
     for module in recipe:
-        [(modname,paramdict)] = module.items()
-        for param in paramdict:
-            if param in checkmodules.get(modname,[]) and not is_cluster_uri(paramdict[param]):
-                relstring = fnstring_relative(paramdict[param],sessiondir)
+        [(mn, mod_dict)] = module.items()
+        for k in base.all_modules[mn].file_or_uri_traits():
+            if k in mod_dict:
+                relstring = fnstring_relative(mod_dict[k],sessiondir)
                 if relstring is not None: # do not translate if path is not below sessiondir
-                    paramdict[param] = os.path.join(SESSIONDIR_TOKEN,relstring)
+                    mod_dict[k]  = os.path.join(SESSIONDIR_TOKEN,relstring)
 
 from PYME.IO.unifiedIO import is_cluster_uri
 def resolve_relative_session_paths(session):

--- a/PYME/LMVis/sessionpaths.py
+++ b/PYME/LMVis/sessionpaths.py
@@ -1,10 +1,14 @@
 from pathlib import Path
 import os
 from traits.trait_errors import TraitError
+
 # this module provides a function 'check_session_paths' to check session paths in session dictionaries
 # enabling using paths relative to a session directory (where the .pvs resides)
 # this is done IF and ONLY IF all datasource paths are below that session directory
 # in doing so it also carries out these path checks for traits parameters of the FileOrURI type in recipes
+
+import logging
+logger = logging.getLogger(__name__)
 
 # a dict of recipe module names with recipe parameters to check, contents populated at runtime
 checkmodules = {}
@@ -137,6 +141,7 @@ def resolve_relative_session_paths(session):
 def check_session_paths(session,sessiondir):
     resolve_relative_session_paths(session) # if started from command line some ds paths may be relative
     if allpaths_relative_to(session,sessiondir):
+        logger.debug('path are all below session dir, rewriting paths with SESSIONDIR_TOKEN')
         session['relative_paths'] = True
         for ds in session['datasources']:
             fname,query = parse_fnq(session['datasources'][ds])
@@ -144,5 +149,6 @@ def check_session_paths(session,sessiondir):
             session['datasources'][ds] = fnq_string(pathstring,query)
         process_recipe_paths(session['recipe'],sessiondir)
     else:
+        logger.debug('some paths not below session dir, leaving paths unchanged')
         session['relative_paths'] = False
         

--- a/PYME/LMVis/sessionpaths.py
+++ b/PYME/LMVis/sessionpaths.py
@@ -1,20 +1,47 @@
 from pathlib import Path
 import os
+from traits.trait_errors import TraitError
+# this module provides a function 'check_session_paths' to check session paths in session dictionaries
+# enabling using paths relative to a session directory (where the .pvs resides)
+# this is done IF and ONLY IF all datasource paths are below that session directory
+# in doing so it also carries out these path checks for traits parameters of the FileOrURI type in recipes
 
-# the idea of this module is to provide two functions to make paths either relative or absolute in session objects
-# typically this will be relative to the '.pvs' session file path
-# it also provides a method register_path_modulechecks to allow the user/module coder to request path
-# translation for some recipe module arguments
-
-# a dict of recipe module names with arguments to check
+# a dict of recipe module names with recipe parameters to check, contents populated at runtime
 checkmodules = {}
+failedmodules = [] # list of modules we cannot instantiate, just for interest
+
+fou_modules_registered = False
 
 # it seems best to request this directly in the python files in which the modules are defined
 # example:     register_modulecheck('PYMEcs.MBMcorrection','mbmfile','mbmsettings')
-# can this possibly be autoregistered by modifying the FileOrURI object suitably?
+# NOTE: manual addition should not be required anymore as we now check all known modules for FileOrURI traits automatically
 def register_path_modulechecks(module,*entries):
     checkmodules[module] = entries
 
+def register_fou_modules():
+    from PYME.recipes.traits import FileOrURI
+    from PYME.recipes.base import all_modules
+
+    for modname in all_modules:
+        try:
+            mod = all_modules[modname]()
+        except TraitError:
+            failedmodules.append(modname)
+            continue # skip modules we cannot load
+        fou_traits = []
+        class_traits = mod.class_traits()
+        for trait in class_traits:
+            if isinstance(class_traits[trait].trait_type,FileOrURI):
+                fou_traits.append(trait)
+        if len(fou_traits) > 0:
+            checkmodules[modname] = fou_traits
+
+    fou_modules_registered = True
+
+def chk_fou_modules_registered():
+    if not fou_modules_registered:
+        register_fou_modules()
+    
 SESSIONDIR_TOKEN = '$session_dir$'
 
 def fnstring_absolute(fnstring,sessiondir):
@@ -37,6 +64,7 @@ def get_session_dirP(sessionpath):
 # this means we can repeatedly call this on session objects without doing any damage
 # this function only briefly kept for compatibility until all pvs rewritten
 def make_session_paths_absolute_compat(session,sessionpath):
+    chk_fou_modules_registered()
     sessionabs = session.copy()
     sessiondir = get_session_dirP(sessionpath)
     for ds in session['datasources']:
@@ -89,13 +117,14 @@ def allpaths_relative_to(session,sessiondir):
 
 # now a little nicer
 def process_recipe_paths(recipe,sessiondir):
+    chk_fou_modules_registered()
     # users can request certain recipe module arguments to be "path-translated" by registering the module/arguments
     for module in recipe:
         [(modname,paramdict)] = module.items()
         for param in paramdict:
-            if param in checkmodules.get(modname,[]):
+            if param in checkmodules.get(modname,[]) and not is_cluster_uri(paramdict[param]):
                 relstring = fnstring_relative(paramdict[param],sessiondir)
-                if relstring is not None:
+                if relstring is not None: # do not translate if path is not below sessiondir
                     paramdict[param] = os.path.join(SESSIONDIR_TOKEN,relstring)
 
 from PYME.IO.unifiedIO import is_cluster_uri

--- a/PYME/LMVis/sessionpaths.py
+++ b/PYME/LMVis/sessionpaths.py
@@ -48,6 +48,9 @@ def chk_fou_modules_registered():
     
 SESSIONDIR_TOKEN = '$session_dir$'
 
+####
+#### BEGIN BLOCK remaining functions for compatibility reading - REMOVE EVENTUALLY
+####
 def fnstring_absolute(fnstring,sessiondir):
     fnamep = Path(fnstring)
     if fnamep.is_absolute():
@@ -82,6 +85,10 @@ def make_session_paths_absolute_compat(session,sessionpath):
                     if field in module[checkmod]:
                         module[checkmod][field] = fnstring_absolute(module[checkmod][field],sessiondir)
     return sessionabs
+
+####
+#### END BLOCK remaining functions for compatibility reading - REMOVE EVENTUALLY
+####
 
 # split filename?query type string in fname and query parts
 def parse_fnq(dsfnstr):

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -61,7 +61,7 @@ import numpy as np
 
 #from PYME.DSView import eventLogViewer
 
-
+from PYME.LMVis.sessionpaths import make_session_relative, make_session_absolute
 
 from PYME.LMVis import statusLog
 #from PYME.recipes import recipeGui
@@ -823,7 +823,7 @@ class VisGUICore(object):
             
         return args
 
-    def get_session_yaml(self):
+    def get_session_yaml(self,sessionpath=None):
         import yaml
         from PYME.recipes.base import MyDumper
         session = {'format_version': 0.1,}
@@ -831,11 +831,13 @@ class VisGUICore(object):
 
         # TODO - View and layer settings
         session.update(self.glCanvas.get_session_info())
+        if sessionpath is not None:
+            session = make_session_relative(session,sessionpath)
         return '# PYMEVis saved session\n' + yaml.dump(session, Dumper=MyDumper)
     
     def save_session(self, filename):
         with open(filename, 'w') as f:
-            f.write(self.get_session_yaml())
+            f.write(self.get_session_yaml(sessionpath=filename))
 
     def OnSaveSession(self, event):
         '''GUI callback to save session to a file, shows a file dialog'''
@@ -850,6 +852,7 @@ class VisGUICore(object):
         with open(filename, 'r') as f:
             session = yaml.safe_load(f)
 
+        session = make_session_absolute(session,filename)
         self.pipeline.load_session(session)
 
         # load layers

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -874,10 +874,11 @@ class VisGUICore(object):
         from PYME.LMVis.sessionpaths import make_session_paths_absolute_compat, SESSIONDIR_TOKEN
         fpath = Path(filename)
         sessiondir = fpath.resolve().parent # note that filename could be relative, in that case need to resolve to obtain session dir
-        session = yaml.safe_load(fpath.read_text().replace(SESSIONDIR_TOKEN,str(sessiondir)))
+        session = yaml.safe_load(fpath.read_text().replace(SESSIONDIR_TOKEN,str(sessiondir))) # replace any possibly present SESSIONDIR_TOKEN
 
+        # temporary compatibility call
         if PYME.config.get('VisGUI-session_paths_compat',False):
-            session = make_session_paths_absolute_compat(session,filename) # keep only briefly for compatibility with few existing files
+            make_session_paths_absolute_compat(session,filename) # keep only briefly for compatibility with few existing files
 
         self.pipeline.load_session(session)
 

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -871,14 +871,10 @@ class VisGUICore(object):
     def load_session(self, filename):
         import yaml
         from pathlib import Path
-        from PYME.LMVis.sessionpaths import make_session_paths_absolute_compat, SESSIONDIR_TOKEN
+        from PYME.LMVis.sessionpaths import SESSIONDIR_TOKEN
         fpath = Path(filename)
         sessiondir = fpath.resolve().parent # note that filename could be relative, in that case need to resolve to obtain session dir
         session = yaml.safe_load(fpath.read_text().replace(SESSIONDIR_TOKEN,str(sessiondir))) # replace any possibly present SESSIONDIR_TOKEN
-
-        # temporary compatibility call
-        if PYME.config.get('VisGUI-session_paths_compat',False):
-            make_session_paths_absolute_compat(session,filename) # keep only briefly for compatibility with few existing files
 
         self.pipeline.load_session(session)
 

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -876,7 +876,9 @@ class VisGUICore(object):
         sessiondir = fpath.resolve().parent # note that filename could be relative, in that case need to resolve to obtain session dir
         session = yaml.safe_load(fpath.read_text().replace(SESSIONDIR_TOKEN,str(sessiondir)))
 
-        session = make_session_paths_absolute_compat(session,filename) # keep only briefly for compatibility with few existing files
+        if PYME.config.get('VisGUI-session_paths_compat',False):
+            session = make_session_paths_absolute_compat(session,filename) # keep only briefly for compatibility with few existing files
+
         self.pipeline.load_session(session)
 
         # load layers

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -871,10 +871,10 @@ class VisGUICore(object):
     def load_session(self, filename):
         import yaml
         from pathlib import Path
-        from PYME.LMVis.sessionpaths import make_session_paths_absolute_compat
+        from PYME.LMVis.sessionpaths import make_session_paths_absolute_compat, SESSIONDIR_TOKEN
         fpath = Path(filename)
         sessiondir = fpath.resolve().parent # note that filename could be relative, in that case need to resolve to obtain session dir
-        session = yaml.safe_load(fpath.read_text().replace('$session_dir$',str(sessiondir)))
+        session = yaml.safe_load(fpath.read_text().replace(SESSIONDIR_TOKEN,str(sessiondir)))
 
         session = make_session_paths_absolute_compat(session,filename) # keep only briefly for compatibility with few existing files
         self.pipeline.load_session(session)

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -222,6 +222,12 @@ class ModuleBase(HasStrictTraits):
     def toYAML(self):
         return yaml.dump(self.cleaned_dict_repr(), Dumper=MyDumper)
 
+    @classmethod
+    def file_or_uri_traits(cls):
+        from PYME.recipes import traits
+        """Return a list of FileOrURI traits, as these can require special handling (potentially warn if this list is not empty)"""
+        return [k for k, v in cls.class_traits().items() if isinstance(v.trait_type, traits.FileOrURI)]
+
     def check_inputs(self, namespace):
         """
         Checks that module inputs are present in namespace, raising an exception if they are missing. Existing to simplify


### PR DESCRIPTION
Addresses paths handling for saved sessions and adds a GUI interface for `load_extra_datasources`.

**Is this a bugfix or an enhancement?**

Enhancement for general session paths handling and (smallish) bug fix to resolve all paths prior to session saving.

**Proposed changes:**

1. Resolve all file paths when requesting session info via `_get_session_datasources`.
2. Add a GUI interface to load extra datasources.
2. Add the ability make session paths (and some paths in recipes) relative to the `.pvs` session file.

**Details:**

1. Originally file paths were returned as stored with the data source. When started from the command line these may be relative to the shell's current working directory (CWD) and this would then fail, for example, when opening the generated `.pvs` file from the Finder window - because `PYMEVis` will generally start with a quite different CWD. Therefore, we now return fully resolved paths when building the session dictionary. But see also 3.
2. In practice it can be quite a bit more convenient to add relevant extra datasources via the GUI (rather than from the command line), tweak the recipe and then save the whole session in a `.pvs` file. Thus this PR also adds a simple GUI interface to the `pipeline` method `load_extra_datasources`.
3. To optionally use relative file paths when writing session files is likely the proposed addition that is the most experimental in this PR. The motivation arises from two scenarios, the first being our prime motivator. (a) Our files and thus also session files often sit in shared directories, for example in OneDrive or Dropbox. As a result absolute paths differ between machines but relative paths stay the same. (b) We sometimes  move files en-bloc with their session files into a subdirectory, different directory etc. This generally preserves relative paths but clearly not absolute paths.

**about 3 - relative filepaths:**

This PR implements the functionality to write relative paths in sessions (and related recipe modules) but enables this only if explicitly requested by setting the `PYME.config` variable `VisGUI-session_paths_relative` to `true` (it is false by default).

The paths translation is careful in the sense that if paths are already in the state requested (relative or absolute) they are left untouched and if errors are encountered when paths are attempted to be rewritten relative then a warning is issued and the original session dict is returned with paths untouched.

We also enable manual addition of modules with their relevant fields to translate absolute paths in `traits.File` fields in recipes. There may be a better (automagic) way, but in practice we have one or two modules that need this.

Perhaps not everybody will want/like this relative paths functionality but at least in our tests everything seems quite robust and in practice makes life a whole lot easier. In addition, as it is not happening by default we can gain some experience with this feature and see if it is worthwhile.

