### PR TITLE
Wxpython dependency tweaks for macos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,11 @@ dependencies = [
   "numpy>=1.22",
   "scipy",
   "matplotlib",
-  "wxpython",
+  # next two lines to restrict to wxpython<4.3 until bug on macos fixed, see also
+  #    https://github.com/wxWidgets/Phoenix/issues/2937 and
+  #    https://github.com/python-microscopy/python-microscopy/issues/1694
+  "wxpython!=4.3.0,!=4.3.1; platform_system == 'Darwin'",
+  "wxpython; platform_system != 'Darwin'",
   "cython",
   "tables",
   "pyopengl",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "numpy>=1.22",
   "scipy",
   "matplotlib",
-  # next two lines to restrict to wxpython<4.3 until bug on macos fixed, see also
+  # next two lines to avoid broken wxpythons (4.3.0, 4.3.1) on macos, see also
   #    https://github.com/wxWidgets/Phoenix/issues/2937 and
   #    https://github.com/python-microscopy/python-microscopy/issues/1694
   "wxpython!=4.3.0,!=4.3.1; platform_system == 'Darwin'",


### PR DESCRIPTION
Addresses issue #1694 .

**Is this a bugfix or an enhancement?**

Bugfix for issue #1694, excludes the "broken" wxpython versions 4.3.0 and 4.3.1 on macOS. Pre-release wxpython 4.3.2a is already fixed and tested ok for me, so this should ensure we get the latest wxpython also on macOS once 4.3.2 is out. Other platforms are without version restrictions.

**Proposed changes:**

Spell out wxpython version requirements in pyproject.toml.
