### PR TITLE
remove invalid wx sizer flags

### DIFF
--- a/PYME/Acquire/Hardware/AndorNeo/AndorNeoControlFrame.py
+++ b/PYME/Acquire/Hardware/AndorNeo/AndorNeoControlFrame.py
@@ -69,7 +69,7 @@ class AndorNeoPanel(wx.Panel):
 
         self.tCCDTemp = wx.TextCtrl(self, -1, '0', size=(30, -1))
         hsizer2.Add(self.tCCDTemp, 1, wx.wx.RIGHT|wx.ALIGN_CENTER_VERTICAL, 5)
-        sbCooling.Add(hsizer2, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        sbCooling.Add(hsizer2, 0, wx.EXPAND, 0)
 
         self.bSetTemp = wx.Button(self, -1, 'Set', style=wx.BU_EXACTFIT)
         self.bSetTemp.Bind(wx.EVT_BUTTON, self.OnBSetTempButton)
@@ -85,30 +85,30 @@ class AndorNeoPanel(wx.Panel):
         self.tEMGain.Bind(wx.EVT_TEXT, self.OnEMGainTextChange)
         self.tEMGain.Bind(wx.EVT_TEXT_ENTER, self.OnBSetGainButton)
         self.tEMGain.Bind(wx.EVT_COMBOBOX, self.OnBSetGainButton)
-        hsizer2.Add(self.tEMGain, 1, wx.EXPAND|wx.RIGHT|wx.ALIGN_CENTER_VERTICAL, 5)
+        hsizer2.Add(self.tEMGain, 1, wx.EXPAND|wx.RIGHT, 5)
 
         self.bSetGain = wx.Button(self, -1, 'Set', style=wx.BU_EXACTFIT)
         self.bSetGain.Bind(wx.EVT_BUTTON, self.OnBSetGainButton)
-        hsizer2.Add(self.bSetGain, 0, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL, 0)
+        hsizer2.Add(self.bSetGain, 0, wx.EXPAND, 0)
 
-        sbEMGain.Add(hsizer2, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        sbEMGain.Add(hsizer2, 0, wx.EXPAND, 0)
 
         self.stTrueEMGain = wx.StaticText(self, -1, '????')
         self.stTrueEMGain.SetForegroundColour(wx.RED)
-        sbEMGain.Add(self.stTrueEMGain, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        sbEMGain.Add(self.stTrueEMGain, 0, wx.EXPAND, 0)
 
-        hsizer.Add(sbEMGain, 1, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL, 0)
-        vsizer.Add(hsizer, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        hsizer.Add(sbEMGain, 1, wx.EXPAND, 0)
+        vsizer.Add(hsizer, 0, wx.EXPAND, 0)
 
         self.cbShutter = wx.CheckBox(self, -1, u'Spurious Noise Filter')
         self.cbShutter.SetValue(False)
         self.cbShutter.Bind(wx.EVT_CHECKBOX, self.OnCbShutterCheckbox)
-        vsizer.Add(self.cbShutter, 0, wx.ALIGN_CENTER_VERTICAL|wx.TOP, 5)
+        vsizer.Add(self.cbShutter, 0, wx.TOP, 5)
 
         self.cbStaticBlemishCorrection = wx.CheckBox(self, -1, u'Static Blemish Correction')
         self.cbStaticBlemishCorrection.SetValue(False)
         self.cbStaticBlemishCorrection.Bind(wx.EVT_CHECKBOX, self.OnCbStaticBlemishCorrection)
-        vsizer.Add(self.cbStaticBlemishCorrection, 0, wx.ALIGN_CENTER_VERTICAL|wx.TOP, 5)
+        vsizer.Add(self.cbStaticBlemishCorrection, 0, wx.TOP, 5)
 
         self.SetSizer(vsizer)
 

--- a/PYME/Acquire/Hardware/LaserControlFrame.py
+++ b/PYME/Acquire/Hardware/LaserControlFrame.py
@@ -38,9 +38,9 @@ class LaserPanel(wx.Panel):
         self.bs1.Add(self.cbOn, 0, wx.ALL | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL, 2)
         
         self.bs1.AddStretchSpacer()
-        self.bs1.Add(wx.StaticLine(self, style=wx.LI_VERTICAL, size=(2,25)), 0,wx.LEFT | wx.RIGHT | wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 5)
+        self.bs1.Add(wx.StaticLine(self, style=wx.LI_VERTICAL, size=(2,25)), 0,wx.LEFT | wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, 5)
         
-        self.bs1.Add(wx.StaticText(self, wx.ID_ANY, 'Power:'), 0,wx.ALL | wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 2)
+        self.bs1.Add(wx.StaticText(self, wx.ID_ANY, 'Power:'), 0,wx.ALL | wx.ALIGN_CENTER_VERTICAL, 2)
         
         self.tcPower= wx.TextCtrl(self, wx.ID_ANY, '1', size=(40,-1))
         self.bs1.Add(self.tcPower, 0,wx.ALL | wx.ALIGN_CENTRE | wx.ALIGN_CENTER_VERTICAL, 2)
@@ -53,10 +53,10 @@ class LaserPanel(wx.Panel):
         self.bSetPower.Enable(self.laser.IsPowerControlable())
         
         self.bs1.AddStretchSpacer()
-        self.bs1.Add(wx.StaticLine(self, style=wx.LI_VERTICAL, size=(2,25)), 0,wx.LEFT | wx.RIGHT | wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 5)
+        self.bs1.Add(wx.StaticLine(self, style=wx.LI_VERTICAL, size=(2,25)), 0,wx.LEFT | wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, 5)
         
         self.tcPulse= wx.TextCtrl(self, wx.ID_ANY, '0', size=(40,-1))
-        self.bs1.Add(self.tcPulse, 0,wx.ALL | wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 2)
+        self.bs1.Add(self.tcPulse, 0,wx.ALL | wx.ALIGN_CENTER_VERTICAL, 2)
         self.tcPulse.Enable(not self.laser.IsOn())
         
         self.bPulse = wx.Button(self, wx.ID_ANY, 'Pulse', style=wx.BU_EXACTFIT)

--- a/PYME/Acquire/Hardware/uc480/AndorControlFrame.py
+++ b/PYME/Acquire/Hardware/uc480/AndorControlFrame.py
@@ -72,15 +72,15 @@ class AndorPanel(wx.Panel):
         self.rbSingleShot.SetValue(False)
         self.rbSingleShot.SetToolTipString('Allows multiple channels with different integration times and good shutter synchronisation')
         self.rbSingleShot.Bind(wx.EVT_RADIOBUTTON,self.OnRbSingleShotRadiobutton)
-        sbAqMode.Add(self.rbSingleShot, 1, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL, 0)
+        sbAqMode.Add(self.rbSingleShot, 1, wx.EXPAND, 0)
 
         self.rbContin = wx.RadioButton(cp, -1, 'Continuous')
         self.rbContin.SetValue(True)
         self.rbContin.SetToolTipString('Allows fastest speeds, albeit without good syncronisation (fixable) or integration time flexibility')
         self.rbContin.Bind(wx.EVT_RADIOBUTTON, self.OnRbContinRadiobutton)
-        sbAqMode.Add(self.rbContin, 1, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL, 0)
+        sbAqMode.Add(self.rbContin, 1, wx.EXPAND, 0)
 
-        vsizer.Add(sbAqMode, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL|wx.TOP, 5)
+        vsizer.Add(sbAqMode, 0, wx.EXPAND|wx.TOP, 5)
 
         #self.bUpdateInt = wx.Button(id=wxID_ANDORFRAMEBUPDATEINT,
         #      label='Update Integration Time', name='bUpdateInt',
@@ -126,7 +126,7 @@ class AndorPanel(wx.Panel):
         hsizer.Add(self.cbBaselineClamp, 0, wx.ALIGN_CENTER_VERTICAL, 0)
 
         sbReadout.Add(hsizer, 0, wx.TOP, 2)
-        vsizer.Add(sbReadout, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL|wx.TOP, 5)
+        vsizer.Add(sbReadout, 0, wx.EXPAND|wx.TOP, 5)
 
         cp.SetSizer(vsizer)
 
@@ -148,7 +148,7 @@ class AndorPanel(wx.Panel):
 
         self.tCCDTemp = wx.TextCtrl(self, -1, '0', size=(30, -1))
         hsizer2.Add(self.tCCDTemp, 1, wx.wx.RIGHT|wx.ALIGN_CENTER_VERTICAL, 5)
-        sbCooling.Add(hsizer2, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        sbCooling.Add(hsizer2, 0, wx.EXPAND, 0)
 
         self.bSetTemp = wx.Button(self, -1, 'Set', style=wx.BU_EXACTFIT)
         self.bSetTemp.Bind(wx.EVT_BUTTON, self.OnBSetTempButton)
@@ -164,25 +164,25 @@ class AndorPanel(wx.Panel):
         self.tEMGain.Bind(wx.EVT_TEXT, self.OnEMGainTextChange)
         self.tEMGain.Bind(wx.EVT_TEXT_ENTER, self.OnBSetGainButton)
         self.tEMGain.Bind(wx.EVT_COMBOBOX, self.OnBSetGainButton)
-        hsizer2.Add(self.tEMGain, 1, wx.EXPAND|wx.RIGHT|wx.ALIGN_CENTER_VERTICAL, 5)
+        hsizer2.Add(self.tEMGain, 1, wx.EXPAND|wx.RIGHT, 5)
 
         self.bSetGain = wx.Button(self, -1, 'Set', style=wx.BU_EXACTFIT)
         self.bSetGain.Bind(wx.EVT_BUTTON, self.OnBSetGainButton)
-        hsizer2.Add(self.bSetGain, 0, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL, 0)
+        hsizer2.Add(self.bSetGain, 0, wx.EXPAND, 0)
 
-        sbEMGain.Add(hsizer2, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        sbEMGain.Add(hsizer2, 0, wx.EXPAND, 0)
 
         self.stTrueEMGain = wx.StaticText(self, -1, '????')
         self.stTrueEMGain.SetForegroundColour(wx.RED)
-        sbEMGain.Add(self.stTrueEMGain, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        sbEMGain.Add(self.stTrueEMGain, 0, wx.EXPAND, 0)
 
-        hsizer.Add(sbEMGain, 1, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL, 0)
-        vsizer.Add(hsizer, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        hsizer.Add(sbEMGain, 1, wx.EXPAND, 0)
+        vsizer.Add(hsizer, 0, wx.EXPAND, 0)
 
         self.cbShutter = wx.CheckBox(self, -1, u'Camera Shutter Open')
         self.cbShutter.SetValue(True)
         self.cbShutter.Bind(wx.EVT_CHECKBOX, self.OnCbShutterCheckbox)
-        vsizer.Add(self.cbShutter, 0, wx.ALIGN_CENTER_VERTICAL|wx.TOP, 5)
+        vsizer.Add(self.cbShutter, 0, wx.TOP, 5)
 
         self.cp = self._createCollapsingPane()
 

--- a/PYME/Acquire/Hardware/uc480/ucCamControlFrame.py
+++ b/PYME/Acquire/Hardware/uc480/ucCamControlFrame.py
@@ -44,16 +44,16 @@ class ucCamPanel(wx.Panel):
         self.sl.SetTickFreq(10)
         self.Bind(wx.EVT_SCROLL,self.onSlide)
         hsizer.Add(self.sl, 1, wx.ALL|wx.EXPAND, 2)
-        ucGain.Add(hsizer, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        ucGain.Add(hsizer, 0, wx.EXPAND, 0)
 
         self.stGainFactor = wx.StaticText(self, -1, 'Gain Factor = %3.2f' % self.cam.GetGainFactor())
-        ucGain.Add(self.stGainFactor, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        ucGain.Add(self.stGainFactor, 0, wx.EXPAND, 0)
 
         self.stepc = wx.StaticText(self, -1, 'Electrons/Count = %3.2f' % (self.cam.noise_properties['ElectronsPerCount']))
-        ucGain.Add(self.stepc, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        ucGain.Add(self.stepc, 0, wx.EXPAND, 0)
 
 
-        vsizer.Add(ucGain, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        vsizer.Add(ucGain, 0, wx.EXPAND, 0)
 
         self.SetSizer(vsizer)
 

--- a/PYME/Acquire/sampleInformation.py
+++ b/PYME/Acquire/sampleInformation.py
@@ -267,7 +267,7 @@ class SampleInfoDialog(wx.Dialog):
 
         btSizer.Realize()
 
-        sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALL, 5)
 
         self.SetSizerAndFit(sizer1)
 

--- a/PYME/Acquire/sampleInformationDjangoDirect.py
+++ b/PYME/Acquire/sampleInformationDjangoDirect.py
@@ -205,7 +205,7 @@ class SampleInfoDialog(wx.Dialog):
 
         btSizer.Realize()
 
-        sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALL, 5)
 
         self.SetSizerAndFit(sizer1)
 

--- a/PYME/Acquire/ui/intsliders.py
+++ b/PYME/Acquire/ui/intsliders.py
@@ -154,7 +154,7 @@ class IntegrationSliders(wx.Panel):
             # TODO - fix this for new wx
 
         if nsliders > 1:
-            sz = wx.StaticBoxSizer(wx.StaticBox(self, -1, self.chaninfo.names[c] + " (ms)"), wx.HORIZONTAl)
+            sz = wx.StaticBoxSizer(wx.StaticBox(self, -1, self.chaninfo.names[c] + " (ms)"), wx.HORIZONTAL)
         else:
             sz = wx.BoxSizer(wx.HORIZONTAL)
 

--- a/PYME/Acquire/ui/intsliders.py
+++ b/PYME/Acquire/ui/intsliders.py
@@ -69,7 +69,7 @@ class IntegrationSliders_(wx.Panel):
             else:
                 sz = wx.BoxSizer(wx.HORIZONTAL)
 
-            sz.Add(sl, 1, wx.ALL|wx.EXPAND|wx.ALIGN_CENTER_VERTICAL, 2)
+            sz.Add(sl, 1, wx.ALL|wx.EXPAND, 2)
             sz.Add(sl_val, 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
             sz.Add(wx.StaticText(self, -1, 'ms'), 0, wx.ALL|wx.ALIGN_CENTER_VERTICAL, 2)
             sizer_2.Add(sz,1,wx.EXPAND,0)

--- a/PYME/Acquire/ui/mpd_picosecond_delay_panel.py
+++ b/PYME/Acquire/ui/mpd_picosecond_delay_panel.py
@@ -30,18 +30,18 @@ class DelayPanel(wx.Panel):
         self.sl.SetTickFreq(25000)
         self.Bind(wx.EVT_SCROLL,self.on_slide)
         hsizer.Add(self.sl, 1, wx.ALL|wx.EXPAND, 2)
-        delay.Add(hsizer, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        delay.Add(hsizer, 0, wx.EXPAND, 0)
 
         
 
-        vsizer.Add(delay, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        vsizer.Add(delay, 0, wx.EXPAND, 0)
 
         hsizer = wx.BoxSizer(wx.HORIZONTAL)
         self.cb_highspeed = wx.CheckBox(self, wx.ID_ANY, 'High-Speed mode (no GUI update)')
         self.cb_highspeed.SetValue(self.delayer.high_speed_mode)
         self.cb_highspeed.Bind(wx.EVT_CHECKBOX, self.on_cb_highspeed)
 
-        vsizer.Add(hsizer, 0, wx.EXPAND|wx.ALIGN_CENTER_HORIZONTAL, 0)
+        vsizer.Add(hsizer, 0, wx.EXPAND, 0)
 
         self.SetSizer(vsizer)
 

--- a/PYME/DSView/displaySettingsPanel.py
+++ b/PYME/DSView/displaySettingsPanel.py
@@ -68,7 +68,7 @@ class dispSettingsPanel(wx.Panel):
         self.hlDispMapping = histLimits.HistLimitPanel(self, -1, self.dsa, self.vp.do.getDisp1Off(), self.vp.do.getDisp1Off() + 255./self.vp.do.getDisp1Gain(), True, size=(100, 80))
         self.hlDispMapping.Bind(histLimits.EVT_LIMIT_CHANGE, self.OnMappingChange)
 
-        hsizer.Add(self.hlDispMapping, 1, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        hsizer.Add(self.hlDispMapping, 1, wx.EXPAND|wx.ALL, 5)
 
         vsizer2 = wx.BoxSizer(wx.VERTICAL)
         self.bOptimise = wx.Button(self, -1, 'Optimise', style=wx.BU_EXACTFIT)
@@ -94,9 +94,9 @@ class dispSettingsPanel(wx.Panel):
 
         #scaleSizer.Add(self.cbScale, 0, wx.ALL, 5)
         #hsizer.Add(wx.StaticText(self, -1, 'Scale: '), 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
-        vsizer2.Add(self.cbScale, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.EXPAND, 5)
+        vsizer2.Add(self.cbScale, 0, wx.EXPAND, 5)
 
-        hsizer.Add(vsizer2, 0, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        hsizer.Add(vsizer2, 0, wx.EXPAND|wx.ALL, 5)
 
         #vsizer.Add(hsizer, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.ALL, 5)
 

--- a/PYME/DSView/modules/composite.py
+++ b/PYME/DSView/modules/composite.py
@@ -200,7 +200,7 @@ class ShiftmapSelectionDialog(wx.Dialog):
 
         btSizer.Realize()
 
-        sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALL, 5)
 
         self.SetSizer(sizer1)
         sizer1.Fit(self)

--- a/PYME/DSView/modules/composite.py
+++ b/PYME/DSView/modules/composite.py
@@ -170,7 +170,9 @@ class ShiftmapSelectionDialog(wx.Dialog):
 
         sizer1 = wx.BoxSizer(wx.VERTICAL)
         
-        sizer2 = wx.GridSizer(nChans, 2, 5, 5)
+        # rows=0 => let wx work out the number of rows from the column count. We add a
+        # header row on top of one row per channel, so an explicit nChans would be too few.
+        sizer2 = wx.GridSizer(0, 2, 5, 5)
         
         sizer2.Add(wx.StaticText(self, -1, 'Channel:'))
         sizer2.Add(wx.StaticText(self, -1, 'Shiftmap:'))

--- a/PYME/DSView/modules/deconvolution.py
+++ b/PYME/DSView/modules/deconvolution.py
@@ -405,7 +405,7 @@ class WienerDeconvolver(wx.Panel):
 
         sizer3.Add(self.fpPSF, 1, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 
-        sizer2.Add(sizer3, 0, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL | wx.ALL, 0)
+        sizer2.Add(sizer3, 0, wx.EXPAND | wx.ALL, 0)
         
         sizer3 = wx.BoxSizer(wx.HORIZONTAL)
         sizer3.Add(wx.StaticText(self, -1, 'Offset:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
@@ -413,7 +413,7 @@ class WienerDeconvolver(wx.Panel):
 
         sizer3.Add(self.tOffset, 1, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 
-        sizer2.Add(sizer3, 0, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL | wx.ALL, 0)
+        sizer2.Add(sizer3, 0, wx.EXPAND | wx.ALL, 0)
 
         sizer3 = wx.BoxSizer(wx.HORIZONTAL)
         sizer3.Add(wx.StaticText(self, -1, u'Regularisation \u03BB:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
@@ -421,7 +421,7 @@ class WienerDeconvolver(wx.Panel):
 
         sizer3.Add(self.tRegLambda, 1, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 
-        sizer2.Add(sizer3, 0, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL | wx.ALL, 0)
+        sizer2.Add(sizer3, 0, wx.EXPAND | wx.ALL, 0)
         
         sizer3 = wx.BoxSizer(wx.HORIZONTAL)
         sizer3.AddSpacer(10)
@@ -431,7 +431,7 @@ class WienerDeconvolver(wx.Panel):
 
         sizer3.Add(self.bCalculate, 1, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 
-        sizer2.Add(sizer3, 0, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL | wx.ALL, 0)
+        sizer2.Add(sizer3, 0, wx.EXPAND | wx.ALL, 0)
 
         self.SetSizerAndFit(sizer2)
         

--- a/PYME/DSView/modules/segmentation.py
+++ b/PYME/DSView/modules/segmentation.py
@@ -109,7 +109,7 @@ class SegmentationPanel(wx.Panel):
         btn = wx.Button(self, -1, 'Apply')
         btn.Bind(wx.EVT_BUTTON, self.OnApply)
 
-        sizer1.Add(btn, 0, wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        sizer1.Add(btn, 0, wx.ALIGN_RIGHT|wx.ALL, 5)
 
 #        btn = wx.Button(self, -1, 'Done')
 #        btn.Bind(wx.EVT_BUTTON, self.OnDone)

--- a/PYME/Deconv/deconvDialogs.py
+++ b/PYME/Deconv/deconvDialogs.py
@@ -384,7 +384,9 @@ class DeconvProgressPanel(wx.Panel):
 
         self.gProgress = wx.Gauge(self, -1, numIters)
 
-        sizer1.Add(self.gProgress, 5, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        # sizer1.Add(self.gProgress, 5, wx.EXPAND|wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        sizer1.Add(self.gProgress, 5, wx.EXPAND | wx.ALL, 5)
+
 
         #btSizer = wx.StdDialogButtonSizer()
 
@@ -395,7 +397,7 @@ class DeconvProgressPanel(wx.Panel):
 
         #btSizer.Realize()
 
-        sizer1.Add(btn, 0, wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        sizer1.Add(btn, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
 
         self.SetSizer(sizer1)
         sizer1.Fit(self)

--- a/PYME/LMVis/Extras/animation.py
+++ b/PYME/LMVis/Extras/animation.py
@@ -299,7 +299,7 @@ class EditDialog(wx.Dialog):
 
         bt_sizer.Realize()
 
-        sizer1.Add(bt_sizer, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        sizer1.Add(bt_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 5)
 
         # set total size
         self.SetSizer(sizer1)

--- a/PYME/LMVis/genImageDialog.py
+++ b/PYME/LMVis/genImageDialog.py
@@ -142,7 +142,7 @@ class GenImageDialog(wx.Dialog):
             self.cbTriangSoftRender.SetValue(True)
             sizer2.Add(self.cbTriangSoftRender, 1, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 
-            sizer1.Add(sizer2, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+            sizer1.Add(sizer2, 0, wx.ALL, 5)
 
         if mode in ['3Dhistogram', '3Dgaussian', '3Dtriangles']:
             zThick = 50

--- a/PYME/LMVis/importTextDialog.py
+++ b/PYME/LMVis/importTextDialog.py
@@ -271,9 +271,9 @@ class ImportMatDialog(wx.Dialog):
 
         sizer2.Add(self.cbVarNames, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 
-        sizer1.Add(sizer2, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 0)
+        sizer1.Add(sizer2, 0, wx.ALL, 0)
 
-        sizer1.Add(wx.StaticText(self, -1, 'Field Names must evaluate to a list of field names present in the file,\n and should use "x", "y", "sig", "A"  and "error_x" to refer to the \nfitted position, std dev., amplitude, and error respectively.'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
+        sizer1.Add(wx.StaticText(self, -1, 'Field Names must evaluate to a list of field names present in the file,\n and should use "x", "y", "sig", "A"  and "error_x" to refer to the \nfitted position, std dev., amplitude, and error respectively.'), 0, wx.ALL, 5)
 
         sizer2 = wx.BoxSizer(wx.HORIZONTAL)
         sizer2.Add(wx.StaticText(self, -1, 'Field Names:'), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
@@ -281,7 +281,7 @@ class ImportMatDialog(wx.Dialog):
 
         sizer2.Add(self.tFieldNames, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 
-        sizer1.Add(sizer2, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 0)
+        sizer1.Add(sizer2, 0, wx.ALL, 0)
 
         btSizer = wx.StdDialogButtonSizer()
 
@@ -296,7 +296,7 @@ class ImportMatDialog(wx.Dialog):
 
         btSizer.Realize()
 
-        sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5)
+        sizer1.Add(btSizer, 0, wx.ALIGN_RIGHT|wx.ALL, 5)
 
         self.SetSizer(sizer1)
         sizer1.Fit(self)

--- a/PYME/LMVis/pointSettingsPanel.py
+++ b/PYME/LMVis/pointSettingsPanel.py
@@ -82,7 +82,7 @@ class PointSettingsPanel(wx.Panel):
             self.chPointColour.SetSelection(colKeys.index(currentCol))
         
         
-        hsizer.Add(self.chPointColour, 0,wx.ALL|wx.ALIGN_CENTER_VERTICAL|wx.EXPAND, 5)
+        hsizer.Add(self.chPointColour, 0,wx.ALL|wx.EXPAND, 5)
 
         bsizer.Add(hsizer, 0, wx.ALL|wx.EXPAND, 0)
         

--- a/PYME/ui/progress.py
+++ b/PYME/ui/progress.py
@@ -91,7 +91,7 @@ class UserErrorDialog(wx.Dialog):
         s_b.SetIcon(wx.ArtProvider.GetIcon(wx.ART_ERROR, client=wx.ART_MESSAGE_BOX, size=(32, 32)))
         hsizer.Add(s_b, 0, wx.ALL | wx.ALIGN_CENTRE_VERTICAL, 2)
         hsizer.Add(wx.StaticText(self, label='%s' % exc_val), 1,
-                   wx.ALL | wx.ALIGN_CENTRE_VERTICAL|wx.EXPAND, 2)
+                   wx.ALL | wx.EXPAND, 2)
         vsizer.Add(hsizer, 0, wx.ALL, 2)
         
         btnsizer = wx.StdDialogButtonSizer()

--- a/tests/PYME/ui/test_sizer_flags.py
+++ b/tests/PYME/ui/test_sizer_flags.py
@@ -1,0 +1,359 @@
+"""
+If this test begins failing for functional code we should quickly scrap it.
+This is simply a claude-coded check for wx flags that the current wxWidgets (3.2.9)
+and wxpython 4.2.5 will reject.
+It does not run wx code, it just parses our source code and looks for faulty sizer calls.
+
+wxWidgets 3.x added consistency checks to ``wxSizer::DoInsert`` which raise a
+``wxAssertionError`` (i.e. a hard failure under wxPython) when an ``Add`` call
+passes an alignment flag that the sizer would silently ignore. Because the
+offending flag never had any effect, removing it is always a no-op for layout --
+but leaving it in place turns the whole panel into a crash.
+
+The rules below were established empirically against wxPython 4.2.5 /
+wxWidgets 3.2.9:
+
+1. ``EXPAND`` combined with any of ``ALIGN_RIGHT``, ``ALIGN_CENTER_HORIZONTAL``,
+   ``ALIGN_BOTTOM`` or ``ALIGN_CENTER_VERTICAL`` ("wxEXPAND overrides alignment
+   flags in box sizers").
+2. A vertical box sizer with ``ALIGN_CENTER_VERTICAL`` or ``ALIGN_BOTTOM``
+   ("only horizontal alignment flags can be used in vertical sizers").
+3. A horizontal box sizer with ``ALIGN_CENTER_HORIZONTAL`` or ``ALIGN_RIGHT``
+   ("only vertical alignment flags can be used in horizontal sizers").
+
+``ALIGN_LEFT`` and ``ALIGN_TOP`` are both zero and so are always harmless, grid
+sizers accept every alignment flag, and ``ALIGN_CENTER`` (both centre bits at
+once) is specifically exempt from rules 2 and 3.
+
+This is a static check: it parses the source rather than building any windows,
+so it runs headless and does not need a display.
+"""
+import ast
+import os
+import warnings
+from collections import namedtuple
+
+import pytest
+
+wx = pytest.importorskip('wx')
+
+#: sizer classifications
+BOX_V = 'vertical box sizer'
+BOX_H = 'horizontal box sizer'
+GRID = 'grid sizer'
+UNKNOWN = 'unknown'
+
+#: index of the ``flags`` argument, by sizer method name
+_FLAG_ARG_INDEX = {'Add': 2, 'Prepend': 2, 'Insert': 3}
+
+_GRID_CLASSES = ('GridSizer', 'FlexGridSizer', 'GridBagSizer')
+
+_BAD_WITH_EXPAND = (wx.ALIGN_RIGHT | wx.ALIGN_CENTER_HORIZONTAL
+                    | wx.ALIGN_BOTTOM | wx.ALIGN_CENTER_VERTICAL)
+_BAD_IN_V = wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_BOTTOM
+_BAD_IN_H = wx.ALIGN_CENTER_HORIZONTAL | wx.ALIGN_RIGHT
+
+Violation = namedtuple('Violation', ['path', 'lineno', 'sizer', 'kind', 'flags', 'reason'])
+
+
+def _dotted_name(node):
+    """Return the dotted name of a Name/Attribute node, or None."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted_name(node.value)
+        return None if base is None else '%s.%s' % (base, node.attr)
+    return None
+
+
+def _wx_attr(node):
+    """Return the attribute name of a ``wx.XXX`` reference, or None."""
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) \
+            and node.value.id == 'wx':
+        return node.attr
+    return None
+
+
+def _sizer_kind(call):
+    """Classify a ``wx.*Sizer(...)`` constructor call.
+
+    Parameters
+    ----------
+    call : ast.Call
+        The candidate constructor call.
+
+    Returns
+    -------
+    str or None
+        One of `BOX_V`, `BOX_H`, `GRID`, `UNKNOWN`, or None if the call does not
+        construct a sizer.
+    """
+    cls = _wx_attr(call.func)
+    if cls is None or not cls.endswith('Sizer'):
+        return None
+
+    if cls in _GRID_CLASSES:
+        return GRID
+    if cls == 'StdDialogButtonSizer':
+        return BOX_H
+
+    # BoxSizer(orient), StaticBoxSizer(box, orient), WrapSizer(orient)
+    orients = [_wx_attr(a) for a in call.args]
+    orients += [_wx_attr(k.value) for k in call.keywords
+                if k.arg in ('orient', 'orientation')]
+    orients = [o for o in orients if o in ('VERTICAL', 'HORIZONTAL')]
+
+    if len(orients) == 1:
+        return BOX_V if orients[0] == 'VERTICAL' else BOX_H
+    if cls == 'StaticBoxSizer':
+        return BOX_V  # wx default when the orientation is omitted
+    return UNKNOWN
+
+
+def _eval_flags(node):
+    """Evaluate an OR-ed expression of wx flag constants.
+
+    Returns
+    -------
+    bits : int
+        The combined flag value.
+    resolved : bool
+        False if any term could not be resolved to an integer, in which case
+        `bits` is meaningless.
+    """
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        left, left_ok = _eval_flags(node.left)
+        right, right_ok = _eval_flags(node.right)
+        return left | right, left_ok and right_ok
+    if isinstance(node, ast.Constant) and isinstance(node.value, int):
+        return node.value, True
+    name = _wx_attr(node)
+    if name is not None and isinstance(getattr(wx, name, None), int):
+        return getattr(wx, name), True
+    return 0, False
+
+
+def _reasons(kind, bits):
+    """Return the reasons wx would reject this flag combination (may be empty)."""
+    if kind in (GRID, UNKNOWN):
+        return []
+
+    if (bits & wx.EXPAND) and (bits & _BAD_WITH_EXPAND):
+        # this check fires first in wx and exempts nothing
+        return ['EXPAND overrides alignment flags in box sizers']
+
+    # wxALIGN_CENTRE (both centre bits) is accepted in either orientation
+    if (bits & wx.ALIGN_CENTER_HORIZONTAL) and (bits & wx.ALIGN_CENTER_VERTICAL):
+        bits &= ~(wx.ALIGN_CENTER_HORIZONTAL | wx.ALIGN_CENTER_VERTICAL)
+
+    if kind == BOX_V and (bits & _BAD_IN_V):
+        return ['only horizontal alignment flags can be used in vertical sizers']
+    if kind == BOX_H and (bits & _BAD_IN_H):
+        return ['only vertical alignment flags can be used in horizontal sizers']
+    return []
+
+
+def find_violations(source, path='<string>'):
+    """Find sizer ``Add`` calls that pass flags wx will reject.
+
+    Parameters
+    ----------
+    source : str
+        Python source code.
+    path : str, optional
+        Name used in the returned records.
+
+    Returns
+    -------
+    list of Violation
+        Empty if the source is clean (or cannot be parsed).
+
+    Notes
+    -----
+    A sizer's orientation is resolved by looking back for the most recent
+    assignment of that name at or above the call's line. Calls whose sizer or
+    flags cannot be resolved statically are ignored rather than reported, so
+    this check yields false negatives but not false positives.
+    """
+    try:
+        with warnings.catch_warnings():
+            # parsing legacy sources re-raises their own escape/syntax warnings,
+            # which have nothing to do with what we are checking here
+            warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter('ignore', SyntaxWarning)
+            tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    # sizer name -> [(lineno, kind), ...] in source order
+    assignments = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        if not isinstance(node.value, ast.Call):
+            continue
+        kind = _sizer_kind(node.value)
+        if kind is None:
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in targets:
+            name = _dotted_name(target)
+            if name:
+                assignments.setdefault(name, []).append((node.lineno, kind))
+    for records in assignments.values():
+        records.sort()
+
+    def kind_at(name, lineno):
+        prior = [k for ln, k in assignments.get(name, []) if ln <= lineno]
+        if prior:
+            return prior[-1]
+        # only assigned later (e.g. in another method) -- usable if unambiguous
+        kinds = set(k for _, k in assignments.get(name, []))
+        return kinds.pop() if len(kinds) == 1 else None
+
+    violations = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        index = _FLAG_ARG_INDEX.get(node.func.attr)
+        if index is None:
+            continue
+        sizer = _dotted_name(node.func.value)
+        if sizer is None:
+            continue
+        kind = kind_at(sizer, node.lineno)
+        if kind is None:
+            continue
+
+        flag_node = None
+        if len(node.args) > index:
+            flag_node = node.args[index]
+        else:
+            for keyword in node.keywords:
+                if keyword.arg == 'flag':
+                    flag_node = keyword.value
+        if flag_node is None:
+            continue
+
+        bits, resolved = _eval_flags(flag_node)
+        if not resolved:
+            continue
+
+        flags = ast.get_source_segment(source, flag_node) or ''
+        for reason in _reasons(kind, bits):
+            violations.append(Violation(path, node.lineno, sizer, kind,
+                                        ' '.join(flags.split()), reason))
+    return violations
+
+
+def _pyme_source_files():
+    """Yield the paths of all python files in the PYME package."""
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'PYME'))
+    if not os.path.isdir(root):
+        pytest.skip('PYME source tree not found at %s' % root)
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d != '__pycache__']
+        for filename in sorted(filenames):
+            if filename.endswith('.py'):
+                yield os.path.join(dirpath, filename)
+
+
+def test_no_ignored_sizer_flags():
+    """No sizer Add call in PYME may pass a flag that wx would reject."""
+    violations = []
+    for path in _pyme_source_files():
+        with open(path, 'r', encoding='utf-8', errors='replace') as f:
+            source = f.read()
+        violations.extend(find_violations(source, os.path.relpath(path)))
+
+    assert not violations, 'wx will raise on %d sizer Add call(s):\n%s' % (
+        len(violations),
+        '\n'.join('  %s:%d  %s.Add(..., %s) -- %s (%s)'
+                  % (v.path, v.lineno, v.sizer, v.flags, v.reason, v.kind)
+                  for v in violations))
+
+
+# --- unit tests for the rules themselves ------------------------------------
+
+def _check(body, sizer='wx.BoxSizer(wx.VERTICAL)'):
+    source = 'import wx\ns = %s\ns.Add(w, 0, %s, 5)\n' % (sizer, body)
+    return find_violations(source)
+
+
+@pytest.mark.parametrize('flags, sizer', [
+    # rule 1 -- EXPAND overrides alignment, in either orientation
+    ('wx.EXPAND | wx.ALIGN_CENTER_VERTICAL', 'wx.BoxSizer(wx.VERTICAL)'),
+    ('wx.EXPAND | wx.ALIGN_CENTER_HORIZONTAL', 'wx.BoxSizer(wx.HORIZONTAL)'),
+    ('wx.EXPAND | wx.ALIGN_RIGHT', 'wx.BoxSizer(wx.VERTICAL)'),
+    ('wx.EXPAND | wx.ALIGN_BOTTOM', 'wx.BoxSizer(wx.HORIZONTAL)'),
+    ('wx.EXPAND | wx.ALIGN_CENTER', 'wx.BoxSizer(wx.VERTICAL)'),
+    # rule 2 -- vertical alignment in a vertical sizer
+    ('wx.ALIGN_CENTER_VERTICAL | wx.ALL', 'wx.BoxSizer(wx.VERTICAL)'),
+    ('wx.ALIGN_BOTTOM', 'wx.BoxSizer(wx.VERTICAL)'),
+    ('wx.ALIGN_CENTER_VERTICAL', 'wx.StaticBoxSizer(box, wx.VERTICAL)'),
+    ('wx.ALIGN_CENTER_VERTICAL', 'wx.StaticBoxSizer(box)'),
+    # rule 3 -- horizontal alignment in a horizontal sizer
+    ('wx.ALIGN_CENTER_HORIZONTAL | wx.ALL', 'wx.BoxSizer(wx.HORIZONTAL)'),
+    ('wx.ALIGN_RIGHT', 'wx.BoxSizer(wx.HORIZONTAL)'),
+    ('wx.ALIGN_RIGHT', 'wx.StdDialogButtonSizer()'),
+])
+def test_rejected_combinations(flags, sizer):
+    assert len(_check(flags, sizer)) == 1
+
+
+@pytest.mark.parametrize('flags, sizer', [
+    # perpendicular alignment is fine
+    ('wx.ALIGN_CENTER_VERTICAL | wx.ALL', 'wx.BoxSizer(wx.HORIZONTAL)'),
+    ('wx.ALIGN_CENTER_HORIZONTAL | wx.ALL', 'wx.BoxSizer(wx.VERTICAL)'),
+    ('wx.ALIGN_RIGHT | wx.ALL', 'wx.BoxSizer(wx.VERTICAL)'),
+    ('wx.ALIGN_BOTTOM', 'wx.BoxSizer(wx.HORIZONTAL)'),
+    # ALIGN_CENTER (both centre bits) is exempt from rules 2 and 3
+    ('wx.ALIGN_CENTER', 'wx.BoxSizer(wx.VERTICAL)'),
+    ('wx.ALIGN_CENTER', 'wx.BoxSizer(wx.HORIZONTAL)'),
+    ('wx.ALIGN_CENTER_HORIZONTAL | wx.ALIGN_CENTER_VERTICAL', 'wx.BoxSizer(wx.VERTICAL)'),
+    # ALIGN_LEFT and ALIGN_TOP are zero
+    ('wx.EXPAND | wx.ALIGN_LEFT | wx.ALIGN_TOP', 'wx.BoxSizer(wx.VERTICAL)'),
+    # grid sizers accept everything
+    ('wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT', 'wx.GridSizer(2, 2, 0, 0)'),
+    ('wx.EXPAND | wx.ALIGN_CENTER_VERTICAL', 'wx.FlexGridSizer(2, 2, 0, 0)'),
+    # plain border/expand flags
+    ('wx.EXPAND | wx.ALL', 'wx.BoxSizer(wx.VERTICAL)'),
+])
+def test_accepted_combinations(flags, sizer):
+    assert _check(flags, sizer) == []
+
+
+def test_unresolvable_flags_are_not_reported():
+    """A flag expression we cannot evaluate must not produce a false positive."""
+    source = ('import wx\n'
+              's = wx.BoxSizer(wx.VERTICAL)\n'
+              's.Add(w, 0, some_flags | wx.ALIGN_CENTER_VERTICAL, 5)\n')
+    assert find_violations(source) == []
+
+
+def test_orientation_tracked_per_reassignment():
+    """Reassigning a sizer name switches which flags are legal from there on."""
+    source = ('import wx\n'
+              's = wx.BoxSizer(wx.HORIZONTAL)\n'
+              's.Add(w, 0, wx.ALIGN_CENTER_VERTICAL, 5)\n'   # legal
+              's = wx.BoxSizer(wx.VERTICAL)\n'
+              's.Add(w, 0, wx.ALIGN_CENTER_VERTICAL, 5)\n')   # illegal
+    violations = find_violations(source)
+    assert [v.lineno for v in violations] == [5]
+
+
+def test_insert_and_prepend_flag_positions():
+    """Insert takes the flags one argument later than Add and Prepend."""
+    source = ('import wx\n'
+              's = wx.BoxSizer(wx.VERTICAL)\n'
+              's.Prepend(w, 0, wx.ALIGN_CENTER_VERTICAL, 5)\n'
+              's.Insert(0, w, 0, wx.ALIGN_CENTER_VERTICAL, 5)\n')
+    assert [v.lineno for v in find_violations(source)] == [3, 4]
+
+
+def test_flag_keyword_argument():
+    source = ('import wx\n'
+              's = wx.BoxSizer(wx.VERTICAL)\n'
+              's.Add(w, flag=wx.ALIGN_CENTER_VERTICAL | wx.ALL, border=5)\n')
+    assert len(find_violations(source)) == 1


### PR DESCRIPTION
Addresses issue #1706 and follow-ons from #1705. Also capitalized an `L` in `wx.HORIZONTAL` so it resolves even though it isn't used.

**Is this a bugfix or an enhancement?**
bugfix on later wxwidgets/wxpython

**Proposed changes:**
follow-on from #1705 , using a Claude-coded parse of our source code to look for invalid wx sizer flags. Added the check as a unit test to prevent us from doing this in the future.

Remove horizontal sizer flags on horizontal sizers, align with expand, etc.


**Checklist:**
Not all of these have been tested, but I spot checked several and they crash us out like #1705 does on 
wxpython                  4.2.5           py311h8325047_2    conda-forge
wxwidgets                 3.2.9                h34c1157_0    conda-forge

(spot checked 3 files fixes, mentioned in commit messages, by removing the fix and hitting the bug through the GUI)

**Notes:**
Some of these are tough to test at the moment because they exist in code which is never called. Some things we might want to just remove include `LaserControlFrame.py` and `IntegrationSliders.IntegrationSliders_`. Several others under e.g. if False statements. But with the test hitting them as failures I added them as fixes. 
