### PR TITLE
Meson fixes for windows build

### DIFF
--- a/PYME/Analysis/points/SoftRend/meson.build
+++ b/PYME/Analysis/points/SoftRend/meson.build
@@ -26,7 +26,7 @@ srcs = ['triRend.c','drawTriang.c', 'triangRend.c']
 
 #message('numpy include dir:', np_include_dir)
 
-if host_machine.system() == 'windows'
+if cc.get_id() == 'msvc'
   copts = ['/fp:fast']
 else
   copts = ['-O3', '-fno-exceptions', '-ffast-math', '-Wno-unused-but-set-variable']

--- a/PYME/Analysis/points/SoftRend/meson.build
+++ b/PYME/Analysis/points/SoftRend/meson.build
@@ -26,13 +26,19 @@ srcs = ['triRend.c','drawTriang.c', 'triangRend.c']
 
 #message('numpy include dir:', np_include_dir)
 
+if host_machine.system() == 'windows'
+  copts = ['/fp:fast']
+else
+  copts = ['-O3', '-fno-exceptions', '-ffast-math', '-Wno-unused-but-set-variable']
+endif
+
 py.extension_module(
     'triRend',
     srcs + qhullSources,
     include_directories: [np_include_dir, 'qhull'],
     subdir: 'PYME/Analysis/points/SoftRend',
     dependencies: py.dependency(),
-    c_args: ['-O3', '-fno-exceptions', '-ffast-math', '-Wno-unused-but-set-variable'],
+    c_args: copts,
     install: true,
     #cpp_args: ['-std=c++17'],
 )

--- a/PYME/experimental/meson.build
+++ b/PYME/experimental/meson.build
@@ -54,7 +54,7 @@ install_data(data_files, install_dir: install_dir)
 #FIXME - Extension()
 #FIXME - Extension()
 
-if host_machine.system() == 'windows'
+if cc.get_id() == 'msvc'
   copts = ['/fp:fast']
 else
   copts = ['-O3', '-fno-exceptions', '-ffast-math']
@@ -106,7 +106,7 @@ py.extension_module(
     install: true,
 )
 
-if host_machine.system() == 'windows'
+if cc.get_id() == 'msvc'
   copts2 = ['/fp:fast']
 else
   copts2 = ['-O3', '-ffast-math']

--- a/PYME/experimental/meson.build
+++ b/PYME/experimental/meson.build
@@ -53,6 +53,13 @@ install_data(data_files, install_dir: install_dir)
 #FIXME - Extension()
 #FIXME - Extension()
 #FIXME - Extension()
+
+if host_machine.system() == 'windows'
+  copts = ['/fp:fast']
+else
+  copts = ['-O3', '-fno-exceptions', '-ffast-math']
+endif
+
 py.extension_module(
     '_triangle_mesh',
     [
@@ -61,7 +68,7 @@ py.extension_module(
     include_directories: [np_include_dir],
     subdir: 'PYME/experimental',
     dependencies: py.dependency(),
-    c_args: ['-O3', '-fno-exceptions', '-ffast-math'],
+    c_args: copts,
     install: true,
 )
 
@@ -73,7 +80,7 @@ py.extension_module(
     include_directories: [np_include_dir],
     subdir: 'PYME/experimental',
     dependencies: py.dependency(),
-    c_args: ['-O3', '-fno-exceptions', '-ffast-math'],
+    c_args: copts,
     install: true,
 )
 py.extension_module(
@@ -84,7 +91,7 @@ py.extension_module(
     include_directories: [np_include_dir],
     subdir: 'PYME/experimental',
     dependencies: py.dependency(),
-    c_args: ['-O3', '-fno-exceptions', '-ffast-math'],
+    c_args: copts,
     install: true,
 )
 py.extension_module(
@@ -95,9 +102,15 @@ py.extension_module(
     include_directories: [np_include_dir],
     subdir: 'PYME/experimental',
     dependencies: py.dependency(),
-    c_args: ['-O3', '-fno-exceptions', '-ffast-math'],
+    c_args: copts,
     install: true,
 )
+
+if host_machine.system() == 'windows'
+  copts2 = ['/fp:fast']
+else
+  copts2 = ['-O3', '-ffast-math']
+endif
 
 py.extension_module(
     'triangle_mesh_utils',
@@ -107,6 +120,6 @@ py.extension_module(
     include_directories: [np_include_dir],
     subdir: 'PYME/experimental',
     dependencies: py.dependency(),
-    c_args: ['-O3', '-ffast-math'],
+    c_args: copts2,
     install: true,
 )

--- a/PYME/experimental/triangle_mesh_utils.c
+++ b/PYME/experimental/triangle_mesh_utils.c
@@ -8,7 +8,7 @@
 
 #define EPS 1e-12
 
-inline float norm(const float *pos)
+inline float vnorm(const float *pos)
 {
     float n = 0;
     int i = 0;
@@ -137,7 +137,7 @@ static void update_single_vertex_neighbours(int v_idx, halfedge_t *halfedges, vo
         // calculate the edge length of this halfedge
         loop_vertex = &(vertices[(curr_edge->vertex)]);
         difference((curr_vertex->position), (loop_vertex->position), position);
-        l = norm(position);
+        l = vnorm(position);
         curr_edge->length = l;
 
         // traverse to twin, if possible
@@ -189,7 +189,7 @@ static void update_single_vertex_neighbours(int v_idx, halfedge_t *halfedges, vo
             // calculate the edge length
             loop_vertex = &(vertices[(next_edge->vertex)]);
             difference((curr_vertex->position), (loop_vertex->position), position);
-            l = norm(position);
+            l = vnorm(position);
             twin_edge->length = l;
 
             // traverse to twin (the next emanating halfedge)
@@ -219,7 +219,7 @@ static void update_single_vertex_neighbours(int v_idx, halfedge_t *halfedges, vo
 
     curr_vertex->valence = i;
 
-    nn = norm(normal);
+    nn = vnorm(normal);
     if (nn > EPS) {
         for (k = 0; k < VECTORSIZE; ++k)
             (curr_vertex->normal)[k] = normal[k]/nn;
@@ -373,7 +373,7 @@ static void update_face_normal(int f_idx, halfedge_t *halfedges, void *vertices_
     difference((next_vertex->position), v1, v);
 
     cross(u, v, n);
-    nn = norm(n);
+    nn = vnorm(n);
     curr_face->area = 0.5*nn;
 
     if (nn > EPS){

--- a/PYME/experimental/triangle_mesh_utils.h
+++ b/PYME/experimental/triangle_mesh_utils.h
@@ -83,7 +83,7 @@ typedef struct vertex_d { //flat version of vertex_t
     int32_t locally_manifold;
 } vertex_d;
 
-float norm(const float *vertex);
+float vnorm(const float *vertex);
 void cross(const float *a, const float *b, float *n);
 void difference(const float *a, const float *b, float *d);
 void vsum(const float *a, const float *b, float *out);

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,14 @@ np_include_dir = include_directories(run_command(py,  ['-c',  'import numpy; pri
 #message('numpy include dir:', np_include_dir)
 message('install_dir:', py.get_install_dir())
 
-if host_machine.system() != 'windows'
+# we define cc here and can then use it in lower level meson.build files
+# traversed via the subdir command
+cc = meson.get_compiler('c')
+# for examples how to test for compiler specific flags
+# see also https://github.com/GNOME/gtk/blob/main/meson.build
+# especially use of "cc.get_supported_arguments(test_cflags)"
+
+if cc.get_id() != 'msvc'
    add_global_arguments(
      #'-fcompare-debug-secondary',
      #'-wno'

--- a/meson.build
+++ b/meson.build
@@ -22,16 +22,17 @@ np_include_dir = include_directories(run_command(py,  ['-c',  'import numpy; pri
 #message('numpy include dir:', np_include_dir)
 message('install_dir:', py.get_install_dir())
 
-add_global_arguments(
- #'-fcompare-debug-secondary',
- #'-wno'
- '-ffast-math',
- '-Wno-unused-parameter',
- '-Wno-unused-variable',
- '-Wno-unused-function',
- language: 'c'
- )
-
+if host_machine.system() != 'windows'
+   add_global_arguments(
+     #'-fcompare-debug-secondary',
+     #'-wno'
+     '-ffast-math',
+     '-Wno-unused-parameter',
+     '-Wno-unused-variable',
+     '-Wno-unused-function',
+     language: 'c'
+   )
+endif
 
 
 subdir('PYME')


### PR DESCRIPTION
Addresses issue that current PYME does not successfully build on windows with meson.

**Is this a bugfix or an enhancement?**

Bugfix.

**Proposed changes:**

Two issues were encountered, (1) the use of `norm` in `PYME/experimental/triangle_mesh_utils.c` conflicts with some msvc header in `complex.h` or similar and (2) various CFLAGS for gcc/clang break compilation with msvc.

1. was fixed by renaming `norm` to `vnorm` (read "vector norm").
2. was approached by making various conditionals for `cc.get_id()` identifiying the compiler as MSVC. The use of compile flags could presumably be further improved in a platform dependent way using this and related mechanisms. For examples of pretty nice looking usage see also https://github.com/GNOME/gtk/blob/main/meson.build, especially use of `cc.get_supported_arguments(test_cflags)` to validate CFLAGS before passing as a project option.



**Checklist:**
Tested with latest PYME and meson build on win 11 using MSVC. Builds and runs fine with these changes although likely remaining warnings about "ignored" arguments with remaining standard CFLAGS (e.g. `-ffast-math`) where `if cc.get_id() == ...` has not yet been added to the local `meson.build` files.