### PR TITLE
add a bffile datasource and bioformats load path in image.py

### DIFF
--- a/PYME/IO/DataSources/BioformatsBFFDataSource.py
+++ b/PYME/IO/DataSources/BioformatsBFFDataSource.py
@@ -1,0 +1,74 @@
+
+import numpy as np
+from bffile import BioFile
+from .BaseDataSource import XYTCDataSource
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class DataSource(XYTCDataSource):
+    moduleName = 'BioformatsBFFDataSource'
+
+    def __init__(self, filename, series=0):
+        self.filename = filename
+        self.series_num = series
+
+        # Keep the file open for the lifetime of the DataSource so the lazy
+        # array can read
+        self._bf = BioFile(filename)
+        self._bf.open()
+        self._arr = self._bf.as_array(series=series)  # LazyBioArray (T,C,Z,Y,X), squeezed
+
+        # Use OME metadata for dimension sizes (avoids squeezing ambiguity)
+        pixels = self._bf.ome_metadata.images[series].pixels
+        self.sizeX = pixels.size_x
+        self.sizeY = pixels.size_y
+        self.sizeZ = pixels.size_z
+        self.sizeT = pixels.size_t
+        self.sizeC = pixels.size_c
+
+        self.additionalDims = 'TC'
+
+    def _tczyxs_index(self, t, c, z):
+        """Build an index tuple for the lazy array, skipping squeezed dimensions.
+
+        ``LazyBioArray.dims`` contains only the non-squeezed dimension names in
+        TCZYXS order.  We include an integer index for each of T, C, Z that is
+        actually present; Y and X are left as full slices so the result is a 2-D
+        view.
+        """
+        dim_to_idx = {'T': t, 'C': c, 'Z': z}
+        return tuple(dim_to_idx[d] for d in self._arr.dims if d in dim_to_idx)
+
+    # ------------------------------------------------------------------
+    # XYTCDataSource interface
+    # ------------------------------------------------------------------
+
+    def getSlice(self, ind):
+        c = int(ind // (self.sizeZ * self.sizeT))
+        t = int((ind // self.sizeZ) % self.sizeT)
+        z = int(ind % self.sizeZ)
+
+        key = self._tczyxs_index(t, c, z)
+        plane = self._arr[key] if key else self._arr
+        return np.asarray(plane).squeeze()
+
+    def getSliceShape(self):
+        return (self.sizeY, self.sizeX)
+
+    def getNumSlices(self):
+        return self.sizeC * self.sizeT * self.sizeZ
+
+    def getEvents(self):
+        return []
+
+    def release(self):
+        try:
+            self._bf.close()
+        except Exception:
+            pass
+
+    def __del__(self):
+        self.release()
+

--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -1077,7 +1077,93 @@ class ImageStack(object):
             self.mode = 'LM'
             
         
+    def _loadBioformatsBFF(self, filename):
+        """Load a file using the bffile package (bioformats via pims-bioformats-file).
+
+        bffile wraps Bio-Formats and exposes a lazy NumPy-compatible interface.
+        Dimensions are reported via OME metadata, and individual planes are read
+        on demand through ``LazyBioArray.__getitem__``.
+        """
+        from bffile import BioFile
+        from PYME.IO.DataSources import BioformatsBFFDataSource
+
+        series_num = 0
+        fn = filename
+
+        if '?' in filename:
+            fn, query = filename.split('?')
+            from urllib.parse import parse_qs
+            try:
+                series_num = int(parse_qs(query)['series'][0])
+            except KeyError:
+                pass
+        else:
+            # Check whether the file contains multiple series and ask the user
+            # to pick one when a GUI is available.
+            with BioFile(fn) as bf:
+                n_series = bf.series_count()
+                if n_series > 1:
+                    series_names = [
+                        img.name or 'Image {}'.format(i)
+                        for i, img in enumerate(bf.ome_metadata.images)
+                    ]
+                    print('BioformatsBFF: file has {} series, need to pick one.'.format(n_series))
+                    if self.haveGUI:
+                        import wx
+                        dlg = wx.SingleChoiceDialog(None, 'Series', 'Select a series', series_names)
+                        if dlg.ShowModal() == wx.ID_OK:
+                            series_num = dlg.GetSelection()
+                        dlg.Destroy()
+                    else:
+                        logger.warning('File has multiple series, no GUI available - using series 0.')
+
+        print('BioformatsBFF: loading data (series={})'.format(series_num))
+        self.dataSource = BioformatsBFFDataSource.DataSource(fn, series=series_num)
+
+        self.mdh = MetaDataHandler.NestedClassMDHandler(MetaData.BareBones)
+
+        print('BioformatsBFF: parsing OME metadata')
+        # Re-open briefly to retrieve the OME XML; the DataSource holds its own handle.
+        with BioFile(fn) as bf:
+            ome_xml = bf.ome_xml
+
+        if ome_xml:
+            OMEmd = MetaDataHandler.OMEXMLMDHandler(ome_xml.encode('utf8'))
+            self.mdh.copyEntriesFrom(OMEmd)
+
+        print('BioformatsBFF: done')
+
+        # Fix voxel sizes if the OME metadata did not contain physical pixel sizes.
+        if self.haveGUI and (
+            (self.mdh.getOrDefault('voxelsize.x', -1) < 0) or
+            (self.mdh.getOrDefault('voxelsize.y', -1) < 0)
+        ):
+            from PYME.DSView.voxSizeDialog import VoxSizeDialog
+            dlg = VoxSizeDialog(None)
+            dlg.ShowModal()
+            self.mdh.setEntry('voxelsize.x', dlg.GetVoxX())
+            self.mdh.setEntry('voxelsize.y', dlg.GetVoxY())
+            self.mdh.setEntry('voxelsize.z', dlg.GetVoxZ())
+            dlg.Destroy()
+
+        self.dataSource = BufferedDataSource.DataSource(self.dataSource, min(self.dataSource.getNumSlices(), 50))
+        self.SetData(self.dataSource)
+        self.seriesName = getRelFilename(fn)
+        self.mode = 'default'
+
     def _loadBioformats(self, filename):
+        # Prefer the bffile-based loader; fall back to the legacy javabridge/
+        # python-bioformats loader when bffile is not installed.
+        try:
+            import bffile  # noqa: F401 - only test availability here
+        except ImportError:
+            logger.debug('bffile not available, trying legacy python-bioformats')
+        else:
+            # If bffile is importable, use that code path and surface any
+            # downstream error directly rather than silently falling back.
+            self._loadBioformatsBFF(filename)
+            return
+
         try:
             import bioformats
         except ImportError:
@@ -1350,6 +1436,16 @@ class ImageStack(object):
                 try:
                     self._loadBioformats(filename)
                 except (ImportError, RuntimeError):
+                    # If bffile is installed, _loadBioformats() should have used
+                    # the bffile path. In that case, surface the original error
+                    # instead of masking it as a missing legacy bioformats install.
+                    try:
+                        import bffile  # noqa: F401
+                    except ImportError:
+                        pass
+                    else:
+                        raise
+
                     # We don't have bioformats - check to see if the file is in a format which we could also read
                     # natively (.tiff). Complains loudly about having to do this as by convention the .tiff extension
                     # is used to force bioformats loading of tiffs which we otherwise wouldn't understand.

--- a/PYME/IO/meson.build
+++ b/PYME/IO/meson.build
@@ -44,6 +44,7 @@ py.install_sources(py_sources, subdir:'PYME/IO')
 subdir('FileUtils')
 py_sources = files(
     'DataSources/BioformatsDataSource.py',
+    'DataSources/BioformatsBFFDataSource.py',
     'DataSources/BaseDataSource.py',
     'DataSources/TiffDataSource.py',
     'DataSources/MultiviewDataSource.py',


### PR DESCRIPTION
Addresses issue #bioformats installation. Posting as a draft for discussion - unclear if this is a direction we're interested in or not, but it was helpful for me to load some nd2 files from a collaborator. 

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- add option to load using [bffile](https://github.com/imaging-formats/bffile)

**loading tested with**
- single-channel nd2 file
- multi-channel nd2 file

**untested**
-time series
- other file types