### PR TITLE
permission error fix in test_cluster_spooler.py teardown

### DIFF
--- a/tests/PYME/IO/test_cluster_spooler.py
+++ b/tests/PYME/IO/test_cluster_spooler.py
@@ -38,8 +38,11 @@ def teardown_module():
         proc.kill()
         
     print('Killed all servers')
-    
-    shutil.rmtree(tmp_root)
+    def _wait_for_poll_exit(func, path, _):
+        # wait for the server process to exit and release the file lock before we try to delete the spooler dir
+        import time
+        time.sleep(1)
+    shutil.rmtree(tmp_root, onerror=_wait_for_poll_exit)
     
     
 


### PR DESCRIPTION
Addresses issue test passes, but in teardown the servers need a slight delay to close before releasing the temporary directory for deletion. Also works with a 0.1 s delay on my machine, but just to be safe... left it at 1 s.

<img width="596" height="1111" alt="image" src="https://github.com/user-attachments/assets/5b351532-4c64-4c4c-a0b5-0ddadc5f3f91" />






**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
