### PR TITLE
ids peak camera bug fixes & adding software triggering

### DIFF
--- a/PYME/Acquire/Hardware/ids_peak_cam.py
+++ b/PYME/Acquire/Hardware/ids_peak_cam.py
@@ -320,12 +320,18 @@ class IDS_Camera(Camera):
         --------
         GetIntegTime
         """
+        fps_target = 1 / exposure_time  # [FPS]
+        lower = self._node_map.FindNode("AcquisitionFrameRate").Minimum()  # [FPS]
+        upper = self._node_map.FindNode("AcquisitionFrameRate").Maximum()  # [FPS]
+        fps = np.clip(fps_target, lower, upper)
+        self._node_map.FindNode("AcquisitionFrameRate").SetValue(fps)
+        self._node_map.FindNode("ExposureTime").Maximum()  # [us]
         # get acceptable range, in units of microseconds
-        lower = self._node_map.FindNode("ExposureTime").Minimum()  # [us]
-        upper = self._node_map.FindNode("ExposureTime").Maximum()  # [us]
-        exp_time = np.clip(exposure_time * 1e6, lower, upper)  # [us]
-        logger.info(f'Setting exposure time to {exp_time} us')
-        self._node_map.FindNode("ExposureTime").SetValue(exp_time)
+        # lower = self._node_map.FindNode("ExposureTime").Minimum()  # [us]
+        # upper = self._node_map.FindNode("ExposureTime").Maximum()  # [us]
+        # exp_time = np.clip(exposure_time * 1e6, lower, upper)  # [us]
+        # logger.info(f'Setting exposure time to {exp_time} us')
+        # self._node_map.FindNode("ExposureTime").SetValue(exp_time)
     
     def GetPicWidth(self):
         """

--- a/PYME/Acquire/Hardware/ids_peak_cam.py
+++ b/PYME/Acquire/Hardware/ids_peak_cam.py
@@ -291,6 +291,7 @@ class IDS_Camera(Camera):
                 # line0 should be (trigger) input with optocoupler for all IDS
                 # cameras covered in IDS peak 2.10.0 with hardware triggering
                 self._node_map.FindNode('TriggerSource').SetCurrentEntry('Line0')
+                self._node_map.FindNode('TriggerMode').SetCurrentEntry('On')
             else:
                 raise NotImplementedError('Single shot mode not implemented')
             


### PR DESCRIPTION
Addresses issue #1545 

**Is this a bugfix or an enhancement?**
- enhancement: adding software triggering mode (and optionless hardware triggering)
- bugfix: tell the camera what pixel mode we want
- bugfix: set integration time and then framerate in `SetIntegTime`
**Proposed changes:**


12 bit working OK, including at saturation.

![image](https://github.com/user-attachments/assets/249a1d4b-b723-4db9-857a-753925155320)

![image](https://github.com/user-attachments/assets/25d4514f-583c-4ec2-b741-1dd38c3e8609)


Might at some point consider allowing packed formats if we need to speed up data transfer.
Will likely follow-up with some hardware triggering option methods e.g. rising/falling edge, delay, etc.