### PR TITLE
Make reflection focus lock controllable through scope.state

### DIFF
--- a/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
+++ b/PYME/Acquire/Hardware/focus_locks/reflection_focus_lock.py
@@ -202,21 +202,32 @@ class ReflectedLinePIDFocusLock(PID):
         return self.auto_mode
 
     @webframework.register_endpoint('/EnableLock', output_is_json=False)
-    def EnableLock(self):
+    def EnableLock(self, enable=True):
         """
         Returns offset to last-known offset before enabling the lock.
 
         The servo is generally more robust to changing its setpoint when it is running than when you toggle it off, move
         off the setpoint, and then slam it on again. This just makes the slam small.
         """
-        # make sure piezo is ready
-        retry = 0
-        while not self.piezo.OnTarget() and retry < 3:
-            logger.debug('waiting for piezo to stop moving')
-            time.sleep(0.1)
-            retry += 1
-        logger.debug('Enabling focus lock')
-        self.set_auto_mode(True)
+        
+        # enable could be a string
+        enable = enable and not (enable == 'False')
+
+        if enable:
+            # make sure piezo is ready
+            retry = 0
+            while not self.piezo.OnTarget() and retry < 3:
+                logger.debug('waiting for piezo to stop moving')
+                time.sleep(0.1)
+                retry += 1
+            logger.debug('Enabling focus lock')
+            self.set_auto_mode(True)
+        else: # disable
+            # take out the lock so we can log offset and disable 'at once'
+            with self._piezo_control_lock:
+                self.piezo.LogFocusCorrection(self.piezo.GetOffset())
+                self.set_auto_mode(False)
+                logger.debug('Disabling focus lock')
     
     @webframework.register_endpoint('/EnableLockAndHome', output_is_json=False)
     def EnableLockAndHome(self):
@@ -225,11 +236,7 @@ class ReflectedLinePIDFocusLock(PID):
 
     @webframework.register_endpoint('/DisableLock', output_is_json=False)
     def DisableLock(self):
-        # take out the lock so we can log offset and disable 'at once'
-        with self._piezo_control_lock:
-            self.piezo.LogFocusCorrection(self.piezo.GetOffset())
-            self.set_auto_mode(False)
-            logger.debug('Disabling focus lock')
+        self.EnableLock(False)
 
     def register(self):
         if self.mode == 'time':
@@ -518,9 +525,9 @@ class RLPIDFocusLockClient(object):
         response = self._session.get(self.base_url + '/LockOK')
         return bool(response.json())
 
-    def EnableLock(self):
-        self._enabled = True
-        return self._session.get(self.base_url + '/EnableLock')
+    def EnableLock(self, enable=True):
+        self._enabled = enable
+        return self._session.get(self.base_url + '/EnableLock&enable=%s' % enable)
     
     def EnableLockAndHome(self):
         self._enabled = True

--- a/PYME/Acquire/acquiremainframe.py
+++ b/PYME/Acquire/acquiremainframe.py
@@ -254,7 +254,7 @@ class PYMEMainFrame(acquirebase.PYMEAcquireBase, AUIFrame):
             self.AddCamTool(*t)
         
         if len(self.scope.positioning.keys()) > 0.5:
-            self.pos_sl = positionUI.PositionPanel(self.scope, self, self.scope.joystick)
+            self.pos_sl = positionUI.PositionPanelV2(self.scope, self, self.scope.joystick)
             self.time1.register_callback(self.pos_sl.update)
 
             self.AddTool(self.pos_sl, 'Positioning')

--- a/PYME/Analysis/deTile.py
+++ b/PYME/Analysis/deTile.py
@@ -290,6 +290,10 @@ def assemble_tiles_xyztc(data, mdh, correlate=False, dark=None, flat=None):
 
     Assumes tiles are along the time axis.
 
+    NOTE: This is the most naive and simple implementation, and will put the entire tiled reconstruction and
+    a similarly sized occupancy matrix into RAM. There is a good chance that it will blow up on large datasets. 
+    TODO - create a pyramid instead.
+
     Parameters:
     -----------
     ds : arraylike (5D - x, y, z, t, c)

--- a/PYME/Analysis/points/spherical_harmonics.py
+++ b/PYME/Analysis/points/spherical_harmonics.py
@@ -591,8 +591,18 @@ class ScaledShell(object):
         # get scaled shell radius at those angles
         r_shell = reconstruct_shell(self.modes, self.coefficients, azimuth_qs, zenith_qs)
 
+        pts = self.get_fitted_shell(azimuth_qs, zenith_qs)
+
+        #print(r_qs - r_shell)
+
         # return the (scaled space) difference
-        d = r_qs - r_shell
+        #d = r_qs - r_shell
+        d_ = pts - points
+
+        s = 2.0*(r_qs> r_shell) - 1.0
+        #print(s)
+
+        d = s*np.sqrt((d_*d_).sum(0))
         
         #scale distance TODO - actually scale to make slightly closer to being euclidean
         return d

--- a/PYME/IO/h5rFile.py
+++ b/PYME/IO/h5rFile.py
@@ -164,6 +164,13 @@ class H5RFile(object):
                 from PYME.IO import PZFFormat
                 #special case  for pzf data - also build an index table
                 frameNum = PZFFormat.load_header(data)['FrameNum']
+
+                # modern numpy (> ~1.24) gives us an array rather than a scalar for frameNum
+                # cast to an int to be safe ...
+                # FIXME - this appears to be an undocumented numpy regression / change - should we create an issue?
+                frameNum = int(frameNum)
+
+                #logger.debug('framenum: %s', frameNum)
                 
                 #record a mapping from frame number to the row we added
                 idx_entry = np.array([frameNum, table.nrows -1], dtype='i4').view(dtype=[('FrameNum', 'i4'), ('Position', 'i4')])

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -345,7 +345,7 @@ class Pipeline(object):
     
     @property
     def imageBounds(self):
-        x0, y0, x1, y1, z0, z1 = 0, 0, 0, 0, 0, 0
+        x0, y0, x1, y1, z0, z1 = 1e9, 1e9, -1e9, -1e9, 1e9, -1e9
         for ds in self.dataSources.values():
             try:
                 ib = ds.image_bounds

--- a/PYME/LMVis/shader_programs/GLProgram.py
+++ b/PYME/LMVis/shader_programs/GLProgram.py
@@ -27,7 +27,7 @@ import os
 
 class GLProgram(object):
 
-    def __init__(self, vs_filename=None, fs_filename=None, gs_filename=None, max_glsl_version='120', clipping={'x':[-1e6, 1e6], 'y' : [-1e6, 1e6], 'z': [-1e6, 1e6], 'v' : [-1e6, 1e6]}):
+    def __init__(self, vs_filename=None, fs_filename=None, gs_filename=None, max_glsl_version='120', clipping={'x':[-1e9, 1e9], 'y' : [-1e9, 1e9], 'z': [-1e9, 1e9], 'v' : [-1e9, 1e9]}):
         self._shader_program = None
         self._max_glsl_version = max_glsl_version
 
@@ -97,10 +97,10 @@ class GLProgram(object):
         glUniformMatrix4fv(self.get_uniform_location('clip_rotation_matrix'), 1, GL_FALSE, self.v_matrix)
 
     def clear_shader_clipping(self):
-        self.xmin, self.xmax = -1e6, 1e6
-        self.ymin, self.ymax = -1e6, 1e6
-        self.zmin, self.zmax = -1e6, 1e6
-        self.vmin, self.vmax = -1e6, 1e6
+        self.xmin, self.xmax = -1e9, 1e9
+        self.ymin, self.ymax = -1e9, 1e9
+        self.zmin, self.zmax = -1e9, 1e9
+        self.vmin, self.vmax = -1e9, 1e9
 
         self.set_clipping_uniforms()
 

--- a/PYME/LMVis/view_clipping_pane.py
+++ b/PYME/LMVis/view_clipping_pane.py
@@ -107,7 +107,7 @@ class ClippingPanel(wx.Panel):
         #print 'bbox: ' + repr(bb)
         
         if bb is None:
-            return [-1e6, 1e6]
+            return [1e-9, 1e9]
         
         
         if self.axis == 'x':

--- a/PYME/LMVis/views.py
+++ b/PYME/LMVis/views.py
@@ -35,7 +35,7 @@ except ImportError:
 
 
 clipping_dtype = [('x', '<f4', (2,)), ('y', '<f4', (2,)), ('z', '<f4', (2,)), ('v', '<f4', (2,))]
-dummy_clipping = np.array([-1e6, 1e6, -1e6, 1e6, -1e6, 1e6, -1e6, 1e6], 'f4').view(clipping_dtype)
+dummy_clipping = np.array([-1e9, 1e9, -1e9, 1e9, -1e9, 1e9, -1e9, 1e9], 'f4').view(clipping_dtype)
 
 def_clip_plane_orientation = np.array([1,0,0,0], 'f8')#np.eye(4,4,dtype='f')
 

--- a/PYME/recipes/recipe.py
+++ b/PYME/recipes/recipe.py
@@ -767,7 +767,7 @@ class Recipe(HasTraits):
                 #  pipe our table into h5r or hdf source depending on the extension
                 if extension == '.h5r':
                     if t.name == 'DriftResults':
-                        tab = tabular.H5RDriftResults(h5f, t.name)
+                        tab = tabular.H5RDSource(h5f, t.name)
                     else:
                         tab = tabular.H5RSource(h5f, t.name)
                 else:

--- a/PYME/simulation/locify.py
+++ b/PYME/simulation/locify.py
@@ -115,7 +115,7 @@ def points_from_sdf(sdf, r_max=1, centre=(0,0,0), dx_min=1, p=0.1):
         #contains_points = np.abs(np.sum([np.sign(c) for c in corner_dists], axis=0)) < 9
         # for some reason the sign test doesn't seem to work properly. Use a generous
         # distance based test instead
-        contains_points = np.min([np.abs(c) for c in corner_dists], axis=0) < ( dx)
+        contains_points = np.min([np.abs(c) for c in corner_dists], axis=0) < ( 1.5*dx)
         #print(dx, np.min([np.abs(c) for c in corner_dists], axis=0), contains_points)
         
         verts = verts[:, contains_points]

--- a/PYME/simulation/locify.py
+++ b/PYME/simulation/locify.py
@@ -82,20 +82,32 @@ def points_from_sdf(sdf, r_max=1, centre=(0,0,0), dx_min=1, p=0.1):
 
     '''
     dx = 1.2 * r_max
+
+    dx = (2**np.ceil(np.log2(dx/dx_min)))*dx_min - 0.1
     
-    vx, vy, vz = [v.ravel() for v in np.mgrid[-1:2, -1:2, -1:2]]
+    #vx, vy, vz = [v.ravel() for v in np.mgrid[-1:2, -1:2, -1:2]]
+
+    #v_offs = np.vstack([vx, vy, vz])
+    #print(v_offs.shape)
     
-    verts = dx * np.vstack([vx, vy, vz]) + np.array(centre)[:,None]
+    #verts = dx * v_offs + np.array(centre)[:,None]
     #print(verts.shape)
+
+    verts = np.array(centre)[:,None]
     
     c_offs = np.array(
-        [[-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1], [-1, -1, 1], [1, -1, 1], [1, 1, 1], [-1, 1, 1]])
+        [[-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1], [-1, -1, 1], [1, -1, 1], [1, 1, 1], [-1, 1, 1]], 'f')
+    
     #test_offs =
+
+    #print(dx, verts.T)
     
     while dx > dx_min:
-        dx /= 2.0
+       
         #test and discard.
         corners = [verts + dx * c_offs[i][:, None] for i in range(8)]
+        #print(dx)
+        #print(np.array(corners).shape)
         corner_dists = [sdf(c) for c in corners] + [sdf(verts), ]
         
         #corner_dists = [sdf(verts),]
@@ -103,27 +115,32 @@ def points_from_sdf(sdf, r_max=1, centre=(0,0,0), dx_min=1, p=0.1):
         #contains_points = np.abs(np.sum([np.sign(c) for c in corner_dists], axis=0)) < 9
         # for some reason the sign test doesn't seem to work properly. Use a generous
         # distance based test instead
-        contains_points = np.min([np.abs(c) for c in corner_dists], axis=0) < 2 * dx
+        contains_points = np.min([np.abs(c) for c in corner_dists], axis=0) < ( dx)
+        #print(dx, np.min([np.abs(c) for c in corner_dists], axis=0), contains_points)
         
         verts = verts[:, contains_points]
         #print(verts.shape)
+        dx /= 2.0
         
         #subdivide
-        verts = np.concatenate([verts + dx * c_offs[i][:, None] for i in range(8)], axis=1)
+        verts = np.concatenate([verts + dx * c_offs[i, :][:, None] for i in range(8)], axis=1)
         #print(verts.shape)
+
     
     # because we use a fairly relaxed / conservative criterea for discarding above (which will
     # effectively match the cell containing the surface AND it's neighbours)
     # we perform a more stringent test on the final set of points.
-    corners = [verts + dx * c_offs[i][:, None] for i in range(8)]
-    corner_dists = [sdf(c) for c in corners]
+    #corners = [verts + dx * c_offs[i][:, None] for i in range(9)]
+    #corner_dists = [sdf(c) for c in corners]
+    #print(dx, corner_dists)
     
-    contains_points = (np.abs(np.sum([np.sign(c) for c in corner_dists], axis=0)) < 8) & (sdf(verts) < dx)
+    #contains_points = (np.abs(np.sum([np.sign(c) for c in corner_dists], axis=0)) < 9) & (sdf(verts) < dx)
+    contains_points = (sdf(verts) < dx/2)
     verts = verts[:, contains_points]
     
     #print(verts.shape)
-    
-    return verts[:, np.random.rand(verts.shape[1]) < p]
+    #return verts
+    return verts[:, (np.random.rand(verts.shape[1]) < p)]
 
 def testPattern():
     '''generate a test pattern'''

--- a/PYME/simulation/pointsets.py
+++ b/PYME/simulation/pointsets.py
@@ -114,10 +114,10 @@ class SHNucleusSource(PointSource):
         print('axis_scales:', axis_scales)
         r_max = 1.5*np.max(axis_scales)
 
-        #pts = locify.points_from_sdf(shell.radial_distance_to_shell, r_max=r_max, dx_min=0.1*self.point_spacing)
+        pts = locify.points_from_sdf(shell.radial_distance_to_shell, r_max=r_max, dx_min=0.1*self.point_spacing)
 
-        #print('pts.shape:', pts.shape)
-        #return pts
+        print('pts.shape:', pts.shape)
+        return pts
 
         
         zenith = []


### PR DESCRIPTION
@Yujin-Bao small modification to the reflection focus lock to enable it to be controlled through `scope.state`

On top of some other changes I already had open, so lots of commits - you should only need the last one (af0b80ce32f67db702689047142b1e43b6b2ffcb). 

to get this to work, you'll also need the following line in your init.py file (probably in the focus lock section)

```python
scope.state.registerHandler('FocusLock.enabled', scope.focus_lock.LockEnabled, scope.focus_lock.EnableLock)
```