### PR TITLE
fix to ensure the incitial clipping limits fit the data in PYMEVis

### DIFF
--- a/PYME/LMVis/view_clipping_pane.py
+++ b/PYME/LMVis/view_clipping_pane.py
@@ -107,7 +107,7 @@ class ClippingPanel(wx.Panel):
         #print 'bbox: ' + repr(bb)
         
         if bb is None:
-            return [1e-9, 1e9]
+            return [-1e9, 1e9]
         
         
         if self.axis == 'x':


### PR DESCRIPTION
adresses #1597 

- in datasets with negative coordiantes current initial defaults often clip a part of the data
- this fix attempts to correct that
