### PR TITLE
Numpy 2 compatibility

### DIFF
--- a/PYME/IO/DataSources/BGSDataSource.py
+++ b/PYME/IO/DataSources/BGSDataSource.py
@@ -41,7 +41,8 @@ class dataBuffer: #buffer our io to avoid decompressing multiple times
         #return self.dataSource.getSlice(ind)
         if ind in self.bufferedSlices: #return from buffer
             #print int(numpy.where(self.bufferedSlices == ind)[0])
-            return self.buffer[int(np.where(self.bufferedSlices == ind)[0]),:,:]
+            # TODO - consider alternative to numpy.where for speed
+            return self.buffer[int(np.where(self.bufferedSlices == ind)[0].squeeze()),:,:]
         else: #get from our data source and store in buffer
             sl = self.dataSource.getSlice(ind)
             self.bufferedSlices[self.insertAt] = ind

--- a/PYME/IO/PZFFormat.py
+++ b/PYME/IO/PZFFormat.py
@@ -373,9 +373,9 @@ def loads(datastring):
 
         data = data.astype('f')*header['QuantScale']
         #print('data dtype: %s' % data.dtype)
-        data = (data*data + header['QuantOffset']).astype(DATA_FMTS[int(header['DataFormat'])])
+        data = (data*data + header['QuantOffset']).astype(DATA_FMTS[data_format])
     
     #print(dimOrder, [w, h, d])
-    data = data.view(DATA_FMTS[int(header['DataFormat'])]).reshape([w,h,d], order=dimOrder)
+    data = data.view(DATA_FMTS[data_format]).reshape([w,h,d], order=dimOrder)
     
     return data, header

--- a/PYME/IO/PZFFormat.py
+++ b/PYME/IO/PZFFormat.py
@@ -65,12 +65,12 @@ def ChunkedHuffmanCompress(data, quantization=None):
     
     #comp_chunks = compPool.map(bcl.HuffmanCompress, raw_chunks) 
     
-    s = np.array([num_chunks], 'u2').tostring()
+    s = np.array([num_chunks], 'u2').tobytes()
     
     for j, r in enumerate(raw_chunks):
         c = comp_chunk_d[j]
-        s += np.array([len(c), len(r)], 'u4').tostring()
-        s += c.tostring()
+        s += np.array([len(c), len(r)], 'u4').tobytes()
+        s += c.tobytes()
         
     return s
 
@@ -84,11 +84,11 @@ def ChunkedHuffmanCompress_o(data):
     
     comp_chunks = compPool.map(bcl.HuffmanCompress, raw_chunks) 
     
-    s = np.array([num_chunks], 'u2').tostring()
+    s = np.array([num_chunks], 'u2').tobytes()
     
     for c, r in zip(comp_chunks, raw_chunks):
-        s += np.array([len(c), len(r)], 'u4').tostring()
-        s += c.tostring()
+        s += np.array([len(c), len(r)], 'u4').tobytes()
+        s += c.tobytes()
         
     return s
 
@@ -271,10 +271,10 @@ def dumps(data, sequenceID=0, frameNum=0, frameTimestamp=0, compression = DATA_C
         header['DataCompression'] = DATA_COMP_HUFFCODE
 
         if quantization:
-            dataString = bcl.HuffmanCompressQuant(d1, quantizationOffset, quantizationScale).tostring()
+            dataString = bcl.HuffmanCompressQuant(d1, quantizationOffset, quantizationScale).tobytes()
         else:
             d2 = bcl.HuffmanCompress(d1)
-            dataString = d2.tostring()
+            dataString = d2.tobytes()
     elif compression == DATA_COMP_HUFFCODE_CHUNKS:
         header['DataCompression'] = DATA_COMP_HUFFCODE_CHUNKS
         
@@ -282,9 +282,9 @@ def dumps(data, sequenceID=0, frameNum=0, frameTimestamp=0, compression = DATA_C
     else:
         #print('saving raw')
         #print(header['DimOrder'][0])
-        dataString = d1.tostring(order=header['DimOrder'][0])
+        dataString = d1.tobytes(order=header['DimOrder'][0])
         
-    return header.tostring() + dataString
+    return header.tobytes() + dataString
  
 
 def load_header(datastring):

--- a/PYME/IO/PZFFormat.py
+++ b/PYME/IO/PZFFormat.py
@@ -94,10 +94,11 @@ def ChunkedHuffmanCompress_o(data):
 
 def _chunkDecompress(args):
     chunk, length = args
-    return bcl.HuffmanDecompress(np.fromstring(chunk, 'u1'), length)
+    # .copy() to ensure the buffer isn't read-only
+    return bcl.HuffmanDecompress(np.frombuffer(chunk, 'u1').copy(), length)
     
 def ChunkedHuffmanDecompress(datastring):
-    num_chunks = np.fromstring(datastring[:2], 'u2')
+    num_chunks = np.frombuffer(datastring[:2], 'u2')
     
     #compPool = ThreadPool(NUM_COMP_THREADS)
     
@@ -105,7 +106,7 @@ def ChunkedHuffmanDecompress(datastring):
     
     comp_chunks = []
     for i in range(num_chunks):
-        chunk_len, raw_len = np.fromstring(datastring[sp:(sp+8)], 'u4')
+        chunk_len, raw_len = np.frombuffer(datastring[sp:(sp+8)], 'u4')
         sp += 8
         comp_chunks.append((datastring[sp:(sp+ chunk_len)], raw_len))
         sp += chunk_len
@@ -289,9 +290,9 @@ def dumps(data, sequenceID=0, frameNum=0, frameTimestamp=0, compression = DATA_C
 
 def load_header(datastring):
     if (_ord(datastring[2]) >= 3):
-        return np.fromstring(datastring[:HEADER_LENGTH_V3], header_dtype_v3)
+        return np.frombuffer(datastring[:HEADER_LENGTH_V3], header_dtype_v3)
     else:
-        return np.fromstring(datastring[:HEADER_LENGTH], header_dtype)
+        return np.frombuffer(datastring[:HEADER_LENGTH], header_dtype)
 
    
 def loads(datastring):
@@ -351,7 +352,8 @@ def loads(datastring):
         data = np.fromstring(data_s, 'u1')
     elif header['DataCompression'] == DATA_COMP_HUFFCODE:
         #logging.debug('Decompressing ...')
-        data = bcl.HuffmanDecompress(np.fromstring(data_s, 'u1'), outsize)
+        # need to copy else buffer source will be read only
+        data = bcl.HuffmanDecompress(np.frombuffer(data_s, 'u1').copy(), outsize)
     elif header['DataCompression'] == DATA_COMP_HUFFCODE_CHUNKS:
         data = ChunkedHuffmanDecompress(data_s)
     else:

--- a/PYME/IO/PZFFormat.py
+++ b/PYME/IO/PZFFormat.py
@@ -328,17 +328,21 @@ def loads(datastring):
         
     w, h, d = header['Width'][0], header['Height'][0], header['Depth'][0]
 
-    if header['DataQuantization'] == DATA_QUANT_SQRT:
+    data_format = int(header['DataFormat'][0])
+    data_compression = int(header['DataCompression'][0])
+    data_quantization = int(header['DataQuantization'][0])
+
+    if data_quantization == DATA_QUANT_SQRT:
         #quantized data is always 8 bit
         outsize = w * h * d
     else:
-        outsize = w*h*d*DATA_FMTS_SIZES[int(header['DataFormat'])]
+        outsize = w*h*d*DATA_FMTS_SIZES[data_format]
     
     
     if header['Version'] < 3:
         data_offset = HEADER_LENGTH
     else:
-        data_offset = int(header['DataOffset'])
+        data_offset = int(header['DataOffset'][0])
         
     data_s = datastring[data_offset:]
 
@@ -347,21 +351,21 @@ def loads(datastring):
 
     #logging.debug('Compressed size: %s' % len(data_s))
     
-    if header['DataCompression'] == DATA_COMP_RAW:
+    if data_compression == DATA_COMP_RAW:
         #no need to decompress
         data = np.frombuffer(data_s, 'u1')
-    elif header['DataCompression'] == DATA_COMP_HUFFCODE:
+    elif data_compression == DATA_COMP_HUFFCODE:
         #logging.debug('Decompressing ...')
         # need to copy else buffer source will be read only
         data = bcl.HuffmanDecompress(np.frombuffer(data_s, 'u1').copy(), outsize)
-    elif header['DataCompression'] == DATA_COMP_HUFFCODE_CHUNKS:
+    elif data_compression == DATA_COMP_HUFFCODE_CHUNKS:
         data = ChunkedHuffmanDecompress(data_s)
     else:
         raise RuntimeError('Compression type not understood')
 
     #logging.debug('Uncompressed shape: %s, %s, (%d, %d, %d)' % (data.shape, w * h * d, w, h, d))
         
-    if header['DataQuantization'] == DATA_QUANT_SQRT:
+    if data_quantization == DATA_QUANT_SQRT:
         #un-quantize data
         #logging.debug('Dequantizing')
         

--- a/PYME/IO/PZFFormat.py
+++ b/PYME/IO/PZFFormat.py
@@ -349,7 +349,7 @@ def loads(datastring):
     
     if header['DataCompression'] == DATA_COMP_RAW:
         #no need to decompress
-        data = np.fromstring(data_s, 'u1')
+        data = np.frombuffer(data_s, 'u1')
     elif header['DataCompression'] == DATA_COMP_HUFFCODE:
         #logging.debug('Decompressing ...')
         # need to copy else buffer source will be read only

--- a/PYME/IO/buffer_helpers.pyx
+++ b/PYME/IO/buffer_helpers.pyx
@@ -6,7 +6,7 @@ cimport numpy as np
 # We now need to fix a datatype for our arrays. I've used the variable
 # DTYPE for this, which is assigned to the usual NumPy runtime
 # type info object.
-DTYPE = np.int
+DTYPE = np.int64
 # "ctypedef" assigns a corresponding compile-time type to DTYPE_t. For
 # every type in the numpy module there's a corresponding compile-time
 # type with a _t-suffix.

--- a/PYME/localization/FitFactories/Interpolators/CSInterpolator.py
+++ b/PYME/localization/FitFactories/Interpolators/CSInterpolator.py
@@ -50,7 +50,7 @@ class CSInterpolator(__interpolator):
 
         ox = X[0] - 0.5*self.PSF2Offset
         oy = Y[0]
-        oz = Z #[0]
+        oz = Z[0]
 
         #rx = (ox % self.dx)/self.dx
         #ry = (oy % self.dy)/self.dy
@@ -87,7 +87,7 @@ class CSInterpolator(__interpolator):
 
         ox = X[0] - 0.5*self.PSF2Offset
         oy = Y[0]
-        oz = Z #[0]
+        oz = Z[0]
 
         #rx = (ox % self.dx)/self.dx
         #ry = (oy % self.dy)/self.dy

--- a/PYME/localization/FitFactories/Interpolators/LinearInterpolator.py
+++ b/PYME/localization/FitFactories/Interpolators/LinearInterpolator.py
@@ -43,7 +43,7 @@ class LinearInterpolator(__interpolator):
 
         ox = X[0] - 0.5*self.PSF2Offset
         oy = Y[0]
-        oz = Z #[0]
+        oz = Z[0]
 
         #rx = (ox % self.dx)/self.dx
         #ry = (oy % self.dy)/self.dy
@@ -76,7 +76,7 @@ class LinearInterpolator(__interpolator):
 
         ox = X[0]
         oy = Y[0]
-        oz = Z #[0]
+        oz = Z[0]
 
         #rx = (ox % self.dx)/self.dx
         #ry = (oy % self.dy)/self.dy

--- a/PYME/localization/FitFactories/Interpolators/LinearInterpolator.py
+++ b/PYME/localization/FitFactories/Interpolators/LinearInterpolator.py
@@ -21,7 +21,7 @@
 #
 ################
 from .baseInterpolator import __interpolator
-from numpy import *
+import numpy as np
 from PYME.localization.cInterp import cInterp
 
 class LinearInterpolator(__interpolator):
@@ -29,7 +29,7 @@ class LinearInterpolator(__interpolator):
         """function which is called after model loading and can be
         overridden to allow for interpolation specific precomputations"""
          #compute the gradient of the PSF for interpolated jacobians
-        self.gradX, self.gradY, self.gradZ = gradient(self.interpModel)
+        self.gradX, self.gradY, self.gradZ = np.gradient(self.interpModel)
         self.gradX /= self.dx
         self.gradY /= self.dy
         self.gradZ /= self.dz
@@ -104,9 +104,9 @@ class LinearInterpolator(__interpolator):
         """placeholder to be overrriden to return coordinates needed for interpolation"""
         #generate grid to evaluate function on
         vs = metadata.voxelsize_nm
-        X = vs.x*mgrid[xslice]
-        Y = vs.y*mgrid[yslice]
-        Z = array([0]).astype('f')
+        X = vs.x*np.mgrid[xslice]
+        Y = vs.y*np.mgrid[yslice]
+        Z = np.array([0]).astype('f')
         
         
 

--- a/PYME/localization/FitFactories/SplitterFitInterpBNR.py
+++ b/PYME/localization/FitFactories/SplitterFitInterpBNR.py
@@ -78,12 +78,12 @@ def f_J_Interp3d2c(p,interpolator, Xg, Yg, Zg, Xr, Yr, Zr, safeRegion, axialShif
     y0 = min(max(y0, safeRegion[1][0]), safeRegion[1][1])
     z0 = min(max(z0, safeRegion[2][0] + axialShift), safeRegion[2][1] - axialShift)
 
-    g = interpolator.interp(Xg - x0 + 1, Yg - y0 + 1, Zg[0] - z0 + 1)
-    r = interpolator.interp(Xr - x0 + 1, Yr - y0 + 1, Zr[0] - z0 + 1)
-    
-    gx, gy, gz = interpolator.interpG(Xg - x0 + 1, Yg - y0 + 1, Zg[0] - z0 + 1)
-    rx, ry, rz = interpolator.interpG(Xr - x0 + 1, Yr - y0 + 1, Zr[0] - z0 + 1)
-    
+    g = interpolator.interp(Xg - x0 + 1, Yg - y0 + 1, Zg - z0 + 1)
+    r = interpolator.interp(Xr - x0 + 1, Yr - y0 + 1, Zr - z0 + 1)
+
+    gx, gy, gz = interpolator.interpG(Xg - x0 + 1, Yg - y0 + 1, Zg - z0 + 1)
+    rx, ry, rz = interpolator.interpG(Xr - x0 + 1, Yr - y0 + 1, Zr - z0 + 1)
+
     bg = np.ones_like(gx)
     zb = np.zeros_like(gx)
     


### PR DESCRIPTION
Addresses issue failing tests:
- \tests\PYME\IO\test_pzf.py
- \tests\PYME\localization\FitFactories\Interpolators\test_interpolators.py
- \tests\PYME\test_imports.py
- me opening an h5 file in PYMEImage 

**Is this a bugfix or an enhancement?**
compatibility enhancement / bugfix for later numpy
**Proposed changes:**

# PZFFormat.py

- switch numpy.fromstring (deprecated alternative) to numpy.frombuffer. 
-- copy buffers which are passed to bcl.HuffmanDecompress where we need it to be writable (otherwise we get ValueError: buffer source array is read-only)
- use tobytes instead of [its deprecated/removed alias tostring
](https://numpy.org/doc/2.1/reference/generated/numpy.ndarray.tostring.html)
- index 0-dimensional arrays from the header


# buffer_helpers.pyx

- remove deprecated/removed numpy.int in favor of int64 (which here matches the int64_t type being used)

# CSInterpolator.py

- index 0 dimensional array Z position.

# LinearInterpolator

- index 0 dimensional array Z position
- change numpy import so we don't clobber the built-in `min` method. This might seem superfluous, but is a clean fix to the current error on later numpy around the `dx = min(int((interpolator.shape[1] - len(X))/2), xm) - 2` lines. These otherwise blow up on a `numpy.exceptions.AxisError: axis 5 is out of bounds for array of dimension 0`. 

# BGSDataSource

- same squeeze fix as #1632, otherwise opening an h5 file in PYMEImage fails

# Notes
- I have only tested with unit tests, and opening PYMEImage / running a test frame localization.