### PR TITLE
remove deprecated/removed numpy warning

### DIFF
--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -21,6 +21,7 @@
 #
 ##################
 
+import warnings
 import wx
 
 from PYME.DSView import scrolledImagePanel
@@ -1026,7 +1027,8 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
 
         """
         if not isinstance(ovl, overlays.Overlay):
-            logger.warning('using old-style overlay function, please re-write %s as a class', getattr(ovl, '__qualname__', ovl))
+            warnings.warn(f'using old-style overlay function, please re-write {getattr(ovl, "__qualname__", ovl)} as a class',
+                          DeprecationWarning, stacklevel=2)
             ovl = overlays.FunctionOverlay(ovl, display_name)
         
         self.overlays.append(ovl)

--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -21,7 +21,6 @@
 #
 ##################
 
-import warnings
 import wx
 
 from PYME.DSView import scrolledImagePanel
@@ -1027,7 +1026,7 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
 
         """
         if not isinstance(ovl, overlays.Overlay):
-            warnings.warn('using old-style overlay function, please re-write as a class', DeprecationWarning)
+            logger.warning('using old-style overlay function, please re-write %s as a class', getattr(ovl, '__qualname__', ovl))
             ovl = overlays.FunctionOverlay(ovl, display_name)
         
         self.overlays.append(ovl)

--- a/PYME/DSView/arrayViewPanel.py
+++ b/PYME/DSView/arrayViewPanel.py
@@ -1027,7 +1027,7 @@ class ArrayViewPanel(scrolledImagePanel.ScrolledImagePanel):
 
         """
         if not isinstance(ovl, overlays.Overlay):
-            warnings.warn(numpy.VisibleDeprecationWarning('using old-style overlay function, please re-write as a class'))
+            warnings.warn('using old-style overlay function, please re-write as a class', DeprecationWarning)
             ovl = overlays.FunctionOverlay(ovl, display_name)
         
         self.overlays.append(ovl)

--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -45,7 +45,7 @@ def deprecated_name(name):
     def _dec(cls):
         
         def _dep_name(*args, **kwargs):
-            warnings.warn(VisibleDeprecationWarning('%s is deprecated, use %s instead' % (name, cls.__name__)))
+            warnings.warn('%s is deprecated, use %s instead' % (name, cls.__name__), DeprecationWarning)
             return cls(*args, **kwargs)
         
         globals()[name] = _dep_name
@@ -1032,7 +1032,7 @@ class MappingFilter(TabularBase):
         """
         
         if not isinstance(resultsSource, TabularBase):
-            warnings.warn(VisibleDeprecationWarning('Mapping filter created with something that is not a tabular object. This will be unsupported in a future release. Consider DictSource or ColumnSource instead'))
+            warnings.warn('Mapping filter created with something that is not a tabular object. This will be unsupported in a future release. Consider DictSource or ColumnSource instead', DeprecationWarning)
 
         self._modifies_bounds = kwargs.pop('modifies_bounds', False)
         

--- a/PYME/__init__.py
+++ b/PYME/__init__.py
@@ -20,3 +20,5 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ################
+import warnings
+warnings.filterwarnings('always', category=DeprecationWarning, module=r'PYME\..*')

--- a/PYME/localization/FitFactories/Interpolators/baseInterpolator.py
+++ b/PYME/localization/FitFactories/Interpolators/baseInterpolator.py
@@ -171,7 +171,7 @@ class __interpolator:
             self.IntYVals = vs.y*np.mgrid[-20:20]
             self.IntZVals = vs.z*np.mgrid[-20:20]
 
-            self.dx, self.dy, self.dx = vs
+            self.dx, self.dy, self.dz = vs
 
             P = np.arange(0,1.01,.01)
 

--- a/PYME/localization/FitFactories/Interpolators/baseInterpolator.py
+++ b/PYME/localization/FitFactories/Interpolators/baseInterpolator.py
@@ -171,7 +171,7 @@ class __interpolator:
             self.IntYVals = vs.y*np.mgrid[-20:20]
             self.IntZVals = vs.z*np.mgrid[-20:20]
 
-            self.dx, self.dy, self.dz = vs
+            self.dx, self.dy, self.dx = vs
 
             P = np.arange(0,1.01,.01)
 


### PR DESCRIPTION
Addresses issue Opening the annotation module in PYMEImage fails on later numpy's 

```
DEBUG:PYME.ui.AUIFrame:Creating fold panel
Traceback (most recent call last):
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\DSView\dsviewer.py", line 236, in OnToggleModule
    self.LoadModule(mn)
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\DSView\dsviewer.py", line 243, in LoadModule
    modules.loadModule(moduleName, self)
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\DSView\modules\__init__.py", line 122, in loadModule
    _load_mod(mod, modName, dsviewer)
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\DSView\modules\__init__.py", line 133, in _load_mod
    ret = mod.Plug(parent)
          ^^^^^^^^^^^^^^^^
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\DSView\modules\annotation.py", line 725, in Plug
    return Annotater(dsviewer)
           ^^^^^^^^^^^^^^^^^^^
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\DSView\modules\annotation.py", line 599, in __init__
    self.view.add_overlay(self.DrawOverlays, 'Annotations')
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\DSView\arrayViewPanel.py", line 1030, in add_overlay
    warnings.warn(numpy.VisibleDeprecationWarning('using old-style overlay function, please re-write as a class'))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\aesb\AppData\Local\miniforge3\envs\pipyme311\Lib\site-packages\numpy\__init__.py", line 805, in __getattr__
    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
AttributeError: module 'numpy' has no attribute 'VisibleDeprecationWarning'
```

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
remove the removed numpy VisibleDeprecationWarning and pass DeprecationWarning as the category