### PR TITLE
Meson importlib fix

### DIFF
--- a/PYME/DSView/modules/__init__.py
+++ b/PYME/DSView/modules/__init__.py
@@ -37,13 +37,8 @@ logger = logging.getLogger(__name__)
 # with those installs __path__ resolves to some stub that cannot be parsed in the usual way
 # localmodules = [os.path.splitext(os.path.split(p)[-1])[0] for p in glob.glob(__path__[0] + '/[a-zA-Z]*.py')]
 
-# import.resources should be used instead, see also https://mesonbuild.com/meson-python/how-to-guides/editable-installs.html#data-files
-# the code below should be fully backwards compatible with other installs and newer py3s
-import importlib.resources
-localmodules = []
-for file in importlib.resources.files(__package__).iterdir():
-    if not file.name.startswith('_') and file.name.endswith('.py'):
-        localmodules.append(file.stem)
+from PYME.util.packageutils import package_files_matching
+localmodules = package_files_matching(__package__,'[a-zA-Z]*.py')
 
 modLocations = {}
 for m in localmodules:

--- a/PYME/DSView/modules/__init__.py
+++ b/PYME/DSView/modules/__init__.py
@@ -33,7 +33,17 @@ from PYME import config
 import logging
 logger = logging.getLogger(__name__)
 
-localmodules = [os.path.splitext(os.path.split(p)[-1])[0] for p in glob.glob(__path__[0] + '/[a-zA-Z]*.py')]
+# this fails with meson "develop" installs AKA editable installs
+# with those installs __path__ resolves to some stub that cannot be parsed in the usual way
+# localmodules = [os.path.splitext(os.path.split(p)[-1])[0] for p in glob.glob(__path__[0] + '/[a-zA-Z]*.py')]
+
+# import.resources should be used instead, see also https://mesonbuild.com/meson-python/how-to-guides/editable-installs.html#data-files
+# the code below should be fully backwards compatible with other installs and newer py3s
+import importlib.resources
+localmodules = []
+for file in importlib.resources.files(__package__).iterdir():
+    if not file.name.startswith('_') and file.name.endswith('.py'):
+        localmodules.append(file.stem)
 
 modLocations = {}
 for m in localmodules:

--- a/PYME/LMVis/Extras/__init__.py
+++ b/PYME/LMVis/Extras/__init__.py
@@ -32,7 +32,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-mods = list(set([os.path.splitext(os.path.split(p)[-1])[0] for p in glob.glob(__path__[0] + '/[a-zA-Z]*.py') + glob.glob(__path__[0] + '/[a-zA-Z]*.pyc')]))
+#mods = list(set([os.path.splitext(os.path.split(p)[-1])[0] for p in glob.glob(__path__[0] + '/[a-zA-Z]*.py') + glob.glob(__path__[0] + '/[a-zA-Z]*.pyc')]))
+from PYME.util.packageutils import package_files_matching
+mods = package_files_matching(__package__,['[a-zA-Z]*.py','[a-zA-Z]*.pyc'])
+
 mods.sort()
 
 

--- a/PYME/localization/FitFactories/Interpolators/__init__.py
+++ b/PYME/localization/FitFactories/Interpolators/__init__.py
@@ -23,7 +23,9 @@
 import glob
 import os
 
-__all__ = [os.path.splitext(os.path.split(p)[-1])[0] for p in glob.glob(__path__[0] + '/[a-zA-Z]*.py')]
+#__all__ = [os.path.splitext(os.path.split(p)[-1])[0] for p in glob.glob(__path__[0] + '/[a-zA-Z]*.py')]
+from PYME.util.packageutils import package_files_matching
+__all__ = package_files_matching(__package__,'[a-zA-Z]*.py')
 
 interpolatorList = [i for i in __all__]
 interpolatorList.remove('baseInterpolator')

--- a/PYME/localization/FitFactories/__init__.py
+++ b/PYME/localization/FitFactories/__init__.py
@@ -29,7 +29,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 # discover PYME-internal fitfactories
-_pyme_ff = [os.path.splitext(os.path.split(p)[-1])[0] for p in glob.glob(__path__[0] + '/[a-zA-Z]*.py')]
+#_pyme_ff = [os.path.splitext(os.path.split(p)[-1])[0] for p in glob.glob(__path__[0] + '/[a-zA-Z]*.py')]
+from PYME.util.packageutils import package_files_matching
+_pyme_ff = package_files_matching(__package__,'[a-zA-Z]*.py')
 _pyme_ff.sort() #sort builtin and plugins before combining so that builtins always appear at the top.
 _pyme_ff_pkg = 'PYME.localization.FitFactories'
 

--- a/PYME/localization/FitFactories/zEstimators/__init__.py
+++ b/PYME/localization/FitFactories/zEstimators/__init__.py
@@ -23,7 +23,9 @@
 import glob
 import os
 
-__all__ = [os.path.splitext(os.path.split(p)[-1])[0] for p in glob.glob(__path__[0] + '/[a-zA-Z]*.py')]
+#__all__ = [os.path.splitext(os.path.split(p)[-1])[0] for p in glob.glob(__path__[0] + '/[a-zA-Z]*.py')]
+from PYME.util.packageutils import package_files_matching
+__all__ = package_files_matching(__package__,'[a-zA-Z]*.py')
 
 estimatorList = [i for i in __all__]
 estimatorList.sort()

--- a/PYME/meson.build
+++ b/PYME/meson.build
@@ -164,6 +164,7 @@ py_sources = files(
     'util/execfile.py',
     'util/authenticate.py',
     'util/uilaunch.py',
+    'util/packageutils.py',
 )
 py.install_sources(py_sources, subdir:'PYME/util')
 

--- a/PYME/util/packageutils.py
+++ b/PYME/util/packageutils.py
@@ -1,0 +1,27 @@
+import importlib.resources
+import pathlib
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+# import.resources should be used instead of using __path__ and similar package variables directly,
+# as direct access breaks with pip/meson editable installs
+# see also https://mesonbuild.com/meson-python/how-to-guides/editable-installs.html#data-files
+# the code below should be fully backwards compatible with non-editable installs, older setup.py based installs
+# and newer py3s
+
+def package_files_matching(calling_package,patterns):
+    modules = []
+    if not isinstance(patterns,list):
+        patterns = [patterns]
+    logger.debug("Local modules for package %s" % calling_package)
+    for file in importlib.resources.files(calling_package).iterdir():
+        for pattern in patterns:
+            if pathlib.PurePath(file.name).match(pattern):
+                modules.append(file.stem)
+                break # make sure each file is only added once
+
+    logger.debug("Matching modules " + repr(modules))
+
+    return modules

--- a/PYME/util/packageutils.py
+++ b/PYME/util/packageutils.py
@@ -5,11 +5,18 @@ import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
+# the use of __path__ is not recommended any more, the package_files_matching funcs below aims for replacing the previous use
+# TODO: similarly, the use of __file__ is discouraged, see specifically
+#                  https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package/58941536#58941536
+#       there are still plenty of uses of __file__ in the dist; the current use of __file__ is quite heterogneous,
+#       and may need different replacements; cirrent uses should be replaced over time;
+#       if common use cases lend itself to encapsulation the functionally could be collected here
+
 # import.resources should be used instead of using __path__ and similar package variables directly,
 # as direct access breaks with pip/meson editable installs
 # see also https://mesonbuild.com/meson-python/how-to-guides/editable-installs.html#data-files
 # the code below should be fully backwards compatible with non-editable installs, older setup.py based installs
-# and newer py3s
+# when using newer py3s (post 3.9 or so)
 
 def package_files_matching(calling_package,patterns):
     modules = []


### PR DESCRIPTION
Addresses issue #1619 (partially) .

**Is this a bugfix or an enhancement?**
Bugfix/improvement for uses of `__path__` to find modules matching a pattern.

**Proposed changes:**

Instead use `importlib.resources.files` approach to find module names matching a pattern.

This PR does not yet tackle the use of `__file__` throughout the dist. The use of `__file__` is more heterogeneous and may require a range of different fixes. Perhaps more importantly, the `__path__` related issues lead to runtime errors with editable builds. The current use of `__file__` seems by contrast not to break anything in our "standard installs". So I would consider this a lower priority and indeed seeing a case where it DOES break would be instructive (perhaps when installing from a wheel?).

**Checklist:**

Tested to some degree of meson editable builds and using the previous seup.py based installs. Seems to work fine for both.