### PR TITLE
PYMEImage half-pixel display fix

### DIFF
--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -457,7 +457,8 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
 
         
         im2 = wx_compat.BitmapFromImage(im)
-        dc.DrawBitmap(im2,int(-sc2/2),int(-sc2/2))
+        # dc.DrawBitmap(im2,int(-sc2/2),int(-sc2/2))  # starts from the center of the ulc pixel, which is weird
+        dc.DrawBitmap(im2, 0, 0)  # starts from the edge of the ulc pixel, which displays the entire image
         
         self._draw_selection(self, dc) 
         self._draw_contours(self, dc)

--- a/PYME/DSView/overlays.py
+++ b/PYME/DSView/overlays.py
@@ -264,15 +264,16 @@ class CrosshairsOverlay(Overlay):
             sX, sY = vp.imagepanel.Size
             
             dc.SetPen(wx.Pen(wx.CYAN,1))
+            # 0.5 pixel offset is to draw through center of pixels
             if(vp.do.slice == vp.do.SLICE_XY):
-                lx = vp.do.xp
-                ly = vp.do.yp
+                lx = vp.do.xp + 0.5
+                ly = vp.do.yp + 0.5
             elif(vp.do.slice == vp.do.SLICE_XZ):
-                lx = vp.do.xp
-                ly = vp.do.zp
+                lx = vp.do.xp + 0.5
+                ly = vp.do.zp + 0.5
             elif(vp.do.slice == vp.do.SLICE_YZ):
-                lx = vp.do.yp
-                ly = vp.do.zp
+                lx = vp.do.yp + 0.5
+                ly = vp.do.zp + 0.5
         
             
             xc, yc = vp.pixel_to_screen_coordinates(lx, ly)            


### PR DESCRIPTION
Addresses issue of drawing array view from the center of the ulc pixel, rather than from the edge. With my stage-scanning stuff it is more noticable than normal since I'm looking at small images more often than not.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- start drawing from the edge of the ulc pixel in arrayview
- shift the crosshair lines to draw through the center of the pixel



Left: previous behavior, Right: behavior of this PR
<img width="474" height="343" alt="image" src="https://github.com/user-attachments/assets/cf53e02d-f2d7-4158-a13a-c0620012d0e8" />



**Checklist:**
- [ ] Are there any other side effects of the change?
I don't immediately know if there are other side effects to this change. The pixel hit seems to be the same (i.e. x: X, y: Y) display at the bottom is still functioning correctly.
I have not checked XZ or YZ projections, in part because that is erroring for my test dataset anyway pre-fix
