### PR TITLE
MPD picosecond delayer error reporting fix, get freq div fix, and edge property fix

### DIFF
--- a/PYME/Acquire/Hardware/mpd_picosecond_delayer.py
+++ b/PYME/Acquire/Hardware/mpd_picosecond_delayer.py
@@ -22,7 +22,7 @@ mpd_psd_errors = {
 
 def check_success(resp):
         if b'ERR' in resp:
-            err_no = int((resp.split(b'ERR')[-1]).decode())
+            err_no = int((resp.split(b'ERR')[-1]).rstrip(b'#').decode())
             try:
                 raise RuntimeError(mpd_psd_errors[err_no])
             except KeyError:
@@ -235,7 +235,7 @@ class PicosecondDelayer(object):
             significant edge for trigger input. False: falling edge, True:
             rising edge.
         """
-        self._divide_by = bool(self.send_command(b'SE%d#' % rising))
+        self._edge = bool(self.send_command(b'SE%d#' % rising))
 
     @property
     def io(self):
@@ -380,7 +380,7 @@ class PicosecondDelayer(object):
             frequency divider factor. Possible values are integers from 1 to
             999.
         """
-        self._divide_by = int(self.send_command(b'RO#'))
+        self._divide_by = int(self.send_command(b'RV#'))
         return self._divide_by
     
     def GetMaxDelay(self):


### PR DESCRIPTION
Addresses some small bugs in my initial implementation

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- strip the '#' termination on the reply from the MPD so we print the device's error message
- use the correct serial command to request the divide by freq from the device
- fix the edge property setter to set the right attribute






**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
