### PR TITLE
fix hx/hy assignment regression for line profiles

### DIFF
--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -765,7 +765,7 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
 
         self.do.inOnChange = True
         try:
-            self.do.xp, self.do.yp, self.do.zp = [int(p) for p in pos_3d]
+            self.do.xp, self.do.yp, self.do.zp = [int(round(p)) for p in pos_3d]
         finally:
             self.do.inOnChange = False
             
@@ -793,11 +793,11 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
         pos = self._evt_pixel_coords(event)
         
         if (self.do.slice == self.do.SLICE_XY):
-            self.do.selection.start.x, self.do.selection.start.y = [int(p) for p in pos]
+            self.do.selection.start.x, self.do.selection.start.y = [int(round(p)) for p in pos]
         elif (self.do.slice == self.do.SLICE_XZ):
-            self.do.selection.start.x, self.do.selection.start.z = [int(p) for p in pos]
+            self.do.selection.start.x, self.do.selection.start.z = [int(round(p)) for p in pos]
         elif (self.do.slice == self.do.SLICE_YZ):
-            self.do.selection.start.y, self.do.selection.start.z = [int(p) for p in pos]
+            self.do.selection.start.y, self.do.selection.start.z = [int(round(p)) for p in pos]
             
         self.do.selection.trace = []
         self.do.selection.trace.append(tuple(pos))
@@ -814,11 +814,11 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
         pos = self._evt_pixel_coords(event)
         
         if (self.do.slice == self.do.SLICE_XY):
-            self.do.selection.finish.x, self.do.selection.finish.y = [int(p) for p in pos]
+            self.do.selection.finish.x, self.do.selection.finish.y = [int(round(p)) for p in pos]
         elif (self.do.slice == self.do.SLICE_XZ):
-            self.do.selection.finish.x, self.do.selection.finish.z = [int(p) for p in pos]
+            self.do.selection.finish.x, self.do.selection.finish.z = [int(round(p)) for p in pos]
         elif (self.do.slice == self.do.SLICE_YZ):
-            self.do.selection.finish.y, self.do.selection.finish.z = [int(p) for p in pos]
+            self.do.selection.finish.y, self.do.selection.finish.z = [int(round(p)) for p in pos]
 
 
         if event.ShiftDown(): #lock

--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -358,6 +358,9 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
                     pts = numpy.vstack(self.pixel_to_screen_coordinates(x, y)).T
                     dc.DrawSpline(pts.astype('i'))
             elif self.do.selection.width == 1:
+                lx, ly, hx, hy = self.do.GetSliceSelection()
+                lx, ly = self.pixel_to_screen_coordinates(lx, ly)
+                hx, hy = self.pixel_to_screen_coordinates(hx, hy)
                 dc.DrawLine(int(lx),int(ly),int( hx),int(hy))
             else:
                 lx, ly, hx, hy = self.do.GetSliceSelection()


### PR DESCRIPTION
Addresses regression in arrayViewPanel ([commit here](https://github.com/python-microscopy/python-microscopy/commit/f6e5bdd6748af39ae3d1c7d774841246a631cba1)) where hx, hy never get assigned for line profiles (width=1) .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- call do.GetSliceSelection() for line profiles (width=1)
- round to get pixel identity rather than casting to int, which is a floor operation. 



<img width="48" height="183" alt="image" src="https://github.com/user-attachments/assets/c4332d55-53e1-446c-9b49-228344e005aa" />
produces

```
>>> lx, ly, hx, hy = do.GetSliceSelection()
>>> do.GetSliceSelection()
(0, 0, 0, 6)
```

while
<img width="48" height="70" alt="image" src="https://github.com/user-attachments/assets/b959d040-1b48-4708-af89-8fa99d0253da" />

yields

```
>>> (xi, yi, xf, yf)
(0, 0, 1, 1)
>>> image.data_xytc[xi:xf+1, yi:yf+1,0,0]
array([[ 0.25463662,  2.1478719 ],
       [ 1.99672588, -1.52296621]])
```

There are some remaining quirks:
- `displayOptions.GetSliceSelection` returning start, finish, and us calling things lx, hx is fairly misleading and requires a +1 for the finish to get the full extent.
- There appears to be a bug in `PYME.Analysis.profile_extraction import extract_profile` when drawing along the edge of the frame.


**tested on**
wxPython '4.2.5 msw (phoenix) wxWidgets 3.2.9'
python 3.11
Windows 11