### PR TITLE
InterpFitR fix / numpy compatibility

### DIFF
--- a/PYME/localization/FitFactories/Interpolators/baseInterpolator.py
+++ b/PYME/localization/FitFactories/Interpolators/baseInterpolator.py
@@ -171,7 +171,7 @@ class __interpolator:
             self.IntYVals = vs.y*np.mgrid[-20:20]
             self.IntZVals = vs.z*np.mgrid[-20:20]
 
-            self.dx, self.dy, self.dx = vs
+            self.dx, self.dy, self.dz = vs
 
             P = np.arange(0,1.01,.01)
 

--- a/PYME/localization/FitFactories/zEstimators/genericEstimator.py
+++ b/PYME/localization/FitFactories/zEstimators/genericEstimator.py
@@ -207,7 +207,7 @@ def getStartParameters(data, X, Y, Z=None):
     #print 'p:', p
     #print 'feat:', feat
     
-    z0 = _svr.predict(np.array(feat).reshape(1, -1))
+    z0 = float(_svr.predict(np.array(feat).reshape(1, -1))[0])
     z0 = -max(min(z0, 800), -800)
     #print z0
 


### PR DESCRIPTION
Addresses issue #InterpFitR regressions .

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- assign dz when using a theoretical model, otherwise the cubic spline interpolator tries to calculate gradZ / None
- later numpy compatibility fix for [float, array([x]), float float, ...] initial parameter guess passed to leastsq which hits the

```
model changed
C:\Users\aesb\AppData\Local\miniforge3\envs\pipyme311\Lib\site-packages\scipy\interpolate\_fitpack_py.py:161: RuntimeWarning: The maximal number of iterations (20) allowed for finding smoothing
spline with fp=s has been reached. Probable cause: s too small.
(abs(fp-s)/s>0.001)
  res = _impl.splprep(x, w, u, ub, ue, k, task, s, t, full_output, nest, per,
Traceback (most recent call last):
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\DSView\modules\LMAnalysis.py", line 291, in <lambda>
    bTestF.Bind(wx.EVT_BUTTON, lambda e : self.lmanal.OnTestFrame(e))
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\DSView\modules\LMAnalysis.py", line 654, in OnTestFrame
    ft, fr = self.testFrame()
             ^^^^^^^^^^^^^^^^
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\DSView\modules\LMAnalysis.py", line 966, in testFrame
    res = ft(gui=gui,taskQueue=self.tq)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\localization\remFitBuf.py", line 541, in __call__
    self.res[i] = fitFac.FromPoint(p.x, p.y, roiHalfSize=rs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\localization\FitFactories\InterpFitR.py", line 199, in FromPoint
    (res, cov_x, infodict, mesg, resCode) = self.solver(self.fitfcn, startParameters, dataROI, sigma, self.interpolator, X, Y, Z, safeRegion)
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\Analysis\_fithelpers.py", line 86, in FitModelWeighted_
    return optimize.leastsq(weightedMissfitF, startParameters, (modelFcn, data.ravel(), (1.0/sigmas).astype('f').ravel()) + args, full_output=1, epsfcn=EPS_FCN)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\aesb\AppData\Local\miniforge3\envs\pipyme311\Lib\site-packages\scipy\optimize\_minpack_py.py", line 422, in leastsq
    x0 = asarray(x0).flatten()
         ^^^^^^^^^^^
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (5,) + inhomogeneous part.
```


