### PR TITLE
20260312 LMAnalysis detection overlay roisize

### DIFF
--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -594,6 +594,7 @@ class LMAnalyser2(Plugin):
     def _update_points_overlay(self):
         ''' Make sure the points overlay is up to date with the current analysis progress'''
         mdh = self.analysisController.analysisMDH
+        roi_size = mdh.getOrDefault('Analysis.ROISize', 11)
 
         if not hasattr(self, '_ovl') or not hasattr(self._ovl, 'filter'):
             from PYME.DSView import overlays
@@ -601,9 +602,11 @@ class LMAnalyser2(Plugin):
             filt = tabular.FitResultsSource(self.fitResults)
             self._ovl = overlays.PointDisplayOverlay(filter=filt, md=mdh, display_name='Detections')
             self._ovl.pointMode = 'lm'
+            self._ovl.pointSize = roi_size * 2 + 1
             self.view.add_overlay(self._ovl)
         else:
             self._ovl.filter.setResults(self.fitResults)
+            self._ovl.pointSize = roi_size * 2 + 1
 
     def SetFitInfo(self):
         # TODO - use filter / raw fit results rather than creating a points array.


### PR DESCRIPTION
Bug Fix: In PYMEImage, when detection is tested on a frame, the green box identifying detections is not the same size ast the analysis roi size. It appears that the box was drawn with a default value of 11 pixels

I addedd 3 lines of code to _update_points_overlay to get Analysis.ROISize from the analysis metadata and then use that size to determine size of the box to draw, assuming the roi size is a ROI Half Size (box size of roi_size * 2 + 1).

No variable names are changed. A new variable is created within _update_points_overlay, roi_size.