### PR TITLE
Alternative fix to localization settings_form and form_recipe text escape

### DIFF
--- a/PYME/cluster/clusterUI/localization/templates/localization/settings_form.html
+++ b/PYME/cluster/clusterUI/localization/templates/localization/settings_form.html
@@ -46,10 +46,15 @@
             $('.cu-hidden-seriesname').remove();
             var seriesNames=[];
             $('.cu-selected').each(function(index, item){
-                var sn = item.getAttribute('data-cu-seriesname').text();
+                var sn = item.getAttribute('data-cu-seriesname');
                 if (sn != null) {
                     seriesNames.push(sn);
-                    f.append('<input name="series" class="cu-hidden-seriesname" type="hidden" value="' + sn + '">')
+                    f.append($('<input>', {
+                        name: 'series',
+                        type: 'hidden',
+                        class: 'cu-hidden-seriesname',
+                        value: sn
+                    }));
                 }
             });
             console.log(seriesNames);

--- a/PYME/cluster/clusterUI/recipes/templates/recipes/form_recipe.html
+++ b/PYME/cluster/clusterUI/recipes/templates/recipes/form_recipe.html
@@ -49,16 +49,28 @@
             $('.cu-hidden-filename').remove();
             var fileNames=[];
             $('.cu-selected').each(function(index, item){
-                var sn = item.getAttribute('data-cu-filename').text();
+                var sn = item.getAttribute('data-cu-filename');
                 if (sn != null) {
                     fileNames.push(sn);
-                    f.append('<input name="files" class="cu-hidden-filename" type="hidden" value="' + sn + '">')
+                    // f.append('<input name="files" class="cu-hidden-filename" type="hidden" value="' + sn + '">')
+                    f.append($('<input>', {
+                        name: 'files',
+                        type: 'hidden',
+                        class: 'cu-hidden-filename',
+                        value: sn
+                    }));
                 }
                 // Also check for series, e.g. pcs extensions
-                var sn = item.getAttribute('data-cu-seriesname').text();
+                var sn = item.getAttribute('data-cu-seriesname');
                 if (sn != null) {
                     fileNames.push(sn);
-                    f.append('<input name="files" class="cu-hidden-filename" type="hidden" value="' + sn + '">')
+                    // f.append('<input name="files" class="cu-hidden-filename" type="hidden" value="' + sn + '">')
+                    f.append($('<input>', {
+                        name: 'files',
+                        type: 'hidden',
+                        class: 'cu-hidden-filename',
+                        value: sn
+                    }));
                 }
             });
             console.log(fileNames);


### PR DESCRIPTION
Addresses an issue mentioned in #1205, where the "Launch analysis with selected" button does nothing, and results in
"Uncaught TypeError: item.getAttribute(...).text is not a function" on the browser side.
The `.text()` calls were introduced in response to security concerns (#1110), which it seems can alternatively be avoided by using jQuery instead of javascript to construct the list elements.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- avoid typerror, and avoid passing the series name string as markup



**Checklist:**
I have tested the localization. Have not tested the recipe form fix. 
