### PR TITLE
remove invalid flag from dictchoice dialog

### DIFF
--- a/PYME/ui/custom_traits_editors.py
+++ b/PYME/ui/custom_traits_editors.py
@@ -131,7 +131,7 @@ class DictChoiceStrEditDialog(wx.Dialog):
             self.cbKey.Enable(False)
 
         hsizer.Add(self.cbKey, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
-        vsizer.Add(hsizer, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        vsizer.Add(hsizer, 0, wx.ALL, 5)
 
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
         hsizer.Add(wx.StaticText(self, -1, 'Table_Name:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
@@ -141,7 +141,7 @@ class DictChoiceStrEditDialog(wx.Dialog):
 
         hsizer.Add(self.tVal, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 
-        vsizer.Add(hsizer, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        vsizer.Add(hsizer, 0, wx.ALL, 5)
 
         
         btSizer = wx.StdDialogButtonSizer()
@@ -157,7 +157,7 @@ class DictChoiceStrEditDialog(wx.Dialog):
 
         btSizer.Realize()
 
-        vsizer.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        vsizer.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALL, 5)
 
         self.SetSizer(vsizer)
         vsizer.Fit(self)


### PR DESCRIPTION
Addresses issue #invalid wx alignment flags stoped the dictstringeditor from coming up when trying to e.g. use `Output.HDFOutput` recipe module in the recipe editor.

<details> <summary> Traceback </summary>

'''
Traceback (most recent call last):
  File "/Users/andy/code/python-microscopy/PYME/ui/custom_traits_editors.py", line 277, in OnFilterAdd
    dlg = DictChoiceStrEditDialog(self, mode='new', 
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/andy/code/python-microscopy/PYME/ui/custom_traits_editors.py", line 134, in __init__
    vsizer.Add(hsizer, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
wx._core.wxAssertionError: C++ assertion "CheckSizerFlags(!((flags) & (wxALIGN_CENTRE_VERTICAL)))" failed at ./src/common/sizer.cpp(2273) in DoInsert(): wxALIGN_CENTRE_VERTICAL will be ignored in this sizer: only horizontal alignment flags can be used in vertical sizers

DO NOT PANIC !!

If you're an end user running a program not developed by you, please ignore this message, it is harmless, and please try reporting the problem to the program developers.

You may also set WXSUPPRESS_SIZER_FLAGS_CHECK environment variable to suppress all such checks when running this program.

If you're the developer, simply remove this flag from your code to avoid getting this message. You can also call wxSizerFlags::DisableConsistencyChecks() to globally disable all such checks, but this is strongly not recommended.
'''

</details>

**Is this a bugfix or an enhancement?**
maintenance
**Proposed changes:**
remove flags which were ignored anyway


**Checklist:**


wxpython                  4.2.5           py311h8325047_2    conda-forge
wxwidgets                 3.2.9                h34c1157_0    conda-forge

<img width="415" height="271" alt="Screenshot 2026-09-10 at 2 40 47 PM" src="https://github.com/user-attachments/assets/be610cf1-a38a-42fa-b3f2-415483bf0ba8" />
