### PR TITLE
remove the positionless EVT_COMMAND_RIGHT_CLICK

### DIFF
--- a/PYME/DSView/modules/measure/filterPan.py
+++ b/PYME/DSView/modules/measure/filterPan.py
@@ -72,11 +72,7 @@ class FilterPane(wx.Panel):
             self.Bind(wx.EVT_MENU, self.OnFilterDelete, id=self.ID_FILT_DELETE)
             self.Bind(wx.EVT_MENU, self.OnFilterEdit, id=self.ID_FILT_EDIT)
 
-        # for wxMSW
-        self.lFiltKeys.Bind(wx.EVT_COMMAND_RIGHT_CLICK, self.OnFilterListRightClick)
-
-        # for wxGTK
-        self.lFiltKeys.Bind(wx.EVT_RIGHT_UP, self.OnFilterListRightClick)
+        self.lFiltKeys.Bind(wx.EVT_CONTEXT_MENU, self.OnFilterListRightClick)
 
         self.lFiltKeys.Bind(wx.EVT_LIST_ITEM_SELECTED, self.OnFilterItemSelected)
         self.lFiltKeys.Bind(wx.EVT_LIST_ITEM_DESELECTED, self.OnFilterItemDeselected)
@@ -104,8 +100,8 @@ class FilterPane(wx.Panel):
 
     def OnFilterListRightClick(self, event):
 
-        x = event.GetX()
-        y = event.GetY()
+        pt = self.lFiltKeys.ScreenToClient(event.GetPosition())
+        x, y = pt.x, pt.y
 
         item, flags = self.lFiltKeys.HitTest((x, y))
 

--- a/PYME/ui/custom_traits_editors.py
+++ b/PYME/ui/custom_traits_editors.py
@@ -205,11 +205,7 @@ class DictChoiceStrPanel(wx.Panel):
             self.Bind(wx.EVT_MENU, self.OnFilterDelete, id=self.ID_FILT_DELETE)
             self.Bind(wx.EVT_MENU, self.OnFilterEdit, id=self.ID_FILT_EDIT)
 
-        # for wxMSW
-        self.lFiltKeys.Bind(wx.EVT_COMMAND_RIGHT_CLICK, self.OnFilterListRightClick)
-        self.lFiltKeys.Bind(wx.EVT_COMMAND_LEFT_CLICK, self.OnFilterListRightClick)
-        # for wxGTK
-        self.lFiltKeys.Bind(wx.EVT_RIGHT_UP, self.OnFilterListRightClick)
+        self.lFiltKeys.Bind(wx.EVT_CONTEXT_MENU, self.OnFilterListRightClick)
         self.lFiltKeys.Bind(wx.EVT_LEFT_UP, self.OnFilterListRightClick)
 
         self.lFiltKeys.Bind(wx.EVT_LIST_ITEM_SELECTED, self.OnFilterItemSelected)
@@ -242,8 +238,8 @@ class DictChoiceStrPanel(wx.Panel):
             return self._choices
 
     def OnFilterListRightClick(self, event):
-        x = event.GetX()
-        y = event.GetY()
+        pt = self.lFiltKeys.ScreenToClient(event.GetPosition())
+        x, y = pt.x, pt.y
 
         item, flags = self.lFiltKeys.HitTest((x, y))
 

--- a/PYME/ui/filterPane.py
+++ b/PYME/ui/filterPane.py
@@ -85,11 +85,7 @@ class FilterPanel(wx.Panel):
             self.Bind(wx.EVT_MENU, self.OnFilterDelete, id=self.ID_FILT_DELETE)
             self.Bind(wx.EVT_MENU, self.OnFilterEdit, id=self.ID_FILT_EDIT)
 
-        # for wxMSW
-        self.lFiltKeys.Bind(wx.EVT_COMMAND_RIGHT_CLICK, self.OnFilterListRightClick)
-
-        # for wxGTK
-        self.lFiltKeys.Bind(wx.EVT_RIGHT_UP, self.OnFilterListRightClick)
+        self.lFiltKeys.Bind(wx.EVT_CONTEXT_MENU, self.OnFilterListRightClick)
 
         self.lFiltKeys.Bind(wx.EVT_LIST_ITEM_SELECTED, self.OnFilterItemSelected)
         self.lFiltKeys.Bind(wx.EVT_LIST_ITEM_DESELECTED, self.OnFilterItemDeselected)
@@ -127,8 +123,8 @@ class FilterPanel(wx.Panel):
 
     def OnFilterListRightClick(self, event):
 
-        x = event.GetX()
-        y = event.GetY()
+        pt = self.lFiltKeys.ScreenToClient(event.GetPosition())
+        x, y = pt.x, pt.y
 
         item, flags = self.lFiltKeys.HitTest((x, y))
 


### PR DESCRIPTION
Addresses issue AttributeError when trying to right click a filter key in PYMEVis:

```
AttributeError: 'CommandEvent' object has no attribute 'GetX'. Did you mean: 'GetId'?
Traceback (most recent call last):
  File "C:\Userfiles\andrew\code\python-microscopy\PYME\ui\filterPane.py", line 130, in OnFilterListRightClick
    x = event.GetX()
        ^^^^^^^^^^
```

**Is this a bugfix or an enhancement?**
bugfix for compatibility with wxpython 4+
**Proposed changes:**
- remove binding `EVT_COMMAND_RIGHT_CLICK` binding which fires first and throws an attribute error.
- change to `wx.EVT_CONTEXT_MENU`instead of `wx.EVT_RIGHT_UP` so we can right click without requiring the item to be selected first (let us do single right click instead of e.g. double right click)
- Use `event.GetPosition()`

<img width="209" height="115" alt="image" src="https://github.com/user-attachments/assets/7b7d09d3-ff68-4e1d-988e-21673d8f20b7" />
