### PR TITLE
Numpy 2.X compatibility fixes

### DIFF
--- a/PYME/Analysis/PSFGen/ps_app.c
+++ b/PYME/Analysis/PSFGen/ps_app.c
@@ -110,14 +110,14 @@ static PyObject * genWidefieldPSF(PyObject *self, PyObject *args, PyObject *keyw
 
     /* Do the calculations */
 
-    Xvals = (PyArrayObject *) PyArray_ContiguousFromObject(oX, PyArray_DOUBLE, 0, 1);
+    Xvals = (PyArrayObject *) PyArray_ContiguousFromObject(oX, NPY_DOUBLE, 0, 1);
     if (Xvals == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad X");
       return NULL;
     }
 
-    Yvals = (PyArrayObject *) PyArray_ContiguousFromObject(oY, PyArray_DOUBLE, 0, 1);
+    Yvals = (PyArrayObject *) PyArray_ContiguousFromObject(oY, NPY_DOUBLE, 0, 1);
     if (Yvals == NULL)
     {
         Py_DECREF(Xvals);
@@ -125,7 +125,7 @@ static PyObject * genWidefieldPSF(PyObject *self, PyObject *args, PyObject *keyw
         return NULL;
     }
 
-    Zvals = (PyArrayObject *) PyArray_ContiguousFromObject(oZ, PyArray_DOUBLE, 0, 1);
+    Zvals = (PyArrayObject *) PyArray_ContiguousFromObject(oZ, NPY_DOUBLE, 0, 1);
     if (Zvals == NULL)
     {
         Py_DECREF(Xvals);
@@ -134,7 +134,7 @@ static PyObject * genWidefieldPSF(PyObject *self, PyObject *args, PyObject *keyw
         return NULL;
     }
 
-    Pvals = (PyArrayObject *) PyArray_ContiguousFromObject(oP, PyArray_DOUBLE, 1, 1);
+    Pvals = (PyArrayObject *) PyArray_ContiguousFromObject(oP, NPY_DOUBLE, 1, 1);
     if (Pvals == NULL)
     {
         Py_DECREF(Xvals);
@@ -159,7 +159,7 @@ static PyObject * genWidefieldPSF(PyObject *self, PyObject *args, PyObject *keyw
 
     size_p = PyArray_Size((PyObject*)Pvals);
 
-    //out = (PyArrayObject*) PyArray_FromDims(3,size,PyArray_DOUBLE);
+    //out = (PyArrayObject*) PyArray_FromDims(3,size,NPY_DOUBLE);
     out = (PyArrayObject*) PyArray_New(&PyArray_Type, 3,size,NPY_DOUBLE, NULL, NULL, 0, 1, NULL);
     if (out == NULL)
     {
@@ -342,14 +342,14 @@ static PyObject * genWidefieldPSFW(PyObject *self, PyObject *args, PyObject *key
 
     /* Do the calculations */
 
-    Xvals = (PyArrayObject *) PyArray_ContiguousFromObject(oX, PyArray_DOUBLE, 0, 1);
+    Xvals = (PyArrayObject *) PyArray_ContiguousFromObject(oX, NPY_DOUBLE, 0, 1);
     if (Xvals == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad X");
       return NULL;
     }
 
-    Yvals = (PyArrayObject *) PyArray_ContiguousFromObject(oY, PyArray_DOUBLE, 0, 1);
+    Yvals = (PyArrayObject *) PyArray_ContiguousFromObject(oY, NPY_DOUBLE, 0, 1);
     if (Yvals == NULL)
     {
         Py_DECREF(Xvals);
@@ -357,7 +357,7 @@ static PyObject * genWidefieldPSFW(PyObject *self, PyObject *args, PyObject *key
         return NULL;
     }
 
-    Zvals = (PyArrayObject *) PyArray_ContiguousFromObject(oZ, PyArray_DOUBLE, 0, 1);
+    Zvals = (PyArrayObject *) PyArray_ContiguousFromObject(oZ, NPY_DOUBLE, 0, 1);
     if (Zvals == NULL)
     {
         Py_DECREF(Xvals);
@@ -366,7 +366,7 @@ static PyObject * genWidefieldPSFW(PyObject *self, PyObject *args, PyObject *key
         return NULL;
     }
 
-    Pvals = (PyArrayObject *) PyArray_ContiguousFromObject(oP, PyArray_DOUBLE, 1, 1);
+    Pvals = (PyArrayObject *) PyArray_ContiguousFromObject(oP, NPY_DOUBLE, 1, 1);
     if (Pvals == NULL)
     {
         Py_DECREF(Xvals);
@@ -376,7 +376,7 @@ static PyObject * genWidefieldPSFW(PyObject *self, PyObject *args, PyObject *key
         return NULL;
     }
 
-    Wvals = (PyArrayObject *) PyArray_ContiguousFromObject(oW, PyArray_DOUBLE, 1, 1);
+    Wvals = (PyArrayObject *) PyArray_ContiguousFromObject(oW, NPY_DOUBLE, 1, 1);
     if (Wvals == NULL)
     {
         Py_DECREF(Xvals);
@@ -402,7 +402,7 @@ static PyObject * genWidefieldPSFW(PyObject *self, PyObject *args, PyObject *key
 
     size_p = PyArray_Size((PyObject*)Pvals);
 
-    //out = (PyArrayObject*) PyArray_FromDims(3,size,PyArray_DOUBLE);
+    //out = (PyArrayObject*) PyArray_FromDims(3,size,NPY_DOUBLE);
     out = (PyArrayObject*) PyArray_New(&PyArray_Type, 3,size,NPY_DOUBLE, NULL, NULL, 0, 1, NULL);
     if (out == NULL)
     {

--- a/PYME/Analysis/points/DeClump/deClump.c
+++ b/PYME/Analysis/points/DeClump/deClump.c
@@ -178,7 +178,7 @@ static PyObject * findClumps(PyObject *self, PyObject *args, PyObject *keywds)
          &tO, &xO, &yO, &delta_xO, &nFrames))
         return NULL;
 
-    tA = (PyArrayObject *) PyArray_ContiguousFromObject(tO, PyArray_INT, 0, 1);
+    tA = (PyArrayObject *) PyArray_ContiguousFromObject(tO, NPY_INT, 0, 1);
     if (tA == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad t");
@@ -187,7 +187,7 @@ static PyObject * findClumps(PyObject *self, PyObject *args, PyObject *keywds)
 
     nPts = PyArray_DIM(tA, 0);
 
-    xA = (PyArrayObject *) PyArray_ContiguousFromObject(xO, PyArray_FLOAT, 0, 1);
+    xA = (PyArrayObject *) PyArray_ContiguousFromObject(xO, NPY_FLOAT, 0, 1);
     if ((xA == NULL) || (PyArray_DIM(xA, 0) != nPts))
     {
       Py_DECREF(tA);
@@ -195,7 +195,7 @@ static PyObject * findClumps(PyObject *self, PyObject *args, PyObject *keywds)
       return NULL;
     }
 
-    yA = (PyArrayObject *) PyArray_ContiguousFromObject(yO, PyArray_FLOAT, 0, 1);
+    yA = (PyArrayObject *) PyArray_ContiguousFromObject(yO, NPY_FLOAT, 0, 1);
     if ((yA == NULL) || (PyArray_DIM(xA, 0) != nPts))
     {
       Py_DECREF(tA);
@@ -204,7 +204,7 @@ static PyObject * findClumps(PyObject *self, PyObject *args, PyObject *keywds)
       return NULL;
     }
 
-    delta_xA = (PyArrayObject *) PyArray_ContiguousFromObject(delta_xO, PyArray_FLOAT, 0, 1);
+    delta_xA = (PyArrayObject *) PyArray_ContiguousFromObject(delta_xO, NPY_FLOAT, 0, 1);
     if ((delta_xA == NULL) || (PyArray_DIM(xA, 0) != nPts))
     {
       Py_DECREF(tA);
@@ -223,7 +223,7 @@ static PyObject * findClumps(PyObject *self, PyObject *args, PyObject *keywds)
 
     dims[0] = nPts;
     printf("nPts = %d\n", nPts);
-    assignedA = PyArray_SimpleNew(1, dims, PyArray_INT32);
+    assignedA = PyArray_SimpleNew(1, dims, NPY_INT32);
     if (assignedA == NULL)
     {
         Py_DECREF(tA);
@@ -353,7 +353,7 @@ static PyObject * findClumpsN(PyObject *self, PyObject *args, PyObject *keywds)
 
     //printf("nFrames: %d\n", nFrames);
 
-    tA = (PyArrayObject *) PyArray_ContiguousFromObject(tO, PyArray_INT, 0, 1);
+    tA = (PyArrayObject *) PyArray_ContiguousFromObject(tO, NPY_INT, 0, 1);
     if (tA == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad t");
@@ -362,7 +362,7 @@ static PyObject * findClumpsN(PyObject *self, PyObject *args, PyObject *keywds)
 
     nPts = PyArray_DIM(tA, 0);
 
-    xA = (PyArrayObject *) PyArray_ContiguousFromObject(xO, PyArray_FLOAT, 0, 1);
+    xA = (PyArrayObject *) PyArray_ContiguousFromObject(xO, NPY_FLOAT, 0, 1);
     if ((xA == NULL) || (PyArray_DIM(xA, 0) != nPts))
     {
       Py_DECREF(tA);
@@ -370,7 +370,7 @@ static PyObject * findClumpsN(PyObject *self, PyObject *args, PyObject *keywds)
       return NULL;
     }
 
-    yA = (PyArrayObject *) PyArray_ContiguousFromObject(yO, PyArray_FLOAT, 0, 1);
+    yA = (PyArrayObject *) PyArray_ContiguousFromObject(yO, NPY_FLOAT, 0, 1);
     if ((yA == NULL) || (PyArray_DIM(xA, 0) != nPts))
     {
       Py_DECREF(tA);
@@ -379,7 +379,7 @@ static PyObject * findClumpsN(PyObject *self, PyObject *args, PyObject *keywds)
       return NULL;
     }
 
-    delta_xA = (PyArrayObject *) PyArray_ContiguousFromObject(delta_xO, PyArray_FLOAT, 0, 1);
+    delta_xA = (PyArrayObject *) PyArray_ContiguousFromObject(delta_xO, NPY_FLOAT, 0, 1);
     if ((delta_xA == NULL) || (PyArray_DIM(xA, 0) != nPts))
     {
       Py_DECREF(tA);
@@ -398,7 +398,7 @@ static PyObject * findClumpsN(PyObject *self, PyObject *args, PyObject *keywds)
 
     dims[0] = nPts;
     printf("nPts = %d\n", nPts);
-    assignedA = PyArray_SimpleNew(1, dims, PyArray_INT32);
+    assignedA = PyArray_SimpleNew(1, dims, NPY_INT32);
     if (assignedA == NULL)
     {
         Py_DECREF(tA);
@@ -541,7 +541,7 @@ static PyObject * aggregateWeightedMean(PyObject *self, PyObject *args, PyObject
          &nClumps, &clumpIDO, &varO, &sigmaO))
         return NULL;
 
-    clumpIDA = (PyArrayObject *) PyArray_ContiguousFromObject(clumpIDO, PyArray_INT, 0, 1);
+    clumpIDA = (PyArrayObject *) PyArray_ContiguousFromObject(clumpIDO, NPY_INT, 0, 1);
     if (clumpIDA == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad clumpIDs");
@@ -550,7 +550,7 @@ static PyObject * aggregateWeightedMean(PyObject *self, PyObject *args, PyObject
 
     nPts = PyArray_DIM(clumpIDA, 0);
 
-    varA = (PyArrayObject *) PyArray_ContiguousFromObject(varO, PyArray_FLOAT, 0, 1);
+    varA = (PyArrayObject *) PyArray_ContiguousFromObject(varO, NPY_FLOAT, 0, 1);
     if ((varA == NULL) || (PyArray_DIM(varA, 0) != nPts))
     {
       Py_DECREF(clumpIDA);
@@ -558,7 +558,7 @@ static PyObject * aggregateWeightedMean(PyObject *self, PyObject *args, PyObject
       return NULL;
     }
 
-    sigmaA = (PyArrayObject *) PyArray_ContiguousFromObject(sigmaO, PyArray_FLOAT, 0, 1);
+    sigmaA = (PyArrayObject *) PyArray_ContiguousFromObject(sigmaO, NPY_FLOAT, 0, 1);
     if ((sigmaA == NULL) || (PyArray_DIM(sigmaA, 0) != nPts))
     {
       Py_DECREF(clumpIDA);
@@ -574,7 +574,7 @@ static PyObject * aggregateWeightedMean(PyObject *self, PyObject *args, PyObject
 
     dims[0] = nClumps;
 
-    outVarA = PyArray_SimpleNew(1, dims, PyArray_FLOAT);
+    outVarA = PyArray_SimpleNew(1, dims, NPY_FLOAT);
     if (outVarA == NULL)
     {
         Py_DECREF(clumpIDA);
@@ -584,7 +584,7 @@ static PyObject * aggregateWeightedMean(PyObject *self, PyObject *args, PyObject
         return NULL;
     }
 
-    outSigA = PyArray_SimpleNew(1, dims, PyArray_FLOAT);
+    outSigA = PyArray_SimpleNew(1, dims, NPY_FLOAT);
     if (outSigA == NULL)
     {
         Py_DECREF(clumpIDA);
@@ -719,7 +719,7 @@ static PyObject * aggregateMean(PyObject *self, PyObject *args, PyObject *keywds
          &nClumps, &clumpIDO, &varO))
         return NULL;
 
-    clumpIDA = (PyArrayObject *) PyArray_ContiguousFromObject(clumpIDO, PyArray_INT, 0, 1);
+    clumpIDA = (PyArrayObject *) PyArray_ContiguousFromObject(clumpIDO, NPY_INT, 0, 1);
     if (clumpIDA == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad clumpIDs");
@@ -728,7 +728,7 @@ static PyObject * aggregateMean(PyObject *self, PyObject *args, PyObject *keywds
 
     nPts = PyArray_DIM(clumpIDA, 0);
 
-    varA = (PyArrayObject *) PyArray_ContiguousFromObject(varO, PyArray_FLOAT, 0, 1);
+    varA = (PyArrayObject *) PyArray_ContiguousFromObject(varO, NPY_FLOAT, 0, 1);
     if ((varA == NULL) || (PyArray_DIM(varA, 0) != nPts))
     {
       Py_DECREF(clumpIDA);
@@ -742,7 +742,7 @@ static PyObject * aggregateMean(PyObject *self, PyObject *args, PyObject *keywds
 
     dims[0] = nClumps;
 
-    outVarA = PyArray_SimpleNew(1, dims, PyArray_FLOAT);
+    outVarA = PyArray_SimpleNew(1, dims, NPY_FLOAT);
     if (outVarA == NULL)
     {
         Py_DECREF(clumpIDA);
@@ -857,7 +857,7 @@ static PyObject * aggregateMin(PyObject *self, PyObject *args, PyObject *keywds)
          &nClumps, &clumpIDO, &varO))
         return NULL;
 
-    clumpIDA = (PyArrayObject *) PyArray_ContiguousFromObject(clumpIDO, PyArray_INT, 0, 1);
+    clumpIDA = (PyArrayObject *) PyArray_ContiguousFromObject(clumpIDO, NPY_INT, 0, 1);
     if (clumpIDA == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad clumpIDs");
@@ -866,7 +866,7 @@ static PyObject * aggregateMin(PyObject *self, PyObject *args, PyObject *keywds)
 
     nPts = PyArray_DIM(clumpIDA, 0);
 
-    varA = (PyArrayObject *) PyArray_ContiguousFromObject(varO, PyArray_FLOAT, 0, 1);
+    varA = (PyArrayObject *) PyArray_ContiguousFromObject(varO, NPY_FLOAT, 0, 1);
     if ((varA == NULL) || (PyArray_DIM(varA, 0) != nPts))
     {
       Py_DECREF(clumpIDA);
@@ -880,7 +880,7 @@ static PyObject * aggregateMin(PyObject *self, PyObject *args, PyObject *keywds)
 
     dims[0] = nClumps;
 
-    outVarA = PyArray_SimpleNew(1, dims, PyArray_FLOAT);
+    outVarA = PyArray_SimpleNew(1, dims, NPY_FLOAT);
     if (outVarA == NULL)
     {
         Py_DECREF(clumpIDA);
@@ -987,7 +987,7 @@ static PyObject * aggregateSum(PyObject *self, PyObject *args, PyObject *keywds)
          &nClumps, &clumpIDO, &varO))
         return NULL;
 
-    clumpIDA = (PyArrayObject *) PyArray_ContiguousFromObject(clumpIDO, PyArray_INT, 0, 1);
+    clumpIDA = (PyArrayObject *) PyArray_ContiguousFromObject(clumpIDO, NPY_INT, 0, 1);
     if (clumpIDA == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad clumpIDs");
@@ -996,7 +996,7 @@ static PyObject * aggregateSum(PyObject *self, PyObject *args, PyObject *keywds)
 
     nPts = PyArray_DIM(clumpIDA, 0);
 
-    varA = (PyArrayObject *) PyArray_ContiguousFromObject(varO, PyArray_FLOAT, 0, 1);
+    varA = (PyArrayObject *) PyArray_ContiguousFromObject(varO, NPY_FLOAT, 0, 1);
     if ((varA == NULL) || (PyArray_DIM(varA, 0) != nPts))
     {
       Py_DECREF(clumpIDA);
@@ -1010,7 +1010,7 @@ static PyObject * aggregateSum(PyObject *self, PyObject *args, PyObject *keywds)
 
     dims[0] = nClumps;
 
-    outVarA = PyArray_SimpleNew(1, dims, PyArray_FLOAT);
+    outVarA = PyArray_SimpleNew(1, dims, NPY_FLOAT);
     if (outVarA == NULL)
     {
         Py_DECREF(clumpIDA);

--- a/PYME/Analysis/points/DistHist/distHist.c
+++ b/PYME/Analysis/points/DistHist/distHist.c
@@ -76,14 +76,14 @@ static PyObject * distanceHistogram(PyObject *self, PyObject *args, PyObject *ke
 
     /* Do the calculations */ 
         
-    ax1 = (PyArrayObject *) PyArray_ContiguousFromObject(ox1, PyArray_DOUBLE, 0, 1);
+    ax1 = (PyArrayObject *) PyArray_ContiguousFromObject(ox1, NPY_DOUBLE, 0, 1);
     if (ax1 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad x1");
       return NULL;
     }
 
-    ay1 = (PyArrayObject *) PyArray_ContiguousFromObject(oy1, PyArray_DOUBLE, 0, 1);
+    ay1 = (PyArrayObject *) PyArray_ContiguousFromObject(oy1, NPY_DOUBLE, 0, 1);
     if (ay1 == NULL)
     {
       Py_DECREF(ax1);
@@ -91,7 +91,7 @@ static PyObject * distanceHistogram(PyObject *self, PyObject *args, PyObject *ke
       return NULL;
     }
 
-    ax2 = (PyArrayObject *) PyArray_ContiguousFromObject(ox2, PyArray_DOUBLE, 0, 1);
+    ax2 = (PyArrayObject *) PyArray_ContiguousFromObject(ox2, NPY_DOUBLE, 0, 1);
     if (ax2 == NULL)
     {
       Py_DECREF(ax1);
@@ -100,7 +100,7 @@ static PyObject * distanceHistogram(PyObject *self, PyObject *args, PyObject *ke
       return NULL;
     }
 
-    ay2 = (PyArrayObject *) PyArray_ContiguousFromObject(oy2, PyArray_DOUBLE, 0, 1);
+    ay2 = (PyArrayObject *) PyArray_ContiguousFromObject(oy2, NPY_DOUBLE, 0, 1);
     if (ay2 == NULL)
     {
       Py_DECREF(ax1);
@@ -124,7 +124,7 @@ static PyObject * distanceHistogram(PyObject *self, PyObject *args, PyObject *ke
 
     outDimensions[0] = nBins;
         
-    out = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,PyArray_DOUBLE);
+    out = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,NPY_DOUBLE);
     if (out == NULL)
     {
       Py_DECREF(ax1);
@@ -241,42 +241,42 @@ static PyObject * distanceHistogram3D(PyObject *self, PyObject *args, PyObject *
 
     /* Do the calculations */
 
-    ax1 = (PyArrayObject *) PyArray_ContiguousFromObject(ox1, PyArray_DOUBLE, 0, 1);
+    ax1 = (PyArrayObject *) PyArray_ContiguousFromObject(ox1, NPY_DOUBLE, 0, 1);
     if (ax1 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad x1");
       goto fail;
     }
 
-    ay1 = (PyArrayObject *) PyArray_ContiguousFromObject(oy1, PyArray_DOUBLE, 0, 1);
+    ay1 = (PyArrayObject *) PyArray_ContiguousFromObject(oy1, NPY_DOUBLE, 0, 1);
     if (ay1 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad y1");
       goto fail;
     }
 
-    ax2 = (PyArrayObject *) PyArray_ContiguousFromObject(ox2, PyArray_DOUBLE, 0, 1);
+    ax2 = (PyArrayObject *) PyArray_ContiguousFromObject(ox2, NPY_DOUBLE, 0, 1);
     if (ax2 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad x2");
       goto fail;
     }
 
-    ay2 = (PyArrayObject *) PyArray_ContiguousFromObject(oy2, PyArray_DOUBLE, 0, 1);
+    ay2 = (PyArrayObject *) PyArray_ContiguousFromObject(oy2, NPY_DOUBLE, 0, 1);
     if (ay2 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad y2");
       goto fail;
     }
 
-    az1 = (PyArrayObject *) PyArray_ContiguousFromObject(oz1, PyArray_DOUBLE, 0, 1);
+    az1 = (PyArrayObject *) PyArray_ContiguousFromObject(oz1, NPY_DOUBLE, 0, 1);
     if (az1 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad z1");
       goto fail;
     }
 
-    az2 = (PyArrayObject *) PyArray_ContiguousFromObject(oz2, PyArray_DOUBLE, 0, 1);
+    az2 = (PyArrayObject *) PyArray_ContiguousFromObject(oz2, NPY_DOUBLE, 0, 1);
     if (az2 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad z2");
@@ -300,7 +300,7 @@ static PyObject * distanceHistogram3D(PyObject *self, PyObject *args, PyObject *
 
     outDimensions[0] = nBins;
 
-    out = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,PyArray_DOUBLE);
+    out = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,NPY_DOUBLE);
     if (out == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Error allocating output array");
@@ -435,42 +435,42 @@ static PyObject * vectDistanceHistogram3D(PyObject *self, PyObject *args, PyObje
     rBinAngle = 1.0/bin_size_angle;
     /* Do the calculations */
 
-    ax1 = (PyArrayObject *) PyArray_ContiguousFromObject(ox1, PyArray_DOUBLE, 0, 1);
+    ax1 = (PyArrayObject *) PyArray_ContiguousFromObject(ox1, NPY_DOUBLE, 0, 1);
     if (ax1 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad x1");
       goto fail_vd;
     }
 
-    ay1 = (PyArrayObject *) PyArray_ContiguousFromObject(oy1, PyArray_DOUBLE, 0, 1);
+    ay1 = (PyArrayObject *) PyArray_ContiguousFromObject(oy1, NPY_DOUBLE, 0, 1);
     if (ay1 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad y1");
       goto fail_vd;
     }
 
-    ax2 = (PyArrayObject *) PyArray_ContiguousFromObject(ox2, PyArray_DOUBLE, 0, 1);
+    ax2 = (PyArrayObject *) PyArray_ContiguousFromObject(ox2, NPY_DOUBLE, 0, 1);
     if (ax2 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad x2");
       goto fail_vd;
     }
 
-    ay2 = (PyArrayObject *) PyArray_ContiguousFromObject(oy2, PyArray_DOUBLE, 0, 1);
+    ay2 = (PyArrayObject *) PyArray_ContiguousFromObject(oy2, NPY_DOUBLE, 0, 1);
     if (ay2 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad y2");
       goto fail_vd;
     }
 
-    az1 = (PyArrayObject *) PyArray_ContiguousFromObject(oz1, PyArray_DOUBLE, 0, 1);
+    az1 = (PyArrayObject *) PyArray_ContiguousFromObject(oz1, NPY_DOUBLE, 0, 1);
     if (az1 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad z1");
       goto fail_vd;
     }
 
-    az2 = (PyArrayObject *) PyArray_ContiguousFromObject(oz2, PyArray_DOUBLE, 0, 1);
+    az2 = (PyArrayObject *) PyArray_ContiguousFromObject(oz2, NPY_DOUBLE, 0, 1);
     if (az2 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad z2");
@@ -503,7 +503,7 @@ static PyObject * vectDistanceHistogram3D(PyObject *self, PyObject *args, PyObje
 
     //printf("x1_len: %d, x2_len: %d, od: [%d, %d, %d]\n", x1_len, x2_len, outDimensions[0], outDimensions[1], outDimensions[2]);
 
-    out = (PyArrayObject*) PyArray_SimpleNew(3,outDimensions,PyArray_INT);
+    out = (PyArrayObject*) PyArray_SimpleNew(3,outDimensions,NPY_INT);
     if (out == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Error allocating output array");
@@ -618,14 +618,14 @@ static PyObject * distanceProduct(PyObject *self, PyObject *args, PyObject *keyw
 
     /* Do the calculations */
 
-    ax1 = (PyArrayObject *) PyArray_ContiguousFromObject(ox1, PyArray_DOUBLE, 0, 1);
+    ax1 = (PyArrayObject *) PyArray_ContiguousFromObject(ox1, NPY_DOUBLE, 0, 1);
     if (ax1 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad x");
       return NULL;
     }
 
-    ay1 = (PyArrayObject *) PyArray_ContiguousFromObject(oy1, PyArray_DOUBLE, 0, 1);
+    ay1 = (PyArrayObject *) PyArray_ContiguousFromObject(oy1, NPY_DOUBLE, 0, 1);
     if (ay1 == NULL)
     {
       Py_DECREF(ax1);
@@ -730,14 +730,14 @@ static PyObject * distanceHistogramRS(PyObject *self, PyObject *args, PyObject *
 
     /* Do the calculations */
 
-    ax1 = (PyArrayObject *) PyArray_ContiguousFromObject(ox1, PyArray_DOUBLE, 0, 1);
+    ax1 = (PyArrayObject *) PyArray_ContiguousFromObject(ox1, NPY_DOUBLE, 0, 1);
     if (ax1 == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad x1");
       return NULL;
     }
 
-    ay1 = (PyArrayObject *) PyArray_ContiguousFromObject(oy1, PyArray_DOUBLE, 0, 1);
+    ay1 = (PyArrayObject *) PyArray_ContiguousFromObject(oy1, NPY_DOUBLE, 0, 1);
     if (ay1 == NULL)
     {
       Py_DECREF(ax1);
@@ -745,7 +745,7 @@ static PyObject * distanceHistogramRS(PyObject *self, PyObject *args, PyObject *
       return NULL;
     }
 
-    ax2 = (PyArrayObject *) PyArray_ContiguousFromObject(ox2, PyArray_DOUBLE, 0, 1);
+    ax2 = (PyArrayObject *) PyArray_ContiguousFromObject(ox2, NPY_DOUBLE, 0, 1);
     if (ax2 == NULL)
     {
       Py_DECREF(ax1);
@@ -754,7 +754,7 @@ static PyObject * distanceHistogramRS(PyObject *self, PyObject *args, PyObject *
       return NULL;
     }
 
-    ay2 = (PyArrayObject *) PyArray_ContiguousFromObject(oy2, PyArray_DOUBLE, 0, 1);
+    ay2 = (PyArrayObject *) PyArray_ContiguousFromObject(oy2, NPY_DOUBLE, 0, 1);
     if (ay2 == NULL)
     {
       Py_DECREF(ax1);
@@ -778,7 +778,7 @@ static PyObject * distanceHistogramRS(PyObject *self, PyObject *args, PyObject *
 
     outDimensions[0] = nBins;
 
-    out = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,PyArray_DOUBLE);
+    out = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,NPY_DOUBLE);
     if (out == NULL)
     {
       Py_DECREF(ax1);
@@ -899,14 +899,14 @@ static PyObject * meanSquareDistHist(PyObject *self, PyObject *args, PyObject *k
 
     /* Do the calculations */
 
-    ax = (PyArrayObject *) PyArray_ContiguousFromObject(ox, PyArray_DOUBLE, 0, 1);
+    ax = (PyArrayObject *) PyArray_ContiguousFromObject(ox, NPY_DOUBLE, 0, 1);
     if (ax == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad x");
       return NULL;
     }
 
-    ay = (PyArrayObject *) PyArray_ContiguousFromObject(oy, PyArray_DOUBLE, 0, 1);
+    ay = (PyArrayObject *) PyArray_ContiguousFromObject(oy, NPY_DOUBLE, 0, 1);
     if (ay == NULL)
     {
       Py_DECREF(ax);
@@ -914,7 +914,7 @@ static PyObject * meanSquareDistHist(PyObject *self, PyObject *args, PyObject *k
       return NULL;
     }
 
-    at = (PyArrayObject *) PyArray_ContiguousFromObject(ot, PyArray_DOUBLE, 0, 1);
+    at = (PyArrayObject *) PyArray_ContiguousFromObject(ot, NPY_DOUBLE, 0, 1);
     if (at == NULL)
     {
       Py_DECREF(ax);
@@ -943,7 +943,7 @@ static PyObject * meanSquareDistHist(PyObject *self, PyObject *args, PyObject *k
 
     outDimensions[0] = nBins;
 
-    out = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,PyArray_DOUBLE);
+    out = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,NPY_DOUBLE);
     if (out == NULL)
     {
       Py_DECREF(ax);

--- a/PYME/Analysis/points/EdgeDB/edgeDB.c
+++ b/PYME/Analysis/points/EdgeDB/edgeDB.c
@@ -203,7 +203,7 @@ static PyObject * addEdges(PyObject *self, PyObject *args, PyObject *keywds)
     }
 
 /*
-    delnEdgeArray = (PyArrayObject *) PyArray_ContiguousFromObject(deln_edges, PyArray_INT32, 0, 1);
+    delnEdgeArray = (PyArrayObject *) PyArray_ContiguousFromObject(deln_edges, NPY_INT32, 0, 1);
     if (delnEdgeArray == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad triangulation edges");
@@ -298,7 +298,7 @@ static PyObject * calcEdgeLengths(PyObject *self, PyObject *args, PyObject *keyw
     }
 
 /*
-    delnEdgeArray = (PyArrayObject *) PyArray_ContiguousFromObject(deln_edges, PyArray_INT32, 0, 1);
+    delnEdgeArray = (PyArrayObject *) PyArray_ContiguousFromObject(deln_edges, NPY_INT32, 0, 1);
     if (delnEdgeArray == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad triangulation edges");
@@ -451,10 +451,10 @@ static PyObject * getVertexEdgeLengths(PyObject *self, PyObject *args, PyObject 
 
     numEdges = edb.records[vertexNum].numIncidentEdges;
 
-    //printf("n: %d, %d\n", numEdges, PyArray_INT32);
+    //printf("n: %d, %d\n", numEdges, NPY_INT32);
 
     dims[0] = numEdges;
-    incEdgesA = PyArray_SimpleNew(1, dims, PyArray_FLOAT32);
+    incEdgesA = PyArray_SimpleNew(1, dims, NPY_FLOAT32);
     if (!incEdgesA)
     {
         PyErr_Format(PyExc_RuntimeError, "Error allocating array for edges");
@@ -510,7 +510,7 @@ static PyObject * getVertexNeighbours(PyObject *self, PyObject *args, PyObject *
     //printf("n: %d\n", numEdges);
 
     dims[0] = numEdges;
-    neighbourA = PyArray_SimpleNew(1, dims, PyArray_INT32);
+    neighbourA = PyArray_SimpleNew(1, dims, NPY_INT32);
     if (!neighbourA)
     {
         PyErr_Format(PyExc_RuntimeError, "Error allocating array for edges");
@@ -658,7 +658,7 @@ static PyObject * segment(PyObject *self, PyObject *args, PyObject *keywds)
 
 
     dims[0] = edb.numVertices;
-    objectsArray = PyArray_SimpleNew(1, dims, PyArray_INT32);
+    objectsArray = PyArray_SimpleNew(1, dims, NPY_INT32);
     if (!objectsArray)
     {
         PyErr_Format(PyExc_RuntimeError, "Error allocating array for objects");

--- a/PYME/Analysis/points/SoftRend/triRend.c
+++ b/PYME/Analysis/points/SoftRend/triRend.c
@@ -593,7 +593,7 @@ static PyObject * PyTetAndDraw(PyObject *self, PyObject *args, PyObject *keywds)
         return NULL;
     }
 
-    aPositions = (PyArrayObject *) PyArray_ContiguousFromObject(oPositions, PyArray_DOUBLE, 2, 2);
+    aPositions = (PyArrayObject *) PyArray_ContiguousFromObject(oPositions, NPY_DOUBLE, 2, 2);
     if (aPositions == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad position data");

--- a/PYME/Analysis/points/arcfit/arcmf.c
+++ b/PYME/Analysis/points/arcfit/arcmf.c
@@ -72,14 +72,14 @@ static PyObject * arcmf(PyObject *self, PyObject *args, PyObject *keywds)
 
     /* Do the calculations */ 
         
-    Xvals = (PyArrayObject *) PyArray_ContiguousFromObject(oX, PyArray_DOUBLE, 0, 1);
+    Xvals = (PyArrayObject *) PyArray_ContiguousFromObject(oX, NPY_DOUBLE, 0, 1);
     if (Xvals == NULL) 
     {
       PyErr_Format(PyExc_RuntimeError, "Bad X");   
       return NULL;
     }
     
-    Yvals = (PyArrayObject *) PyArray_ContiguousFromObject(oY, PyArray_DOUBLE, 0, 1);
+    Yvals = (PyArrayObject *) PyArray_ContiguousFromObject(oY, NPY_DOUBLE, 0, 1);
     if (Yvals == NULL)
     {
         Py_DECREF(Xvals);
@@ -87,7 +87,7 @@ static PyObject * arcmf(PyObject *self, PyObject *args, PyObject *keywds)
         return NULL;
     }
 
-    sXvals = (PyArrayObject *) PyArray_ContiguousFromObject(osX, PyArray_DOUBLE, 0, 1);
+    sXvals = (PyArrayObject *) PyArray_ContiguousFromObject(osX, NPY_DOUBLE, 0, 1);
     if (sXvals == NULL)
     {
         Py_DECREF(Xvals);
@@ -96,7 +96,7 @@ static PyObject * arcmf(PyObject *self, PyObject *args, PyObject *keywds)
         return NULL;
     }
 
-    sYvals = (PyArrayObject *) PyArray_ContiguousFromObject(osY, PyArray_DOUBLE, 0, 1);
+    sYvals = (PyArrayObject *) PyArray_ContiguousFromObject(osY, NPY_DOUBLE, 0, 1);
     if (sYvals == NULL)
     {
         Py_DECREF(Xvals);
@@ -239,20 +239,20 @@ static PyObject * arcmft(PyObject *self, PyObject *args, PyObject *keywds)
         goto FINALIZE_arcmft;\
         }
         
-    Xvals = (PyArrayObject *) PyArray_ContiguousFromObject(oX, PyArray_DOUBLE, 0, 1);
+    Xvals = (PyArrayObject *) PyArray_ContiguousFromObject(oX, NPY_DOUBLE, 0, 1);
     if (Xvals == NULL) ABORT("Bad X")
     
-    Yvals = (PyArrayObject *) PyArray_ContiguousFromObject(oY, PyArray_DOUBLE, 0, 1);
+    Yvals = (PyArrayObject *) PyArray_ContiguousFromObject(oY, NPY_DOUBLE, 0, 1);
     if (Yvals == NULL) ABORT("Bad Y")
 
-    sXvals = (PyArrayObject *) PyArray_ContiguousFromObject(osX, PyArray_DOUBLE, 0, 1);
+    sXvals = (PyArrayObject *) PyArray_ContiguousFromObject(osX, NPY_DOUBLE, 0, 1);
     if (sXvals == NULL) ABORT("Bad sX")
 
 
-    sYvals = (PyArrayObject *) PyArray_ContiguousFromObject(osY, PyArray_DOUBLE, 0, 1);
+    sYvals = (PyArrayObject *) PyArray_ContiguousFromObject(osY, NPY_DOUBLE, 0, 1);
     if (sYvals == NULL) ABORT("Bad sY")
     
-    Tvals = (PyArrayObject *) PyArray_ContiguousFromObject(oT, PyArray_DOUBLE, 0, 1);
+    Tvals = (PyArrayObject *) PyArray_ContiguousFromObject(oT, NPY_DOUBLE, 0, 1);
     if (Tvals == NULL) ABORT("Bad T")
     
     pXvals = (double*)Xvals->data;
@@ -391,20 +391,20 @@ static PyObject * py_quad_surf_mf_pos_fixed(PyObject *self, PyObject *args, PyOb
         goto FINALIZE_py_quad_surf_mf_pos_fixed;\
         }
 
-    aX = (PyArrayObject *) PyArray_ContiguousFromObject(oX, PyArray_FLOAT, 0, 1);
+    aX = (PyArrayObject *) PyArray_ContiguousFromObject(oX, NPY_FLOAT, 0, 1);
     if (aX == NULL) ABORT("Bad X")
 
-    aY = (PyArrayObject *) PyArray_ContiguousFromObject(oY, PyArray_FLOAT, 0, 1);
+    aY = (PyArrayObject *) PyArray_ContiguousFromObject(oY, NPY_FLOAT, 0, 1);
     if (aY == NULL) ABORT("Bad Y")
 
-    aZ = (PyArrayObject *) PyArray_ContiguousFromObject(oZ, PyArray_FLOAT, 0, 1);
+    aZ = (PyArrayObject *) PyArray_ContiguousFromObject(oZ, NPY_FLOAT, 0, 1);
     if (aZ == NULL) ABORT("Bad Z")
 
-    aP = (PyArrayObject *) PyArray_ContiguousFromObject(oP, PyArray_FLOAT, 0, 1);
+    aP = (PyArrayObject *) PyArray_ContiguousFromObject(oP, NPY_FLOAT, 0, 1);
     printf("aP: %d, PyArray_Size(aP): %d\n", (int)aP, PyArray_Size((PyObject*)aP));
     if ((aP == NULL) || (PyArray_Size((PyObject*)aP) < 5)) ABORT("Bad P")
 
-    aPos = (PyArrayObject *) PyArray_ContiguousFromObject(oPos, PyArray_FLOAT, 0, 1);
+    aPos = (PyArrayObject *) PyArray_ContiguousFromObject(oPos, NPY_FLOAT, 0, 1);
     if ((aPos == NULL) || (PyArray_Size((PyObject*)aPos) != 3)) ABORT("Bad Pos")
 
     nPts = PyArray_Size((PyObject*)aX);
@@ -482,16 +482,16 @@ static PyObject * py_quad_surf_mf(PyObject *self, PyObject *args, PyObject *keyw
         goto FINALIZE_py_quad_surf_mf;\
         }
 
-    aX = (PyArrayObject *) PyArray_ContiguousFromObject(oX, PyArray_FLOAT, 0, 1);
+    aX = (PyArrayObject *) PyArray_ContiguousFromObject(oX, NPY_FLOAT, 0, 1);
     if (aX == NULL) ABORT("Bad X")
 
-    aY = (PyArrayObject *) PyArray_ContiguousFromObject(oY, PyArray_FLOAT, 0, 1);
+    aY = (PyArrayObject *) PyArray_ContiguousFromObject(oY, NPY_FLOAT, 0, 1);
     if (aY == NULL) ABORT("Bad Y")
 
-    aZ = (PyArrayObject *) PyArray_ContiguousFromObject(oZ, PyArray_FLOAT, 0, 1);
+    aZ = (PyArrayObject *) PyArray_ContiguousFromObject(oZ, NPY_FLOAT, 0, 1);
     if (aZ == NULL) ABORT("Bad Z")
 
-    aP = (PyArrayObject *) PyArray_ContiguousFromObject(oP, PyArray_DOUBLE, 0, 1);
+    aP = (PyArrayObject *) PyArray_ContiguousFromObject(oP, NPY_DOUBLE, 0, 1);
     if (aP == NULL) ABORT("Bad P")
     if (PyArray_Size((PyObject*)aP) != 8) ABORT("P is wrong size")
 

--- a/PYME/Analysis/points/astigmatism/astiglookup.c
+++ b/PYME/Analysis/points/astigmatism/astiglookup.c
@@ -54,14 +54,14 @@ static PyObject * astiglookup(PyObject *self, PyObject *args, PyObject *keywds)
     outDimensions[0] = nPts;
 
     // Allocate output arrays
-    out_z = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,PyArray_INT);
+    out_z = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,NPY_INT);
     if (out_z == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Error allocating output array");
       goto fail;
     }
 
-    out_err = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,PyArray_FLOAT);
+    out_err = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,NPY_FLOAT);
     if (out_err == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Error allocating output array");
@@ -168,14 +168,14 @@ static PyObject * astiglookup4(PyObject *self, PyObject *args, PyObject *keywds)
     outDimensions[0] = nPts;
 
     // Allocate output arrays
-    out_z = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,PyArray_INT);
+    out_z = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,NPY_INT);
     if (out_z == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Error allocating output array");
       goto fail;
     }
 
-    out_err = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,PyArray_FLOAT);
+    out_err = (PyArrayObject*) PyArray_SimpleNew(1,outDimensions,NPY_FLOAT);
     if (out_err == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Error allocating output array");

--- a/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx
+++ b/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx
@@ -1,7 +1,7 @@
 
 cimport numpy as np
 
-ctypedef np.int_t DTYPE_it
+ctypedef np.int64_t DTYPE_it
 ctypedef np.float_t DTYPE_ft
 
 def two_opt_test(np.ndarray[DTYPE_it, ndim=1] route, int i, int k, np.ndarray[DTYPE_ft, ndim=2] distances, int k_max):

--- a/PYME/IO/buffer_helpers.pyx
+++ b/PYME/IO/buffer_helpers.pyx
@@ -10,7 +10,7 @@ DTYPE = np.int
 # "ctypedef" assigns a corresponding compile-time type to DTYPE_t. For
 # every type in the numpy module there's a corresponding compile-time
 # type with a _t-suffix.
-ctypedef np.int_t DTYPE_t
+ctypedef np.int64_t DTYPE_t
 
 cimport cython
 

--- a/PYME/contrib/gohlke/tifffile.c
+++ b/PYME/contrib/gohlke/tifffile.c
@@ -66,6 +66,11 @@ setup(name='_tifffile', ext_modules=[Extension('_tifffile', ['tifffile.c'],
 #include "string.h"
 #include "numpy/arrayobject.h"
 
+/* NPY 1.X backwards compatibility */
+#if NPY_ABI_VERSION < 0x02000000
+  #define PyDataType_ELSIZE(descr) ((descr)->elsize)
+#endif
+
 /* little endian by default */
 #ifndef MSB
 #define MSB 1
@@ -397,7 +402,7 @@ py_unpackints(PyObject *obj, PyObject *args, PyObject *kwds)
          PyErr_Format(PyExc_ValueError, "data size out of range");
          goto _fail;
     }
-    if (dtype->elsize != storagesize) {
+    if (PyDataType_ELSIZE(dtype) != storagesize) {
          PyErr_Format(PyExc_TypeError, "dtype.elsize doesn't fit itemsize");
          goto _fail;
     }
@@ -436,7 +441,7 @@ py_unpackints(PyObject *obj, PyObject *args, PyObject *kwds)
     }
 
     if ((dtype->byteorder != BOC) && (itemsize % 8 == 0)) {
-        switch (dtype->elsize) {
+      switch (PyDataType_ELSIZE(dtype)) {
         case 2: {
             uint16_t *d = (uint16_t *)PyArray_DATA(result);
             for (i = 0; i < PyArray_SIZE(result); i++) {

--- a/PYME/localization/cInterp/cInterp.c
+++ b/PYME/localization/cInterp/cInterp.c
@@ -55,7 +55,7 @@ static PyObject * Interpolate(PyObject *self, PyObject *args, PyObject *keywds)
 
     /* Do the calculations */ 
         
-    amod = (PyArrayObject *) PyArray_ContiguousFromObject(omod, PyArray_FLOAT, 3, 3);
+    amod = (PyArrayObject *) PyArray_ContiguousFromObject(omod, NPY_FLOAT, 3, 3);
     if (amod == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad model");
@@ -76,7 +76,7 @@ static PyObject * Interpolate(PyObject *self, PyObject *args, PyObject *keywds)
 
     //printf("shp: %d, %d", nx, ny);
         
-    out = (PyArrayObject*) PyArray_SimpleNew(3,outDimensions,PyArray_FLOAT);
+    out = (PyArrayObject*) PyArray_SimpleNew(3,outDimensions,NPY_FLOAT);
     if (out == NULL)
     {
       Py_DECREF(amod);
@@ -204,7 +204,7 @@ static PyObject * InterpolateCS(PyObject *self, PyObject *args, PyObject *keywds
         return NULL; 
 
         
-    amod = (PyArrayObject *) PyArray_ContiguousFromObject(omod, PyArray_FLOAT, 3, 3);
+    amod = (PyArrayObject *) PyArray_ContiguousFromObject(omod, NPY_FLOAT, 3, 3);
     if (amod == NULL)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad model");
@@ -225,7 +225,7 @@ static PyObject * InterpolateCS(PyObject *self, PyObject *args, PyObject *keywds
 
     //printf("shp: %d, %d", nx, ny);
         
-    out = (PyArrayObject*) PyArray_SimpleNew(3,outDimensions,PyArray_FLOAT);
+    out = (PyArrayObject*) PyArray_SimpleNew(3,outDimensions,NPY_FLOAT);
     if (out == NULL)
     {
       Py_DECREF(amod);
@@ -365,13 +365,13 @@ static PyObject * InterpolateInplace(PyObject *self, PyObject *args, PyObject *k
 
     /* Do the calculations */ 
         
-    if (PyArray_TYPE(amod) != PyArray_FLOAT)
+    if (PyArray_TYPE(amod) != NPY_FLOAT)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad model");
       return NULL;
     }
 
-    if (PyArray_TYPE(out) != PyArray_FLOAT)
+    if (PyArray_TYPE(out) != NPY_FLOAT)
     {
         PyErr_Format(PyExc_RuntimeError, "bad output array");
         return NULL;
@@ -488,19 +488,19 @@ static PyObject * InterpolateInplaceM(PyObject *self, PyObject *args, PyObject *
 
     /* Do the calculations */ 
         
-    if (PyArray_TYPE(amod) != PyArray_FLOAT)
+    if (PyArray_TYPE(amod) != NPY_FLOAT)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad model");
       return NULL;
     }
 
-    if (PyArray_TYPE(out) != PyArray_FLOAT)
+    if (PyArray_TYPE(out) != NPY_FLOAT)
     {
         PyErr_Format(PyExc_RuntimeError, "bad output array");
         return NULL;
     }
 
-    if (PyArray_TYPE(xv) != PyArray_FLOAT)
+    if (PyArray_TYPE(xv) != NPY_FLOAT)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad x");
       return NULL;
@@ -509,25 +509,25 @@ static PyObject * InterpolateInplaceM(PyObject *self, PyObject *args, PyObject *
     npts = PyArray_DIM(xv, 0);
     //printf("n: %d\n", npts);
 
-    if (PyArray_TYPE(yv) != PyArray_FLOAT || PyArray_DIM(yv, 0) != npts)
+    if (PyArray_TYPE(yv) != NPY_FLOAT || PyArray_DIM(yv, 0) != npts)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad y");
       return NULL;
     }
 
-    if (PyArray_TYPE(zv) != PyArray_FLOAT || PyArray_DIM(zv, 0) != npts)
+    if (PyArray_TYPE(zv) != NPY_FLOAT || PyArray_DIM(zv, 0) != npts)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad z");
       return NULL;
     }
 
-    if (PyArray_TYPE(Av) != PyArray_FLOAT || PyArray_DIM(Av, 0) != npts)
+    if (PyArray_TYPE(Av) != NPY_FLOAT || PyArray_DIM(Av, 0) != npts)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad A");
       return NULL;
     }
 
-    if (PyArray_TYPE(nv) != PyArray_INT || PyArray_DIM(nv, 0) != npts)
+    if (PyArray_TYPE(nv) != NPY_INT || PyArray_DIM(nv, 0) != npts)
     {
       PyErr_Format(PyExc_RuntimeError, "Bad nx");
       return NULL;


### PR DESCRIPTION
Addresses issue of compiling with numpy 2.x mentioned in #1527.

As noted in #1527, numpy 2.X gives compilation errors when attempting to compile several files which stem from subtle changes or dropped deprecated interfaces versus 1.X. The code changes here make PYME compile with latest numpy 2.X while maintaining recent 1.X backwards compatibility.

This PR implements the following changes:

- change all `PyArray_XXTYPE` to `NPY_XXTYPE`, e.g. `NPY_DOUBLE` etc; this appears backwards compatible with 1.X
- in `gohlke/tifffile.c` change access to `dtype->elsize` to `PyDataType_ELSIZE(dtype)` as outlined in https://numpy.org/doc/stable/numpy_2_0_migration_guide.html and include 1.X compatible ifdef'ed macro
- change occasional `ctypedef np.int_t ...` to `ctypedef np.int64_t ...`; apparently this is now required and seems backward compatible

With this everything builds fine as tested using `Python` 3.11, `numpy` 2.2.6 and `matplotlib` 3.10.3.
Also ok (backwards compat test) using `Python` 3.11, `numpy` 1.26.4 and `matplotlib` 3.8.0.

Using numpy 2.X and recent matplotlib (here 3.10.3) most things seem to work fine, I tested briefly `dh5view` line profile plotting which uses the `graphviewpanel` and even that seems fine but there may be matplotlib changes that trigger issues as yet unidentified. Similalrly, there are possible numpy 2.X python level interface changes lurking in some not yet tested part of PYME. At least one can now start testing this further.

**Is this a bugfix or an enhancement?**

bug fix for numpy 2.x compatibility

**Proposed changes:**

As outlined above.

Tested as mentioned above on mac to date.