### PR TITLE
fix parent for analysis settings in spool panel

### DIFF
--- a/PYME/Acquire/ui/spool_panel.py
+++ b/PYME/Acquire/ui/spool_panel.py
@@ -364,7 +364,7 @@ class SpoolingPane(afp.foldingPane):
 
             
         else:
-            clp = afp.collapsingPane(self, caption='Real time analysis ...')
+            clp = afp.collapsingPane(pan, caption='Real time analysis ...')
 
             self.scope.analysisSettings = AnalysisSettingsUI.AnalysisSettings() #Move me???
 


### PR DESCRIPTION
Addresses issue I mentioned in #1507 .

```

ERROR:PYME.ui.mytimer:Error in timer callback
Traceback (most recent call last):
  File "c:\userfiles\code\python-microscopy\PYME\ui\mytimer.py", line 48, in Notify
    a()
  File "c:\userfiles\code\python-microscopy\PYME\Acquire\acquiremainframe.py", line 157, in _check_init_done
    self.doPostInit()
  File "c:\userfiles\code\python-microscopy\PYME\Acquire\acquiremainframe.py", line 291, in doPostInit
    self.pan_spool = spool_panel.SpoolingPane(self, self.scope, acquisition_uis=self._aq_uis)
  File "c:\userfiles\code\python-microscopy\PYME\Acquire\ui\spool_panel.py", line 574, in __init__
    self._init_ctrls()
  File "c:\userfiles\code\python-microscopy\PYME\Acquire\ui\spool_panel.py", line 543, in _init_ctrls
    self.AddNewElement(self._analysis_pan())
  File "c:\userfiles\code\python-microscopy\PYME\Acquire\ui\spool_panel.py", line 379, in _analysis_pan
    pan.SetSizerAndFit(vsizer)
wx._core.wxAssertionError: C++ assertion "CheckExpectedParentIs(w, m_containingWindow)" failed at ..\..\src\common\sizer.cpp(887) in wxSizer::SetContainingWindow(): Windows managed by the sizer associated with the given window must have this window as parent, otherwise they will not be repositioned correctly.

Please use the window wxPanel@0000020CD37B9A40 ("panel", HWND=0000000000020752) with which this sizer is associated, as the parent when creating the window wxPanel@0000020CD37B6F40 ("panel", HWND=0000000000010788) managed by it.
```

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
create the collapsing pane with the analysis setting panel as its parent rather than the parent of that panel (via self) 



tested on wxpython 4.2.2 on windows 11, python 3.10
