### PR TITLE
fix test breaks in spherical_harmonics w/ numpy 2+, scipy 1.16+

### DIFF
--- a/PYME/Analysis/points/spherical_harmonics.py
+++ b/PYME/Analysis/points/spherical_harmonics.py
@@ -798,7 +798,7 @@ class ScaledShell(object):
         errors = np.zeros_like(guess_distances)
         # guess = guess_distances[np.argmin(np.abs(self._distance_error(guess_distances, starting_point, vector)))]
         for ind, query in enumerate(guess_distances):
-            errors[ind] = self._distance_error(query, vector, starting_point)
+            errors[ind] = float(np.squeeze(self._distance_error(query, vector, starting_point)))
 
         return guess_distances[np.argmin(np.abs(errors))]
     

--- a/PYME/Analysis/points/spherical_harmonics.py
+++ b/PYME/Analysis/points/spherical_harmonics.py
@@ -4,7 +4,15 @@ Initial fitting/conversions ripped 100% from David Baddeley / scipy
 """
 from PYME.IO.image import ImageBounds
 import numpy as np
-from scipy.special import sph_harm
+try:
+    # scipy >= 1.15, use sph_harm_y with swapped arg order.
+    from scipy.special import sph_harm_y
+    def sph_harm(m, n, azimuth, zenith):
+        # sph_harm(m, n, azimuth, zenith)  ->  sph_harm_y(n, m, zenith, azimuth)
+        return sph_harm_y(n, m, zenith, azimuth)
+except ImportError:
+    # scipy < 1.15
+    from scipy.special import sph_harm
 from scipy import linalg
 from PYME.Analysis.points import coordinate_tools
 from scipy import optimize

--- a/PYME/Analysis/points/spherical_harmonics.py
+++ b/PYME/Analysis/points/spherical_harmonics.py
@@ -429,7 +429,8 @@ class ScaledShell(object):
         self._fitting_point_bounds = ImageBounds(self.x.min(), self.y.min(),
                                                  self.x.max(), self.y.max(),
                                                  self.z.min(), self.z.max())
-        self.x0, self.y0, self.z0 = self.x.mean(), self.y.mean(), self.z.mean()
+        # Store float64 so arithmetic with COM remains high precision in numpy >= 2.0
+        self.x0, self.y0, self.z0 = float(self.x.mean()), float(self.y.mean()), float(self.z.mean())
 
         self.x_c, self.y_c, self.z_c = self.x - self.x0, self.y - self.y0, self.z - self.z0
 


### PR DESCRIPTION
Addresses issue test_spherical_harmonics multiple failures.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- use sph_harm_y on scipy versions without sph_harm by wrapping and swapping arg order
- cast single element arrays to scalar for assignment on numpy 2
- store fitter center of mass coordinates as float64 so they stay high precision. Fixes kind of a nasty error in normal approximation when subtracting two small values which causes us to be off by more than the 3 decimal precision we specify in the unit test







**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [x] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
