### PR TITLE
sqlite_ns code small syntax fix to make compliant ('...' for "...")

### DIFF
--- a/PYME/misc/sqlite_ns.py
+++ b/PYME/misc/sqlite_ns.py
@@ -35,8 +35,9 @@ class SQLiteNS(object):
         self._protocol = protocol
         self._dbname = os.path.join(tempfile.gettempdir(), '%s.sqlite' %self._protocol)
         with sqlite3.connect(self._dbname) as conn:
-
-            tableNames = [a[0] for a in conn.execute('SELECT name FROM sqlite_master WHERE type="table"').fetchall()]
+            # sqlite wants single quotes around literal strings and the sqlite package just became pickier about this
+            # see also https://www.reddit.com/r/freebsd/comments/1chb82b/sqlite3_pkg_just_became_stricter_with_quoting/
+            tableNames = [a[0] for a in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()]
             if not 'dns' in tableNames:
                 try:
                     conn.execute("CREATE TABLE dns (name TEXT, address TEXT, port INTEGER, creation_time FLOAT, URI TEXT)")


### PR DESCRIPTION
Addresses issue #1577 .

**Is this a bugfix or an enhancement?**
small bugfix that becomes apparent with more recent python `sqlite` packages.

**Proposed changes:**
`sqlite` wants single quotes around literal strings. Accordingly replace double quotes around `table` type with singles.

