### PR TITLE
fix for BufferedDataSource triggering TypeError 0d with numpy >= 2.4

### DIFF
--- a/PYME/IO/DataSources/BufferedDataSource.py
+++ b/PYME/IO/DataSources/BufferedDataSource.py
@@ -51,7 +51,8 @@ class DataSource(XYZTCDataSource): #buffer our io to avoid decompressing multipl
             if ind in self.bufferedSlices: #return from buffer
                 #print int(numpy.where(self.bufferedSlices == ind)[0])
                 #print self.bufferedSlices
-                ret = self.buffer[int(numpy.where(self.bufferedSlices == ind)[0]), :, :].copy()
+                # add explicit squeeze to hopefully ensure 0d (required for int conversion with numpy >= 2.4 or so)
+                ret = self.buffer[int(numpy.where(self.bufferedSlices == ind)[0].squeeze()), :, :].copy()
                 #print 'buf'
             else: #get from our data source and store in buffer
                 sl = self.dataSource.getSlice(ind)

--- a/PYME/IO/DataSources/BufferedDataSource.py
+++ b/PYME/IO/DataSources/BufferedDataSource.py
@@ -52,6 +52,7 @@ class DataSource(XYZTCDataSource): #buffer our io to avoid decompressing multipl
                 #print int(numpy.where(self.bufferedSlices == ind)[0])
                 #print self.bufferedSlices
                 # add explicit squeeze to hopefully ensure 0d (required for int conversion with numpy >= 2.4 or so)
+                # TODO? np.where is notoriously slow. Is there a better way of managing the index? Probably doesn't matter if we keep buffer sizes small (say < 50 frames).
                 ret = self.buffer[int(numpy.where(self.bufferedSlices == ind)[0].squeeze()), :, :].copy()
                 #print 'buf'
             else: #get from our data source and store in buffer


### PR DESCRIPTION
Addresses issue #1631.

**Is this a bugfix or an enhancement?**
Bugfix.


**Proposed changes:**
Add `squeeze` call to ensure 0D array.

**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]
