### PR TITLE
a collection of OBF and container format GUI fixes

### DIFF
--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -813,8 +813,9 @@ class ImageStack(object):
         
         data = OBFDataSource.DataSource(obf, stack_number)
         self.SetData(data)
-        self.seriesName = getRelFilename(filename) + ': ' + data.stack.name
-        self.filename = self.seriesName
+        self.seriesName = filename + ("?stack=%d" % stack_number) # use the valid query syntax to get a unique name that we can actually load back
+        #self.filename = self.seriesName # self.filename is actually set in the calling code AFTER this function has been called, so effectively NOOP
+        #self.query = "stack=%d" % stack_number # we comment this out since we use the query syntax already to make a unique name for the stack in question
         logger.debug(self.filename)
         self.mdh = MetaDataHandler.NestedClassMDHandler(MetaData.BareBones)
         voxel_sizes = data.stack.pixel_sizes
@@ -825,7 +826,21 @@ class ImageStack(object):
         self.mdh['voxelsize.y'] = voxel_sizes[1] / 1E-6 # [m -> um]
         if len(voxel_sizes) > 2:
             self.mdh['voxelsize.z'] = voxel_sizes[2] / 1E-6 # [m -> um]
-        
+        # retrieve the offset info from the stack metadata; this is key to overlaying with MINFLUX localizations
+        # these should generally exist but just in case we wrap this in a try statement
+        try:
+            offsets = data.stack.offsets
+        except AttributeError:
+            pass
+        else:
+            self.mdh['Origin.x'] = 1e9*offsets[0] # convert to nm
+            self.mdh['Origin.y'] = 1e9*offsets[1] # convert to nm
+            if len(data.stack.shape)>2 and data.stack.shape[2]>1:
+                zsize = data.stack.shape[2]
+                origin_z = - 1e3*self.mdh['voxelsize.z'] * zsize/2 # so that center of stack will appear at ~0 in VisGUI
+            else:
+                origin_z = 0
+            self.mdh['Origin.z'] = origin_z
         
 
     def _findAndParseMetadata(self, filename):
@@ -1425,7 +1440,9 @@ class ImageStack(object):
                 self._loadOBF(filename)
                 # hack to get around self.filename = filename below, otherwise if we open multiple
                 # stacks from this same file we won't be able to make composite later
-                filename = self.seriesName
+                filename = self.seriesName 
+                # this hack uses the query syntax to make a unique series name peserves the saving and loading back of session files
+                # see also code in _loadOBF below
             elif os.path.splitext(filename)[1] in ['.tif', '.lsm']: #try tiff
                 self._loadTiff(filename)
             elif filename.endswith('.dcimg'):

--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -934,7 +934,7 @@ class Pipeline(object):
         return charts
 
 
-    def load_extra_datasources(self, **kwargs):
+    def load_extra_datasources(self, haveGUI=False, **kwargs):
         ''' Load additional input data files into the pipeline.
         
        Takes keyword arguments with the following format:
@@ -944,7 +944,7 @@ class Pipeline(object):
        load_extra_datadources(fitResults='fitResults.mat', drift='drift.mat')        
        '''
         
-        self.recipe.load_inputs(kwargs)
+        self.recipe.load_inputs(kwargs, haveGUI=haveGUI)
 
         
     @property

--- a/PYME/LMVis/visCore.py
+++ b/PYME/LMVis/visCore.py
@@ -439,8 +439,9 @@ class VisGUICore(object):
         dsname = ask(self,message='provide short name for datasource')
         if dsname is None:
             return
-        self.pipeline.load_extra_datasources(**{dsname:filename})
-        
+        self.pipeline.load_extra_datasources(**{dsname:filename,'haveGUI':True}) # we pass through the haveGUI flag for some of the image datatypes
+        self.pipeline.Rebuild() # it seems to me one wants to rebuild, otherwise visgui does not seem to "know" about the new DS
+
     def OnOpenFile(self, event):
         filename = wx.FileSelector("Choose a file to open", 
                                    nameUtils.genResultDirectoryPath(),

--- a/PYME/recipes/recipe.py
+++ b/PYME/recipes/recipe.py
@@ -802,7 +802,7 @@ class Recipe(HasTraits):
         self.namespace.update({key_prefix + k: v for k, v in tables.items()})
 
     
-    def load_inputs(self, inputs, metadata_defaults={}, raise_on_error=True):
+    def load_inputs(self, inputs, metadata_defaults={}, raise_on_error=True, haveGUI=False):
         """
         load inputs from a dictionary mapping keys to filenames
         """
@@ -814,14 +814,14 @@ class Recipe(HasTraits):
                 continue
 
             try:
-                self._load_input(v, key=k, metadata_defaults=metadata_defaults, cache=cache)
+                self._load_input(v, key=k, metadata_defaults=metadata_defaults, cache=cache, haveGUI=haveGUI)
             except Exception as e:
                 if raise_on_error:
                     raise RecipeError('Error loading input %s from %s' % (k, v)) from e
                 else:
                     logger.exception('Error loading input %s from %s' % (k, v))
     
-    def _load_input(self, filename, key='input', metadata_defaults={}, cache={}, default_to_image=True, args={}):
+    def _load_input(self, filename, key='input', metadata_defaults={}, cache={}, default_to_image=True, args={}, haveGUI=False):
         """
         Load input data from a file and inject into namespace
         """
@@ -904,7 +904,7 @@ class Recipe(HasTraits):
         else: # assume it's an image
             if query:
                 filename = filename + '?' + query #reconstruct the filename with the query string as this is processed by some imaghe types
-            im = ImageStack(filename=filename, haveGUI=False)
+            im = ImageStack(filename=filename, haveGUI=haveGUI)
             if im.mdh.get('voxelsize.x', None) is None:
                 logger.error('No voxelsize metadata found for image %s, using defaults' % filename)
             im.mdh.mergeEntriesFrom(metadata_defaults)


### PR DESCRIPTION
**Is this a bugfix or an enhancement?**

Mostly a bugfix relating to selecting data from "container formats" (e.g. OBF & MSR), OBF filename overwriting + enhancement for translating OBF image offsets to PYME metadata.

**Proposed changes:**

"Bugs" addressed (bugs not reported via Issues at this stage):

1. OBF series naming broke session saving and loading; to allow for multi-channel overlays we need in PYMEImage apparently distinct series names (filenames). When several images are loaded from the same container (e.g. `.msr`), the stack names were used to make unique names; however, this breakes session saving and loading; made the filenames unique using the supported "query" additions, e.g. "?stack=4". This restores ability to save and reload sessions.
3. we need to pass a `haveGUI` flag for multi-image containers to enable GUI selection when called from visgui; previously the haveGUI flag was always False for the relevant methods called in the chain. The haveGUI flag has now been added to the relevant methods and gets set when the call initiated in VisGUI
4. after loading extra datasources from visgui added pipeline rebuild to make new DS available from `VisGUI` selectors

Enhacements:

- small addition for OBF handling of offset metadata in _loadOBF; this is important to be able to overlay images from .msr container files correctly on MINFLUX coordinate data

**Checklist:**

I checked the functionality to now work probably with GUI dialogs when loading extra data sources in `VisGUI` from container formats, ability to save and load sessions.
