### PR TITLE
Add iterative closest point recipe

### DIFF
--- a/PYME/Analysis/points/coordinate_tools.py
+++ b/PYME/Analysis/points/coordinate_tools.py
@@ -368,7 +368,7 @@ def absolute_orientation(reference, target, weights_reference=None, weights_targ
     rotm = unit_quaternion_to_rotation_matrix(vec[:,0])
 
     # Apply rotation
-    target_rotm = np.dot(rotm, target)
+    target_rotm = np.matmul(rotm, target)
 
     # Compute and apply shift
     # shift0 = reference_cent - (weights_target*target_rotm).sum(1)/weights_target.sum(1)
@@ -377,5 +377,8 @@ def absolute_orientation(reference, target, weights_reference=None, weights_targ
     target_rotm += shift[:,None]
 
     res = np.sum((target_rotm - reference)**2)
+
+    print(rotm)
+    print(shift)
 
     return target_rotm, rotm, shift, res

--- a/PYME/Analysis/points/coordinate_tools.py
+++ b/PYME/Analysis/points/coordinate_tools.py
@@ -329,21 +329,21 @@ def absolute_orientation(reference, target, weights_reference=None, weights_targ
         weights_target = np.ones(target.shape, dtype=target.dtype)
 
     # Move to operating w.r.t centroid
-    reference_cent = (weights_reference*reference).mean(1)
-    target_cent = (weights_target*target).mean(1)
+    reference_cent = ((weights_reference/weights_reference.sum(1)[:,None])*reference).mean(1)
+    target_cent = ((weights_target/weights_target.sum(1)[:,None])*target).mean(1)
     r = reference - reference_cent[:,None]
     t = target - target_cent[:,None]
 
     # Compute pairwise sums
-    S_txrx = (weights_target[0,:]*weights_reference[0,:]*t[0,:]*r[0,:]).sum()
-    S_txry = (weights_target[0,:]*weights_reference[1,:]*t[0,:]*r[1,:]).sum()
-    S_txrz = (weights_target[0,:]*weights_reference[2,:]*t[0,:]*r[2,:]).sum()
-    S_tyrx = (weights_target[1,:]*weights_reference[0,:]*t[1,:]*r[0,:]).sum()
-    S_tyry = (weights_target[1,:]*weights_reference[1,:]*t[1,:]*r[1,:]).sum()
-    S_tyrz = (weights_target[1,:]*weights_reference[2,:]*t[1,:]*r[2,:]).sum()
-    S_tzrx = (weights_target[2,:]*weights_reference[0,:]*t[2,:]*r[0,:]).sum()
-    S_tzry = (weights_target[2,:]*weights_reference[1,:]*t[2,:]*r[1,:]).sum()
-    S_tzrz = (weights_target[2,:]*weights_reference[2,:]*t[2,:]*r[2,:]).sum()
+    S_txrx = ((weights_target[0,:]*weights_reference[0,:]/np.sum(weights_target[0,:]*weights_reference[0,:]))*t[0,:]*r[0,:]).sum()
+    S_txry = ((weights_target[0,:]*weights_reference[1,:]/np.sum(weights_target[0,:]*weights_reference[1,:]))*t[0,:]*r[1,:]).sum()
+    S_txrz = ((weights_target[0,:]*weights_reference[2,:]/np.sum(weights_target[0,:]*weights_reference[2,:]))*t[0,:]*r[2,:]).sum()
+    S_tyrx = ((weights_target[1,:]*weights_reference[0,:]/np.sum(weights_target[1,:]*weights_reference[0,:]))*t[1,:]*r[0,:]).sum()
+    S_tyry = ((weights_target[1,:]*weights_reference[1,:]/np.sum(weights_target[1,:]*weights_reference[1,:]))*t[1,:]*r[1,:]).sum()
+    S_tyrz = ((weights_target[1,:]*weights_reference[2,:]/np.sum(weights_target[1,:]*weights_reference[2,:]))*t[1,:]*r[2,:]).sum()
+    S_tzrx = ((weights_target[2,:]*weights_reference[0,:]/np.sum(weights_target[2,:]*weights_reference[0,:]))*t[2,:]*r[0,:]).sum()
+    S_tzry = ((weights_target[2,:]*weights_reference[1,:]/np.sum(weights_target[2,:]*weights_reference[1,:]))*t[2,:]*r[1,:]).sum()
+    S_tzrz = ((weights_target[2,:]*weights_reference[2,:]/np.sum(weights_target[2,:]*weights_reference[2,:]))*t[2,:]*r[2,:]).sum()
 
     # Compute quaternion matrix
     N = np.array([[(S_txrx+S_tyry+S_tzrz), S_tyrz-S_tzry, S_tzrx-S_txrz, S_txry-S_tyrx],
@@ -362,7 +362,7 @@ def absolute_orientation(reference, target, weights_reference=None, weights_targ
     target_rotm = np.dot(rotm,target)
 
     # Compute and apply shift
-    target_rotm_cent = (weights_target*target_rotm).mean(1)
+    target_rotm_cent = ((weights_target/weights_target.sum(1)[:,None])*target_rotm).mean(1)
     shift = reference_cent - target_rotm_cent
     target_rotm += shift[:,None]
 

--- a/PYME/Analysis/points/coordinate_tools.py
+++ b/PYME/Analysis/points/coordinate_tools.py
@@ -276,3 +276,96 @@ def distance_to_image_mask(mask, points):
 
     return distances
 
+def unit_quaternion_to_rotation_matrix(q):
+    """
+    Convert a unit quaternion to a rotation matrix. Helper function for 
+    absolute_orientation(). Section 3E of reference.
+
+    Parameters
+    ----------
+    q : np.typing.ArrayLike
+        (4,) vector representing the unit quaternion q0 + iqx + jqy + kqz
+
+    References
+    ----------
+    Berthold K. P. Horn, "Closed-form solution of absolute orientation using unit 
+    quaternions," J. Opt. Soc. Am. A 4, 629-642 (1987) 
+
+    """
+    q0, qx, qy, qz = q
+    q02, qx2, qy2, qz2 = q*q
+
+    return np.array([[q02+qx2-qy2-qz2, 2*(qx*qy-q0*qz), 2*(qx*qz+q0*qy)],
+                    [2*(qy*qx+q0*qz), q02-qx2+qy2-qz2, 2*(qy*qz-q0*qx)],
+                    [2*(qz*qx-q0*qy), 2*(qz*qy+q0*qz), q02-qx2-qy2+qz2]])
+
+def absolute_orientation(reference, target, weights_reference=None, weights_target=None):
+    """
+    Compute the rotation and shift from target to reference point cloud.
+
+    Parameters
+    ----------
+    reference : np.typing.ArrayLike
+        (3, N) matrix of points
+    target : np.typing.ArrayLike
+        (3, N) matrix of points
+    weights_reference : np.typing.ArrayLike
+        (3, N) matrix of weights. Should sum to 1 along axis 1.
+    weights_target : np.typing.ArrayLike
+        (3, N) matrix of weights. Should sum to 1 along axis 1.
+
+    References
+    ----------
+    Berthold K. P. Horn, "Closed-form solution of absolute orientation using unit 
+    quaternions," J. Opt. Soc. Am. A 4, 629-642 (1987) 
+
+    """
+    # Map target coordinates to reference.
+    # Note we do not use any scaling
+
+    if weights_reference is None:
+        weights_reference = np.ones(reference.shape, dtype=target.dtype)
+    if weights_target is None:
+        weights_target = np.ones(target.shape, dtype=target.dtype)
+
+    # Move to operating w.r.t centroid
+    reference_cent = (weights_reference*reference).mean(1)
+    target_cent = (weights_target*target).mean(1)
+    r = reference - reference_cent[:,None]
+    t = target - target_cent[:,None]
+
+    # Compute pairwise sums
+    S_txrx = (weights_target[0,:]*weights_reference[0,:]*t[0,:]*r[0,:]).sum()
+    S_txry = (weights_target[0,:]*weights_reference[1,:]*t[0,:]*r[1,:]).sum()
+    S_txrz = (weights_target[0,:]*weights_reference[2,:]*t[0,:]*r[2,:]).sum()
+    S_tyrx = (weights_target[1,:]*weights_reference[0,:]*t[1,:]*r[0,:]).sum()
+    S_tyry = (weights_target[1,:]*weights_reference[1,:]*t[1,:]*r[1,:]).sum()
+    S_tyrz = (weights_target[1,:]*weights_reference[2,:]*t[1,:]*r[2,:]).sum()
+    S_tzrx = (weights_target[2,:]*weights_reference[0,:]*t[2,:]*r[0,:]).sum()
+    S_tzry = (weights_target[2,:]*weights_reference[1,:]*t[2,:]*r[1,:]).sum()
+    S_tzrz = (weights_target[2,:]*weights_reference[2,:]*t[2,:]*r[2,:]).sum()
+
+    # Compute quaternion matrix
+    N = np.array([[(S_txrx+S_tyry+S_tzrz), S_tyrz-S_tzry, S_tzrx-S_txrz, S_txry-S_tyrx],
+                [S_tyrz-S_tzry, (S_txrx-S_tyry-S_tzrz), S_txry+S_tyrx, S_tzrx+S_txrz],
+                [S_tzrx-S_txrz, S_txry+S_tyrx, (-S_txrx+S_tyry-S_tzrz), S_tyrz+S_tzry],
+                [S_txry-S_tyrx, S_tzrx+S_txrz, S_tyrz+S_tzry, (-S_txrx-S_tyry+S_tzrz)]])
+
+    # Get the eigenvalues/eigenvectors. They are sorted high to low, and we only
+    # need the largest one (vec[:,0]), so we don't have to check the values.
+    _, vec = np.linalg.eig(N)
+
+    # Convert quaternion to rotation
+    rotm = unit_quaternion_to_rotation_matrix(vec[:,0])
+
+    # Apply rotation
+    target_rotm = np.dot(rotm,target)
+
+    # Compute and apply shift
+    target_rotm_cent = (weights_target*target_rotm).mean(1)
+    shift = reference_cent - target_rotm_cent
+    target_rotm += shift[:,None]
+
+    res = np.sum((target_rotm - reference)**2)
+
+    return target_rotm, rotm, shift, res

--- a/PYME/recipes/pointcloud.py
+++ b/PYME/recipes/pointcloud.py
@@ -608,10 +608,12 @@ class IterativeClosestPoint(ModuleBase):
                 reference_weights = np.vstack([1/reference[self.sigma_x][idxs_reference], 
                                                 1/reference[self.sigma_y][idxs_reference], 
                                                 1/reference[self.sigma_z][idxs_reference]])
+                
+                # The error has to be less than the localization precision of the dataset
                 rescmp = ((1/reference_weights)**2).sum()
-                reference_weights /= reference_weights.sum(1)[:,None]
             except KeyError:
                 reference_weights = None
+                # No error? Then we should be able to register the points exactly.
                 rescmp = 1  # TODO: What if target_weights finds the sigma keys?
             
             target_pts_sm = np.vstack([target['x'][idxs_target], 
@@ -622,7 +624,6 @@ class IterativeClosestPoint(ModuleBase):
                 target_weights = np.vstack([1/target[self.sigma_x][idxs_target], 
                                             1/target[self.sigma_y][idxs_target], 
                                             1/target[self.sigma_z][idxs_target]])
-                target_weights /= target_weights.sum(1)[:,None]
             except KeyError:
                 target_weights = None
 

--- a/PYME/recipes/pointcloud.py
+++ b/PYME/recipes/pointcloud.py
@@ -608,7 +608,7 @@ class IterativeClosestPoint(ModuleBase):
                 reference_weights = np.vstack([1/reference[self.sigma_x][idxs_reference], 
                                                 1/reference[self.sigma_y][idxs_reference], 
                                                 1/reference[self.sigma_z][idxs_reference]])
-                rescmp = reference_weights.sum()
+                rescmp = ((1/reference_weights)**2).sum()
                 reference_weights /= reference_weights.sum(1)[:,None]
             except KeyError:
                 reference_weights = None

--- a/tests/PYME/Analysis/points/test_coordinate_tools.py
+++ b/tests/PYME/Analysis/points/test_coordinate_tools.py
@@ -168,3 +168,13 @@ def test_absolute_orientation():
 
     np.testing.assert_allclose(cube0, target_rotm)
     assert res < 1e-6
+
+    weights_reference = np.random.rand(*cube0.shape)
+    weights_target = np.random.rand(*cube1.shape)
+
+    target_rotm, rotm, shift, res = coordinate_tools.absolute_orientation(cube0, 
+                                                                          cube1, 
+                                                                          weights_reference=weights_reference, 
+                                                                          weights_target=weights_target)
+    
+    np.testing.assert_array_less(np.abs(cube0-target_rotm), 1/weights_reference)

--- a/tests/PYME/Analysis/points/test_coordinate_tools.py
+++ b/tests/PYME/Analysis/points/test_coordinate_tools.py
@@ -137,3 +137,34 @@ def test_simple_distance_to_image_mask():
 
     distances = coordinate_tools.distance_to_image_mask(mask, points)
     np.testing.assert_array_equal(distances, np.arange(size) - 0.5 * size)
+
+def test_unit_quaternion_to_rotation_matrix():
+    mat = coordinate_tools.unit_quaternion_to_rotation_matrix(np.array([0,0,0,0]))
+    np.testing.assert_array_equal(mat, np.zeros((3,3)))
+    mat = coordinate_tools.unit_quaternion_to_rotation_matrix(np.array([1,0,0,0]))
+    np.testing.assert_array_equal(mat, np.eye(3))
+    mat = coordinate_tools.unit_quaternion_to_rotation_matrix(np.array([0,1,0,0]))
+    np.testing.assert_array_equal(mat, np.diag([1,-1,-1]))
+    mat = coordinate_tools.unit_quaternion_to_rotation_matrix(np.array([0,0,1,0]))
+    np.testing.assert_array_equal(mat, np.diag([-1,1,-1]))
+    mat = coordinate_tools.unit_quaternion_to_rotation_matrix(np.array([0,0,0,1]))
+    np.testing.assert_array_equal(mat, np.diag([-1,-1,1]))
+
+def test_absolute_orientation():
+    from PYME.simulation import locify
+    def round_box(p, w, r):
+        w = np.array(w)
+        q = np.abs(p) - w[:,None]
+        return np.linalg.norm(np.maximum(q,0.0),axis=0) + np.minimum(np.maximum(q[0,:],np.maximum(q[1,:],q[2,:])),0.0) - r
+    
+    shift = [0.5,0,0]
+    rot = np.pi/4
+    cube0 = locify.points_from_sdf(lambda x: round_box(x, [0.5,0.5,0.5], 0), r_max=1, centre=(0,0,0), dx_min=0.2, p=1.0)
+    cube1 = cube0.copy()
+    cube1 += np.array(shift)[:,None]
+    cube1 = np.dot(np.array([[np.cos(rot), 0, np.sin(rot)], [0, 1, 0], [-np.sin(rot), 0, np.cos(rot)]]), cube1)
+
+    target_rotm, rotm, shift, res = coordinate_tools.absolute_orientation(cube0, cube1)
+
+    np.testing.assert_allclose(cube0, target_rotm)
+    assert res < 1e-6

--- a/tests/PYME/recipes/test_pointcloud.py
+++ b/tests/PYME/recipes/test_pointcloud.py
@@ -1,0 +1,89 @@
+import matplotlib
+matplotlib.use('wxagg')
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from PYME.recipes import Recipe
+from PYME.recipes import pointcloud
+from PYME.IO import tabular
+
+def test_iterative_closest_point():
+
+    from PYME.simulation import locify
+    def round_box(p, w, r):
+        w = np.array(w)
+        q = np.abs(p) - w[:,None]
+        return np.linalg.norm(np.maximum(q,0.0),axis=0) + np.minimum(np.maximum(q[0,:],np.maximum(q[1,:],q[2,:])),0.0) - r
+    
+    shift = [0.02,0,0]
+    rot = np.pi/12
+    cube0 = locify.points_from_sdf(lambda x: round_box(x, [0.5,0.5,0.5], 0), r_max=1, centre=(0,0,0), dx_min=0.2, p=1.0)
+    cube1 = cube0.copy()
+    cube1 += np.array(shift)[:,None]
+    cube1 = np.dot(np.array([[np.cos(rot), 0, np.sin(rot)], [0, 1, 0], [-np.sin(rot), 0, np.cos(rot)]]), cube1)
+
+    weights_reference = np.random.rand(*cube0.shape)
+    weights_target = np.random.rand(*cube1.shape)
+
+
+    cube0_ds = tabular.DictSource({"x": cube0[0,:],
+                                   "y": cube0[1,:],
+                                   "z": cube0[2,:],
+                                   "error_x": weights_reference[0,:],
+                                   "error_y": weights_reference[1,:],
+                                   "error_z": weights_reference[2,:]})
+    
+    cube1_ds = tabular.DictSource({"x": cube1[0,:],
+                                   "y": cube1[1,:],
+                                   "z": cube1[2,:],
+                                   "error_x": weights_target[0,:],
+                                   "error_y": weights_target[1,:],
+                                   "error_z": weights_target[2,:]})
+    
+
+    recipe = Recipe()
+    recipe.namespace['reference'] = cube0_ds
+    recipe.namespace['to_register'] = cube1_ds
+
+    icp = pointcloud.IterativeClosestPoint(reference='reference', 
+                                           to_register='to_register', 
+                                           output='output', 
+                                           max_iters=5,
+                                           max_points=50,
+                                           sigma_x="nerf", 
+                                           sigma_y="nerf", 
+                                           sigma_z="nerf")
+    recipe.add_module(icp)
+
+    res = recipe.execute()
+
+    # fig = plt.figure()
+    # ax = fig.add_subplot(projection='3d')
+    # ax.scatter(cube0[0,...], cube0[1,...],cube0[2,...])
+    # ax.scatter(cube1[0,...], cube1[1,...],cube1[2,...])
+    # ax.scatter(res['x'], res['y'], res['z'])
+    # # ax.scatter(res['xp'], res['yp'], res['zp'])
+    # ax.set_xlim([-1,1])
+    # ax.set_ylim([-1,1])
+    # ax.set_zlim([-1,1])
+
+    # plt.show()
+
+    np.testing.assert_allclose(cube0[0,:], res['x'])
+    np.testing.assert_allclose(cube0[1,:], res['y'])
+    np.testing.assert_allclose(cube0[2,:], res['z'])
+
+    icp2 = pointcloud.IterativeClosestPoint(reference='reference', 
+                                           to_register='to_register', 
+                                           output='output', 
+                                           max_iters=5,
+                                           max_points=50)
+    recipe.add_module(icp2)
+
+    res2 = recipe.execute()
+
+    np.testing.assert_array_less(np.abs(cube0[0,:]- res2['x']), 1/weights_reference[0,:])
+    np.testing.assert_array_less(np.abs(cube0[1,:], res2['y']), 1/weights_reference[1,:])
+    np.testing.assert_array_less(np.abs(cube0[2,:], res2['z']), 1/weights_reference[2,:])
+


### PR DESCRIPTION
This adds a recipe for iterative closest point weighted by localization precision to register one point cloud to another. This was built to address slight shifts and rotations in a cell's position before and after washes in some PAINT experiments. 

While this works for my current purposes, we may want to add a parameter for known offsets between two targets and add this as part of the weighting. 

My convergence criteria is also pretty poor, but `absolute_orientation()` naturally converges so it's OK for now.

Also, I did not implement scaling. Could consider adding it.

- [x] Better convergence conditions
- [x] Fix weighting in rotation matrix to sum to 1