### PR TITLE
Enable loading of SMAP files

### DIFF
--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -672,9 +672,18 @@ class MatfileSource(TabularBase):
         for the position data and it's error should ensure that this functions
         with the visualisation backends"""
 
-        import scipy.io
+        try:
+            import scipy.io
 
-        self.res = scipy.io.loadmat(filename)[varName].astype('f4')  # TODO: evaluate why these are cast as floats
+            mf = scipy.io.loadmat(filename)
+        except NotImplementedError:
+            # we have most likely tried to open a MATLAB >7.2 file.
+            import h5py
+
+            # this is SMAP-specific
+            mf = h5py.File(filename)['saveloc']['loc']
+
+        self.res = mf[varName].astype('f4')  # TODO: evaluate why these are cast as floats
         self.res = np.rec.fromarrays(self.res.T, dtype={'names' : columnnames,  'formats' :  ['f4' for i in range(len(columnnames))]})
 
         self._keys = list(columnnames)
@@ -704,9 +713,17 @@ class MatfileColumnSource(TabularBase):
         be present.
         """
         
-        import scipy.io
-        
-        self.res = scipy.io.loadmat(filename)  # TODO: evaluate why these are cast as floats
+        try:
+            import scipy.io
+            
+            self.res = scipy.io.loadmat(filename)  # TODO: evaluate why these are cast as floats
+        except NotImplementedError:
+            # we have most likely tried to open a MATLAB >7.2 file.
+            import h5py
+
+            # this is SMAP-specific
+            self.res = h5py.File(filename)['saveloc']['loc']
+
         
         self._keys = [k for k in self.res.keys() if not k.startswith('_')]
     

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -770,9 +770,17 @@ class VisGUICore(object):
             pass
         elif os.path.splitext(filename)[1] == '.mat':
             from PYME.LMVis import importTextDialog
-            from scipy.io import loadmat
-        
-            mf = loadmat(filename)
+            try:
+                from scipy.io import loadmat
+            
+                mf = loadmat(filename)
+            except NotImplementedError:
+                # we have most likely tried to open a MATLAB >7.2 file.
+                import h5py
+
+                # this is SMAP-specific
+                mf = h5py.File(filename)['saveloc']['loc']
+
             if ('x' not in mf.keys()) or ('y' not in mf.keys()):
                 # This MATLAB file has some weird variable names
 


### PR DESCRIPTION
[SMAP](https://github.com/jries/SMAP) has these nested .mat files 

![image (47)](https://github.com/user-attachments/assets/b0468d02-9c6e-460b-8fd0-3d7e67aa4bc8)


that `scipy` does not load, due to their format being too new:

```
Traceback (most recent call last):
  File "/Users/zachcm/miniforge3/envs/pyme/lib/python3.8/site-packages/wx/core.py", line 2346, in Notify
    self.notify()
  File "/Users/zachcm/miniforge3/envs/pyme/lib/python3.8/site-packages/wx/core.py", line 3552, in Notify
    self.result = self.callable(*self.args, **self.kwargs)
  File "/Users/zachcm/Code/python-microscopy/PYME/LMVis/visCore.py", line 881, in OpenFile
    args = self._populate_open_args(filename)
  File "/Users/zachcm/Code/python-microscopy/PYME/LMVis/visCore.py", line 739, in _populate_open_args
    mf = loadmat(filename)
  File "/Users/zachcm/miniforge3/envs/pyme/lib/python3.8/site-packages/scipy/io/matlab/_mio.py", line 226, in loadmat
    MR, _ = mat_reader_factory(f, **kwargs)
  File "/Users/zachcm/miniforge3/envs/pyme/lib/python3.8/site-packages/scipy/io/matlab/_mio.py", line 80, in mat_reader_factory
    raise NotImplementedError('Please use HDF reader for matlab v7.3 '
NotImplementedError: Please use HDF reader for matlab v7.3 files, e.g. h5py
```

This is a first-thought approach to get these files to load into PYME. I think there's a better way to do it (e.g., even using `tables` so as to not introduce another (optional) dependency). Do you have any thoughts on a preferred approach, @David-Baddeley?