### PR TITLE
development pip install doc improvements

### DIFF
--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -40,11 +40,12 @@ For development installs, after creating and activating a conda environment as a
 
 .. code-block:: bash
 
-      git clone https://github.com/yourusername/python-microscopy.git
+      git clone https://github.com/python-microscopy/python-microscopy.git
       cd python-microscopy
       pip install build meson meson-python ninja cython
       pip install --no-build-isolation -e .
 
+You may alternatively fork the repository and clone your fork (e.g. `git clone https://github.com/yourusername/python-microscopy.git`).
 To rebuild after making changes, run
 
 .. code-block:: bash

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -42,7 +42,7 @@ For development installs, after creating and activating a conda environment as a
 
       git clone https://github.com/python-microscopy/python-microscopy.git
       cd python-microscopy
-      pip install build meson meson-python ninja cython
+      pip install build meson meson-python ninja cython numpy
       pip install --no-build-isolation -e .
 
 You may alternatively fork the repository and clone your fork (e.g. `git clone https://github.com/yourusername/python-microscopy.git`).

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -45,7 +45,7 @@ For development installs, after creating and activating a conda environment as a
       pip install build meson meson-python ninja cython numpy
       pip install --no-build-isolation -e .
 
-You may alternatively fork the repository and clone your fork (e.g. `git clone https://github.com/yourusername/python-microscopy.git`).
+You may alternatively fork the repository and clone your fork (e.g. ``git clone https://github.com/yourusername/python-microscopy.git``).
 To rebuild after making changes, run
 
 .. code-block:: bash

--- a/docs/Installation/Installation.rst
+++ b/docs/Installation/Installation.rst
@@ -53,7 +53,7 @@ To rebuild after making changes, run
       pip install --no-deps --no-build-isolation --editable . 
 
 
-** NOTE: ** everything below this line is out of date, and will be revisited once we have the 
+**NOTE:** everything below this line is out of date, and will be revisited once we have the 
 conda packages and executable installers working again.
 
 Executable installers (Windows and Mac)


### PR DESCRIPTION
Addresses issues with development install instructions.

**Proposed changes:**
- include numpy in the pip install. Including numpy as a build requirement only seems to do anything for building _without_ build isolation, so building with build isolation requires it, and copy and pasting the current lines one after another fails without numpy pre-installed in the environment.
- give an example line for cloning with clones our main repository. I've watched two different people copy and paste that line and then hit an error because yourusername/python-microscopy doesn't resolve. It's valid for people to clone the main, and then fork later if they want to sub a PR. 
- fix the note formatting, which had extra spaces and so only ** Note ** rather than **Note**



Here is a screen grab of the edited section:
<img width="735" height="446" alt="Screenshot 2026-06-30 at 10 42 15 AM" src="https://github.com/user-attachments/assets/007d32b5-01ac-4f1a-bc50-a3f753891531" />
