### PR TITLE
fix for pyproject.toml to add pywin32 dependence iff on win

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "pymecompress>=0.2.0",
   "six",
   "future",
-  #"pywin32 [win]"
+  "pywin32; platform_system=='Windows'",
   "blosc", 
   "django>=2.1",
   #"mpld3", #TODO - optional?


### PR DESCRIPTION
Addresses issue #1623 .

**Is this a bugfix or an enhancement?**
bugfix

**Proposed changes:**

Just implements the syntax to add `pywin32` if and only if on windows. Already tested with `PYME-extra` and confirmed to work as advertised.

Should probably be regarded regardless of (and in addition to) #1630 for the reasons stated there.

Would also be good if outstanding PRs could be looked at at some stage, and new release be made + updated PyPi packages + zenodo archiving of releases. We are readying 1 or 2 publications and it would be good to be able to include references to zenodo and PyPi. Sorry for asking, if we can help somehow would be happy to do so.
