### PR TITLE
add ninja and cython to install list for development install

### DIFF
--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -42,7 +42,7 @@ For development installs, after creating and activating a conda environment as a
 
       git clone https://github.com/yourusername/python-microscopy.git
       cd python-microscopy
-      pip install build meson meson-python cython
+      pip install build meson meson-python ninja cython
       pip install --no-build-isolation -e .
 
 To rebuild after making changes, run

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -42,7 +42,7 @@ For development installs, after creating and activating a conda environment as a
 
       git clone https://github.com/yourusername/python-microscopy.git
       cd python-microscopy
-      pip install build  meson meson-python
+      pip install build meson meson-python cython
       pip install --no-build-isolation -e .
 
 To rebuild after making changes, run


### PR DESCRIPTION
Addresses issue currently if someone follows our instructions they'll get a couple error messages because they are missing necessary build packages

<details> <summary> ninja traceback </summary> 

```
Obtaining file:///Users/andy/code/python-microscopy
  Checking if build backend supports build_editable ... done
  Preparing editable metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing editable metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [2 lines of output]
      
      meson-python: error: Could not find ninja version 1.8.2 or newer.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> from file:///Users/andy/code/python-microscopy

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

```
</details>

After installing ninja, you get the following:
<details> <summary> python traceback </summary> 

```
% pip install --no-build-isolation -e .
Obtaining file:///Users/andy/code/python-microscopy
  Checking if build backend supports build_editable ... done
  Preparing editable metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing editable metadata (pyproject.toml) did not run successfully.
  │ exit code: 127
  ╰─> [67 lines of output]
      + meson setup --reconfigure /Users/andy/code/python-microscopy /Users/andy/code/python-microscopy/build/cp311 -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --native-file=/Users/andy/code/python-microscopy/build/cp311/meson-python-native-file.ini
      Cleaning... 0 files.
      The Meson build system
      Version: 1.10.2
      Source dir: /Users/andy/code/python-microscopy
      Build dir: /Users/andy/code/python-microscopy/build/cp311
      Build type: native build
      Project name: python-microscopy
      Project version: Detected a .git folder, assuming a development install
      C compiler for the host machine: cc (clang 17.0.0 "Apple clang version 17.0.0 (clang-1700.6.3.2)")
      C linker for the host machine: cc ld64 1230.1
      Cython compiler for the host machine: cython (cython 3.2.4)
      Host machine cpu family: aarch64
      Host machine cpu: aarch64
      Program python found: YES (/Users/andy/miniconda3/envs/pipyme311/bin/python3.11)
      Message: install_dir: /usr/local/lib/python3.11/site-packages/
      Message: Installing PYME to: /usr/local/lib/python3.11/site-packages/PYME
      Did not find pkg-config by name 'pkg-config'
      Found pkg-config: NO
      Run-time dependency python found: YES 3.11
      Message: PYME/localization install dir:  /usr/local/lib/python3.11/site-packages/PYME/localization
      Build targets in project: 20
      
      python-microscopy Detected a .git folder, assuming a development install
      
        User defined options
          Native files: /Users/andy/code/python-microscopy/build/cp311/meson-python-native-file.ini
          b_ndebug    : if-release
          b_vscrt     : md
          buildtype   : release
      
      Found ninja-1.13.0.git.kitware.jobserver-pipe-1 at /Users/andy/miniconda3/envs/pipyme311/bin/ninja
      + /Users/andy/miniconda3/envs/pipyme311/bin/ninja
      [1/65] Compiling Cython source /Users/andy/code/python-microscopy/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx
      FAILED: [code=127] PYME/Analysis/points/traveling_salesperson/two_opt_utils.cpython-311-darwin.so.p/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx.c
      cython -M --fast-fail -3 /Users/andy/code/python-microscopy/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx -o PYME/Analysis/points/traveling_salesperson/two_opt_utils.cpython-311-darwin.so.p/PYME/Analysis/points/traveling_salesperson/two_opt_utils.pyx.c
      /bin/sh: cython: command not found
      [2/65] Compiling Cython source /Users/andy/code/python-microscopy/PYME/IO/buffer_helpers.pyx
      FAILED: [code=127] PYME/IO/buffer_helpers.cpython-311-darwin.so.p/PYME/IO/buffer_helpers.pyx.c
      cython -M --fast-fail -3 /Users/andy/code/python-microscopy/PYME/IO/buffer_helpers.pyx -o PYME/IO/buffer_helpers.cpython-311-darwin.so.p/PYME/IO/buffer_helpers.pyx.c
      /bin/sh: cython: command not found
      [3/65] Compiling Cython source /Users/andy/code/python-microscopy/PYME/experimental/_triangle_mesh.pyx
      FAILED: [code=127] PYME/experimental/_triangle_mesh.cpython-311-darwin.so.p/PYME/experimental/_triangle_mesh.pyx.c
      cython -M --fast-fail -3 /Users/andy/code/python-microscopy/PYME/experimental/_triangle_mesh.pyx -o PYME/experimental/_triangle_mesh.cpython-311-darwin.so.p/PYME/experimental/_triangle_mesh.pyx.c
      /bin/sh: cython: command not found
      [4/65] Compiling Cython source /Users/andy/code/python-microscopy/PYME/experimental/_octree.pyx
      FAILED: [code=127] PYME/experimental/_octree.cpython-311-darwin.so.p/PYME/experimental/_octree.pyx.c
      cython -M --fast-fail -3 /Users/andy/code/python-microscopy/PYME/experimental/_octree.pyx -o PYME/experimental/_octree.cpython-311-darwin.so.p/PYME/experimental/_octree.pyx.c
      /bin/sh: cython: command not found
      [5/65] Compiling Cython source /Users/andy/code/python-microscopy/PYME/experimental/func_octree.pyx
      FAILED: [code=127] PYME/experimental/func_octree.cpython-311-darwin.so.p/PYME/experimental/func_octree.pyx.c
      cython -M --fast-fail -3 /Users/andy/code/python-microscopy/PYME/experimental/func_octree.pyx -o PYME/experimental/func_octree.cpython-311-darwin.so.p/PYME/experimental/func_octree.pyx.c
      /bin/sh: cython: command not found
      [6/65] Compiling Cython source /Users/andy/code/python-microscopy/PYME/Acquire/Hardware/Simulator/illuminate.pyx
      FAILED: [code=127] PYME/Acquire/Hardware/Simulator/illuminate.cpython-311-darwin.so.p/PYME/Acquire/Hardware/Simulator/illuminate.pyx.c
      cython -M --fast-fail -3 /Users/andy/code/python-microscopy/PYME/Acquire/Hardware/Simulator/illuminate.pyx -o PYME/Acquire/Hardware/Simulator/illuminate.cpython-311-darwin.so.p/PYME/Acquire/Hardware/Simulator/illuminate.pyx.c
      /bin/sh: cython: command not found
      [7/65] Compiling Cython source /Users/andy/code/python-microscopy/PYME/experimental/_treap.pyx
      FAILED: [code=127] PYME/experimental/_treap.cpython-311-darwin.so.p/PYME/experimental/_treap.pyx.c
      cython -M --fast-fail -3 /Users/andy/code/python-microscopy/PYME/experimental/_treap.pyx -o PYME/experimental/_treap.cpython-311-darwin.so.p/PYME/experimental/_treap.pyx.c
      /bin/sh: cython: command not found
      [8/65] Compiling C object PYME/Analysis/points/SoftRend/triRend.cpython-311-darwin.so.p/triangRend.c.o
      [9/65] Compiling C object PYME/Analysis/points/SoftRend/triRend.cpython-311-darwin.so.p/drawTriang.c.o
      [10/65] Compiling C object PYME/Analysis/points/SoftRend/triRend.cpython-311-darwin.so.p/qhull_user.c.o
      [11/65] Compiling C object PYME/Analysis/points/SoftRend/triRend.cpython-311-darwin.so.p/triRend.c.o
      [12/65] Compiling C object PYME/Analysis/points/SoftRend/triRend.cpython-311-darwin.so.p/qhull_global.c.o
      ninja: build stopped: subcommand failed.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> from file:///Users/andy/code/python-microscopy

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```
</details>

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
give complete list 

**Alternatives**
flag build dependencies more elegantly