### PR TITLE
fix for incompatible function pointer types initializing 'PyCFunction'  in edgeDB.c

### DIFF
--- a/PYME/Analysis/points/EdgeDB/edgeDB.c
+++ b/PYME/Analysis/points/EdgeDB/edgeDB.c
@@ -707,15 +707,15 @@ fail:
 
 
 static PyMethodDef edgeDBMethods[] = {
-    {"addEdges",  addEdges, METH_VARARGS | METH_KEYWORDS,
+    {"addEdges",  (PyCFunction) addEdges, METH_VARARGS | METH_KEYWORDS,
     ""},
-    {"segment",  segment, METH_VARARGS | METH_KEYWORDS,
+    {"segment",  (PyCFunction) segment, METH_VARARGS | METH_KEYWORDS,
     ""},
-    {"calcEdgeLengths",  calcEdgeLengths, METH_VARARGS | METH_KEYWORDS,
+    {"calcEdgeLengths",  (PyCFunction) calcEdgeLengths, METH_VARARGS | METH_KEYWORDS,
     ""},
-    {"getVertexEdgeLengths",  getVertexEdgeLengths, METH_VARARGS | METH_KEYWORDS,
+    {"getVertexEdgeLengths",  (PyCFunction) getVertexEdgeLengths, METH_VARARGS | METH_KEYWORDS,
     ""},
-    {"getVertexNeighbours",  getVertexNeighbours, METH_VARARGS | METH_KEYWORDS,
+    {"getVertexNeighbours",  (PyCFunction) getVertexNeighbours, METH_VARARGS | METH_KEYWORDS,
     ""},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };


### PR DESCRIPTION
Addresses issue where compiling on mac (14.7.x) raises errors in edgeDB.c:

```C
PYME/Analysis/points/EdgeDB/edgeDB.c:710:19: error: incompatible function pointer types initializing 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') with an expression of type 'PyObject *(PyObject *, PyObject *, PyObject *)' (aka 'struct _object *(struct _object *, struct _object *, struct _object *)') [-Wincompatible-function-pointer-types]
  710 |     {"addEdges",  addEdges, METH_VARARGS | METH_KEYWORDS,
      |                   ^~~~~~~~
PYME/Analysis/points/EdgeDB/edgeDB.c:712:18: error: incompatible function pointer types initializing 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') with an expression of type 'PyObject *(PyObject *, PyObject *, PyObject *)' (aka 'struct _object *(struct _object *, struct _object *, struct _object *)') [-Wincompatible-function-pointer-types]
  712 |     {"segment",  segment, METH_VARARGS | METH_KEYWORDS,
      |                  ^~~~~~~
...
```

**Is this a bugfix or an enhancement?**

backwordscompatible bugfix

**Proposed changes:**

Typecast explicitly to `PyCFunction`:

```C
    {"addEdges",  (PyCFunction) addEdges, METH_VARARGS | METH_KEYWORDS, 
...
```

Compiles fine on mac and PC with these tweaks.



**Checklist:**

Tested with latest sources from git.