### PR TITLE
minor fastgraph fix for numpy 1.20+

### DIFF
--- a/PYME/ui/fastGraph.py
+++ b/PYME/ui/fastGraph.py
@@ -102,7 +102,7 @@ class FastGraphPanel(wx.Panel):
 
         
 
-        self.hstep = np.float(self.hmax - self.hmin)/max(self.Size[0] - self.left_margin, 1)
+        self.hstep = float(self.hmax - self.hmin)/max(self.Size[0] - self.left_margin, 1)
 
         #print self.hmin, self.hmax, self.hstep
 


### PR DESCRIPTION
Addresses issue numpy.float alias use.

```
Traceback (most recent call last):
  File "c:\userfiles\code\python-microscopy\PYME\Acquire\acquiremainframe.py", line 225, in doPostInit
    cm.run(self, self.scope)
  File "c:\userfiles\code\python-microscopy\PYME\Acquire\ExecTools.py", line 205, in run
    self.codeObj(parent, scope)
  File "init_fluor_cam_240826.py", line 265, in intensity_trace
    intensity_trace = IntensityTracePanel(MainFrame, scope.frameWrangler)
  File "c:\userfiles\code\python-microscopy\PYME\Acquire\ui\intensity_trace.py", line 34, in __init__
    FastGraphPanel.__init__(self, parent, winid, self.frame_vals,
  File "c:\userfiles\code\python-microscopy\PYME\ui\fastGraph.py", line 54, in __init__
    self.SetData(xvals, data)
  File "c:\userfiles\code\python-microscopy\PYME\ui\fastGraph.py", line 83, in SetData
    self.GenHist()
  File "c:\userfiles\code\python-microscopy\PYME\ui\fastGraph.py", line 105, in GenHist
    self.hstep = np.float(self.hmax - self.hmin)/max(self.Size[0] - self.left_margin, 1)
  File "C:\ProgramData\Miniconda3\envs\sagnac\lib\site-packages\numpy\__init__.py", line 324, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.

```

- [X] Does this maintain backwards compatibility with old data?

