### PR TITLE
swap LUT bottom / top

### DIFF
--- a/PYME/LMVis/layers/LUTOverlayLayer.py
+++ b/PYME/LMVis/layers/LUTOverlayLayer.py
@@ -190,7 +190,7 @@ class LUTOverlayLayer(OverlayLayer):
         if self._texture_id is None:
             self._texture_id = glGenTextures(1)
     
-            image = np.linspace(0, 1, 255).reshape([1, 255]).astype('f')# image.T.reshape(*image.shape) #get our byte order right
+            image = np.linspace(1, 0, 255).reshape([1, 255]).astype('f')# image.T.reshape(*image.shape) #get our byte order right
     
             glActiveTexture(GL_TEXTURE0)
             glBindTexture(GL_TEXTURE_2D, self._texture_id)


### PR DESCRIPTION
Addresses issue #1678

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
swap LUT drawing, since texture bottom is towards top of screen



Looks like the swap got introduced during the overhaul (commit 2eefee6).
Fix tested on macOS 26.3.1, pyopengl 3.1.10, wxpython 4.2.5

<img width="1068" height="726" alt="Screenshot 2026-06-23 at 11 23 02 AM" src="https://github.com/user-attachments/assets/26b8f919-40b5-4713-b70b-d1e8f11453a0" />


