### PR TITLE
Fix test-side unit test issues

### DIFF
--- a/tests/PYME/IO/test_dataserver.py
+++ b/tests/PYME/IO/test_dataserver.py
@@ -21,7 +21,13 @@ def setup_module():
     
     if os.path.exists(tmp_root):
         print('Removing existing temp spooler dir')
-        shutil.rmtree(tmp_root)
+        def chmod_readonly(func, path, _):
+            # test writes are read-only, and we need to 
+            # chmod them to writable before we can delete them
+            import stat
+            os.chmod(path, stat.S_IWRITE)
+            func(path)
+        shutil.rmtree(tmp_root, onerror=chmod_readonly)
         
     os.makedirs(tmp_root)
     proc = subprocess.Popen([sys.executable, '-m', 'PYME.cluster.HTTPDataServer',  '-r', tmp_root, '-f', 'TES1', '-a', 'local'])

--- a/tests/PYME/IO/test_dataserver.py
+++ b/tests/PYME/IO/test_dataserver.py
@@ -39,7 +39,8 @@ def setup_module():
     
 def teardown_module():
     global proc, tmp_root
-    proc.send_signal(signal.SIGINT)
+    sig = signal.SIGINT if sys.platform != 'win32' else signal.CTRL_BREAK_EVENT
+    proc.send_signal(sig)
     time.sleep(5)
     proc.kill()
     

--- a/tests/PYME/IO/test_h5.py
+++ b/tests/PYME/IO/test_h5.py
@@ -93,5 +93,5 @@ def test_h5r():
     
         assert (np.allclose(data['x'], inp['x']))
     finally:
-        shutil.rmtree(tempdir, ignore_errors=True)
+        shutil.rmtree(tempdir)
     

--- a/tests/PYME/IO/test_h5.py
+++ b/tests/PYME/IO/test_h5.py
@@ -93,5 +93,11 @@ def test_h5r():
     
         assert (np.allclose(data['x'], inp['x']))
     finally:
-        shutil.rmtree(tempdir)
+        def wait_for_keepalive(func, path, exc_info):
+            import time
+            from PYME.IO.h5rFile import H5RFile
+            time.sleep(H5RFile.KEEP_ALIVE_TIMEOUT + 1)
+            func(path)
+        # we can't delete the file until the thread releases it, so wait for the keep alive timeout
+        shutil.rmtree(tempdir, onerror=wait_for_keepalive)
     

--- a/tests/PYME/IO/test_h5.py
+++ b/tests/PYME/IO/test_h5.py
@@ -93,5 +93,5 @@ def test_h5r():
     
         assert (np.allclose(data['x'], inp['x']))
     finally:
-        shutil.rmtree(tempdir)
+        shutil.rmtree(tempdir, ignore_errors=True)
     

--- a/tests/PYME/experimental/test_triangle_mesh.py
+++ b/tests/PYME/experimental/test_triangle_mesh.py
@@ -43,7 +43,7 @@ PRE_FLIP_H_FACE = np.array([0,0,1,1,0,1])
 PRE_FLIP_H_TWIN = np.array([-1,-1,4,-1,2,-1])
 PRE_FLIP_H_NEXT = np.array([1,4,3,5,0,2])
 PRE_FLIP_H_PREV = np.array([4,0,5,2,1,3])
-PRE_FLIP_NEIGHBORS = np.array([[1,3],[0,2,3],[1,3],[0,1,2]])
+PRE_FLIP_NEIGHBORS = np.array([[1,3],[0,2,3],[1,3],[0,1,2]], dtype=object)
 
 POST_FLIP_FACES = np.array([[2,0,1],[0,2,3]])
 POST_FLIP_H_VERTEX = np.array([0,0,1,2,2,3])
@@ -51,7 +51,7 @@ POST_FLIP_H_FACE = np.array([0,1,0,0,1,1])
 POST_FLIP_H_TWIN = np.array([4,-1,-1,-1,0,-1])
 POST_FLIP_H_NEXT = np.array([2,4,3,0,5,1])
 POST_FLIP_H_PREV = np.array([3,5,0,2,1,4])
-POST_FLIP_NEIGHBORS = np.array([[1,2,3],[0,2],[0,1,3],[0,2]])
+POST_FLIP_NEIGHBORS = np.array([[1,2,3],[0,2],[0,1,3],[0,2]], dtype=object)
 
 # Ground truth for pre- and post-split
 PRE_SPLIT_FACES = np.array([[3,0,1],[3,1,2]])
@@ -60,7 +60,7 @@ PRE_SPLIT_H_FACE = np.array([0,0,1,1,0,1])
 PRE_SPLIT_H_TWIN = np.array([-1,-1,4,-1,2,-1])
 PRE_SPLIT_H_NEXT = np.array([1,4,3,5,0,2])
 PRE_SPLIT_H_PREV = np.array([4,0,5,2,1,3])
-PRE_SPLIT_NEIGHBORS = np.array([[1,3],[0,2,3],[1,3],[0,1,2]])
+PRE_SPLIT_NEIGHBORS = np.array([[1,3],[0,2,3],[1,3],[0,1,2]], dtype=object)
 
 POST_SPLIT_FACES = np.array([[4,0,1],[4,1,2],[4,2,3],[3,0,4]])
 POST_SPLIT_H_VERTEX = np.array([0,0,1,1,2,2,3,3,4,4,4,4])
@@ -68,7 +68,7 @@ POST_SPLIT_H_FACE = np.array([0,3,0,1,1,2,2,3,0,1,2,3])
 POST_SPLIT_H_TWIN = np.array([11,-1,-1,8,-1,9,-1,10,3,5,7,0])
 POST_SPLIT_H_NEXT = np.array([2,11,8,4,9,6,10,1,0,3,5,7])
 POST_SPLIT_H_PREV = np.array([8,7,0,9,3,10,5,11,2,4,6,1])
-POST_SPLIT_NEIGHBORS = np.array([[1,3,4],[0,2,4],[1,3,4],[0,2,4],[0,1,2,3]])
+POST_SPLIT_NEIGHBORS = np.array([[1,3,4],[0,2,4],[1,3,4],[0,2,4],[0,1,2,3]], dtype=object)
 
 PRE_SNAP_FACES = np.array([[2,0,1],[1,0,3],[2,1,4],[5,0,2],[8,6,7],[7,6,9],[8,7,10],[11,6,8]])
                             # 0,1, 2,3, 4, 5,6, 7, 8, 9,10,11,12,13,14,15,16,17,18,19,20,21,22,23
@@ -77,7 +77,7 @@ PRE_SNAP_H_FACE =   np.array([0,1, 3,0, 1, 2,0, 2, 3, 1, 2, 3, 4, 5, 7, 4, 5, 6,
 PRE_SNAP_H_TWIN =   np.array([8,3,-1,1,-1, 6,5,-1, 0,-1,-1,-1,20,15,-1,13,-1,18,17,-1,12,-1,-1,-1])
 PRE_SNAP_H_NEXT =   np.array([3,9, 8,6, 1,10,0, 5,11, 4, 7, 2,15,21,20,18,13,22,12,17,23,16,19,14])
 PRE_SNAP_H_PREV =   np.array([6,4,11,0, 9, 7,3,10, 2, 1, 5, 8,18,16,23,12,21,19,15,22,14,13,17,20])
-PRE_SNAP_H_NEIGHBORS = np.array([[1,2,3,5],[0,3,2,4],[0,1,4,5],[0,1],[1,2],[0,2],[7,8,9,11],[6,8,9,10],[6,7,10,11],[6,7],[7,8],[6,8]])
+PRE_SNAP_H_NEIGHBORS = np.array([[1,2,3,5],[0,3,2,4],[0,1,4,5],[0,1],[1,2],[0,2],[7,8,9,11],[6,8,9,10],[6,7,10,11],[6,7],[7,8],[6,8]], dtype=object)
 
 POST_SNAP_FACES = np.array([[1,0,3],[2,1,4],[5,0,2],[7,6,9],[8,7,10],[11,6,8]])
                             #  0,  1,  2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17
@@ -86,7 +86,7 @@ POST_SNAP_H_FACE =   np.array([1,  3,  1, 2, 2, 3, 1, 2, 3, 5, 7, 5, 6, 6, 7, 5,
 POST_SNAP_H_TWIN =   np.array([14,-1, -1,12,-1, 9,-1,-1,-1, 5,-1,-1, 3,-1, 0,-1,-1,-1])
 POST_SNAP_H_NEXT =   np.array([6,  5,  0, 7, 3, 8, 2, 4, 1,15,14, 9,16,12,17,11,13,10])
 POST_SNAP_H_PREV =   np.array([2,  8,  6, 4, 7, 1, 0, 3, 5,11,17,15,13,16,10, 9,12,14])
-POST_SNAP_H_NEIGHBORS = np.array([[1,2,3,5],[ 0,3,2,4],[0,1,4,5],[0,1],[1,2],[0,2],[7,8,9,11],[6,8,9,10],[6,7,10,11],[6,7],[7,8],[6,8]])
+POST_SNAP_H_NEIGHBORS = np.array([[1,2,3,5],[ 0,3,2,4],[0,1,4,5],[0,1],[1,2],[0,2],[7,8,9,11],[6,8,9,10],[6,7,10,11],[6,7],[7,8],[6,8]], dtype=object)
 
 def _generate_vertices(num=4):
     """


### PR DESCRIPTION
Addresses issue not passing tests on Win11 / Python 3.11 / Numpy 2.4.2

### test_h5 issue

- in test_h5r we try to rmtree the temp directory immediately after the test, but the HDFSource's underlying h5rfile (which we don't have a handle for) is kept alive by a thread for ~20 s. This causes us to fail on a PermissionError: [WinError 32] The process cannot access the file because it is being used by another process

### test_dataserver issues

- can't delete read-only files from previous test_dataserver.py runs 
- subproccess.Process.send_signal(SIGINT) on Windows throws an ValueError: Unsupported signal: 2

<img width="664" height="840" alt="image" src="https://github.com/user-attachments/assets/73f6495b-d840-4be5-8e6a-0c2cf6844b5b" />


### test_triangle_mesh issue

- Even though we currently skip test_triangle_mesh, there are errors thrown simply from importing the file on later numpy's. We instantiate some ragged test arrays, which in later numpy's require an explicit object dtype to avoid a ValueError: setting an array element with a sequence. 

# Is this a bugfix or an enhancement?
bugfix

# Proposed changes:

- cast ragged arrays to objects in triangle mesh test
- remove read-only temp files from previous dataserver tests
- terminate subprocess using a signal recognized on windows
- wait for underlying h5rfile to close before trying to delete the temporary HDF file.


# Note:
The h5r test fix is pretty clumpsy since the keep_alive isn't accessible from tabular HDF. Might be nice to add that, or hold a reference to the underlying file so it can be closed in a `__del__` or so

