### PR TITLE
pipython gcs piezo updates: analog control option and ontarget tolerance setting

### DIFF
--- a/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
@@ -397,6 +397,7 @@ class GCSPiezoThreaded(PiezoBase):
                     self._on_target = np.asarray([on_targets[axis] for axis in self.axes])
                     if not np.all(self._on_target == old_on_target):
                         # FIXME - something to log which axis would be cool?
+                        # FIXME - analog control of even 1 axis will essentially break this
                         logEvent('PiezoOnTarget', '%s' % self.positions, time.time())
                         self._all_on_target = np.all(self._on_target)
                     targets_matched = np.isclose(self.target_positions, self._last_target_positions,
@@ -444,6 +445,9 @@ class GCSPiezoThreaded(PiezoBase):
         
         Notes
         -----
+        OnTarget events are not aware of analog control, and will not
+        generally fire if even one axis is under analog control.
+
         Requires command level 1. which can be enabled with 
         self.pi.gcsdevice.CCL(1, password)
 

--- a/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
@@ -401,7 +401,7 @@ class GCSPiezoThreaded(PiezoBase):
                         logEvent('PiezoOnTarget', '%s' % self.positions, time.time())
                         self._all_on_target = np.all(self._on_target)
                     targets_matched = np.isclose(self.target_positions, self._last_target_positions,
-                                                 atol=self._ontarget_tol)
+                                                 rtol=0, atol=self._ontarget_tol)
                     if all(targets_matched):
                         self._all_on_target = True
                     else:

--- a/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
+++ b/PYME/Acquire/Hardware/Piezos/piezo_pipython_gcs.py
@@ -216,13 +216,19 @@ class GCSPiezoThreaded(PiezoBase):
 
         joystick: should be a joystick object or None if no joystick; needs to support a few standard methods
 
+        target_tol: float, optional
+            tolerance [um] for on-target position, default is 0.001 um. Applied to
+            all axes. Does not change servo settings in the controller, but flags
+            when a move is considered complete and re-sends a move command durring polling
+            if target position is not reached within tolerance. 
+        
         adc_channels: list, optional
-            list of ADC channels to use for each axis in `axes`. You will need
+            list of ADC channels to use for axes in `axes`. You will need
             to consult the manual for your controller, as the available ADC 
             channels may be offset from the axis number and/or flexibly configurable.
             You will also need to set the command level to 1 (in your init script)
-            with e.,g. stage.pi.gcsdevice.CCL(1, 'password')
-            The password should also be in your controller manual.
+            with e.,g. stage.pi.gcsdevice.CCL(1, 'password') before using the `set_analog_control`
+            method. The password should also be in your controller manual.
         """
         PiezoBase.__init__(self)
         self.pi = GCSDevice()


### PR DESCRIPTION
Addresses issues: 
- my need for external DAQ/FPGA driven fast sample scanning / signal IO  (see #1463) 
- unset ontarget tolerance in `piezo_pipython_gcs.GCSPiezoThreaded`, defaulting to numpy.isclose defaults which are rather small

**Is this a bugfix or an enhancement?**
one of each
**Proposed changes:**
1. add a method to change control for a given axis from serial to an ADC channel on the controller for analog control. 

> On my 3 axis stage, this lets me control two axes with analog lines from a DAQ while still using serial commands to move the remaining axis and poll positions of all 3 axes (useful because I do not have a coarse and fine stage, only the one stage to use for sample positioning and scanning both). There is an oddity or two remaining for control of some axes with serial commands and some with analog signals, but I imagine most folks will not be in the position I am in of using 1 stage/controller for so many tasks, and I am aware of the current limitations: `PiezoOnTarget` events will not generally fire or will fire on coincidence if any axis is in analog control, and extra move commands will be sent to the controller (and ignored for analog axes).

2. Add an initialization arg `piezo_pipython_gcs.GCSPiezoThreaded` setting a target tolerance for use in `numpy.isclose` as the `atol` parameter, so an on-target tolerance of e.g. 1 nm (new default) can be set, rather than 10^-8 micrometers. 

> This should save extra mov commands being sent presumably regularly by the polling thread (my bad) and potentially resulting `PiezoOnTarget` events. Users will need to set the tolerance to something reasonable for their application. I didn't want to make it too large given that the previous default was so minuscule, but 1 nm is likely ambitious for many stages. I have also set the relative tolerance, rtol to zero, even though it was already quite small, to prevent a position-dependant tolerance on large-travel stages. See [numpy.isclose](https://numpy.org/doc/1.25/reference/generated/numpy.isclose.html) , which comares a and b as |a - b| <= (atol + rtol * |b|)


@csoeller , does this look/sound OK to you? I wouldn't want the on-target tolerance to change without you knowing about it, though practically I don't think this will effect actual stage movement.






**Checklist:**
- [X] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [X] Does this maintain backwards compatibility with old data?
- [X] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
