### PR TITLE
Show h5 files as complete series on Windows

### DIFF
--- a/PYME/IO/clusterListing.py
+++ b/PYME/IO/clusterListing.py
@@ -59,7 +59,7 @@ except ImportError: # coundir module is posix only, fall back to more naive meth
             return (fn + '/',  FileInfo(ftype, dirsize(fpath)))
         
         elif fpath.endswith('.h5'):
-            return (fn, FileInfo(FILETYPE_SERIES, os.path.getsize(fpath)))
+            return (fn, FileInfo(FILETYPE_SERIES|FILETYPE_SERIES_COMPLETE, os.path.getsize(fpath)))
         else:
             return (fn,  FileInfo(FILETYPE_NORMAL, os.path.getsize(fpath)))
 


### PR DESCRIPTION
Addresses issue Posix systems show h5 as complete series, while Windows lists them only as series, but incomplete.

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- mark h5 series in clusterListing as finished spooling on Windows, to match posix behavior.

<img width="866" height="46" alt="image" src="https://github.com/user-attachments/assets/d8559d90-ba3f-4bf0-a6ed-bcac3bb85640" />

to

<img width="858" height="77" alt="image" src="https://github.com/user-attachments/assets/b420940d-8ad9-4fd1-ac95-34ec48e6ce27" />


I am having issues localizing an h5 file on Windows. This doesn't solve that, but seems worth fixing up. 