### PR TITLE
use public numpy api to create record rather than importing core

### DIFF
--- a/PYME/IO/tabular.py
+++ b/PYME/IO/tabular.py
@@ -109,7 +109,6 @@ class TabularBase(object):
         numpy recarray version of self
 
         """
-        from numpy.core import records
         if keys is None:
             keys = list(self.keys())
 
@@ -124,7 +123,7 @@ class TabularBase(object):
         dt = [(k, v.dtype, v.shape[1:]) for k, v in zip(keys_, cols)]
         
         #print(dt)
-        return records.fromarrays(cols, names=keys_, dtype=dt)
+        return np.rec.fromarrays(cols, names=keys_, dtype=dt)
 
     def to_hdf(self, filename, tablename='Data', keys=None, metadata=None,
                keep_alive_timeout=0):


### PR DESCRIPTION
Addresses issue accessing numpy.core is deprecated (now _core) and is raising deprecation warnings.

**Is this a bugfix or an enhancement?**
maintenance
**Proposed changes:**
- use public api to create rec array rather than numpy.core.records.fromarrays





**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
