### PR TITLE
image_bounds_superset

### DIFF
--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -434,6 +434,9 @@ class ImageStack(object):
         self.mdh['ImageBounds.z0'] = value.z0
         self.mdh['ImageBounds.z1'] = value.z1
 
+    # PEP8 alias
+    image_bounds = imgBounds
+
     @property
     def metadata(self):
         return self.mdh

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -55,6 +55,8 @@ def deprecated_name(name):
     return _dec
 
 class TabularBase(object):
+    _image_bounds = False
+
     def toDataFrame(self, keys=None):
         warnings.warn('toDataFrame is deprecated, use to_pandas instead', DeprecationWarning)
         self.to_pandas(keys)
@@ -218,6 +220,22 @@ class TabularBase(object):
         for k in keys:
             d[k] = self[(k, return_slice)].tolist()
         return json.dumps(d)
+    
+    @property
+    def image_bounds(self):
+        if self._image_bounds is False:
+            from PYME.IO.image import ImageBounds
+
+            try:
+                if hasattr(self, 'mdh') and ('scanx' not in self.keys() or 'scany' not in self.keys()) and 'Camera.ROIWidth' in self.mdh.getEntryNames():
+                    self._image_bounds = ImageBounds.extractFromMetadata(self.mdh)
+                else:
+                    self._image_bounds = ImageBounds.estimateFromSource(self)
+            except:
+                logger.exception('Error estimating image bounds')
+                self._image_bounds = ImageBounds(0,0,0,0,0,0)
+
+        return self._image_bounds
 
 
 # Data sources (File IO, or adapters to other data formats - e.g. recarrays

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -221,19 +221,24 @@ class TabularBase(object):
             d[k] = self[(k, return_slice)].tolist()
         return json.dumps(d)
     
+    def _calc_image_bounds(self):
+        from PYME.IO.image import ImageBounds
+
+        try:
+            if hasattr(self, 'mdh') and ('scanx' not in self.keys() or 'scany' not in self.keys()) and 'Camera.ROIWidth' in self.mdh.getEntryNames():
+                bds = ImageBounds.extractFromMetadata(self.mdh)
+            else:
+                bds = ImageBounds.estimateFromSource(self)
+        except:
+            logger.exception('Error estimating image bounds')
+            bds = ImageBounds(0,0,0,0,0,0)
+
+        return bds
+    
     @property
     def image_bounds(self):
         if self._image_bounds is False:
-            from PYME.IO.image import ImageBounds
-
-            try:
-                if hasattr(self, 'mdh') and ('scanx' not in self.keys() or 'scany' not in self.keys()) and 'Camera.ROIWidth' in self.mdh.getEntryNames():
-                    self._image_bounds = ImageBounds.extractFromMetadata(self.mdh)
-                else:
-                    self._image_bounds = ImageBounds.estimateFromSource(self)
-            except:
-                logger.exception('Error estimating image bounds')
-                self._image_bounds = ImageBounds(0,0,0,0,0,0)
+            self._image_bounds = self._calc_image_bounds()
 
         return self._image_bounds
 
@@ -1019,11 +1024,18 @@ class MappingFilter(TabularBase):
         the mappings should either be code objects, strings (which will be compiled into code objects),
         or something else (which will be turned into a local variable - eg constants in above example)
 
+        MappingFilter has one optional keyword arguement, modifies_bounds, which is a boolean indicating
+        that the bounds implied by the metadata will no longer match up to the data after mapping - e.g. if
+        the mapping introduces position shifts. For now, this is un-used, but exists as a hook for potential
+        future use cases (see https://github.com/python-microscopy/python-microscopy/pull/1543#issuecomment-2298643266). 
+
         """
         
         if not isinstance(resultsSource, TabularBase):
             warnings.warn(VisibleDeprecationWarning('Mapping filter created with something that is not a tabular object. This will be unsupported in a future release. Consider DictSource or ColumnSource instead'))
 
+        self._modifies_bounds = kwargs.pop('modifies_bounds', False)
+        
         self.resultsSource = resultsSource
 
         self.mappings = {}
@@ -1035,6 +1047,14 @@ class MappingFilter(TabularBase):
             v = kwargs[k]
             self.setMapping(k,v)
 
+    def _calc_image_bounds(self):
+        if self._modifies_bounds and 'x' in self.keys():
+            # it is possible for a mapping to introduce large changes in x and y, hence modifying the image bounds
+            # from their metadata values. We need to estimate bounds from data in this case. 
+            from PYME.IO.image import ImageBounds
+            return ImageBounds.estimateFromSource(self)
+        else:
+            return super()._calc_image_bounds()
 
     def __getitem__(self, keys):
         key, sl = self._getKeySlice(keys)

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -309,7 +309,7 @@ class Pipeline(object):
         self.blobSettings = BlobSettings()
         self.objects = None
 
-        self.imageBounds = ImageBounds(0,0,0,0)
+        #self.imageBounds = ImageBounds(0,0,0,0)
         #self.mdh = MetaDataHandler.NestedClassMDHandler()
         
         self.Triangles = None
@@ -342,7 +342,24 @@ class Pipeline(object):
     @property
     def mdh(self):
         return self.selectedDataSource.mdh
-            
+    
+    @property
+    def imageBounds(self):
+        x0, y0, x1, y1, z0, z1 = 0, 0, 0, 0, 0, 0
+        for ds in self.dataSources.values():
+            try:
+                ib = ds.image_bounds
+                x0 = min(x0, ib.x0)
+                y0 = min(y0, ib.y0)
+                x1 = max(x1, ib.x1)
+                y1 = max(y1, ib.y1)
+                z0 = min(z0, ib.z0)
+                z1 = max(z1, ib.z1)
+            except AttributeError:
+                pass
+
+        return ImageBounds(x0, y0, x1, y1, z0, z1)
+    
     @property
     def output(self):
         return self.colourFilter
@@ -874,15 +891,15 @@ class Pipeline(object):
             self.selectDataSource('FitResults')
 
         # Retrieve or estimate image bounds
-        if False:  # 'imgBounds' in kwargs.keys():
-            # TODO - why is this disabled? Current usage would appear to be when opening from LMAnalysis
-            # during real-time localization, to force image bounds to match raw data, but also potentially useful
-            # for other scenarios where metadata is not fully present.
-            self.imageBounds = kwargs['imgBounds']
-        elif ('scanx' not in self.selectedDataSource.keys() or 'scany' not in self.selectedDataSource.keys()) and 'Camera.ROIWidth' in self.mdh.getEntryNames():
-            self.imageBounds = ImageBounds.extractFromMetadata(self.mdh)
-        else:
-            self.imageBounds = ImageBounds.estimateFromSource(self.selectedDataSource)
+        # if False:  # 'imgBounds' in kwargs.keys():
+        #     # TODO - why is this disabled? Current usage would appear to be when opening from LMAnalysis
+        #     # during real-time localization, to force image bounds to match raw data, but also potentially useful
+        #     # for other scenarios where metadata is not fully present.
+        #     self.imageBounds = kwargs['imgBounds']
+        # elif ('scanx' not in self.selectedDataSource.keys() or 'scany' not in self.selectedDataSource.keys()) and 'Camera.ROIWidth' in self.mdh.getEntryNames():
+        #     self.imageBounds = ImageBounds.extractFromMetadata(self.mdh)
+        # else:
+        #     self.imageBounds = ImageBounds.estimateFromSource(self.selectedDataSource)
         
         #self._process_colour()
 


### PR DESCRIPTION
Make pipeline imageBounds the spanning set of all datasources. Replaces and closes #1541.