### PR TITLE
Logging tweaks

### DIFF
--- a/PYME/Acquire/PYMEAcquire.py
+++ b/PYME/Acquire/PYMEAcquire.py
@@ -48,6 +48,9 @@ warnings.simplefilter('once', wx.wxPyDeprecationWarning)
 import os
 import logging
 import logging.config
+import os
+
+import PYME.config as pyme_config
 
 def setup_logging(default_level=logging.DEBUG):
     """Setup logging configuration
@@ -64,6 +67,19 @@ def setup_logging(default_level=logging.DEBUG):
     if os.path.exists(path):
         with open(path, 'rt') as f:
             config = yaml.safe_load(f)
+
+        if pyme_config.get('Acquire-logging_include_pid', False):
+            # replace the filename in the file handler with a version that includes the PID
+            # this is useful for debugging multiple instances of PYMEAcquire
+            # The caveat is that each time you run the program you will get a new log file
+            # and these will accumulate until manually deleted / removed.
+            # To enable, add the following line to ~/.PYME/config.yaml
+            # Acquire-logging_include_pid: True
+            try:
+                config['handlers']['file']['filename'] = config['handlers']['file']['filename'].replace('.log', f'_{os.getpid()}.log')
+            except KeyError:
+                print('No file handler in logging config - skipping PID replacement')
+            
         logging.config.dictConfig(config)
     else:
         logging.basicConfig(level=default_level)

--- a/PYME/Acquire/acquire_client.py
+++ b/PYME/Acquire/acquire_client.py
@@ -29,6 +29,16 @@ class AcquireClient(object):
         t.daemon = True
         t.start()
 
+    def _check_response(self, response):
+        """
+        Handles the response from the server. Raises an exception if the response is not
+        successful.
+        """
+        if not response.ok:
+            raise Exception('Error: {}'.format(response.text))
+        
+        return response
+
     @property
     def state(self):
         """
@@ -46,20 +56,20 @@ class AcquireClient(object):
         """
         Returns the current state of the scope as a dictionary.
         """
-        return requests.get(self.base_url + '/get_scope_state').json()
+        return self._check_response(requests.get(self.base_url + '/get_scope_state')).json()
     
     def update_scope_state(self, state:dict):
         """
         Updates the scope state with the provided dictionary.
         """
-        requests.post(self.base_url + '/update_scope_state', json=state)
+        self._check_response(requests.post(self.base_url + '/update_scope_state', json=state))
 
     def start_spooling(self, filename='', preflight_mode='abort', settings={}):
         """
         Starts spooling images to disk. If filename is not provided, the default filename will be used.
         """
         
-        requests.post(self.base_url + f'/spool_controller/start_spooling?filename={filename}&preflight_mode={preflight_mode}', json=settings)
+        self._check_response(requests.post(self.base_url + f'/spool_controller/start_spooling?filename={filename}&preflight_mode={preflight_mode}', json=settings))
 
         return self.spooling_finished
 
@@ -69,7 +79,7 @@ class AcquireClient(object):
 
         TODO - Use the long-polling endpoint???
         """
-        return requests.get(self.base_url + '/spool_controller/info').json()
+        return self._check_response(requests.get(self.base_url + '/spool_controller/info')).json()
     
     def spooling_finished(self):
         """

--- a/PYME/util/webframework.py
+++ b/PYME/util/webframework.py
@@ -283,9 +283,15 @@ class JSONAPIRequestHandler(http.server.BaseHTTPRequestHandler):
         
         try:
             resp = handler(**kwargs)
-        except Exception:
+        except Exception as e:
+            logger.exception('Exception in handler %s' % handler)
+            
             import traceback
-            self.send_error(500, 'Server Error\n %s' % traceback.format_exc())
+            explain = f''' {handler.__module__}.{handler.__name__}({', '.join(['%s=%s' % (k, repr(v)) for k, v in kwargs.items()])})
+            {e.__class__.__name__}: {e}
+            {traceback.format_exc()}
+            '''
+            self.send_error(500, message='Server Error', explain=explain)
             return
         
         if isinstance(resp, HTTPResponse):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ psutil
 ujson
 jinja2
 toposort
+setuptools < 60 # setuptools >= 60 has removed compiler support
+#distutils <
 pymecompress >=0.2
 zeroconf<=0.26.3
 


### PR DESCRIPTION
Fixes logging and exception handling when using client and server instances of PYMEAcquire

- Makes sure exceptions are not silently swallowed on the server side
- Makes sure error messages are correctly formatted in the HTTP response (TODO - do we need to set a mime type here and/or format as HTML
- makes sure an exception on the server raises an exception on the client (this was previously happening, but only because we were providing a mal-formed error response. If we had formatted it nicely it would have ended up being ignored).
- Add an option to have different PYMEAcquire processes use different log files

To enable the separated logging, add the following to `.PYME/config.yaml`:
```yaml
Acquire-logging_include_pid: True
```

