### PR TITLE
PYMEAcquire camera dtype support

### DIFF
--- a/PYME/Acquire/Hardware/Camera.py
+++ b/PYME/Acquire/Hardware/Camera.py
@@ -114,7 +114,7 @@ class Camera(object):
     
     # what data type is returned by the camera? For full support it is recommended to use 
     # a format supported in `PYME.IO.PZFFormat`
-    dtype = 'uint16'  # uint16 is the default for PYME, and historically the only supported dtype of PYMEAcquire
+    dtype = np.dtype('uint16')  # uint16 is the default for PYME, and historically the only supported dtype of PYMEAcquire
 
     # Acquisition modes
     MODE_SINGLE_SHOT = 0

--- a/PYME/Acquire/Hardware/Camera.py
+++ b/PYME/Acquire/Hardware/Camera.py
@@ -111,6 +111,10 @@ class CameraMapMixin(object):
 class Camera(object):
     # Frame format - PYME previously supported frames in a custom format, but numpy_frames should always be true for current code
     numpy_frames = 1 #Frames are delivered as numpy arrays.
+    
+    # what data type is returned by the camera? For full support it is recommended to use 
+    # a format supported in `PYME.IO.PZFFormat`
+    dtype = 'uint16'  # uint16 is the default for PYME, and historically the only supported dtype of PYMEAcquire
 
     # Acquisition modes
     MODE_SINGLE_SHOT = 0

--- a/PYME/Acquire/SpoolController.py
+++ b/PYME/Acquire/SpoolController.py
@@ -548,6 +548,7 @@ class SpoolController(object):
                     'Tiff folder': acquisition_backends.TiffFolderBackend,}
         
         backend_kwargs = {}
+        backend_kwargs['dtype'] = self.scope.cam.dtype
         if self.spoolType == 'Cluster':
             backend_kwargs['cluster_h5'] = settings.get('cluster_h5', self.cluster_h5)
             backend_kwargs['compression_settings'] = settings.get('pzf_compression_settings', self.pzf_compression_settings)

--- a/PYME/Acquire/frameWrangler.py
+++ b/PYME/Acquire/frameWrangler.py
@@ -175,7 +175,7 @@ class FrameWrangler(object):
 
         if not keepds:
             self.currentFrame = np.zeros([self.cam.GetPicWidth(), self.cam.GetPicHeight(), 
-                                1], dtype = 'uint16', order = self.order)
+                                1], dtype =self.cam.dtype, order = self.order)
             
         self._cf = self.currentFrame
    
@@ -186,7 +186,7 @@ class FrameWrangler(object):
         #logger.debug('acquire _current_frame_lock in getFrame()')
         with self._current_frame_lock:
             self._cf = np.empty([1, self.cam.GetPicWidth(), self.cam.GetPicHeight(),
-	                                ], dtype = 'uint16', order = self.order)
+	                                ], dtype =self.cam.dtype, order = self.order)
 	        
             if getattr(self.cam, 'numpy_frames', False):
                 cs = self._cf[0,:,:] #self.currentFrame[:,:,0]

--- a/PYME/DSView/displaySettingsPanel.py
+++ b/PYME/DSView/displaySettingsPanel.py
@@ -237,7 +237,11 @@ class dispSettingsPanel2(wx.Panel):
         #if self.hlDispMapping.dragging == None:
         dsa = self.do.ds[:,:,0].ravel('F')
 
-        _min, _max = minmax_u16(dsa)
+        # get min and max efficiently if it is uint16
+        if str(dsa.dtype) == 'uint16':
+            _min, _max = minmax_u16(dsa)
+        else:  # otherwise, just use numpy
+            _min, _max = dsa.min(), dsa.max()
 
         #only perform histogramming on a subset of data points to improve performance
         ##note that this may result in strange behaviour of auto-optimise
@@ -250,9 +254,9 @@ class dispSettingsPanel2(wx.Panel):
 
         # if we are saturating, change the background
         try:
-            if _max >= self.scope.cam.SaturationThreshold:
+            if _max >= self.scope.cam.SaturationThreshold or _min <= -self.scope.cam.SaturationThreshold:
                 self.hlDispMapping.SetBackgroundColour(wx.Colour(0xFF, 0x8F, 0x8F))
-            elif _max >= self.scope.cam.SaturationThreshold/2:
+            elif _max >= self.scope.cam.SaturationThreshold/2 or _min <= -self.scope.cam.SaturationThreshold/2:
                 self.hlDispMapping.SetBackgroundColour(wx.YELLOW)
             else:
                 self.hlDispMapping.SetBackgroundColour(wx.WHITE)

--- a/PYME/DSView/displaySettingsPanel.py
+++ b/PYME/DSView/displaySettingsPanel.py
@@ -23,6 +23,7 @@
 
 import wx
 from PYME.ui import histLimits
+import numpy as np
 
 class dispSettingsFrame(wx.Frame):
     def __init__(self, parent, vp):
@@ -238,7 +239,7 @@ class dispSettingsPanel2(wx.Panel):
         dsa = self.do.ds[:,:,0].ravel('F')
 
         # get min and max efficiently if it is uint16
-        if str(dsa.dtype) == 'uint16':
+        if dsa.dtype == np.uint16:
             _min, _max = minmax_u16(dsa)
         else:  # otherwise, just use numpy
             _min, _max = dsa.min(), dsa.max()

--- a/PYME/IO/acquisition_backends.py
+++ b/PYME/IO/acquisition_backends.py
@@ -273,7 +273,7 @@ class HDFBackend(Backend):
         self._complevel = complevel
         self._complib = complib
         self.series_name = series_name
-        self.dtype = dtype
+        self.dtype = np.dtype(dtype)
         
 
     def store_frame(self, n, frame_data):
@@ -282,7 +282,7 @@ class HDFBackend(Backend):
         if n == 0:
             fs = frame_data.squeeze().shape
             filt = tables.Filters(self._complevel, self._complib, shuffle=True)
-            self.imageData = self.h5File.create_earray(self.h5File.root, 'ImageData', tables.atom.Atom.from_type(self.dtype), (0,fs[0],fs[1]), filters=filt)
+            self.imageData = self.h5File.create_earray(self.h5File.root, 'ImageData', tables.Atom.from_dtype(self.dtype), (0,fs[0],fs[1]), filters=filt)
 
         if frame_data.shape[0] == 1:
             self.imageData.append(frame_data)

--- a/PYME/IO/acquisition_backends.py
+++ b/PYME/IO/acquisition_backends.py
@@ -19,7 +19,10 @@ class Backend(abc.ABC):
     Base class for acquisition backends.
 
     """
-    def __init__(self, dim_order='XYCZT', shape=[-1, -1,-1,1,1], spoof_timestamps=False, cycle_time=None, **kwargs):
+    
+    supported_dtypes = [np.dtype('uint16'),]
+
+    def __init__(self, dim_order='XYCZT', shape=[-1, -1,-1,1,1], spoof_timestamps=False, cycle_time=None, dtype=np.dtype('uint16'), **kwargs):
         if not hasattr(self, 'mdh'):
             self.mdh = MetaDataHandler.DictMDHandler()
         self.mdh['imageID'] = self.sequence_id
@@ -27,6 +30,9 @@ class Backend(abc.ABC):
         self._dim_order=dim_order
         self._shape=shape
         self._finished = False
+        self.dtype = np.dtype(dtype)
+        if self.dtype not in self.supported_dtypes:
+            raise ValueError(f'Data type {self.dtype} not supported by this backend. Supported types are: {self.supported_dtypes}')
         
         self.mdh['DimOrder'] = dim_order
         self.mdh['SizeC'] =  shape[4]
@@ -124,7 +130,7 @@ class Backend(abc.ABC):
 
 class MemoryBackend(Backend):
     def __init__(self, size_x, size_y, n_frames, dtype='uint16', series_name=None, dim_order='XYCZT', shape=[-1, -1,1,1,1], **kwargs):
-        Backend.__init__(self, dim_order, shape, spoof_timestamps=kwargs.pop('spoof_timestamps', False), cycle_time=kwargs.pop('cycle_time', None))
+        Backend.__init__(self, dim_order, shape, spoof_timestamps=kwargs.pop('spoof_timestamps', False), cycle_time=kwargs.pop('cycle_time', None), dtype=dtype)
         self.data = np.empty([size_x, size_y, n_frames], dtype=dtype)
         
         # once we have proper xyztc support in the image viewer
@@ -158,6 +164,8 @@ def distfcn_random(n_servers, i=None):
         return random.randrange(n_servers)
 
 class ClusterBackend(Backend):
+
+    supported_dtypes = [np.dtype(f) for f in PZFFormat.DATA_FMTS]
     default_compression_settings = {
         'compression' : PZFFormat.DATA_COMP_HUFFCODE,
         'quantization' : PZFFormat.DATA_QUANT_NONE,
@@ -166,11 +174,11 @@ class ClusterBackend(Backend):
     }
 
     def __init__(self, series_name, dim_order='XYCZT', shape=[-1, -1,-1,1,1], distribution_fcn=None, compression_settings={}, 
-                cluster_h5=False, serverfilter=clusterIO.local_serverfilter, **kwargs):
+                cluster_h5=False, serverfilter=clusterIO.local_serverfilter, dtype='uint16', **kwargs):
         from PYME.IO import cluster_streaming
         from PYME.IO import PZFFormat
 
-        Backend.__init__(self, dim_order, shape, spoof_timestamps=kwargs.pop('spoof_timestamps', False), cycle_time=kwargs.pop('cycle_time', None))
+        Backend.__init__(self, dim_order, shape, spoof_timestamps=kwargs.pop('spoof_timestamps', False), cycle_time=kwargs.pop('cycle_time', None), dtype=dtype)
 
         self.series_name = series_name
         self.serverfilter = serverfilter
@@ -256,6 +264,10 @@ class ClusterBackend(Backend):
 
 
 class HDFBackend(Backend):
+
+    supported_dtypes = [np.dtype('uint8'), np.dtype('uint16'), 
+                        np.dtype('float32'), np.dtype('float64')]
+
     def __init__(self, series_name, dim_order='XYCZT', shape=[-1, -1,-1,1,1], complevel=6, complib='zlib', evt_time_fcn=time.time, dtype='uint16', **kwargs):
         """
         Parameters
@@ -268,12 +280,11 @@ class HDFBackend(Backend):
         self.h5File = tables.open_file(series_name, 'w')
         self.mdh = MetaDataHandler.HDFMDHandler(self.h5File)
         self.event_logger = HDFEventLogger(self, self.h5File, time_fcn=self._timestamp)
-        Backend.__init__(self, dim_order, shape, spoof_timestamps=kwargs.pop('spoof_timestamps', False), cycle_time=kwargs.pop('cycle_time', None))
+        Backend.__init__(self, dim_order, shape, spoof_timestamps=kwargs.pop('spoof_timestamps', False), cycle_time=kwargs.pop('cycle_time', None), dtype=dtype)
            
         self._complevel = complevel
         self._complib = complib
         self.series_name = series_name
-        self.dtype = np.dtype(dtype)
         
 
     def store_frame(self, n, frame_data):
@@ -311,8 +322,9 @@ class HDFBackend(Backend):
     
 
 class TiffFolderBackend(Backend):
-    def __init__(self, series_name, dim_order='XYCZT', shape=[-1, -1,-1,1,1],  **kwargs):
-        Backend.__init__(self, dim_order, shape, spoof_timestamps=kwargs.pop('spoof_timestamps', False), cycle_time=kwargs.pop('cycle_time', None))
+    def __init__(self, series_name, dim_order='XYCZT', shape=[-1, -1,-1,1,1], dtype='uint16', **kwargs):
+        Backend.__init__(self, dim_order, shape, spoof_timestamps=kwargs.pop('spoof_timestamps', False), cycle_time=kwargs.pop('cycle_time', None),
+                         dtype=dtype)
 
         self.series_name = series_name
 

--- a/PYME/IO/acquisition_backends.py
+++ b/PYME/IO/acquisition_backends.py
@@ -256,7 +256,13 @@ class ClusterBackend(Backend):
 
 
 class HDFBackend(Backend):
-    def __init__(self, series_name, dim_order='XYCZT', shape=[-1, -1,-1,1,1], complevel=6, complib='zlib', evt_time_fcn=time.time, **kwargs):
+    def __init__(self, series_name, dim_order='XYCZT', shape=[-1, -1,-1,1,1], complevel=6, complib='zlib', evt_time_fcn=time.time, dtype='uint16', **kwargs):
+        """
+        Parameters
+        ----------
+        dtype : str, optional
+            dtype of image data, in PyTables type str format. Default is 'uint16'.
+        """
         import tables
 
         self.h5File = tables.open_file(series_name, 'w')
@@ -267,6 +273,7 @@ class HDFBackend(Backend):
         self._complevel = complevel
         self._complib = complib
         self.series_name = series_name
+        self.dtype = dtype
         
 
     def store_frame(self, n, frame_data):
@@ -275,7 +282,7 @@ class HDFBackend(Backend):
         if n == 0:
             fs = frame_data.squeeze().shape
             filt = tables.Filters(self._complevel, self._complib, shuffle=True)
-            self.imageData = self.h5File.create_earray(self.h5File.root, 'ImageData', tables.UInt16Atom(), (0,fs[0],fs[1]), filters=filt)
+            self.imageData = self.h5File.create_earray(self.h5File.root, 'ImageData', tables.atom.Atom.from_type(self.dtype), (0,fs[0],fs[1]), filters=filt)
 
         if frame_data.shape[0] == 1:
             self.imageData.append(frame_data)


### PR DESCRIPTION
Addresses issue encountered in #1463 and #1551 , which is that PYMEAcquire currently forces uint16. This PR allows cameras to use float (e.g. reading voltages off an NIDaq for my raster scanning project) or different int bit depths. This is split out from #1551 to simplify review.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- add dtype attribute to camera base class
- use camera dtype in frameWrangler
- store dtype as backend_kwarg in `SpoolController`. 
- add dtype as input to `HDFBackend`. Note that `MemoryBackend` already takes dtype as a parameter, and `ClusterBackend` already handles other data types through `PZFFormat.dumps`.
- use numpy min/max in histogram update if we aren't working with uint16



**Notes**

- I have not worked with or tested the tiff acquisition backend.  
- this PR can be tested with the following simulated camera class, which just casts the typical `fakeCam` frames to float.

<details/> <summary/> FakeFloatCamera </summary>

```

class FakeFloatCamera(FakeCamera):
    numpy_frames=1
    order= 'C'
    dtype= 'float32'

    def __init__(self, XVals, YVals, noiseMaker, zPiezo, zOffset=50.0, fluors=None, laserPowers=[0,50], xpiezo=None, ypiezo=None, illumFcn = 'ConstIllum', pixel_size_nm=70.):
        super().__init__(XVals, YVals, noiseMaker, zPiezo, zOffset, fluors, laserPowers, xpiezo=xpiezo, ypiezo=ypiezo, illumFcn=illumFcn, pixel_size_nm=pixel_size_nm)
        self._saturation_threshold = np.finfo(np.float32).max

    def ExtractColor(self, chSlice, mode):
        try:
            d = self.compT.getIm().astype('float32')  # get image from completed computation thread
            # print d.nbytes, chSlice.nbytes
            memcpy(chSlice.ctypes.data_as(ctypes.POINTER(ctypes.c_uint8)),
                   d.ctypes.data_as(ctypes.POINTER(ctypes.c_uint8)), chSlice.nbytes)
            # chSlice[:,:] = d
            # self.compTOld = None #set computation thread to None such that we get an error if we try and obtain the same result twice
        except AttributeError:  # triggered if called with None
            logger.error("Grabbing problem: probably called with 'None' thread")
```

</details>
