### PR TITLE
doc: add Windows 11 instructions for MSVC build tools to installation.rst

### DIFF
--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -72,17 +72,31 @@ This assumes a basic familiarity with python and conda. We maintain a conda meta
 On OSX, use ``/path/to/conda/environment/python.app/Contents/MacOS/python setup.py develop`` instead  of ``python setup.py develop`` so that the PYME programs can access the screen. 
 
 Windows users who do not already have MSVC build tools need to install them. On some verisons of Python this can be done using conda, however a more general approach is to download Visual Studio (the free, community version - the installer is also used for downloading build tools). 
-Customize as needed, but for a 64 bit Windows 10 computer you will likely need the following individual components:
+Customize as needed, but for a 64 bit Windows 11 (or Windows 10) computer you will likely need the following individual components:
 
-* Windows 10 SDK
-* MSVC v142 - VS 2019 C++ x64/x86 build tools (latest)
-* C++/CLI support for v142 build tools (latest)
-* Windows Universal C runtime
-* C++ Universal Windows Platform runtime
-* C++ Build Tools core Features
-* C++ core features
-* .NET Framework 4.8 SDK
-* .NET Framework 4.6.1 targeting pack 
+.. tabularcolumns:: |p{7cm}|p{7cm}|
+
++---------------------------------------------------------+---------------------------------------------------------+
+| Windows 11                                              | Windows 10                                              |
++=========================================================+=========================================================+
+| Windows 11 SDK                                          | Windows 10 SDK                                          |
++---------------------------------------------------------+---------------------------------------------------------+
+| MSVC v143 - VS 2022 C++ x64/x86 build tools (latest)    | MSVC v142 - VS 2019 C++ x64/x86 build tools (latest)    |
++---------------------------------------------------------+---------------------------------------------------------+
+| C++/CLI support for v143 build tools (latest)           | C++/CLI support for v142 build tools (latest)           |
++---------------------------------------------------------+---------------------------------------------------------+
+| Windows Universal C runtime                             | Windows Universal C runtime                             |
++---------------------------------------------------------+---------------------------------------------------------+
+| Windows Performance Toolkit                             | C++ Universal Windows Platform runtime                  |
++---------------------------------------------------------+---------------------------------------------------------+
+| C++ Build Insights                                      | C++ Build Tools core Features                           |
++---------------------------------------------------------+---------------------------------------------------------+
+| C++ core features                                       | C++ core features                                       |
++---------------------------------------------------------+---------------------------------------------------------+
+| .NET Framework 4.8.1 SDK                                | .NET Framework 4.8 SDK                                  |
++---------------------------------------------------------+---------------------------------------------------------+
+| .NET Framework 4.8.1 targeting pack                     | .NET Framework 4.6.1 targeting pack                     |
++---------------------------------------------------------+---------------------------------------------------------+
 
 
 


### PR DESCRIPTION
Addresses issue: what appears to be a couple of re-naming on windows 11 / Visual studio 2022 community installer (version 17.13.6). Our uni is dropping Win10 and moving everyone to Win11 before Win10 EOL in October

NOTE: Aiming for "sufficient" if not "necessary". I have not done full diligence on whether e.g. `C++ Build Insights` is necessary - I installed it on my machine in case it was vaguely a rename for ``C++ Build Tools core Features`` which I can no longer find. I would also not pass a test on what ``Windows Performance Toolkit`` contains. I am trying to help someone else install on their machine and figured I would put what I pulled from the Visual Studio installer down here rather than just sending it in an email in case it is useful to others. I see now that @csoeller has a nice document [here](https://github.com/csoeller/pyme-install-docs/blob/master/Installing-a-compiler-on-windows.md), which also covers the 2022 Visual Studio installer but for Win10 and might warrant some changing of at least the Win10 side of this table under the assumption that folks are using the latest installer.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**

![image](https://github.com/user-attachments/assets/b8475f82-90b2-4453-87d8-5e591659775d)

