### PR TITLE
Extract Positioning.Stage_X, Stage_Y, and PIFoc, from OME XML

### DIFF
--- a/PYME/IO/DataSources/BioformatsBFFDataSource.py
+++ b/PYME/IO/DataSources/BioformatsBFFDataSource.py
@@ -73,3 +73,7 @@ class DataSource(XYZTCDataSource):
     def __del__(self):
         self.release()
 
+    @property
+    def ome_series_metadata(self):
+        return self._bf.ome_metadata.images[self.series_num]
+

--- a/PYME/IO/MetaDataHandler.py
+++ b/PYME/IO/MetaDataHandler.py
@@ -917,7 +917,7 @@ class OMEXMLMDHandler(XMLMDHandler):
             
         return ps
         
-    def __init__(self, XMLData = None, mdToCopy=None):
+    def __init__(self, XMLData = None, mdToCopy=None, series=0):
         if not XMLData is None:
             #loading an existing file
             self.doc = parseString(XMLData)
@@ -927,9 +927,11 @@ class OMEXMLMDHandler(XMLMDHandler):
             except IndexError:
                 self.md = self.doc.createElement('MetaData')
                 self.doc.documentElement.appendChild(self.md)
-                
-                #try to load pixel size etc fro OME metadata
-                pix = self.doc.getElementsByTagName('Pixels')[0]
+
+                # Scope all lookups to the requested <Image> element.
+                images = self.doc.getElementsByTagName('Image')
+                img = images[min(series, len(images) - 1)]
+                pix = img.getElementsByTagName('Pixels')[0]
 
                 #using -ve defaults will trigger a voxelsize prompt in the GUI if pixel size metadata is not present
                 self['voxelsize.x'] = self._get_pixel_size_um(pix, 'X', -.1)
@@ -957,7 +959,7 @@ class OMEXMLMDHandler(XMLMDHandler):
                     self['ChannelNames'] = ch_names
                     
                 # extract stage positions if present
-                planes = self.doc.getElementsByTagName('Plane')
+                planes = pix.getElementsByTagName('Plane')
                 if planes:
                     plane = planes[0]
                     try:

--- a/PYME/IO/MetaDataHandler.py
+++ b/PYME/IO/MetaDataHandler.py
@@ -959,36 +959,22 @@ class OMEXMLMDHandler(XMLMDHandler):
                 # extract stage positions if present
                 planes = self.doc.getElementsByTagName('Plane')
                 if planes:
-                    x = float(planes[0].getAttribute('PositionX')) 
-                    x_unit = planes[0].getAttribute('PositionXUnit') # convert to um
-                    if x_unit == 'um':
-                        self['Positioning.Stage_X'] = x
-                    elif x_unit == 'mm':
-                        self['Positioning.Stage_X'] = x * 1000
-                    elif x_unit == 'm':
-                        self['Positioning.Stage_X'] = x * 1000000
-                    else:
-                        self['Positioning.Stage_X'] = x
-                    y = float(planes[0].getAttribute('PositionY'))
-                    y_unit = planes[0].getAttribute('PositionYUnit') # convert to um
-                    if y_unit == 'um':
-                        self['Positioning.Stage_Y'] = y
-                    elif y_unit == 'mm':
-                        self['Positioning.Stage_Y'] = y * 1000
-                    elif y_unit == 'm':
-                        self['Positioning.Stage_Y'] = y * 1000000
-                    else:
-                        self['Positioning.Stage_Y'] = y
-                    z = float(planes[0].getAttribute('PositionZ'))
-                    z_unit = planes[0].getAttribute('PositionZUnit') # convert to um
-                    if z_unit == 'um':
-                        self['Positioning.PIFoc'] = z
-                    elif z_unit == 'mm':
-                        self['Positioning.PIFoc'] = z * 1000
-                    elif z_unit == 'm':
-                        self['Positioning.PIFoc'] = z * 1000000
-                    else:
-                        self['Positioning.PIFoc'] = z
+                    plane = planes[0]
+                    try:
+                        x = float(plane.getAttribute('PositionX'))
+                        self['Positioning.Stage_X'] = x * self._OME_UNITS_TO_UM.get(plane.getAttribute('PositionXUnit'), 1.0)
+                    except (ValueError, TypeError):
+                        pass
+                    try:
+                        y = float(plane.getAttribute('PositionY'))
+                        self['Positioning.Stage_Y'] = y * self._OME_UNITS_TO_UM.get(plane.getAttribute('PositionYUnit'), 1.0)
+                    except (ValueError, TypeError):
+                        pass
+                    try:
+                        z = float(plane.getAttribute('PositionZ'))
+                        self['Positioning.PIFoc'] = z * self._OME_UNITS_TO_UM.get(plane.getAttribute('PositionZUnit'), 1.0)
+                    except (ValueError, TypeError):
+                        pass
 
             
                 

--- a/PYME/IO/MetaDataHandler.py
+++ b/PYME/IO/MetaDataHandler.py
@@ -956,9 +956,40 @@ class OMEXMLMDHandler(XMLMDHandler):
                 if any(ch_names):
                     self['ChannelNames'] = ch_names
                     
-                #except:
-                #    pass
-            
+                # extract stage positions if present
+                planes = self.doc.getElementsByTagName('Plane')
+                if planes:
+                    x = float(planes[0].getAttribute('PositionX')) 
+                    x_unit = planes[0].getAttribute('PositionXUnit') # convert to um
+                    if x_unit == 'um':
+                        self['Positioning.Stage_X'] = x
+                    elif x_unit == 'mm':
+                        self['Positioning.Stage_X'] = x * 1000
+                    elif x_unit == 'm':
+                        self['Positioning.Stage_X'] = x * 1000000
+                    else:
+                        self['Positioning.Stage_X'] = x
+                    y = float(planes[0].getAttribute('PositionY'))
+                    y_unit = planes[0].getAttribute('PositionYUnit') # convert to um
+                    if y_unit == 'um':
+                        self['Positioning.Stage_Y'] = y
+                    elif y_unit == 'mm':
+                        self['Positioning.Stage_Y'] = y * 1000
+                    elif y_unit == 'm':
+                        self['Positioning.Stage_Y'] = y * 1000000
+                    else:
+                        self['Positioning.Stage_Y'] = y
+                    z = float(planes[0].getAttribute('PositionZ'))
+                    z_unit = planes[0].getAttribute('PositionZUnit') # convert to um
+                    if z_unit == 'um':
+                        self['Positioning.PIFoc'] = z
+                    elif z_unit == 'mm':
+                        self['Positioning.PIFoc'] = z * 1000
+                    elif z_unit == 'm':
+                        self['Positioning.PIFoc'] = z * 1000000
+                    else:
+                        self['Positioning.PIFoc'] = z
+
             
                 
             

--- a/PYME/IO/MetaDataHandler.py
+++ b/PYME/IO/MetaDataHandler.py
@@ -964,17 +964,17 @@ class OMEXMLMDHandler(XMLMDHandler):
                     plane = planes[0]
                     try:
                         x = float(plane.getAttribute('PositionX'))
-                        self['Positioning.Stage_X'] = x * self._OME_UNITS_TO_UM.get(plane.getAttribute('PositionXUnit'), 1.0)
+                        self['Positioning.x'] = x * self._OME_UNITS_TO_UM.get(plane.getAttribute('PositionXUnit'), 1.0)
                     except (ValueError, TypeError):
                         pass
                     try:
                         y = float(plane.getAttribute('PositionY'))
-                        self['Positioning.Stage_Y'] = y * self._OME_UNITS_TO_UM.get(plane.getAttribute('PositionYUnit'), 1.0)
+                        self['Positioning.y'] = y * self._OME_UNITS_TO_UM.get(plane.getAttribute('PositionYUnit'), 1.0)
                     except (ValueError, TypeError):
                         pass
                     try:
                         z = float(plane.getAttribute('PositionZ'))
-                        self['Positioning.PIFoc'] = z * self._OME_UNITS_TO_UM.get(plane.getAttribute('PositionZUnit'), 1.0)
+                        self['Positioning.z'] = z * self._OME_UNITS_TO_UM.get(plane.getAttribute('PositionZUnit'), 1.0)
                     except (ValueError, TypeError):
                         pass
 

--- a/PYME/IO/image.py
+++ b/PYME/IO/image.py
@@ -1141,12 +1141,11 @@ class ImageStack(object):
         self.mdh = MetaDataHandler.NestedClassMDHandler(MetaData.BareBones)
 
         print('BioformatsBFF: parsing OME metadata')
-        # Re-open briefly to retrieve the OME XML; the DataSource holds its own handle.
-        with BioFile(fn) as bf:
-            ome_xml = bf.ome_xml
+        # Use the already-open file handle; avoids a redundant open/close cycle.
+        ome_xml = self.dataSource._bf.ome_xml
 
         if ome_xml:
-            OMEmd = MetaDataHandler.OMEXMLMDHandler(ome_xml.encode('utf8'))
+            OMEmd = MetaDataHandler.OMEXMLMDHandler(ome_xml.encode('utf8'), series=series_num)
             self.mdh.copyEntriesFrom(OMEmd)
 
         print('BioformatsBFF: done')
@@ -1223,7 +1222,7 @@ class ImageStack(object):
         print("Bioformats:loading metadata")
         OMEXML = bioformats.get_omexml_metadata(filename).encode('utf8')
         print("Bioformats:parsing metadata")
-        OMEmd = MetaDataHandler.OMEXMLMDHandler(OMEXML)
+        OMEmd = MetaDataHandler.OMEXMLMDHandler(OMEXML, series=series_num or 0)
         self.mdh.copyEntriesFrom(OMEmd)
         print("Bioformats:done")
         


### PR DESCRIPTION
Addresses issue wanting to know stage position after loading nd2 file through bffiledatasource.



<img width="354" height="75" alt="Screenshot 2026-08-03 at 5 09 35 PM" src="https://github.com/user-attachments/assets/8d3b8e43-a75c-4a03-a273-273125f372e6" />


I think PIFoc is a little odd to use by default for Z, but for now I think Positioning.Stage_Z is unused.