### PR TITLE
remove unsupported method from ThorlabsMFF(FilterWheelBase)

### DIFF
--- a/PYME/Acquire/Hardware/thorlabs_mff_flipper.py
+++ b/PYME/Acquire/Hardware/thorlabs_mff_flipper.py
@@ -389,10 +389,6 @@ class ThorlabsMFF(FilterWheelBase):
     def GetPosName(self):
         return self.GetFilterNames()[self.GetCurrentIndex()]
     
-    def SetPosByName(self, position_name):
-        ind = self.position_names.index(position_name)
-        self.SetPos(self.positions[ind])
-    
     def register(self, scope_state):
         scope_state.registerHandler('Flippers.%s.Position' % self.name, 
                                     self._get_physical_position, self._set_physical_position)


### PR DESCRIPTION
SetPosByName was replaced when refactoring to just use the `FilterWheelBase.SetFilterPos` method using the `name` kwarg.

Addresses ThorlabsMFF broken method that doesn't need to be there - sorry.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- remove SetPosByName method, which is non-op anyway because SetPos method doesn't exist.






**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
