### PR TITLE
remove win32api in getUsername

### DIFF
--- a/PYME/IO/FileUtils/nameUtils.py
+++ b/PYME/IO/FileUtils/nameUtils.py
@@ -33,13 +33,13 @@ seps = re.compile('[\\\\/*]')
 
 def getUsername():
     """
-    Returns the user name in a platform independant way
+    Returns the user name in a platform dependant way: Windows users get underscores
+    to replace spaces for potential sample database backwards compatibility.
     """
+    import getpass
     if sys.platform == 'win32':
-        import win32api
-        return '_'.join(win32api.GetUserName().split(' '))
+        return '_'.join(getpass.getuser().split(' '))
     else: # OSX / linux
-        import getpass
         #return os.getlogin() #broken when not runing from command line
         #return os.environ.get('USER', 'nobody')
         return getpass.getuser()


### PR DESCRIPTION
Addresses issue #1623.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
remove win32api call in fileUtils.nameUtils. I left the space-to-underscore conversion under windows just in case someone is relying on that for sampleDB calls. 

Only other win32api call in the repo is in `fortran_interrupt_defeat.py` which I haven't looked into much but would appear to be bitrot from an old (py2?) scipy stats workaround.




**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
