### PR TITLE
Fix for pco camera crashing/capturing black frames/being stuck

### DIFF
--- a/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
@@ -20,6 +20,7 @@ import ctypes.wintypes
 import queue
 import threading
 import time
+import copy
 
 k32_dll = ctypes.windll.kernel32  # lets us use the recommended WaitForSingleObject call (see pco.sdk)
                                   # instead of the not-recommended-for-polling pco_sdk.get_buffer_status()
@@ -580,7 +581,7 @@ class PcoSdkCam(Camera):
             res = pco_sdk.force_trigger(self._handle)
             # FIFO queue the queable buffers so we don't
             # grab images before a trigger in _poll_loop
-            self._buffers_to_queue.put(self._i)
+            self._buffers_to_queue.put(copy.deepcopy(self._i)) # ensure we put a copy of the index, not a reference
             self._i += 1
             if self._i >= self._n_buffers:
                 self._i = 0

--- a/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
@@ -519,9 +519,12 @@ class PcoSdkCam(Camera):
 
     @property
     def _timeout(self):
-        # set the time longer for all hardware check
-        # for example, LC settling time is usually set at 300 ms (current minimum is 150 ms)
-        return int(max(2*100*self.GetCycleTime(), 1000))
+        # set the timeout (ms)based on cycle time
+        # timeout should be longer than cycle time + readout time + some margin for windows timing uncertainty (default to 2x cycle time)
+        # timeout should not be too long, otherwise one bad buffer can block things and cause overflows.
+        # TODO: reduce the minimum timeout to something more reasonable (e.g. 100 ms)?? Current hardcoded value of 1s is very likely excessive
+        # and may cause issues, especially if the camera is running at a high frame rate.
+        return int(max(2*1000*self.GetCycleTime(), 1000))
     
     def StartExposure(self):
         #logger.debug(f'PcoSdkCam: StartExposure called from thread {threading.current_thread().name} at {time.time()}')

--- a/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
+++ b/PYME/Acquire/Hardware/pco/pco_sdk_cam.py
@@ -581,10 +581,11 @@ class PcoSdkCam(Camera):
 
     def TriggerAq(self):
         if (self._mode == self.MODE_SINGLE_SHOT) or (self._mode == self.MODE_SOFTWARE_TRIGGER):
-            res = pco_sdk.force_trigger(self._handle)
+            # res = pco_sdk.force_trigger(self._handle)
             # FIFO queue the queable buffers so we don't
             # grab images before a trigger in _poll_loop
             self._buffers_to_queue.put(copy.deepcopy(self._i)) # ensure we put a copy of the index, not a reference
+            res = pco_sdk.force_trigger(self._handle)
             self._i += 1
             if self._i >= self._n_buffers:
                 self._i = 0

--- a/PYME/Acquire/frameWrangler.py
+++ b/PYME/Acquire/frameWrangler.py
@@ -419,9 +419,18 @@ class FrameWrangler(object):
         NB: This is largely legacy code, as the camera is usually used in 
         free-running mode."""
         for callback in self.HardwareChecks:
-            if not callback():
-                logger.debug('Waiting for hardware')
+            try:
+                ready = callback()
+            except Exception:
+                logger.exception('Hardware check %r raised an exception', callback)
                 return False
+
+            if not ready:
+                logger.debug('Waiting for hardware: %r reported not-ready', callback)
+                return False
+            # if not callback():
+            #     logger.debug('Waiting for hardware')
+            #     return False
 
         return True
 


### PR DESCRIPTION
Addresses issue of pco edge 4.2 LT used on the OI-DIC microscope.

**Is this a bugfix or an enhancement?**
This is a bugfix.

**Proposed changes:**
Recycle buffer when encoutering timeouts or other errors. Flag errors in `pco_sdk_cam.py` for `framewrangler.py` to restart the camera. Add a logging to report which hardware is not ready, which is useful for debugging what causes the delay in the single-shot mode. There might be some redundancy in the type of errors might be encountered because I only have the timeout error in my logging based on my test, but I still keep the code as is to be safe.


**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
