### PR TITLE
avoid our very own deprecation warning

### DIFF
--- a/PYME/recipes/output.py
+++ b/PYME/recipes/output.py
@@ -220,7 +220,7 @@ class ImageOutput(OutputModule):
         _ensure_output_directory(out_filename)
         
         v = self.generate(namespace)
-        v.Save(out_filename)
+        v.save(out_filename)
 
 
 @register_module('RGBImageOutput')


### PR DESCRIPTION
Addresses issue we lowercased `ImageStack.save`, and passthrough uppercase Save with a deprecation warning.

