### PR TITLE
include required header files in build

### DIFF
--- a/PYME/experimental/meson.build
+++ b/PYME/experimental/meson.build
@@ -45,6 +45,9 @@ data_files = files(
     '_octree.pyx',
     'func_octree.pyx',
     '_treap.pyx',
+    # required by downstream packages (e.g. ch-shrinkwrap) that cdef extern from these files
+    'triangle_mesh_utils.h',
+    'triangle_mesh_utils.c',
 )
 
 install_data(data_files, install_dir: install_dir)


### PR DESCRIPTION
needed for ch-shrinkwrap to build against bundled PYME
