### PR TITLE
Fix recipe tab only displaying in 1/4 of window size on macOS issue

### DIFF
--- a/PYME/contrib/wxPlotPanel.py
+++ b/PYME/contrib/wxPlotPanel.py
@@ -83,16 +83,18 @@ flag, and the actual resizing of the figure is triggered by an Idle event."""
     def _SetSize( self ):
         pixels = tuple( self.GetClientSize() )
 
-        # currently just a hack which (somehow) achieves that
-        # the 'Pipeline Recipe' Tab scales properly with post 3.6 (3.8+?) matplotlib on macOS high DPI displays
+        # currently mainly a hack which (somehow) achieves that
+        # the 'Pipeline Recipe' Tab scales properly with > 3.8.X (3.10.X+?) matplotlib
+        # on macOS high DPI displays
         # (without it the 'Pipeline Recipe' plot is only a quarter of the canvas size on
-        #     macOS high DPI displays and matplotlib>=3.8)
-        # hack seems to work fine with matplotlib <= 3.6
-        # needs testing on windows
+        #     macOS high DPI displays and matplotlib>=3.10)
+        # hack seems to work fine with matplotlib <= 3.8 as dpi seems firm on 100.0
+        # tests ok on windows as well
         logger.debug("pixels[0] %d" % pixels[0])
         logger.debug("dpi %.1f" % self.figure.get_dpi())
+
         dpi = self.figure.get_dpi()
-        if dpi == 200.0: # bad hack for now
+        if abs(dpi - 200.0) < 0.5: # bad hack for now; now a little more robust in comparison
             dpi = 100.0
 
         if not tuple(self.canvas.GetSize()) == pixels:

--- a/PYME/contrib/wxPlotPanel.py
+++ b/PYME/contrib/wxPlotPanel.py
@@ -17,6 +17,9 @@ matplotlib.interactive( True )
 import numpy as num
 import wx
 
+import logging
+logger = logging.getLogger(__name__)
+
 class PlotPanel (wx.Panel):
     """The PlotPanel has a Figure and a Canvas. OnSize events simply set a
 flag, and the actual resizing of the figure is triggered by an Idle event."""
@@ -79,11 +82,24 @@ flag, and the actual resizing of the figure is triggered by an Idle event."""
 
     def _SetSize( self ):
         pixels = tuple( self.GetClientSize() )
+
+        # currently just a hack which (somehow) achieves that
+        # the 'Pipeline Recipe' Tab scales properly with post 3.6 (3.8+?) matplotlib on macOS high DPI displays
+        # (without it the 'Pipeline Recipe' plot is only a quarter of the canvas size on
+        #     macOS high DPI displays and matplotlib>=3.8)
+        # hack seems to work fine with matplotlib <= 3.6
+        # needs testing on windows
+        logger.debug("pixels[0] %d" % pixels[0])
+        logger.debug("dpi %.1f" % self.figure.get_dpi())
+        dpi = self.figure.get_dpi()
+        if dpi == 200.0: # bad hack for now
+            dpi = 100.0
+
         if not tuple(self.canvas.GetSize()) == pixels:
             self.SetSize( pixels )
             self.canvas.SetSize( pixels )
-            self.figure.set_size_inches( float( pixels[0] )/self.figure.get_dpi(),
-                                         float( pixels[1] )/self.figure.get_dpi() )
+            self.figure.set_size_inches( float( pixels[0] )/dpi,
+                                         float( pixels[1] )/dpi )
             try:
                 if self.IsShownOnScreen():
                     self.draw()

--- a/PYME/contrib/wxPlotPanel.py
+++ b/PYME/contrib/wxPlotPanel.py
@@ -83,7 +83,7 @@ flag, and the actual resizing of the figure is triggered by an Idle event."""
     def _SetSize( self ):
         pixels = tuple( self.GetClientSize() )
 
-        # currently mainly a hack which (somehow) achieves that
+        # currently mainly a hack which forces the "calculation dpi" to 100 and achieves that
         # the 'Pipeline Recipe' Tab scales properly with > 3.8.X (3.10.X+?) matplotlib
         # on macOS high DPI displays
         # (without it the 'Pipeline Recipe' plot is only a quarter of the canvas size on
@@ -94,7 +94,7 @@ flag, and the actual resizing of the figure is triggered by an Idle event."""
         logger.debug("dpi %.1f" % self.figure.get_dpi())
 
         dpi = self.figure.get_dpi()
-        if abs(dpi - 200.0) < 0.5: # bad hack for now; now a little more robust in comparison
+        if abs(dpi - 100.0) > 0.5: # force dpi value for calculation to 100
             dpi = 100.0
 
         if not tuple(self.canvas.GetSize()) == pixels:

--- a/PYME/contrib/wxPlotPanel.py
+++ b/PYME/contrib/wxPlotPanel.py
@@ -83,19 +83,21 @@ flag, and the actual resizing of the figure is triggered by an Idle event."""
     def _SetSize( self ):
         pixels = tuple( self.GetClientSize() )
 
-        # currently mainly a hack which forces the "calculation dpi" to 100 and achieves that
-        # the 'Pipeline Recipe' Tab scales properly with > 3.8.X (3.10.X+?) matplotlib
-        # on macOS high DPI displays
-        # (without it the 'Pipeline Recipe' plot is only a quarter of the canvas size on
-        #     macOS high DPI displays and matplotlib>=3.10)
-        # hack seems to work fine with matplotlib <= 3.8 as dpi seems firm on 100.0
-        # tests ok on windows as well
-        logger.debug("pixels[0] %d" % pixels[0])
-        logger.debug("dpi %.1f" % self.figure.get_dpi())
+        # matplotlib dpi calculation seems to be *odd* (historically dpi seems to have been fixed to 100 for gui plots, 
+        # this has changed with recent (>3.8.X) releases on high dpi displays, but it seems that the
+        # change is only partial, so get_dpi is no longer a good reflection of how the figure
+        # scaling will actually be performed. This is likely a matplotlib bug.
+        # Workaround for now is to fix dpi we use for scaling to 100, but there is a fair chance this will
+        # break again if the matplotlib bug gets fixed.
+        
+        # TODO - keep an eye on this with new matplotlib versions
+        
+        # TODO - what happens if we call set_dpi() on the figure (potentially important if we plan both dsplaying
+        # and printing/exporting the figure).
 
-        dpi = self.figure.get_dpi()
-        if abs(dpi - 100.0) > 0.5: # force dpi value for calculation to 100
-            dpi = 100.0
+        # dpi = self.figure.get_dpi()
+        # force dpi value for calculation to 100
+        dpi = 100.0
 
         if not tuple(self.canvas.GetSize()) == pixels:
             self.SetSize( pixels )


### PR DESCRIPTION
Addresses issue #1627 .

**Is this a bugfix or an enhancement?**
Bugfix.

**Proposed changes:**
Force effective dpi for calculation to 100 in `wxPlotPanel._SetSize()`. By inspection it is backwards compatible with older matplolibs.

**Rationale**
The fix could be regarded as a hack.

In defence of this approach:

1. It works and changes working in the recipe tab on macOS with high DPI from unworkable to very nice (recent numpy backends support dpi=200 by default which gives nice high res on such monitors including the retina displays).
2. The original calculation and implementation may be a hack anyway, if you change the DPI by request to anything other than 100 (e.g. using `rcParams`) the plot in the wxWindow gets screwed up, either too small or too big. So then why not force it to 100 for the sake of the calculation.
3. Happy if somebody comes up with a better solution. The PR includes `logger.debug` calls so you see what is going on if future issues were to arise.



**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]
