### PR TITLE
add analysis metadata parameter to set initial sigma value used in LatGaussFitFR fitting

### DIFF
--- a/PYME/localization/FitFactories/AstigGaussFitFR.py
+++ b/PYME/localization/FitFactories/AstigGaussFitFR.py
@@ -119,8 +119,8 @@ class GaussianFitFactory(FFBase.FitFactory):
         y0 =  vs.y*y
         
         bgm = np.mean(background)
-
-        startParameters = [A, x0, y0, 250/2.35, 250/2.35, dataMean.min(), .001, .001]
+        sigma_guess = self.metadata.getOrDefault('Analysis.PSFSigmaGuess', 250/2.35)
+        startParameters = [A, x0, y0, sigma_guess, sigma_guess, dataMean.min(), .001, .001]
 
         #do the fit
         (res, cov_x, infodict, mesg, resCode) = self.solver(self.fitfcn, startParameters, dataMean, sigma, X, Y)
@@ -167,7 +167,7 @@ import PYME.localization.MetaDataEdit as mde
 
 PARAMETERS = [
     mde.IntParam('Analysis.ROISize', u'ROI half size', 7),
-
+    mde.FloatParam('Analysis.PSFSigmaGuess', u'Initial guess for Gaussian sigma (nm)', 250/2.35),
 ]
 
 DESCRIPTION = 'Vanilla 2D Gaussian fit.'

--- a/PYME/localization/FitFactories/LatGaussFitFR.py
+++ b/PYME/localization/FitFactories/LatGaussFitFR.py
@@ -168,12 +168,12 @@ class GaussianFitFactory(FFBase.FitFactory):
         fitBackground = self.metadata.getOrDefault('Analysis.FitBackground', True)
         
         if fitBackground:
-            startParameters = [A, x0, y0, 250/2.35, dataMean.min(), .001, .001]
+            startParameters = [A, x0, y0, self.metadata['Analysis.SigmaGuess'], dataMean.min(), .001, .001]
     
             #do the fit
             (res, cov_x, infodict, mesg, resCode) = self.solver(self.fitfcn, startParameters, dataMean, sigma, X, Y)
         else:
-            startParameters = [A, x0, y0, 250 / 2.35]
+            startParameters = [A, x0, y0, self.metadata['Analysis.SigmaGuess']]
     
             #do the fit
             (res, cov_x, infodict, mesg, resCode) = self.solver(f_gauss2d_no_bg, startParameters, dataMean, sigma, X, Y)
@@ -212,7 +212,7 @@ import PYME.localization.MetaDataEdit as mde
 
 PARAMETERS = [
     mde.IntParam('Analysis.ROISize', u'ROI half size', 5),
-
+    mde.FloatParam('Analysis.SigmaGuess', u'Initial guess for Gaussian sigma (nm)', 250/2.35),
 ]
 
 DESCRIPTION = 'Vanilla 2D Gaussian fit.'

--- a/PYME/localization/FitFactories/LatGaussFitFR.py
+++ b/PYME/localization/FitFactories/LatGaussFitFR.py
@@ -168,12 +168,12 @@ class GaussianFitFactory(FFBase.FitFactory):
         fitBackground = self.metadata.getOrDefault('Analysis.FitBackground', True)
         
         if fitBackground:
-            startParameters = [A, x0, y0, self.metadata['Analysis.SigmaGuess'], dataMean.min(), .001, .001]
+            startParameters = [A, x0, y0, self.metadata.getOrDefault('Analysis.PSFSigmaGuess', 250/2.35), dataMean.min(), .001, .001]
     
             #do the fit
             (res, cov_x, infodict, mesg, resCode) = self.solver(self.fitfcn, startParameters, dataMean, sigma, X, Y)
         else:
-            startParameters = [A, x0, y0, self.metadata['Analysis.SigmaGuess']]
+            startParameters = [A, x0, y0, self.metadata.getOrDefault('Analysis.PSFSigmaGuess', 250/2.35)]
     
             #do the fit
             (res, cov_x, infodict, mesg, resCode) = self.solver(f_gauss2d_no_bg, startParameters, dataMean, sigma, X, Y)
@@ -212,7 +212,7 @@ import PYME.localization.MetaDataEdit as mde
 
 PARAMETERS = [
     mde.IntParam('Analysis.ROISize', u'ROI half size', 5),
-    mde.FloatParam('Analysis.SigmaGuess', u'Initial guess for Gaussian sigma (nm)', 250/2.35),
+    mde.FloatParam('Analysis.PSFSigmaGuess', u'Initial guess for Gaussian sigma (nm)', 250/2.35),
 ]
 
 DESCRIPTION = 'Vanilla 2D Gaussian fit.'

--- a/PYME/localization/FitFactories/SplitterFitFNR.py
+++ b/PYME/localization/FitFactories/SplitterFitFNR.py
@@ -239,10 +239,11 @@ class GaussianFitFactory(FFBase.FFBase):
         y0 =  Yg.mean()
 
         fitBackground = self.metadata.getOrDefault('Analysis.FitBackground', True)
+        sigma_guess = self.metadata.getOrDefault('Analysis.PSFSigmaGuess', 250/2.35)
         if fitBackground:
-            startParameters = numpy.array([Ag, Ar, x0, y0, 250/2.35, 0, 0])
+            startParameters = numpy.array([Ag, Ar, x0, y0, sigma_guess, 0, 0])
         else:
-            startParameters = numpy.array([Ag, Ar, x0, y0, 250/2.35])
+            startParameters = numpy.array([Ag, Ar, x0, y0, sigma_guess])
         
         dataROI = np.maximum(dataROI - bgROI, -sigma)
         
@@ -305,6 +306,7 @@ PARAMETERS = [#mde.ChoiceParam('Analysis.InterpModule','Interp:','LinearInterpol
               #mde.ChoiceParam('Analysis.EstimatorModule', 'Z Start Est:', 'astigEstimator', choices=zEstimators.estimatorList),
               #mde.ChoiceParam('PRI.Axis', 'PRI Axis:', 'y', choices=['x', 'y'])
               mde.IntParam('Analysis.ROISize', u'ROI half size', 5),
+              mde.FloatParam('Analysis.PSFSigmaGuess', u'Initial guess for Gaussian sigma (nm)', 250/2.35),
               ]
               
 DESCRIPTION = 'Ratiometric multi-colour 2D Gaussian fit (large shifts).'


### PR DESCRIPTION
Addresses issue: if you are using LatGaussFitFR.py to fit e.g. large beads imaged on low NA setup, rather than single molecules on high NA oil immersion, you'd like to change the initial sigma value.

**Is this a bugfix or an enhancement?**
enhancement
**Proposed changes:**
- introduce Analysis.SigmaGuess metadata parameter to LatGaussFitFR.py






**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
