### PR TITLE
make sure initial slider range isn't [0, 0] when camera integ time is < 1 ms

### DIFF
--- a/PYME/Acquire/ui/intsliders.py
+++ b/PYME/Acquire/ui/intsliders.py
@@ -140,6 +140,7 @@ class IntegrationSliders(wx.Panel):
         c = 1
         
         # slider works in integer ms, ensure at least 1 ms to avoid 0 range error
+        # TODO - do we need to revisit the UI for cameras where you might routinely want to set sub ms exposure times?
         itime = max([1e3*self.scope.state['Camera.IntegrationTime'], 1])
         
         sl = wx.Slider(self, -1, int(itime), 1, int(min(5*itime, 10000)), size=wx.Size(100,-1),style=wx.SL_HORIZONTAL)#|wx.SL_AUTOTICKS)#|wx.SL_LABELS)

--- a/PYME/Acquire/ui/intsliders.py
+++ b/PYME/Acquire/ui/intsliders.py
@@ -139,8 +139,8 @@ class IntegrationSliders(wx.Panel):
         #for c in range(nsliders):
         c = 1
         
-        itime = 1e3*self.scope.state['Camera.IntegrationTime']
-
+        # slider works in integer ms, ensure at least 1 ms to avoid 0 range error
+        itime = max([1e3*self.scope.state['Camera.IntegrationTime'], 1])
         
         sl = wx.Slider(self, -1, int(itime), 1, int(min(5*itime, 10000)), size=wx.Size(100,-1),style=wx.SL_HORIZONTAL)#|wx.SL_AUTOTICKS)#|wx.SL_LABELS)
         


### PR DESCRIPTION
Addresses `IntegrationSliders` init issue if camera loads up with an integration time < 1 ms. At that point, an attempt is currently made to instantiate a slider with min 0, max 0, position 0, which fails. This is due to the int base of the slider, and e.g. int(0.9)->0

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- make sure the `itime` used to create the slider has a value of at least 1 [ms] so the slider has a non-zero range.

**alternative**
- if we are stuck with int for the sliders, would be worth considering moving to base us in the `IntegrationSliders` class