### PR TITLE
Tiling miscellaneous

### DIFF
--- a/PYME/Acquire/Utils/tiler.py
+++ b/PYME/Acquire/Utils/tiler.py
@@ -85,6 +85,12 @@ class Tiler(pointScanner.PointScanner, AcquisitionBase):
 
         tiling_settings.update(settings.get('tiling_settings', scope.tile_settings))
         
+        #fix timing when using fake camera
+        #TODO - move logic into backend?
+        if scope.cam.__class__.__name__ == 'FakeCamera':
+            backend_kwargs['spoof_timestamps'] = True
+            backend_kwargs['cycle_time'] = scope.cam.GetIntegTime()
+        
         return cls(scope=scope, backend=backend, backend_kwargs=backend_kwargs, **tiling_settings)
     
     @classmethod

--- a/PYME/Acquire/Utils/tiler.py
+++ b/PYME/Acquire/Utils/tiler.py
@@ -142,6 +142,7 @@ class Tiler(pointScanner.PointScanner, AcquisitionBase):
         pointScanner.PointScanner.start(self)
 
         self.dtStart = datetime.datetime.now()
+        self._backend.initialise()
         self.frame_num = 0
         
     def on_frame(self, frameData, **kwargs):

--- a/PYME/Acquire/Utils/tiler.py
+++ b/PYME/Acquire/Utils/tiler.py
@@ -153,6 +153,7 @@ class Tiler(pointScanner.PointScanner, AcquisitionBase):
         
     def on_frame(self, frameData, **kwargs):
         pos = self.scope.GetPos()
+        
         pointScanner.PointScanner.on_frame(self, frameData, **kwargs)
         
         d = frameData.astype('f').squeeze()
@@ -173,13 +174,23 @@ class Tiler(pointScanner.PointScanner, AcquisitionBase):
 
         self.frame_num += 1
         
-        t = time.time()
-        if t > (self._last_update_time + 1):
-            self._last_update_time = t
-            self.on_progress.send(self)
+        if self.running:
+            t = time.time()
+            if t > (self._last_update_time + 1):
+                self._last_update_time = t
+                self.on_progress.send(self)
+
+        else:
+            self._finalise()
         
     def _stop(self):
         pointScanner.PointScanner._stop(self, send_stop=False)
+        
+    def _finalise(self):
+        # this does the finalisation steps that need to be done after the scan is complete.
+        # It is separate from _stop(), as _stop() is called by PointScanner.on_frame() **before** the final frame
+        # has been saved. We want to have the final frame saved before we do the finalisation steps.
+            
         self.on_progress.send(self)
         t_ = time.time()
 

--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -376,7 +376,7 @@ class PYMEMainFrame(acquirebase.PYMEAcquireBase, AUIFrame):
 
 
         self.aqPanel = afp.foldPanel(self, -1, wx.DefaultPosition,
-                                     wx.Size(240,1000), single_active_pane=True)
+                                     wx.Size(240,1000), single_active_pane=True, constrain_children=True)
 
         if mode == 'compact':
             self._mgr.AddPane(self.toolPanel, aui.AuiPaneInfo().

--- a/PYME/Acquire/protocol_acquisition.py
+++ b/PYME/Acquire/protocol_acquisition.py
@@ -169,12 +169,12 @@ class ProtocolAcquisition(AcquisitionBase):
                                                                 cluster_h5=self._aggregate_h5,
                                                                 serverfilter=self.clusterFilter,
                                                                 shape=[-1,-1,1,-1,1], #spooled aquisitions are time series (for now)
-                                                                evt_time_fcn=self._time_fcn)
+                                                                **kwargs)
             
         else: # assume hdf
             self._backend = acquisition_backends.HDFBackend(self.filename, complevel=kwargs.get('complevel', 6), complib=kwargs.get('complib','zlib'),
                             shape=[-1,-1,1,-1,1], # spooled series are time-series (for now)
-                            evt_time_fcn=self._time_fcn)
+                            **kwargs)
         
         
         self._stopping = False

--- a/PYME/Acquire/protocol_acquisition.py
+++ b/PYME/Acquire/protocol_acquisition.py
@@ -50,7 +50,7 @@ def getReducedFilename(filename):
 class ProtocolAcquisition(AcquisitionBase):
     """Spooler base class"""
     def __init__(self, filename, frameSource, frame_wrangler, protocol = p.NullProtocol, 
-                 fakeCamCycleTime=None, maxFrames = p.maxint, backend='hdf', backend_kwargs={}, **kwargs):
+                 maxFrames = p.maxint, backend='hdf', backend_kwargs={}, **kwargs):
         """Create a new spooler.
         
         Parameters
@@ -95,8 +95,6 @@ class ProtocolAcquisition(AcquisitionBase):
         self.spool_complete = False
         
         self._spooler_uuid = uuid.uuid4()
-            
-        self._fakeCamCycleTime = fakeCamCycleTime
 
         self._last_gui_update = 0
 
@@ -121,17 +119,16 @@ class ProtocolAcquisition(AcquisitionBase):
                 return None #bail if we failed the pre flight check, and the user didn't choose to continue
         
         #fix timing when using fake camera
+        #TODO - move logic into backend?
         if scope.cam.__class__.__name__ == 'FakeCamera':
-            fakeCycleTime = scope.cam.GetIntegTime()
-        else:
-            fakeCycleTime = None
+            backend_kwargs['spoof_timestamps'] = True
+            backend_kwargs['cycle_time'] = scope.cam.GetIntegTime()
         
         #logger.info('Creating spooler for %s' % series_name)
         return cls(filename=series_name,
                     frameSource=scope.frameWrangler.onFrame,
                     frame_wrangler=scope.frameWrangler,
                     protocol=protocol,
-                    fakeCamCycleTime=fakeCycleTime, 
                     maxFrames=settings.get('max_frames', sys.maxsize),
                     stack_settings=settings.get('stack_settings', None),
                     backend=backend, backend_kwargs=backend_kwargs,) 
@@ -360,18 +357,18 @@ class ProtocolAcquisition(AcquisitionBase):
         for mdgen in MetaDataHandler.provideStopMetadata:
            mdgen(self.md)
 
-    def _fake_time(self):
-        """Generate a fake timestamp for use with the simulator where the camera
-        cycle time does not match the actual time elapsed to generate the frame"""
-        #return self.tStart + self.frame_num*self.scope.cam.GetIntegTime()
-        return self.tStart + self.frame_num*self._fakeCamCycleTime
+    # def _fake_time(self):
+    #     """Generate a fake timestamp for use with the simulator where the camera
+    #     cycle time does not match the actual time elapsed to generate the frame"""
+    #     #return self.tStart + self.frame_num*self.scope.cam.GetIntegTime()
+    #     return self.tStart + self.frame_num*self._fakeCamCycleTime
     
-    @property
-    def _time_fcn(self):
-        if self._fakeCamCycleTime:
-            return self._fake_time
-        else:
-            return time.time
+    # @property
+    # def _time_fcn(self):
+    #     if self._fakeCamCycleTime:
+    #         return self._fake_time
+    #     else:
+    #         return time.time
 
     def FlushBuffer(self):
         pass

--- a/PYME/Analysis/piecewiseMapping.py
+++ b/PYME/Analysis/piecewiseMapping.py
@@ -119,6 +119,10 @@ def frames_to_times(fr, events, mdh):
     """
     Use events and metadata to convert frame numbers to seconds
 
+    2024/11/1 - This used to return the start time of the subsequent frame (i.e. approx but not 
+    exactly the end time of the frame). Changed to return the start time of the current frame, 
+    which should be more accurate with camera restarts
+
     Parameters
     ----------
     fr: ndarray
@@ -139,7 +143,7 @@ def frames_to_times(fr, events, mdh):
     #se = array([('0', 'start', startTime)], dtype=events.dtype)
     se = np.empty(1, dtype=events.dtype)
     se['EventName'] = 'start'
-    se['EventDescr'] = '0'
+    se['EventDescr'] = '-1'
     se['Time'] = startTime
 
     #get events corresponding to aquisition starts
@@ -149,8 +153,8 @@ def frames_to_times(fr, events, mdh):
 
     sfr = np.array([int(e['EventDescr'].decode()) for e in startEvents])
 
-    si = sfr.searchsorted(fr, side = 'right')
-    return startEvents['Time'][si-1] + (fr - sfr[si-1]) * cycTime
+    si = sfr.searchsorted(fr, side = 'left')
+    return startEvents['Time'][si-1] + (fr - (sfr[si-1]+1)) * cycTime
     
 
 class piecewiseMap:

--- a/PYME/IO/acquisition_backends.py
+++ b/PYME/IO/acquisition_backends.py
@@ -18,7 +18,7 @@ class Backend(abc.ABC):
     Base class for acquisition backends.
 
     """
-    def __init__(self, dim_order='XYCZT', shape=[-1, -1,-1,1,1], evt_time_fcn=time.time):
+    def __init__(self, dim_order='XYCZT', shape=[-1, -1,-1,1,1], spoof_timestamps=False, cycle_time=None, **kwargs):
         if not hasattr(self, 'mdh'):
             self.mdh = MetaDataHandler.DictMDHandler()
         self.mdh['imageID'] = self.sequence_id
@@ -33,9 +33,13 @@ class Backend(abc.ABC):
 
         self.imNum = -1 # for event logger compatibility
 
+        self._spoof_timestamps = spoof_timestamps
+        self._fakeCamCycleTime = cycle_time
+        self._t_start = time.time() # record start time for fake timestamps
+
         if not hasattr(self, 'event_logger'):
             # if we haven't already defined an event logger in a derived class, create a memory logger
-            self.event_logger = MemoryEventLogger(spooler=self, time_fcn=evt_time_fcn)
+            self.event_logger = MemoryEventLogger(spooler=self, time_fcn=self._timestamp)
 
 
     @abc.abstractmethod
@@ -60,6 +64,7 @@ class Backend(abc.ABC):
         # set imNum to 0 (now handling the first frame)
         # TODO - this is a hack to fix startAq event frame nums, and there has to be a better way of doing this.
         self.imNum = 0
+        self._t_start = time.time() # record start time for fake timestamps
         
     
     def finalise(self, events=None):
@@ -89,10 +94,22 @@ class Backend(abc.ABC):
         '''
         raise NotImplementedError('getURL() not implemented - this might not be a cluster-aware backend')
 
+    def _timestamp(self):
+        if self._spoof_timestamps:
+            return self._fake_time()
+        else:
+            return time.time()
+    
+    def _fake_time(self):
+        """Generate a fake timestamp for use with the simulator where the camera
+        cycle time does not match the actual time elapsed to generate the frame"""
+        #return self.tStart + self.frame_num*self.scope.cam.GetIntegTime()
+        return self._t_start + max(self.imNum, 0)*self._fakeCamCycleTime
+
 
 class MemoryBackend(Backend):
-    def __init__(self, size_x, size_y, n_frames, dtype='uint16', series_name=None, dim_order='XYCZT', shape=[-1, -1,1,1,1], evt_time_fcn=time.time, **kwargs):
-        Backend.__init__(self, dim_order, shape, evt_time_fcn=evt_time_fcn)
+    def __init__(self, size_x, size_y, n_frames, dtype='uint16', series_name=None, dim_order='XYCZT', shape=[-1, -1,1,1,1], **kwargs):
+        Backend.__init__(self, dim_order, shape, spoof_timestamps=kwargs.pop('spoof_timestamps', False), cycle_time=kwargs.pop('cycle_time', None))
         self.data = np.empty([size_x, size_y, n_frames], dtype=dtype)
         
         # once we have proper xyztc support in the image viewer
@@ -128,11 +145,11 @@ class ClusterBackend(Backend):
     }
 
     def __init__(self, series_name, dim_order='XYCZT', shape=[-1, -1,-1,1,1], distribution_fcn=None, compression_settings={}, 
-                cluster_h5=False, serverfilter=clusterIO.local_serverfilter, evt_time_fcn = time.time, **kwargs):
+                cluster_h5=False, serverfilter=clusterIO.local_serverfilter, **kwargs):
         from PYME.IO import cluster_streaming
         from PYME.IO import PZFFormat
 
-        Backend.__init__(self, dim_order, shape, evt_time_fcn=evt_time_fcn)
+        Backend.__init__(self, dim_order, shape, spoof_timestamps=kwargs.pop('spoof_timestamps', False), cycle_time=kwargs.pop('cycle_time', None))
 
         self.series_name = series_name
         self.serverfilter = serverfilter
@@ -220,8 +237,8 @@ class HDFBackend(Backend):
 
         self.h5File = tables.open_file(series_name, 'w')
         self.mdh = MetaDataHandler.HDFMDHandler(self.h5File)
-        self.event_logger = HDFEventLogger(self, self.h5File, time_fcn=evt_time_fcn)
-        Backend.__init__(self, dim_order, shape)
+        self.event_logger = HDFEventLogger(self, self.h5File, time_fcn=self._timestamp)
+        Backend.__init__(self, dim_order, shape, spoof_timestamps=kwargs.pop('spoof_timestamps', False), cycle_time=kwargs.pop('cycle_time', None))
            
         self._complevel = complevel
         self._complib = complib

--- a/PYME/IO/acquisition_backends.py
+++ b/PYME/IO/acquisition_backends.py
@@ -31,7 +31,7 @@ class Backend(abc.ABC):
         self.mdh['SizeT'] =  shape[3]
         self.mdh['SizeZ'] =  shape[2]
 
-        self.imNum = 0 # for event logger compatibility
+        self.imNum = -1 # for event logger compatibility
 
         if not hasattr(self, 'event_logger'):
             # if we haven't already defined an event logger in a derived class, create a memory logger

--- a/PYME/IO/acquisition_backends.py
+++ b/PYME/IO/acquisition_backends.py
@@ -56,7 +56,11 @@ class Backend(abc.ABC):
         """ Called before acquisition starts, may be overridden to e.g. save metadata.
         NOTE: We typically save metadata in advance of the data so that analysis can start while acquisition is underway.
         """
-        pass
+        
+        # set imNum to 0 (now handling the first frame)
+        # TODO - this is a hack to fix startAq event frame nums, and there has to be a better way of doing this.
+        self.imNum = 0
+        
     
     def finalise(self, events=None):
         """ Called after acquisition is complete, may be overridden to e.g. flush buffers, close files, , write events etc ...
@@ -193,6 +197,7 @@ class ClusterBackend(Backend):
         self.imNum = n+1
 
     def initialise(self):
+        super().initialise()
         self._streamer.put(self._series_location + '/metadata.json', self.mdh.to_JSON().encode())
     
     def finalise(self):

--- a/PYME/ui/manualFoldPanel.py
+++ b/PYME/ui/manualFoldPanel.py
@@ -660,6 +660,8 @@ class foldPanel(wx.Panel, cascading_layout.CascadingLayoutMixin):
         except KeyError:
             self.padding = 5
 
+        self._constrain_children = kwargs.pop('constrain_children', False)
+
         self._stretch_sizer = kwargs.pop('bottom_spacer', True)
         self._one_pane_active = kwargs.pop('single_active_pane', False)
 
@@ -713,7 +715,11 @@ class foldPanel(wx.Panel, cascading_layout.CascadingLayoutMixin):
 
     def cascading_layout(self, depth=0):
         #logger.info('cascade layout - %s' % self)
-        cascading_layout.CascadingLayoutMixin.cascading_layout(self, depth+1)
+        if not self._constrain_children:
+            cascading_layout.CascadingLayoutMixin.cascading_layout(self, depth+1)
+        else:
+            self.Layout()
+
         self.fold1()
 
     def Clear(self):


### PR DESCRIPTION
Work in progress, trying to fix some issues with the old-style tiling reconstruction from a series. 
@Yujin-Bao 

So far:

- stage motion before the start of acquisition could generate duplicate `startAq 0` events (which look like they belong *after* the first frame). `startAq` events before acquisition start will now be recorded as `startAq -1`

TODO:

- make sure positions are linked to the correct frame (this will involve a bit of tweaking to the mappings so we don't need to index with frameNum -1). For robustness, this will likely mean:
    - going from frame nums to *timestamps* **for the middle of the frame (rather than start/end)**
    - using these to index into a position vs time mapping

