### PR TITLE
work around missing makeColumnEditable method in custom traits editor

### DIFF
--- a/PYME/ui/custom_traits_editors.py
+++ b/PYME/ui/custom_traits_editors.py
@@ -360,7 +360,10 @@ class DictFloatEditList(editList.EditListCtrl):
         self.InsertColumn(0, 'Parameter')
         self.InsertColumn(1, 'Value')
 
-        self.makeColumnEditable(1)
+        try:
+            self.makeColumnEditable(1)
+        except AttributeError:
+            pass
         self.populate()
 
         self.Bind(wx.EVT_LIST_END_LABEL_EDIT, self._on_values_change)

--- a/PYME/ui/custom_traits_editors.py
+++ b/PYME/ui/custom_traits_editors.py
@@ -361,6 +361,9 @@ class DictFloatEditList(editList.EditListCtrl):
         self.InsertColumn(1, 'Value')
 
         try:
+            # Temporary workaround for makeColumnEditible dissappearing in recent wx
+            # TODO - find a permanent fix
+            # TODO - prevent editing in column 0
             self.makeColumnEditable(1)
         except AttributeError:
             pass


### PR DESCRIPTION
Attempts to fix bug #1567.

Issue in custom_traists_editors that is triggered by method not being available in some cases. Just wrapping it into a try-block seems to fix it (but may need checking if anything else needs to be done for full functionality of the traits editor).
