### PR TITLE
OBF loading fixes (and info display enhancement)

### DIFF
--- a/PYME/IO/DataSources/OBFDataSource.py
+++ b/PYME/IO/DataSources/OBFDataSource.py
@@ -47,13 +47,20 @@ class DataSource(XYTCDataSource):
         self.stack = stack
         
     def getSlice(self, ind):
-        return self.stack.data[:,:,ind].squeeze()
+        if len(self.stack.data.shape) == 2:
+            assert(ind == 0)
+            return self.stack.data[:,:]
+        else:
+            return self.stack.data[:,:,ind].squeeze()
 
     def getSliceShape(self):
         return self.stack.data.shape[:2]
 
-    def getNumSlices(self):
-        return self.stack.data.shape[2]
+    def getNumSlices(self): # we allow for 2D
+        if len(self.stack.data.shape) > 2:
+            return self.stack.data.shape[2]
+        else:
+            return 1
 
     def getEvents(self):
         return []

--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -803,7 +803,7 @@ class ImageStack(object):
         logger.debug('file: {}'.format(filename))
         if len(obf.stacks) > 1 and stack_number is None and self.haveGUI:
                 import wx
-                options = ['%d: %s' % (ind, stack.name) for (ind, stack) in enumerate(obf.stacks)]
+                options = ['%d: %s (%dx%dx%d)' % (ind, stack.name, *stack.shape[0:3]) for (ind, stack) in enumerate(obf.stacks)]
                 
                 dlg = wx.SingleChoiceDialog(None, 'Stack', 'Select a stack', options)
                 if dlg.ShowModal() == wx.ID_OK:

--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -803,16 +803,10 @@ class ImageStack(object):
         logger.debug('file: {}'.format(filename))
         if len(obf.stacks) > 1 and stack_number is None and self.haveGUI:
                 import wx
-                options = []
-                # provide some dimension info on stacks if possible
-                for (ind, stack) in enumerate(obf.stacks):
-                    if len(stack.shape) >= 3:
-                        options.append('%d: %s (%dx%dx%d)' % (ind, stack.name, *stack.shape[0:3]))
-                    elif len(stack.shape) >= 2:
-                        options.append('%d: %s (%dx%d)' % (ind, stack.name, *stack.shape[0:2]))
-                    else:
-                        options.append('%d: %s' % (ind, stack.name))
-                
+                def format_stack_info(ind, stack):
+                    return '%d: %s (shape %s)' % (ind, stack.name, stack.shape)
+                                                  
+                options = [format_stack_info(ind, stack) for (ind, stack) in enumerate(obf.stacks)]                
                 dlg = wx.SingleChoiceDialog(None, 'Stack', 'Select a stack', options)
                 if dlg.ShowModal() == wx.ID_OK:
                     stack_number = dlg.GetSelection()

--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -803,7 +803,15 @@ class ImageStack(object):
         logger.debug('file: {}'.format(filename))
         if len(obf.stacks) > 1 and stack_number is None and self.haveGUI:
                 import wx
-                options = ['%d: %s (%dx%dx%d)' % (ind, stack.name, *stack.shape[0:3]) for (ind, stack) in enumerate(obf.stacks)]
+                options = []
+                # provide some dimension info on stacks if possible
+                for (ind, stack) in enumerate(obf.stacks):
+                    if len(stack.shape) >= 3:
+                        options.append('%d: %s (%dx%dx%d)' % (ind, stack.name, *stack.shape[0:3]))
+                    elif len(stack.shape) >= 2:
+                        options.append('%d: %s (%dx%d)' % (ind, stack.name, *stack.shape[0:2]))
+                    else:
+                        options.append('%d: %s' % (ind, stack.name))
                 
                 dlg = wx.SingleChoiceDialog(None, 'Stack', 'Select a stack', options)
                 if dlg.ShowModal() == wx.ID_OK:
@@ -821,7 +829,8 @@ class ImageStack(object):
             raise NotImplementedError('Scale factors other than 1 not yet supported for OBF metadata')
         self.mdh['voxelsize.x'] = voxel_sizes[0] / 1E-6 # [m -> um]
         self.mdh['voxelsize.y'] = voxel_sizes[1] / 1E-6 # [m -> um]
-        self.mdh['voxelsize.z'] = voxel_sizes[2] / 1E-6 # [m -> um]
+        if len(voxel_sizes) > 2:
+            self.mdh['voxelsize.z'] = voxel_sizes[2] / 1E-6 # [m -> um]
         
         
 

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -889,7 +889,8 @@ class VisGUICore(object):
                                    #nameUtils.genResultDirectoryPath(), 
                                    extension='.pvs')
         if not filename == '':
-            self.save_session(filename)
+            from pathlib import Path
+            self.save_session(Path(filename).with_suffix('.pvs'))
     
     def load_session(self, filename):
         import yaml


### PR DESCRIPTION
The existing OBF loader (very usefully provided by @barentine) croaks when presented with 2D data as experienced locally with data from Abberior STEDYCON system.

This PR fixes that.

In addition, it provides slightly more detailed info when many stacks are contained in the OBF file (this includes MINFLUX `.msr` files etc). We often have 10-15 datasets in a single OBF file and short of a full previewer (as implemented in Fiji Bioformats interface) getting at least the shape info can significantly help identifying the right confocal scan to select etc.

Finally, this PR sneaks in a fix for VisGUI session file saving. The existing code did not enforce the `.pvs` extension which in practice becomes quite problematic. The small fix to `visCore.py` seeks to rectify this. We use session files now all the time and getting a fix in would be great. Hopefully ok to make it part of this PR.

**Is this a bugfix or an enhancement?**

Mostly bugfix but also some enhancement aspect, see above.

**Proposed changes:**

Checks for 2D in OBF load and some stack info printing enhancement. Plus session file extension enforcement which I'd view as a bugfix.

**Checklist:**

Checked with latest code from github mostly on macos, all changes though should be platform agnostic.
