### PR TITLE
make session loading more robust against defunct datasource

### DIFF
--- a/PYME/LMVis/pipeline.py
+++ b/PYME/LMVis/pipeline.py
@@ -812,7 +812,13 @@ class Pipeline(object):
         self.recipe._update_from_module_list(session_info['recipe'])
         self.recipe.execute()
 
-        self.selectDataSource(session_info['selected_datasource'])
+        sds = session_info['selected_datasource']
+        if sds in self.dataSources:
+            self.selectDataSource(sds)
+        else:
+            from PYME import pyme_warnings as warnings
+            warnings.warn("selected datasource '%s' from session file not available, falling back to an available one" % sds)
+            self.selectDataSource(next(iter(self.dataSources.keys()))) # arbitrarily pick the first ds in the list of keys
 
         self.Rebuild()
 


### PR DESCRIPTION
Addresses issue where an non-existing datasource is selected in a saved session. Upon loading this leads to a full-on fail of the session load.

The small "fix" makes this more robust and drops back to an existing one (random, but probably often `FitResults`) and warns.

**Is this a bugfix or an enhancement?**
It is a fix that is a minor enhacement. In daily practice it is relatively easy to choose a later "defunct" datasource for display when changing recipes and then saving that session with the "wrong" datasource selected for display. 

**Proposed changes:**

This small  change just checks and picks another existing datasource for output and warns if so. Effect is that it is easier to fix and save an updated session rather than editing the session file in an editor (ugly).


**Checklist:**
The below is a list of things what will be considered when reviewing PRs. It is not prescriptive, and does not
imply that PRs which touch any of these will be rejected but gives a rough indication of where there is a potential 
for hangups (i.e. factors which could turn a 5 min review into a half hour or longer and shunt it to the bottom
of the TODO list).

- [ ] Does the PR avoid variable renaming in existing code, whitespace changes, and other forms of tidying? [There is a place for code tidying, but it makes reviewing 
much simpler if this is kept separate from functional changes. The auto-formatting performed by some editors is particulaly egregious and can lead to files with thousands
of non-functional changes with a few functional changes scattered amoungst them]

If an enhancement (or non-trivial bugfix):

- [ ] Has this been discussed in advance (feature request, PR proposal, email, or direct conversation)?
- [ ] Does this change how users interact with the software? How will these changes be communicated?
- [ ] Does this maintain backwards compatibility with old data?
- [ ] Does this change the required dependencies?
- [ ] Are there any other side effects of the change?
