### PR TITLE
add scalebar color picker to PYMEVis

### DIFF
--- a/PYME/LMVis/displayPane.py
+++ b/PYME/LMVis/displayPane.py
@@ -417,13 +417,20 @@ class DisplayPaneHorizontal(wx.Panel):
         chScaleBar.SetSelection(chInd)
         hsizer.Add(chScaleBar, 0, wx.RIGHT  | wx.ALIGN_CENTER_VERTICAL, 5)
 
+        #Scale bar color
+        hsizer.Add(wx.StaticText(self, -1, ''), 0, wx.LEFT | wx.ALIGN_CENTER_VERTICAL, 5)
+
+        self.sb_color_ctrl = wx.ColourPickerCtrl(self, colour=wx.WHITE, size=(40, -1))
+        self.sb_color_ctrl.Bind(wx.EVT_COLOURPICKER_CHANGED, self.OnScaleBarColorChanged)
+        hsizer.Add(self.sb_color_ctrl, 0, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, 5)
+
         hsizer.AddSpacer(10)
 
         #Background colour
 
         hsizer.Add(wx.StaticText(self, -1, 'BG Colour: '), 0, wx.LEFT  | wx.ALIGN_CENTER_VERTICAL,5)
 
-        colour_ctrl = wx.ColourPickerCtrl(self)
+        colour_ctrl = wx.ColourPickerCtrl(self, size=(40, -1))
         colour_ctrl.Bind(wx.EVT_COLOURPICKER_CHANGED, self.OnColourChanged)
         hsizer.Add(colour_ctrl, 0, wx.RIGHT  | wx.ALIGN_CENTER_VERTICAL, 5)
         
@@ -433,6 +440,12 @@ class DisplayPaneHorizontal(wx.Panel):
         
         chScaleBar.Bind(wx.EVT_CHOICE, self.OnChangeScaleBar)
         
+    def OnScaleBarColorChanged(self, event):
+        if self.glCanvas.ScaleBarOverlayLayer is not None:
+            colour = event.GetColour()
+            self.glCanvas.ScaleBarOverlayLayer._color = [colour.Red()/255., colour.Green()/255., colour.Blue()/255.]
+            self.glCanvas.Refresh()
+
     def OnColourChanged(self, event):
         self.glCanvas.clear_colour = np.array(event.GetColour().Get(True))/255.
         self.glCanvas.Refresh()

--- a/PYME/LMVis/layers/ScaleBarOverlayLayer.py
+++ b/PYME/LMVis/layers/ScaleBarOverlayLayer.py
@@ -93,5 +93,6 @@ class ScaleBarOverlayLayer(OverlayLayer):
                 self._bind_data('scalebar', self._verts, 0*self._verts, self._cols, sp, core_profile=core_profile)
 
                 glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
+                glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)  # standard blending so dark can be visible on light background
                 glDrawArrays(GL_TRIANGLES, 0, 6)
 

--- a/PYME/LMVis/layers/ScaleBarOverlayLayer.py
+++ b/PYME/LMVis/layers/ScaleBarOverlayLayer.py
@@ -94,5 +94,6 @@ class ScaleBarOverlayLayer(OverlayLayer):
 
                 glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
                 glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)  # standard blending so dark can be visible on light background
+                # Should we just disable blend instead? or should we make all layers disable blend on exit (and be responsible for enabling it on entry if needed?)
                 glDrawArrays(GL_TRIANGLES, 0, 6)
 


### PR DESCRIPTION
Addresses issues #1673

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- change blend style of scalebar render so a dark scalebar can show up on a light background
- add a colourpicker box for the scalebar color so one can change it through the GUI

**notes**
- only tested on windows at the moment
- @David-Baddeley  I do agree with conversations in  #1258 that it would be great to replace the GUI change here with something that brings PYMEImage and PYMEVis closer into alignment, but maybe a second button here is workable in the meantime.

<img width="587" height="122" alt="image" src="https://github.com/user-attachments/assets/8b6639b6-d9d1-4865-86ec-69f147db1178" />
