### PR TITLE
backwards compatibel fixes for traits.api in traits 7.X onwards

### DIFF
--- a/PYME/LMVis/layers/base.py
+++ b/PYME/LMVis/layers/base.py
@@ -223,7 +223,11 @@ class BaseLayer(HasTraits):
         pass
 
     def settings_dict(self):
-        d =  self.get([n for n in self.class_trait_names() if not n.startswith('_')])
+        params = [n for n in self.class_trait_names() if not n.startswith('_')]
+        try:
+            d =  self.get(params)
+        except AttributeError:
+            d = self.trait_get(params)
         for k, v in d.items():
             if isinstance(v, dict) and not type(v) == dict:
                 v = dict(v)

--- a/PYME/LMVis/layers/base.py
+++ b/PYME/LMVis/layers/base.py
@@ -224,10 +224,7 @@ class BaseLayer(HasTraits):
 
     def settings_dict(self):
         params = [n for n in self.class_trait_names() if not n.startswith('_')]
-        try:
-            d =  self.get(params)
-        except AttributeError:
-            d = self.trait_get(params)
+        d = self.trait_get(params)
         for k, v in d.items():
             if isinstance(v, dict) and not type(v) == dict:
                 v = dict(v)

--- a/PYME/LMVis/layers/image_layer.py
+++ b/PYME/LMVis/layers/image_layer.py
@@ -191,10 +191,7 @@ class ImageRenderLayer(EngineLayer):
         self.on_trait_change(self._set_method, 'method')
 
         # update any of our traits which were passed as command line arguments
-        try:
-            self.set(**kwargs)
-        except AttributeError:
-            self.trait_set(**kwargs)
+        self.trait_set(**kwargs)
 
         # update datasource and method
         self.dsname = dsname
@@ -277,10 +274,7 @@ class ImageRenderLayer(EngineLayer):
         cmap = do.cmaps[self.channel].name
         visible = do.show[self.channel]
 
-        try:
-            self.set(clim=clim, cmap=cmap, visible=visible, z_pos=do.zp, t_pos=do.tp)
-        except AttributeError:
-            self.trait_set(clim=clim, cmap=cmap, visible=visible, z_pos=do.zp, t_pos=do.tp)     
+        self.trait_set(clim=clim, cmap=cmap, visible=visible, z_pos=do.zp, t_pos=do.tp)     
         
 
     def update_from_datasource(self, ds):

--- a/PYME/LMVis/layers/image_layer.py
+++ b/PYME/LMVis/layers/image_layer.py
@@ -191,7 +191,10 @@ class ImageRenderLayer(EngineLayer):
         self.on_trait_change(self._set_method, 'method')
 
         # update any of our traits which were passed as command line arguments
-        self.set(**kwargs)
+        try:
+            self.set(**kwargs)
+        except AttributeError:
+            self.trait_set(**kwargs)
 
         # update datasource and method
         self.dsname = dsname
@@ -273,8 +276,11 @@ class ImageRenderLayer(EngineLayer):
 
         cmap = do.cmaps[self.channel].name
         visible = do.show[self.channel]
-        
-        self.set(clim=clim, cmap=cmap, visible=visible, z_pos=do.zp, t_pos=do.tp)
+
+        try:
+            self.set(clim=clim, cmap=cmap, visible=visible, z_pos=do.zp, t_pos=do.tp)
+        except AttributeError:
+            self.trait_set(clim=clim, cmap=cmap, visible=visible, z_pos=do.zp, t_pos=do.tp)     
         
 
     def update_from_datasource(self, ds):

--- a/PYME/LMVis/layers/labels.py
+++ b/PYME/LMVis/layers/labels.py
@@ -55,7 +55,10 @@ class LabelLayer(SimpleLayer):
         self.on_trait_change(self.update, 'cmap, clim, dsname, font_size, format_string')
 
         # update any of our traits which were passed as command line arguments
-        self.set(**kwargs)
+        try:
+            self.set(**kwargs)
+        except AttributeError:
+            self.trait_set(**kwargs)
 
         self.update()
         

--- a/PYME/LMVis/layers/labels.py
+++ b/PYME/LMVis/layers/labels.py
@@ -55,10 +55,7 @@ class LabelLayer(SimpleLayer):
         self.on_trait_change(self.update, 'cmap, clim, dsname, font_size, format_string')
 
         # update any of our traits which were passed as command line arguments
-        try:
-            self.set(**kwargs)
-        except AttributeError:
-            self.trait_set(**kwargs)
+        self.trait_set(**kwargs)
 
         self.update()
         

--- a/PYME/LMVis/layers/mesh.py
+++ b/PYME/LMVis/layers/mesh.py
@@ -183,7 +183,10 @@ class TriangleRenderLayer(EngineLayer):
         self.on_trait_change(self._set_method, 'method')
 
         # update any of our traits which were passed as command line arguments
-        self.set(**kwargs)
+        try:
+            self.set(**kwargs)
+        except AttributeError:
+            self.trait_set(**kwargs)
 
         # update datasource and method
         self.dsname = dsname

--- a/PYME/LMVis/layers/mesh.py
+++ b/PYME/LMVis/layers/mesh.py
@@ -183,10 +183,7 @@ class TriangleRenderLayer(EngineLayer):
         self.on_trait_change(self._set_method, 'method')
 
         # update any of our traits which were passed as command line arguments
-        try:
-            self.set(**kwargs)
-        except AttributeError:
-            self.trait_set(**kwargs)
+        self.trait_set(**kwargs)
 
         # update datasource and method
         self.dsname = dsname

--- a/PYME/LMVis/layers/pointcloud.py
+++ b/PYME/LMVis/layers/pointcloud.py
@@ -193,7 +193,10 @@ class PointCloudRenderLayer(EngineLayer):
         self.on_trait_change(self._set_method, 'method')
 
         # update any of our traits which were passed as command line arguments
-        self.set(**kwargs)
+        try:
+            self.set(**kwargs)
+        except AttributeError:
+            self.trait_set(**kwargs)
         
         # update datasource name and method
         #logger.debug('Setting dsname and method')

--- a/PYME/LMVis/layers/pointcloud.py
+++ b/PYME/LMVis/layers/pointcloud.py
@@ -193,10 +193,7 @@ class PointCloudRenderLayer(EngineLayer):
         self.on_trait_change(self._set_method, 'method')
 
         # update any of our traits which were passed as command line arguments
-        try:
-            self.set(**kwargs)
-        except AttributeError:
-            self.trait_set(**kwargs)
+        self.trait_set(**kwargs)
         
         # update datasource name and method
         #logger.debug('Setting dsname and method')

--- a/PYME/LMVis/layers/quiver.py
+++ b/PYME/LMVis/layers/quiver.py
@@ -109,10 +109,7 @@ class QuiverRenderLayer(EngineLayer):
         self.on_trait_change(self._set_method, 'method')
 
         # update any of our traits which were passed as command line arguments
-        try:
-            self.set(**kwargs)
-        except AttributeError:
-            self.trait_set(**kwargs)
+        self.trait_set(**kwargs)
 
         # update datasource and method
         self.dsname = dsname

--- a/PYME/LMVis/layers/quiver.py
+++ b/PYME/LMVis/layers/quiver.py
@@ -109,7 +109,10 @@ class QuiverRenderLayer(EngineLayer):
         self.on_trait_change(self._set_method, 'method')
 
         # update any of our traits which were passed as command line arguments
-        self.set(**kwargs)
+        try:
+            self.set(**kwargs)
+        except AttributeError:
+            self.trait_set(**kwargs)
 
         # update datasource and method
         self.dsname = dsname

--- a/PYME/LMVis/layers/tracks.py
+++ b/PYME/LMVis/layers/tracks.py
@@ -103,7 +103,10 @@ class TrackRenderLayer(EngineLayer):
         self.on_trait_change(self._set_method, 'method')
         
         # update any of our traits which were passed as command line arguments
-        self.set(**kwargs)
+        try:
+            self.set(**kwargs)
+        except AttributeError:
+            self.trait_set(**kwargs)
         
         # update datasource name and method
         #logger.debug('Setting dsname and method')

--- a/PYME/LMVis/layers/tracks.py
+++ b/PYME/LMVis/layers/tracks.py
@@ -103,10 +103,7 @@ class TrackRenderLayer(EngineLayer):
         self.on_trait_change(self._set_method, 'method')
         
         # update any of our traits which were passed as command line arguments
-        try:
-            self.set(**kwargs)
-        except AttributeError:
-            self.trait_set(**kwargs)
+        self.trait_set(**kwargs)
         
         # update datasource name and method
         #logger.debug('Setting dsname and method')

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -205,7 +205,11 @@ class ModuleBase(HasStrictTraits):
         ct = self.class_traits()
             
         mod_traits_cleaned = {}
-        for k, v in self.get().items():
+        try:
+            params = self.get().items()
+        except AttributeError:
+            params = self.trait_get().items()
+        for k, v in params:
             if not k.startswith('_'): #don't save private data - this is usually used for caching etc ..,
                 try:
                     if (not (v == ct[k].default)) or (k.startswith('input')) or (k.startswith('output')) or isinstance(ct[k], (Input, Output)):

--- a/PYME/recipes/base.py
+++ b/PYME/recipes/base.py
@@ -205,10 +205,7 @@ class ModuleBase(HasStrictTraits):
         ct = self.class_traits()
             
         mod_traits_cleaned = {}
-        try:
-            params = self.get().items()
-        except AttributeError:
-            params = self.trait_get().items()
+        params = self.trait_get().items()
         for k, v in params:
             if not k.startswith('_'): #don't save private data - this is usually used for caching etc ..,
                 try:

--- a/PYME/recipes/recipeGui.py
+++ b/PYME/recipes/recipeGui.py
@@ -155,10 +155,7 @@ class RecipePlotPanel(wxPlotPanel.PlotPanel):
                     self.ax.text(v[0]+.05, v[1]+.18 - .05*(len(s) - 1) , '\n'.join(s), size=fontSize, weight='bold')
                 #print repr(k)
 
-                try:
-                    params = k.get().items()
-                except AttributeError:
-                    params = k.trait_get().items()
+                params = k.trait_get().items()
 
                 s2 = []
                 for i in params:

--- a/PYME/recipes/recipeGui.py
+++ b/PYME/recipes/recipeGui.py
@@ -154,8 +154,12 @@ class RecipePlotPanel(wxPlotPanel.PlotPanel):
                 else:
                     self.ax.text(v[0]+.05, v[1]+.18 - .05*(len(s) - 1) , '\n'.join(s), size=fontSize, weight='bold')
                 #print repr(k)
-                
-                params = k.get().items()
+
+                try:
+                    params = k.get().items()
+                except AttributeError:
+                    params = k.trait_get().items()
+
                 s2 = []
                 for i in params:
                     pn, p = i

--- a/PYME/recipes/traits.py
+++ b/PYME/recipes/traits.py
@@ -12,6 +12,7 @@ except ImportError:
 
 # definitions below have been adapted based on https://docs.enthought.com/traits-futures/0.2/_modules/traits/trait_types.html
 # these Dict have been deprecated for a while and need to be defined here for newer traits.api modules
+# FIXME - change usage within code and remove aliases
 DictStrAny = Dict(str, Any)
 DictStrStr = Dict(str, str)
 DictStrList = Dict(str, list)
@@ -19,6 +20,7 @@ DictStrFloat = Dict(str, float)
 DictStrBool = Dict(str, bool)
 
 # -- List Traits ------- same as dict traits; we define only a subset of all possible List traits here
+# FIXME - change usage within code and remove aliases
 ListInt = List(int)
 ListFloat = List(float)
 ListStr = List(str)

--- a/PYME/recipes/traits.py
+++ b/PYME/recipes/traits.py
@@ -10,6 +10,21 @@ try:
 except ImportError:
     from traits.api import *
 
+# definitions below have been adapted based on https://docs.enthought.com/traits-futures/0.2/_modules/traits/trait_types.html
+# these Dict have been deprecated for a while and need to be defined here for newer traits.api modules
+DictStrAny = Dict(str, Any)
+DictStrStr = Dict(str, str)
+DictStrList = Dict(str, list)
+DictStrFloat = Dict(str, float)
+DictStrBool = Dict(str, bool)
+
+# -- List Traits ------- same as dict traits; we define only a subset of all possible List traits here
+ListInt = List(int)
+ListFloat = List(float)
+ListStr = List(str)
+ListUnicode = List(str)
+ListComplex = List(complex)
+ListBool = List(bool)
 
 #Monkey-patch traits so that editors need enter / focus change to update by default
 from traits import trait_types


### PR DESCRIPTION
Allows use of latest traits package releases version 7.x.

7.x has removed a number of deprecated interfaces, notably `HasTraits.get` and `HasTraits.set`, as well as some of the `ListXXX` and `DictXXX` traits.

I semiregularly build complete PYME installs from `conda-forge` using `PYME-test-env` and during latest builds `traits` 7 gets used without explicit pinning. This PR seems to get everything working fine according to my testing so far. The proposed changes seem preferable over pinning `traits` to pre-7.

**Is this a bugfix or an enhancement?**

Compatibility "bugfix" for recent traits package versions.

**Proposed changes:**

- we wrap traits `set` and `get` calls in a try block to fall back to the replacement `trait_get` and `trait_set` methods. 
- define `DictStrFloat`, `ListFloat` etc in `PYME.recipes.traits`.

`trait_get` etc may have been available since traits 4.X, we could alternatively just change the `.get` and `.set` calls to their `trait_x` alternatives without explicit try blocks.


**Checklist:**
Tested with latest git source and `traits` 6.x and also `traits` 7.0.