### PR TITLE
draw fitInfo for localization on single frame datasource

### DIFF
--- a/PYME/DSView/modules/LMAnalysis.py
+++ b/PYME/DSView/modules/LMAnalysis.py
@@ -828,7 +828,8 @@ class LMAnalyser2(Plugin):
 
 
     def update(self, dsviewer):
-        if 'fitInf' in dir(self) and not self.dsviewer.playbackpanel.playback_running:
+        playback_running = getattr(self.dsviewer, 'playbackpanel', None) is not None and self.dsviewer.playbackpanel.playback_running
+        if 'fitInf' in dir(self) and not playback_running:
             if self.do.ds.shape[3] > 1:
                 # stack is a time series
                 idx = self.do.tp


### PR DESCRIPTION
Addresses issue `playbackpanel` doesn't exist for 1-frame imagestacks, so if you e.g. `Test this frame` for localization analysis on a single image, you hit
```
Traceback (most recent call last):
  File "/Users/andy/code/python-microscopy/PYME/DSView/displayOptions.py", line 332, in OnChange
    fcn()
  File "/Users/andy/code/python-microscopy/PYME/DSView/dsviewer.py", line 300, in update
    uCallback(self)
  File "/Users/andy/code/python-microscopy/PYME/DSView/modules/LMAnalysis.py", line 833, in update
    if 'fitInf' in dir(self) and not self.dsviewer.playbackpanel.playback_running:
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'DSViewFrame' object has no attribute 'playbackpanel'
```

**Is this a bugfix or an enhancement?**
bugfix
**Proposed changes:**
- check if playbackpanel exists, and if it doesn't, assume that we are not currently scrolling frames.






**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
