### PR TITLE
pick python executable for MacOS

### DIFF
--- a/PYME/DSView/dsviewer.py
+++ b/PYME/DSView/dsviewer.py
@@ -405,9 +405,9 @@ def OSXActivateKludge():
     import os 
     subprocess.Popen(['osascript', '-e', """\
         tell application "System Events"
-          set procName to name of first process whose unix id is %s
+          set proc to first process whose unix id is %s
+          set frontmost of proc to true
         end tell
-        tell application procName to activate
     """ % os.getpid()])
 
 class MyApp(wx.App):


### PR DESCRIPTION
on a miniconda3 install on my M1 Mac, first time doing the new pip / meson install on this machine, any time I opened PYME I would get a window pop-up asking me to choose the Python app. If I navigated to my Conda environment binary, I couldn't select it. Hitting X on the window would give:
and hang:
```
WARNING:PYME.DSView.modules:Plugin [recipes] injects into parent namespace, could result in circular references
DEBUG:PYME.ui.AUIFrame:Creating fold panel
165:173: execution error: Can’t get application "python3.11". (-1728)
```


**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
allow choice of .app bundle (current state) or executables on OSX. 
didn't need to manually select anything in a gui after this fix (helped by Claude). 


Alternative fixes welcome, just wanted to post what got me going again.
