### PR TITLE
Bffile datasource / loading tweaks

### DIFF
--- a/PYME/IO/DataSources/BioformatsBFFDataSource.py
+++ b/PYME/IO/DataSources/BioformatsBFFDataSource.py
@@ -1,13 +1,13 @@
 
 import numpy as np
 from bffile import BioFile
-from .BaseDataSource import XYTCDataSource
+from .BaseDataSource import XYZTCDataSource
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-class DataSource(XYTCDataSource):
+class DataSource(XYZTCDataSource):
     moduleName = 'BioformatsBFFDataSource'
 
     def __init__(self, filename, series=0):
@@ -28,7 +28,8 @@ class DataSource(XYTCDataSource):
         self.sizeT = pixels.size_t
         self.sizeC = pixels.size_c
 
-        self.additionalDims = 'TC'
+        XYZTCDataSource.__init__(self, input_order='XYZTC',
+                                 size_z=self.sizeZ, size_t=self.sizeT, size_c=self.sizeC)
 
     def _tczyxs_index(self, t, c, z):
         """Build an index tuple for the lazy array, skipping squeezed dimensions.

--- a/PYME/IO/DataSources/BioformatsBFFDataSource.py
+++ b/PYME/IO/DataSources/BioformatsBFFDataSource.py
@@ -10,18 +10,18 @@ logger = logging.getLogger(__name__)
 class DataSource(XYZTCDataSource):
     moduleName = 'BioformatsBFFDataSource'
 
-    def __init__(self, filename, series=0):
+    def __init__(self, filename, taskQueue=None, series=0):
         self.filename = filename
-        self.series_num = series
+        self.series_num = 0 if series is None else series
 
         # Keep the file open for the lifetime of the DataSource so the lazy
         # array can read
         self._bf = BioFile(filename)
         self._bf.open()
-        self._arr = self._bf.as_array(series=series)  # LazyBioArray (T,C,Z,Y,X), squeezed
+        self._arr = self._bf.as_array(series=self.series_num)  # LazyBioArray (T,C,Z,Y,X), squeezed
 
         # Use OME metadata for dimension sizes (avoids squeezing ambiguity)
-        pixels = self._bf.ome_metadata.images[series].pixels
+        pixels = self._bf.ome_metadata.images[self.series_num].pixels
         self.sizeX = pixels.size_x
         self.sizeY = pixels.size_y
         self.sizeZ = pixels.size_z

--- a/PYME/IO/MetaDataHandler.py
+++ b/PYME/IO/MetaDataHandler.py
@@ -949,6 +949,12 @@ class OMEXMLMDHandler(XMLMDHandler):
                 self['OME.SizeC'] = int(pix.getAttribute('SizeC'))
                 
                 self['OME.DimensionOrder'] = pix.getAttribute('DimensionOrder')
+
+                # Extract channel names from <Channel Name="..."> elements
+                channels = pix.getElementsByTagName('Channel')
+                ch_names = [ch.getAttribute('Name') for ch in channels]
+                if any(ch_names):
+                    self['ChannelNames'] = ch_names
                     
                 #except:
                 #    pass


### PR DESCRIPTION
Addresses issues:
- channel names not getting pulled in `OMEXMLMDHandler`
- base datasource was 4D, not 5D (my bad), and was subject to autopromotion which (in my case) assumed the sub-100 frame was a stack rather than a short time series. 

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**

- inherit from `XYZTCDataSource` for `BioformatsBFFDataSource`
- check for channel names in OME metadata handler
